### PR TITLE
[@mantine/core] Tabs: add support for `orientation` prop

### DIFF
--- a/docs/src/components/Layout/Navbar/NavbarDocsCategory/NavbarDocsCategory.tsx
+++ b/docs/src/components/Layout/Navbar/NavbarDocsCategory/NavbarDocsCategory.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Link } from 'gatsby';
 import cx from 'clsx';
 import { ChevronDownIcon } from '@modulz/radix-icons';
 import { Text } from '@mantine/core';
+import { useLocation } from '@reach/router';
 import { getDocsData } from '../../get-docs-data';
 import useStyles from './NavbarDocsCategory.styles';
 
@@ -14,7 +15,18 @@ interface NavbarDocsCategoryProps {
 export default function NavbarDocsCategory({ group, onLinkClick }: NavbarDocsCategoryProps) {
   const classes = useStyles();
   const [collapsed, setCollapsed] = useState(false);
+  const activeCoreItemRef = useRef(null);
+  const location = useLocation();
 
+  React.useEffect(() => {
+    if (activeCoreItemRef.current) {
+      activeCoreItemRef.current.scrollIntoView({
+        behavior: 'smooth',
+        inline: 'center',
+        block: 'center',
+      });
+    }
+  }, [activeCoreItemRef.current]);
   const uncategorized = group.uncategorized.map((link) => (
     <Link
       key={link.slug}
@@ -40,6 +52,7 @@ export default function NavbarDocsCategory({ group, onLinkClick }: NavbarDocsCat
             activeClassName={classes.linkActive}
             to={link.slug}
             onClick={onLinkClick}
+            ref={location.pathname === link.slug ? activeCoreItemRef : null}
           >
             {link.title}
           </Link>

--- a/docs/src/components/Layout/Navbar/NavbarDocsCategory/NavbarDocsCategory.tsx
+++ b/docs/src/components/Layout/Navbar/NavbarDocsCategory/NavbarDocsCategory.tsx
@@ -21,7 +21,7 @@ export default function NavbarDocsCategory({ group, onLinkClick }: NavbarDocsCat
   React.useEffect(() => {
     if (activeCoreItemRef.current) {
       activeCoreItemRef.current.scrollIntoView({
-        behavior: 'smooth',
+        behavior: 'auto',
         inline: 'center',
         block: 'center',
       });

--- a/docs/src/docs/core/Tabs.mdx
+++ b/docs/src/docs/core/Tabs.mdx
@@ -118,7 +118,8 @@ function TabsDemo() {
 Tabs component follows [WAI-ARIA recommendations](https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-2/tabs.html) on accessibility.
 Component fully supports keyboard events handling and has correct aria-roles:
 
-- Use right and left arrow keys to change tabs
+- Use right and left arrow keys to change tabs when orientation is horizontal
+- Use down and up arrow keys to change tabs when orientation is vertical
 - Only selected tab control can be focused
 - All elements have correct roles: tab, tablist and tabpanel
-- aria-orientation is always set to horizontal as component does not support vertical tabs
+- aria-orientation is set based off `orientation` prop (default is horizontal)

--- a/docs/src/docs/hooks/use-window-scroll.mdx
+++ b/docs/src/docs/hooks/use-window-scroll.mdx
@@ -5,7 +5,7 @@ title: 'use-window-scroll'
 category: 'utils'
 order: 1
 slug: /hooks/use-window-scroll/
-description: 'Adds event listener to window on component mount and removes it on unmount'
+description: 'Subscribe to window scroll and scroll smoothly to given position'
 import: "import { useWindowScroll } from '@mantine/hooks';"
 docs: 'hooks/use-window-scroll.mdx'
 source: 'mantine-hooks/src/use-window-scroll/use-window-scroll.ts'

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine/eslint-config",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "eslint.config.js",
   "license": "MIT",
   "author": "Vitaly Rtishchev <rtivital@gmail.com>",
@@ -20,7 +20,8 @@
     "eslint-plugin-jest": "^24.3.6",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.24.0",
-    "eslint-plugin-react-hooks": "^4.2.0"
+    "eslint-plugin-react-hooks": "^4.2.0",
+    "jest": "^26.6.3"
   },
   "dependencies": {},
   "devDependencies": {}

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine/eslint-config",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "main": "eslint.config.js",
   "license": "MIT",
   "author": "Vitaly Rtishchev <rtivital@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Vitaly Rtishchev <rtivital@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "postinstall": "cd docs && yarn",
+    "postinstall": "npm run docs:docgen && npm run docs:sizes && cd docs && yarn",
     "syncpack": "syncpack list-mismatches",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.tsx",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "workspaces": [
     "src/*"
   ],
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Mantine Components Monorepo",
   "main": "index.js",
   "repository": "https://github.com/mantinedev/mantine.git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "workspaces": [
     "src/*"
   ],
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Mantine Components Monorepo",
   "main": "index.js",
   "repository": "https://github.com/mantinedev/mantine.git",

--- a/src/mantine-core/package.json
+++ b/src/mantine-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mantine/core",
   "description": "React components library focused on usability, accessibility and developer experience",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "browser": "lib/index.umd.js",
@@ -16,7 +16,7 @@
     "directory": "src/mantine-core"
   },
   "peerDependencies": {
-    "@mantine/hooks": "2.0.4",
+    "@mantine/hooks": "2.0.5",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "react-jss": ">=10.1.1"

--- a/src/mantine-core/package.json
+++ b/src/mantine-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mantine/core",
   "description": "React components library focused on usability, accessibility and developer experience",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "browser": "lib/index.umd.js",
@@ -16,7 +16,7 @@
     "directory": "src/mantine-core"
   },
   "peerDependencies": {
-    "@mantine/hooks": "2.0.3",
+    "@mantine/hooks": "2.0.4",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "react-jss": ">=10.1.1"

--- a/src/mantine-core/src/components/Input/Input.story.tsx
+++ b/src/mantine-core/src/components/Input/Input.story.tsx
@@ -1,10 +1,25 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { createUseStyles } from 'react-jss';
 import { MagnifyingGlassIcon } from '@modulz/radix-icons';
 import Textarea from 'react-textarea-autosize';
 import { DEFAULT_THEME, MANTINE_SIZES } from '../../theme';
 import { ActionIcon } from '../ActionIcon/ActionIcon';
 import { Input } from './Input';
+
+const useStyles = createUseStyles({
+  input: {
+    border: '2px solid red',
+
+    '&::placeholder': {
+      color: 'red',
+    },
+  },
+});
+
+function WithStyles() {
+  return <Input classNames={useStyles()} placeholder="red" />;
+}
 
 const actionIcon = (
   <ActionIcon size="sm">
@@ -92,6 +107,7 @@ storiesOf('@mantine/core/Input', module)
   .add('Dark theme', () => (
     <div style={{ background: DEFAULT_THEME.colors.dark[7], minHeight: '100vh', padding: 50 }}>
       {getStates({
+        variant: 'default',
         themeOverride: { colorScheme: 'dark' },
         inputStyle: { paddingTop: 9, paddingBottom: 9 },
       })}
@@ -106,4 +122,5 @@ storiesOf('@mantine/core/Input', module)
         inputStyle: { paddingTop: 9, paddingBottom: 9 },
       })}
     </div>
-  ));
+  ))
+  .add('With classNames', () => <WithStyles />);

--- a/src/mantine-core/src/components/Input/Input.styles.ts
+++ b/src/mantine-core/src/components/Input/Input.styles.ts
@@ -6,12 +6,15 @@ import {
   createMemoStyles,
   MantineSize,
 } from '../../theme';
+import type { InputVariant } from './Input';
 
 interface InputStyles {
   theme: MantineTheme;
   radius: MantineNumberSize;
   size: MantineSize;
+  variant: InputVariant;
   multiline: boolean;
+  invalid: boolean;
 }
 
 export const sizes = {
@@ -22,59 +25,26 @@ export const sizes = {
   xl: 60,
 };
 
-export default createMemoStyles({
-  withIcon: {},
-
-  root: ({ radius, theme }: InputStyles) => ({
-    position: 'relative',
-    borderRadius: getSizeValue({ size: radius, sizes: theme.radius }),
-
-    '&, & *': { boxSizing: 'border-box' },
-  }),
-
-  default: ({ theme, radius, size, multiline }: InputStyles) => ({
-    '& $input': {
+function getVariantStyles({ variant, theme }: Pick<InputStyles, 'variant' | 'theme'>) {
+  if (variant === 'default') {
+    return {
       backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
-      minHeight: getSizeValue({ size, sizes }),
-      height: multiline ? 'auto' : getSizeValue({ size, sizes }),
-      paddingLeft: getSizeValue({ size, sizes }) / 3,
-      paddingRight: getSizeValue({ size, sizes }) / 3,
-      borderRadius: getSizeValue({ size: radius, sizes: theme.radius }),
       border: `1px solid ${
         theme.colorScheme === 'dark' ? theme.colors.dark[3] : theme.colors.gray[4]
       }`,
       transition: 'border-color 100ms ease, box-shadow 100ms ease',
-      color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
 
       '&:focus': {
         outline: 'none',
         borderColor: theme.colors[theme.primaryColor][theme.colorScheme === 'dark' ? 5 : 7],
       },
-    },
+    };
+  }
 
-    '&$invalid $input': {
-      borderColor: theme.colors.red[theme.colorScheme === 'dark' ? 5 : 7],
-    },
-
-    '& $withIcon': {
-      paddingLeft: getSizeValue({ size, sizes }),
-    },
-
-    '& $icon': {
-      width: getSizeValue({ size, sizes }),
-    },
-  }),
-
-  filled: ({ theme, radius, size, multiline }: InputStyles) => ({
-    '& $input': {
-      minHeight: getSizeValue({ size, sizes }),
-      height: multiline ? 'auto' : getSizeValue({ size, sizes }),
-      paddingLeft: getSizeValue({ size, sizes }) / 3,
-      paddingRight: getSizeValue({ size, sizes }) / 3,
-      borderRadius: getSizeValue({ size: radius, sizes: theme.radius }),
+  if (variant === 'filled') {
+    return {
       border: '1px solid transparent',
       backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.gray[1],
-      color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
 
       '&:focus': {
         outline: 'none',
@@ -86,31 +56,11 @@ export default createMemoStyles({
       '&::placeholder': {
         color: theme.colorScheme === 'dark' ? theme.colors.dark[2] : theme.colors.gray[6],
       },
-    },
+    };
+  }
 
-    '& $input:disabled': {
-      '&::placeholder': {
-        color: theme.colors.gray[5],
-      },
-    },
-
-    '&$invalid $input': {
-      borderColor: theme.colorScheme === 'dark' ? theme.colors.red[5] : 'transparent',
-      backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.red[0],
-    },
-
-    '& $withIcon': {
-      paddingLeft: getSizeValue({ size, sizes }),
-    },
-
-    '& $icon': {
-      width: getSizeValue({ size, sizes }),
-      color: theme.colors.gray[6],
-    },
-  }),
-
-  unstyled: ({ theme, size }: InputStyles) => ({
-    '& $input': {
+  if (variant === 'unstyled') {
+    return {
       color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
       backgroundColor: 'transparent',
       height: 28,
@@ -120,76 +70,113 @@ export default createMemoStyles({
       '&:disabled': {
         backgroundColor: 'transparent',
       },
-    },
+    };
+  }
 
-    '& $icon': {
-      width: 28,
-    },
+  return null;
+}
 
-    '& $withIcon': {
-      paddingLeft: getSizeValue({ size, sizes }),
-    },
-  }),
+function getInvalidStyles({ invalid, theme }: Pick<InputStyles, 'invalid' | 'theme'>) {
+  if (!invalid) {
+    return null;
+  }
 
-  input: ({ theme, size, multiline }: InputStyles) => ({
-    ...getFontStyles(theme),
-    WebkitTapHighlightColor: 'transparent',
-    lineHeight: multiline ? theme.lineHeight : `${getSizeValue({ size, sizes }) - 2}px`,
-    appearance: 'none',
-    resize: 'none',
-    boxSizing: 'border-box',
-    fontSize: getSizeValue({ size, sizes: theme.fontSizes }),
-    width: '100%',
-    color: theme.black,
-    display: 'block',
-    textAlign: 'left',
+  const color = theme.colors.red[theme.colorScheme === 'dark' ? 6 : 7];
 
-    '&:disabled': {
-      backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[1],
-      opacity: 0.6,
-      cursor: 'not-allowed',
-    },
+  return {
+    color,
+    borderColor: color,
 
     '&::placeholder': {
       opacity: 1,
-      color: theme.colorScheme === 'dark' ? theme.colors.dark[2] : theme.colors.gray[5],
+      color,
     },
+  };
+}
 
-    '&::-webkit-inner-spin-button, &::-webkit-outer-spin-button, &::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button, &::-webkit-search-results-decoration':
-      {
-        appearance: 'none',
-      },
+export default createMemoStyles({
+  root: ({ radius, theme }: InputStyles) => ({
+    position: 'relative',
+    borderRadius: getSizeValue({ size: radius, sizes: theme.radius }),
 
-    '&[type=number]': {
-      MozAppearance: 'textfield',
-    },
+    '&, & *': { boxSizing: 'border-box' },
   }),
 
-  icon: ({ theme }: InputStyles) => ({
+  input: ({ theme, size, multiline, radius, variant, invalid }: InputStyles) => {
+    const sizeStyles =
+      variant === 'default' || variant === 'filled'
+        ? {
+            minHeight: getSizeValue({ size, sizes }),
+            height: multiline ? 'auto' : getSizeValue({ size, sizes }),
+            paddingLeft: getSizeValue({ size, sizes }) / 3,
+            paddingRight: getSizeValue({ size, sizes }) / 3,
+            borderRadius: getSizeValue({ size: radius, sizes: theme.radius }),
+          }
+        : null;
+
+    return {
+      ...getFontStyles(theme),
+      ...getVariantStyles({ variant, theme }),
+      WebkitTapHighlightColor: 'transparent',
+      lineHeight: multiline ? theme.lineHeight : `${getSizeValue({ size, sizes }) - 2}px`,
+      appearance: 'none',
+      resize: 'none',
+      boxSizing: 'border-box',
+      fontSize: getSizeValue({ size, sizes: theme.fontSizes }),
+      width: '100%',
+      color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
+      display: 'block',
+      textAlign: 'left',
+      ...sizeStyles,
+
+      '&:disabled': {
+        backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[1],
+        color: theme.colors.dark[2],
+        opacity: 0.6,
+        cursor: 'not-allowed',
+
+        '&:placeholder': {
+          color: theme.colors.dark[2],
+        },
+      },
+
+      '&::placeholder': {
+        opacity: 1,
+        color: theme.colorScheme === 'dark' ? theme.colors.dark[2] : theme.colors.gray[5],
+      },
+
+      '&::-webkit-inner-spin-button, &::-webkit-outer-spin-button, &::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button, &::-webkit-search-results-decoration':
+        {
+          appearance: 'none',
+        },
+
+      '&[type=number]': {
+        MozAppearance: 'textfield',
+      },
+
+      ...getInvalidStyles({ invalid, theme }),
+    };
+  },
+
+  withIcon: ({ size }) => ({
+    paddingLeft: getSizeValue({ size, sizes }),
+  }),
+
+  icon: ({ theme, size, invalid }: InputStyles) => ({
     pointerEvents: 'none',
     position: 'absolute',
     left: 0,
     top: 0,
     bottom: 0,
-    color: theme.colorScheme === 'dark' ? theme.colors.dark[2] : theme.colors.gray[5],
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-  }),
-
-  invalid: ({ theme }: InputStyles) => ({
-    '& $input': {
-      color: theme.colors.red[theme.colorScheme === 'dark' ? 5 : 7],
-      borderColor: theme.colors.red[theme.colorScheme === 'dark' ? 5 : 7],
-
-      '&::placeholder': {
-        color: theme.colors.red[theme.colorScheme === 'dark' ? 5 : 7],
-      },
-    },
-
-    '& $icon': {
-      color: theme.colors.red[theme.colorScheme === 'dark' ? 5 : 7],
-    },
+    width: getSizeValue({ size, sizes }),
+    color: invalid
+      ? theme.colors.red[theme.colorScheme === 'dark' ? 6 : 7]
+      : theme.colorScheme === 'dark'
+      ? theme.colors.dark[2]
+      : theme.colors.gray[6],
   }),
 
   rightSection: {

--- a/src/mantine-core/src/components/Input/Input.styles.ts
+++ b/src/mantine-core/src/components/Input/Input.styles.ts
@@ -135,7 +135,7 @@ export default createMemoStyles({
         opacity: 0.6,
         cursor: 'not-allowed',
 
-        '&:placeholder': {
+        '&::placeholder': {
           color: theme.colors.dark[2],
         },
       },

--- a/src/mantine-core/src/components/Input/Input.test.tsx
+++ b/src/mantine-core/src/components/Input/Input.test.tsx
@@ -34,14 +34,14 @@ describe('@mantine/core/Input', () => {
       icon: '$',
       rightSection: 'test',
     },
-    Object.keys(InputStylesApi).filter((key) => key !== 'invalid'),
+    Object.keys(InputStylesApi),
     'input'
   );
 
   itSupportsStylesApi(
     Input,
     { invalid: true, icon: '$', rightSection: 'test', __staticSelector: 'test-input' },
-    Object.keys(InputStylesApi).filter((key) => key !== 'invalid'),
+    Object.keys(InputStylesApi),
     'test-input',
     'static selector'
   );

--- a/src/mantine-core/src/components/Input/Input.tsx
+++ b/src/mantine-core/src/components/Input/Input.tsx
@@ -88,18 +88,21 @@ export function Input<
     elementRef?: React.ForwardedRef<U>;
   }) {
   const theme = useMantineTheme(themeOverride);
-  const classes = useStyles({ radius, theme, size, multiline }, classNames, __staticSelector);
   const _variant = variant || (theme.colorScheme === 'dark' ? 'filled' : 'default');
+  const classes = useStyles(
+    { radius, theme, size, multiline, variant: _variant, invalid },
+    classNames,
+    __staticSelector
+  );
   const _styles = mergeStyles(classes, styles);
   const Element: any = component;
 
   return (
     <div
-      className={cx(classes.root, { [classes.invalid]: invalid }, classes[_variant], className)}
+      className={cx(classes.root, classes[_variant], className)}
       style={{
         ...style,
         ..._styles.root,
-        ...(invalid ? _styles.invalid : null),
         ..._styles[variant],
       }}
       {...wrapperProps}

--- a/src/mantine-core/src/components/Input/styles.api.ts
+++ b/src/mantine-core/src/components/Input/styles.api.ts
@@ -1,11 +1,9 @@
-import useStyles from './Input.styles';
-import { InputVariant } from './Input';
+import { InputStylesNames } from './Input';
 
-export const Input: Omit<MantineClasses<typeof useStyles>, InputVariant> = {
+export const Input: Record<InputStylesNames, string> = {
   root: 'Root element',
   icon: 'Input icon wrapper on the left side of the input, controlled by icon prop',
   withIcon: 'Input element styles when used with icon, controlled by icon prop',
   input: 'Main input element',
-  invalid: 'Invalid input modified',
   rightSection: 'Input right section, controlled by rightSection prop',
 };

--- a/src/mantine-core/src/components/Select/Select.story.tsx
+++ b/src/mantine-core/src/components/Select/Select.story.tsx
@@ -48,6 +48,7 @@ storiesOf('@mantine/core/Select', module)
         searchable
         label="Choose your favorite library/framework"
         placeholder="Choose value"
+        limit={2}
         data={data}
         style={{ marginTop: 20 }}
         nothingFound="No options"

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -87,6 +87,9 @@ export interface SelectProps
 
   /** aria-label for clear button */
   clearButtonLabel?: string;
+
+  /** Limit amount of items displayed at a time for searchable select */
+  limit?: number;
 }
 
 function defaultFilter(value: string, item: SelectItem) {
@@ -126,6 +129,7 @@ export function Select({
   clearable = false,
   nothingFound,
   clearButtonLabel,
+  limit = Infinity,
   ...others
 }: SelectProps) {
   const theme = useMantineTheme(themeOverride);
@@ -170,7 +174,9 @@ export function Select({
   };
 
   const shouldFilter = searchable && data.every((item) => item.label !== inputValue);
-  const filteredData = shouldFilter ? data.filter((item) => filter(inputValue, item)) : data;
+  const filteredData = shouldFilter
+    ? data.filter((item) => filter(inputValue, item)).slice(0, limit)
+    : data;
 
   const items = filteredData.map((item, index) => (
     <Item

--- a/src/mantine-core/src/components/Tabs/TabControl/TabControl.styles.ts
+++ b/src/mantine-core/src/components/Tabs/TabControl/TabControl.styles.ts
@@ -10,13 +10,14 @@ interface TabControlStyles {
   theme: MantineTheme;
   reduceMotion: boolean;
   color: string;
+  orientation: 'horizontal' | 'vertical';
 }
 
 export default createMemoStyles({
   tabActive: {},
   tabLabel: {},
 
-  tabControl: ({ theme }: TabControlStyles) => ({
+  tabControl: ({ theme, orientation }: TabControlStyles) => ({
     ...getFontStyles(theme),
     ...getFocusStyles(theme),
     WebkitTapHighlightColor: 'transparent',
@@ -28,6 +29,7 @@ export default createMemoStyles({
     padding: [0, theme.spacing.md],
     fontSize: theme.fontSizes.sm,
     cursor: 'pointer',
+    width: orientation === 'vertical' && '100%',
 
     '&:disabled': {
       cursor: 'not-allowed',
@@ -35,14 +37,14 @@ export default createMemoStyles({
     },
   }),
 
-  default: ({ theme, reduceMotion, color }: TabControlStyles) => ({
+  default: ({ theme, reduceMotion, color, orientation }: TabControlStyles) => ({
     transition: reduceMotion ? 'none' : 'border-color 150ms ease, color 150ms ease',
     color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
-    borderBottom: '2px solid transparent',
+    [orientation === 'horizontal' ? 'borderBottom' : 'borderRight']: '2px solid transparent',
 
     '&$tabActive': {
       color: getThemeColor({ theme, color, shade: theme.colorScheme === 'dark' ? 6 : 7 }),
-      borderBottomColor: getThemeColor({
+      [orientation === 'horizontal' ? 'borderBottomColor' : 'borderRightColor']: getThemeColor({
         theme,
         color,
         shade: theme.colorScheme === 'dark' ? 6 : 7,
@@ -50,11 +52,12 @@ export default createMemoStyles({
     },
   }),
 
-  outline: ({ theme }: TabControlStyles) => ({
-    borderTopRightRadius: theme.radius.sm,
+  outline: ({ theme, orientation }: TabControlStyles) => ({
+    borderBottomLeftRadius: orientation === 'vertical' && theme.radius.sm,
+    borderTopRightRadius: orientation === 'horizontal' && theme.radius.sm,
     borderTopLeftRadius: theme.radius.sm,
     border: '1px solid transparent',
-    borderBottom: 0,
+    [orientation === 'horizontal' ? 'borderBottom' : 'borderRight']: 0,
     color: theme.colorScheme === 'dark' ? theme.colors.dark[1] : theme.colors.gray[7],
 
     '&$tabActive': {
@@ -76,14 +79,14 @@ export default createMemoStyles({
     },
   }),
 
-  tabInner: {
+  tabInner: ({ orientation }: TabControlStyles) => ({
     boxSizing: 'border-box',
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: orientation === 'horizontal' ? 'center' : 'flex-start',
     lineHeight: 1,
     height: '100%',
-  },
+  }),
 
   tabIcon: ({ theme }: TabControlStyles) => ({
     '&:not(:only-child)': {

--- a/src/mantine-core/src/components/Tabs/TabControl/TabControl.styles.ts
+++ b/src/mantine-core/src/components/Tabs/TabControl/TabControl.styles.ts
@@ -29,7 +29,7 @@ export default createMemoStyles({
     padding: [0, theme.spacing.md],
     fontSize: theme.fontSizes.sm,
     cursor: 'pointer',
-    width: orientation === 'vertical' && '100%',
+    width: orientation === 'vertical' ? '100%' : 'auto',
 
     '&:disabled': {
       cursor: 'not-allowed',
@@ -53,8 +53,8 @@ export default createMemoStyles({
   }),
 
   outline: ({ theme, orientation }: TabControlStyles) => ({
-    borderBottomLeftRadius: orientation === 'vertical' && theme.radius.sm,
-    borderTopRightRadius: orientation === 'horizontal' && theme.radius.sm,
+    borderBottomLeftRadius: orientation === 'vertical' ? theme.radius.sm : 0,
+    borderTopRightRadius: orientation === 'horizontal' ? theme.radius.sm : 0,
     borderTopLeftRadius: theme.radius.sm,
     border: '1px solid transparent',
     [orientation === 'horizontal' ? 'borderBottom' : 'borderRight']: 0,

--- a/src/mantine-core/src/components/Tabs/TabControl/TabControl.styles.ts
+++ b/src/mantine-core/src/components/Tabs/TabControl/TabControl.styles.ts
@@ -57,7 +57,8 @@ export default createMemoStyles({
     borderTopRightRadius: orientation === 'horizontal' ? theme.radius.sm : 0,
     borderTopLeftRadius: theme.radius.sm,
     border: '1px solid transparent',
-    [orientation === 'horizontal' ? 'borderBottom' : 'borderRight']: 0,
+    borderBottom: orientation === 'horizontal' ? 0 : '1px solid transparent',
+    borderRight: orientation === 'vertical' ? 0 : '1px solid transparent',
     color: theme.colorScheme === 'dark' ? theme.colors.dark[1] : theme.colors.gray[7],
 
     '&$tabActive': {

--- a/src/mantine-core/src/components/Tabs/TabControl/TabControl.tsx
+++ b/src/mantine-core/src/components/Tabs/TabControl/TabControl.tsx
@@ -16,6 +16,7 @@ export interface TabControlProps
   tabProps: TabProps;
   color?: string;
   variant?: TabsVariant;
+  orientation?: 'horizontal' | 'vertical';
 }
 
 export function TabControl({
@@ -29,13 +30,14 @@ export function TabControl({
   variant = 'default',
   classNames,
   styles,
+  orientation = 'horizontal',
   ...others
 }: TabControlProps) {
   const { label, icon, color: overrideColor, elementRef: _, ...props } = tabProps;
   const theme = useMantineTheme(themeOverride);
   const reduceMotion = useReducedMotion();
   const classes = useStyles(
-    { reduceMotion, color: overrideColor || color, theme },
+    { reduceMotion, color: overrideColor || color, theme, orientation },
     classNames,
     'tabs'
   );

--- a/src/mantine-core/src/components/Tabs/Tabs.story.tsx
+++ b/src/mantine-core/src/components/Tabs/Tabs.story.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
-import { ImageIcon } from '@modulz/radix-icons';
+import { ImageIcon, ChatBubbleIcon, MixerVerticalIcon } from '@modulz/radix-icons';
 import { DEFAULT_THEME, MantineProvider } from '../../theme';
 import { Text } from '../Text/Text';
 import { Tabs, Tab } from './Tabs';
@@ -137,6 +137,21 @@ storiesOf('@mantine/core/Tabs', module)
         <Tab label="No body" />
         <Tab label="Only tabs" />
         <Tab label="Nothing here" />
+      </Tabs>
+    </div>
+  ))
+  .add('Vertical', () => (
+    <div style={{ padding: 50 }}>
+      <Tabs orientation="vertical">
+        <Tab label="Gallery" icon={<ImageIcon />}>
+          Gallery tab content
+        </Tab>
+        <Tab label="Messages" icon={<ChatBubbleIcon />}>
+          Messages tab content
+        </Tab>
+        <Tab label="Settings" icon={<MixerVerticalIcon />}>
+          Settings tab content
+        </Tab>
       </Tabs>
     </div>
   ))

--- a/src/mantine-core/src/components/Tabs/Tabs.styles.ts
+++ b/src/mantine-core/src/components/Tabs/Tabs.styles.ts
@@ -13,7 +13,10 @@ export default createMemoStyles({
 
   tabsListWrapper: {},
   tabsList: {},
-  pills: {},
+
+  pills: ({ orientation }: TabsStyles) => ({
+    marginRight: orientation === 'vertical' ? 20 : 0,
+  }),
 
   body: ({ theme, tabPadding, orientation }: TabsStyles) => ({
     [orientation === 'horizontal' ? 'paddingTop' : 'paddingLeft']: getSizeValue({

--- a/src/mantine-core/src/components/Tabs/Tabs.styles.ts
+++ b/src/mantine-core/src/components/Tabs/Tabs.styles.ts
@@ -3,35 +3,42 @@ import { createMemoStyles, MantineTheme, MantineNumberSize, getSizeValue } from 
 interface TabsStyles {
   theme: MantineTheme;
   tabPadding: MantineNumberSize;
+  orientation: 'horizontal' | 'vertical';
 }
 
 export default createMemoStyles({
-  root: {},
+  root: ({ orientation }: TabsStyles) => ({
+    display: orientation === 'vertical' ? 'flex' : 'block',
+  }),
+
   tabsListWrapper: {},
   tabsList: {},
   pills: {},
 
-  body: ({ theme, tabPadding }: TabsStyles) => ({
-    paddingTop: getSizeValue({ size: tabPadding, sizes: theme.spacing }),
+  body: ({ theme, tabPadding, orientation }: TabsStyles) => ({
+    [orientation === 'horizontal' ? 'paddingTop' : 'paddingLeft']: getSizeValue({
+      size: tabPadding,
+      sizes: theme.spacing,
+    }),
   }),
 
-  default: ({ theme }: TabsStyles) => ({
-    borderBottom: `2px solid ${
+  default: ({ theme, orientation }: TabsStyles) => ({
+    [orientation === 'horizontal' ? 'borderBottom' : 'borderRight']: `2px solid ${
       theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[2]
     }`,
 
     '& $tabsList': {
-      marginBottom: -2,
+      [orientation === 'horizontal' ? 'marginBottom' : 'marginRight']: -2,
     },
   }),
 
-  outline: ({ theme }: TabsStyles) => ({
-    borderBottom: `1px solid ${
+  outline: ({ theme, orientation }: TabsStyles) => ({
+    [orientation === 'horizontal' ? 'borderBottom' : 'borderRight']: `1px solid ${
       theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[2]
     }`,
 
     '& $tabsList': {
-      marginBottom: -1,
+      [orientation === 'horizontal' ? 'marginBottom' : 'marginRight']: -1,
     },
   }),
 });

--- a/src/mantine-core/src/components/Tabs/Tabs.test.tsx
+++ b/src/mantine-core/src/components/Tabs/Tabs.test.tsx
@@ -67,26 +67,33 @@ describe('@mantine/core/Tabs', () => {
     expect(spy).toHaveBeenCalledTimes(2);
   });
 
-  it('supports keyboard events', () => {
-    const element = mount(<Tabs initialTab={1}>{content}</Tabs>);
+  it.each([
+    ['horizontal' as const, 'ArrowRight', 'ArrowLeft'],
+    ['vertical' as const, 'ArrowDown', 'ArrowUp'],
+  ])('supports keyboard events (%s)', (orientation, next, previous) => {
+    const element = mount(
+      <Tabs initialTab={1} orientation={orientation}>
+        {content}
+      </Tabs>
+    );
     expect(tabContent(element)).toBe('tab-2');
 
     const keydown = (position: number, code: string) =>
       element.find(TabControl).at(position).simulate('keydown', { nativeEvent: { code } });
 
-    keydown(1, 'ArrowRight');
+    keydown(1, next);
     expect(tabContent(element)).toBe('tab-3');
 
-    keydown(2, 'ArrowRight');
+    keydown(2, next);
     expect(tabContent(element)).toBe('tab-3');
 
-    keydown(2, 'ArrowLeft');
+    keydown(2, previous);
     expect(tabContent(element)).toBe('tab-2');
 
-    keydown(1, 'ArrowLeft');
+    keydown(1, previous);
     expect(tabContent(element)).toBe('tab-1');
 
-    keydown(0, 'ArrowLeft');
+    keydown(0, previous);
     expect(tabContent(element)).toBe('tab-1');
   });
 

--- a/src/mantine-core/src/components/Tabs/Tabs.tsx
+++ b/src/mantine-core/src/components/Tabs/Tabs.tsx
@@ -49,6 +49,9 @@ export interface TabsProps
 
   /** Controls tab content padding-top */
   tabPadding?: MantineNumberSize;
+
+  /** Controls tab orientation */
+  orientation?: 'horizontal' | 'vertical';
 }
 
 function getPreviousTab(active: number, tabs: TabType[]) {
@@ -96,10 +99,11 @@ export function Tabs({
   classNames,
   styles,
   tabPadding = 'xs',
+  orientation = 'horizontal',
   ...others
 }: TabsProps) {
   const theme = useMantineTheme(themeOverride);
-  const classes = useStyles({ theme, tabPadding }, classNames as any, 'tabs');
+  const classes = useStyles({ theme, tabPadding, orientation }, classNames as any, 'tabs');
   const _styles = mergeStyles(classes, styles as any);
 
   const controlRefs = useRef<Record<string, HTMLButtonElement>>({});
@@ -118,14 +122,17 @@ export function Tabs({
 
   const activeTab = clamp(_activeTab, 0, tabs.length - 1);
 
+  const nextTabCode = orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown';
+  const previousTabCode = orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp';
+
   const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
-    if (event.nativeEvent.code === 'ArrowRight') {
+    if (event.nativeEvent.code === nextTabCode) {
       const nextTab = getNextTab(activeTab, tabs);
       handleActiveTabChange(nextTab);
       controlRefs.current[nextTab].focus();
     }
 
-    if (event.nativeEvent.code === 'ArrowLeft') {
+    if (event.nativeEvent.code === previousTabCode) {
       const previousTab = getPreviousTab(activeTab, tabs);
       handleActiveTabChange(previousTab);
       controlRefs.current[previousTab].focus();
@@ -141,6 +148,7 @@ export function Tabs({
       onKeyDown={handleKeyDown}
       color={color}
       variant={variant}
+      orientation={orientation}
       elementRef={(node) => {
         controlRefs.current[index] = node;
       }}
@@ -162,7 +170,8 @@ export function Tabs({
           className={classes.tabsList}
           style={_styles.tabsList}
           role="tablist"
-          aria-orientation="horizontal"
+          direction={orientation === 'horizontal' ? 'row' : 'column'}
+          aria-orientation={orientation}
           spacing={variant === 'pills' ? 'md' : 0}
           position={position}
           grow={grow}

--- a/src/mantine-core/src/components/Tabs/demos/colorsConfigurator.tsx
+++ b/src/mantine-core/src/components/Tabs/demos/colorsConfigurator.tsx
@@ -42,5 +42,15 @@ export const colorsConfigurator: MantineDemo = {
       ],
     },
     { name: 'tabPadding', type: 'size', initialValue: 'xs', defaultValue: 'xs' },
+    {
+      name: 'orientation',
+      type: 'segmented',
+      initialValue: 'horizontal',
+      defaultValue: 'horizontal',
+      data: [
+        { value: 'horizontal', label: 'Horizontal' },
+        { value: 'vertical', label: 'Vertical' },
+      ],
+    },
   ],
 };

--- a/src/mantine-dates/package.json
+++ b/src/mantine-dates/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mantine/dates",
   "description": "Calendars, date and time pickers based on Mantine components",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "browser": "lib/index.umd.js",
@@ -10,8 +10,8 @@
   "author": "Vitaly Rtishchev <rtivital@gmail.com>",
   "homepage": "https://mantine.dev/dates/getting-started/",
   "peerDependencies": {
-    "@mantine/core": "2.0.3",
-    "@mantine/hooks": "2.0.3",
+    "@mantine/core": "2.0.4",
+    "@mantine/hooks": "2.0.4",
     "dayjs": "^1.10.5",
     "react": ">=16.8.0",
     "react-jss": ">=10.1.1"

--- a/src/mantine-dates/package.json
+++ b/src/mantine-dates/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mantine/dates",
   "description": "Calendars, date and time pickers based on Mantine components",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "browser": "lib/index.umd.js",
@@ -10,8 +10,8 @@
   "author": "Vitaly Rtishchev <rtivital@gmail.com>",
   "homepage": "https://mantine.dev/dates/getting-started/",
   "peerDependencies": {
-    "@mantine/core": "2.0.4",
-    "@mantine/hooks": "2.0.4",
+    "@mantine/core": "2.0.5",
+    "@mantine/hooks": "2.0.5",
     "dayjs": "^1.10.5",
     "react": ">=16.8.0",
     "react-jss": ">=10.1.1"

--- a/src/mantine-hooks/README.md
+++ b/src/mantine-hooks/README.md
@@ -26,7 +26,7 @@ npm install @mantine/hooks
 - [use-color-scheme](https://mantine.dev/hooks/use-color-scheme/) – detect system color scheme
 - [use-debounced-value](https://mantine.dev/hooks/use-debounced-value/) – - debounce value with useEffect
 - [use-document-title](https://mantine.dev/hooks/use-document-title/) - set document.title property
-- [use-focus-tap](https://mantine.dev/hooks/use-focus-tap/) – trap focus at given node
+- [use-focus-trap](https://mantine.dev/hooks/use-focus-trap/) – trap focus at given node
 - [use-form](https://mantine.dev/hooks/use-form/) – bare minimum form state management
 - [use-id](https://mantine.dev/hooks/use-id/) – ensure id for form controls binding
 - [use-list-state](https://mantine.dev/hooks/use-list-state/) – hook for convenient array state management
@@ -36,6 +36,13 @@ npm install @mantine/hooks
 - [use-reduced-motion](https://mantine.dev/hooks/use-reduced-motion/) – check if user prefers to reduce motion
 - [use-scroll-lock](https://mantine.dev/hooks/use-scroll-lock/) – lock document.body scroll at current position
 - [use-window-event](https://mantine.dev/hooks/use-window-event/) – adds event listener to window object on component mount and removes it on unmount
+- [use-window-scroll](https://mantine.dev/hooks/use-window-scroll/) – subscribe to window scroll and scroll smoothly to given position
+- [use-toggle](https://mantine.dev/hooks/use-toggle/) – switch between two states
+- [use-uncontrolled](https://mantine.dev/hooks/use-uncontrolled/) – manage state of both controlled and uncontrolled components
+- [use-interval](https://mantine.dev/hooks/use-interval/) – wrapper around `window.setInterval`
+- [use-force-update](https://mantine.dev/hooks/use-force-update/) – force component to render without state change
+- [use-did-update](https://mantine.dev/hooks/use-did-update/) – call function in useEffect when value changes, but not when component mounts
+- [use-isomorphic-effect](https://mantine.dev/hooks/use-isomorphic-effect/) – switch between useEffect during SSR and useLayoutEffect after hydration
 
 ## Licence
 

--- a/src/mantine-hooks/package.json
+++ b/src/mantine-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine/hooks",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "browser": "lib/index.umd.js",

--- a/src/mantine-hooks/package.json
+++ b/src/mantine-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine/hooks",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "browser": "lib/index.umd.js",

--- a/src/mantine-notifications/package.json
+++ b/src/mantine-notifications/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mantine/notifications",
   "description": "Notification system based on Mantine components",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "browser": "lib/index.umd.js",
@@ -16,8 +16,8 @@
     "directory": "src/mantine-notifications"
   },
   "peerDependencies": {
-    "@mantine/core": "2.0.3",
-    "@mantine/hooks": "2.0.3",
+    "@mantine/core": "2.0.4",
+    "@mantine/hooks": "2.0.4",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "react-jss": ">=10.1.1"

--- a/src/mantine-notifications/package.json
+++ b/src/mantine-notifications/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mantine/notifications",
   "description": "Notification system based on Mantine components",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "browser": "lib/index.umd.js",
@@ -16,8 +16,8 @@
     "directory": "src/mantine-notifications"
   },
   "peerDependencies": {
-    "@mantine/core": "2.0.4",
-    "@mantine/hooks": "2.0.4",
+    "@mantine/core": "2.0.5",
+    "@mantine/hooks": "2.0.5",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "react-jss": ">=10.1.1"

--- a/src/mantine-prism/package.json
+++ b/src/mantine-prism/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mantine/prism",
   "description": "Code highlight with Mantine theme",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "browser": "lib/index.umd.js",
@@ -16,8 +16,8 @@
     "directory": "src/mantine-prism"
   },
   "peerDependencies": {
-    "@mantine/core": "2.0.3",
-    "@mantine/hooks": "2.0.3",
+    "@mantine/core": "2.0.4",
+    "@mantine/hooks": "2.0.4",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "react-jss": ">=10.1.1"

--- a/src/mantine-prism/package.json
+++ b/src/mantine-prism/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mantine/prism",
   "description": "Code highlight with Mantine theme",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "browser": "lib/index.umd.js",
@@ -16,8 +16,8 @@
     "directory": "src/mantine-prism"
   },
   "peerDependencies": {
-    "@mantine/core": "2.0.4",
-    "@mantine/hooks": "2.0.4",
+    "@mantine/core": "2.0.5",
+    "@mantine/hooks": "2.0.5",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "react-jss": ">=10.1.1"

--- a/src/mantine-tag-picker/package.json
+++ b/src/mantine-tag-picker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mantine/tag-picker",
   "description": "Notion style tag picker built with Mantine",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "browser": "lib/index.umd.js",
@@ -16,8 +16,8 @@
     "directory": "src/mantine-tag-picker"
   },
   "peerDependencies": {
-    "@mantine/core": "2.0.3",
-    "@mantine/hooks": "2.0.3",
+    "@mantine/core": "2.0.4",
+    "@mantine/hooks": "2.0.4",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "react-jss": ">=10.1.1"

--- a/src/mantine-tag-picker/package.json
+++ b/src/mantine-tag-picker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mantine/tag-picker",
   "description": "Notion style tag picker built with Mantine",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "browser": "lib/index.umd.js",
@@ -16,8 +16,8 @@
     "directory": "src/mantine-tag-picker"
   },
   "peerDependencies": {
-    "@mantine/core": "2.0.4",
-    "@mantine/hooks": "2.0.4",
+    "@mantine/core": "2.0.5",
+    "@mantine/hooks": "2.0.5",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "react-jss": ">=10.1.1"

--- a/src/mantine-tests/package.json
+++ b/src/mantine-tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mantine/tests",
   "private": true,
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "browser": "lib/index.umd.js",

--- a/src/mantine-tests/package.json
+++ b/src/mantine-tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mantine/tests",
   "private": true,
-  "version": "2.0.4",
+  "version": "2.0.5",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "browser": "lib/index.umd.js",


### PR DESCRIPTION
Implementing the item found here: https://trello.com/c/zZYcbrU4/8-mantine-core-tabs-add-vertical-orientation-support

#### Todo

- [x] Make sure that dark color scheme is supported in all variants
- [x] Make sure that all component variants have correct styles
- [x] Make sure that component uses up and down arrows to change current tab instead of right and left arrows
- [x] Change aria-orientation according to tabs orientation
- [x] Add segmented control which changes orientation to colorsConfigurator demo
