### PR TITLE
feat: add ability for multiple highlights

### DIFF
--- a/src/mantine-core/src/components/Highlight/Highlight.story.tsx
+++ b/src/mantine-core/src/components/Highlight/Highlight.story.tsx
@@ -14,6 +14,9 @@ storiesOf('@mantine/core/Highlight', module)
     <>
       <Highlight highlight="that">Nothing nothing</Highlight>
       <Highlight highlight="Highlight all">Highlight all</Highlight>
+      <Highlight highlight={['Highlight', 'array']}>Highlight array</Highlight>
+      <Highlight highlight="multiple" multiple>Multiple strings will be highlighted with multiple enabled</Highlight>
+      <Highlight highlight={['hello', 'world']} multiple>Even arrays like hello world will be highlighted multiple, hello world!</Highlight>
     </>
   ))
   .add('Themes', () => <>{themes}</>)

--- a/src/mantine-core/src/components/Highlight/Highlight.test.tsx
+++ b/src/mantine-core/src/components/Highlight/Highlight.test.tsx
@@ -43,35 +43,47 @@ describe('@mantine/core/Highlight/highlighter', () => {
   const VALUE = 'Hello, World';
 
   it('highlights start of string', () => {
-    expect(highlighter(VALUE, 'Hell')).toEqual({ start: '', highlighted: 'Hell', end: 'o, World' });
+    expect(highlighter(VALUE, 'Hell')).toEqual([
+      { chunk: 'Hell', highlighted: true },
+      { chunk: 'o, World', highlighted: false },
+    ]);
   });
 
   it('Highlights middle of string', () => {
-    expect(highlighter(VALUE, 'llo, W')).toEqual({
-      start: 'He',
-      highlighted: 'llo, W',
-      end: 'orld',
-    });
+    expect(highlighter(VALUE, 'llo, W')).toEqual([
+      { chunk: 'He', highlighted: false },
+      { chunk: 'llo, W', highlighted: true },
+      { chunk: 'orld', highlighted: false },
+    ]);
+  });
+
+  it('Highlights multiple of string', () => {
+    expect(highlighter(VALUE, ['Hell', 'world'])).toEqual([
+      { chunk: 'Hell', highlighted: true },
+      { chunk: 'o, ', highlighted: false },
+      { chunk: 'World', highlighted: true },
+    ]);
   });
 
   it('highlights uppercased value', () => {
-    expect(highlighter(VALUE, 'HELL')).toEqual({ start: '', highlighted: 'Hell', end: 'o, World' });
-    expect(highlighter(VALUE, 'Hello,')).toEqual({
-      start: '',
-      highlighted: 'Hello,',
-      end: ' World',
-    });
+    expect(highlighter(VALUE, 'HELL')).toEqual([
+      { chunk: 'Hell', highlighted: true },
+      { chunk: 'o, World', highlighted: false },
+    ]);
+    expect(highlighter(VALUE, 'Hello,')).toEqual([
+      { chunk: 'Hello,', highlighted: true },
+      { chunk: ' World', highlighted: false },
+    ]);
   });
 
   it('highlights value with whitespace', () => {
-    expect(highlighter(VALUE, 'Hello  \t')).toEqual({
-      start: '',
-      highlighted: 'Hello',
-      end: ', World',
-    });
+    expect(highlighter(VALUE, 'Hello  \t')).toEqual([
+      { chunk: 'Hello', highlighted: true },
+      { chunk: ', World', highlighted: false },
+    ]);
   });
 
   it('does not highlight if nothing found', () => {
-    expect(highlighter(VALUE, 'Hi, there')).toEqual({ start: VALUE, highlighted: '', end: '' });
+    expect(highlighter(VALUE, 'Hi, there')).toEqual([{ chunk: VALUE, highlighted: false }]);
   });
 });


### PR DESCRIPTION
Attempts to resolve: #143 

Current issues, the search is forward only, so an input of `world\,Hello` would result in 'Hello `world`' (only world being highlighted.

it might be better to use regex for this?

Syntax for multiple is currently `\,` however this can be easily changed.