### PR TITLE
[@mantine/hooks] use-click-outside: Prevent extra invocations of handler if both events fire

### DIFF
--- a/src/mantine-hooks/src/use-click-outside/use-click-outside.ts
+++ b/src/mantine-hooks/src/use-click-outside/use-click-outside.ts
@@ -9,6 +9,7 @@ export function useClickOutside<T extends HTMLElement = any>(
   useEffect(() => {
     const listener = (event: any) => {
       if (ref.current && !ref.current.contains(event.target)) {
+        event.preventDefault();
         handler();
       }
     };


### PR DESCRIPTION
closes #74 