### PR TITLE
Select - Possible Simple Fix to Placeholder/defaultValue

### DIFF
--- a/src/mantine-core/src/Select/Select.tsx
+++ b/src/mantine-core/src/Select/Select.tsx
@@ -62,7 +62,7 @@ export function Select({
 
   if (placeholder) {
     options.unshift(
-      <option key="placeholder" value="" selected disabled hidden>
+      <option key="placeholder" value="xx-placeholder-xx" disabled hidden>
         {placeholder}
       </option>
     );
@@ -97,6 +97,7 @@ export function Select({
         rightSectionProps={{ style: { pointerEvents: 'none' } }}
         required={required}
         themeOverride={themeOverride}
+        defaultValue={placeholder ? 'xx-placeholder-xx' : null }
       >
         {options}
       </Input>

--- a/src/mantine-core/src/Select/Select.tsx
+++ b/src/mantine-core/src/Select/Select.tsx
@@ -49,6 +49,7 @@ export function Select({
   inputStyle,
   description,
   elementRef,
+  defaultValue,
   ...others
 }: SelectProps) {
   const theme = useMantineTheme(themeOverride);
@@ -97,7 +98,7 @@ export function Select({
         rightSectionProps={{ style: { pointerEvents: 'none' } }}
         required={required}
         themeOverride={themeOverride}
-        defaultValue={placeholder ? 'xx-placeholder-xx' : null}
+        defaultValue={defaultValue || (placeholder ? 'xx-placeholder-xx' : null)}
       >
         {options}
       </Input>

--- a/src/mantine-core/src/Select/Select.tsx
+++ b/src/mantine-core/src/Select/Select.tsx
@@ -97,7 +97,7 @@ export function Select({
         rightSectionProps={{ style: { pointerEvents: 'none' } }}
         required={required}
         themeOverride={themeOverride}
-        defaultValue={placeholder ? 'xx-placeholder-xx' : null }
+        defaultValue={placeholder ? 'xx-placeholder-xx' : null}
       >
         {options}
       </Input>


### PR DESCRIPTION
I haven't tested this - I am editing from the GitHub GUI not from my VSCode.

However this could have a clash if for some reason the user wanted to use `xx-placeholder-xx` as a value, however unlikely that is.

Not sure what the best solution would be.