### PR TITLE
Update burger-sizes.demo.tsx

### DIFF
--- a/docs/src/docs/demos/core/Burger/burger-sizes.demo.tsx
+++ b/docs/src/docs/demos/core/Burger/burger-sizes.demo.tsx
@@ -4,7 +4,7 @@ import CodeDemo from '../../../../components/CodeDemo/CodeDemo';
 
 function BurgerWrapper(props: React.ComponentPropsWithoutRef<typeof Burger>) {
   const [opened, setOpened] = useState(false);
-  const title = opened ? 'Open navigation' : 'Close navigation';
+  const title = opened ? 'Close navigation' : 'Open navigation';
 
   return (
     <Burger


### PR DESCRIPTION
The title text is incorrect in the demo.

Hovering on the unopened burger should say 'Open' and hovering on the `x` should say 'Close'.