### PR TITLE
use-controlled - fix controlled input behavior

### DIFF
--- a/docs/src/docs/hooks/use-uncontrolled.mdx
+++ b/docs/src/docs/hooks/use-uncontrolled.mdx
@@ -91,5 +91,5 @@ function useUncontrolled<T>(configuration: {
   onChange(value: T): void;
   onValueUpdate?(value: T): void;
   rule: (value: T) => boolean;
-}): readonly [T, (val: T) => void];
+}): readonly [T, (val: T) => void, 'controlled' | 'uncontrolled'];
 ```

--- a/src/mantine-core/src/components/Select/Select.story.tsx
+++ b/src/mantine-core/src/components/Select/Select.story.tsx
@@ -16,12 +16,13 @@ const largeData = Array(50)
     label: `Item ${index}`,
   }));
 
-function Controlled() {
+function Controlled({ clearable = false }: { clearable?: boolean }) {
   const [value, setValue] = useState(null);
 
   return (
     <div>
       <Select
+        clearable={clearable}
         label="Controlled"
         placeholder="Controlled"
         value={value}
@@ -55,6 +56,14 @@ storiesOf('@mantine/core/Select', module)
       />
       <Controlled />
       <Select
+        label="Controlled (fixed value)"
+        placeholder="Choose value"
+        searchable
+        value="react"
+        data={data}
+        style={{ marginTop: 20 }}
+      />
+      <Select
         label="Large data set"
         placeholder="Choose value"
         searchable
@@ -83,6 +92,16 @@ storiesOf('@mantine/core/Select', module)
         data={data}
         style={{ marginTop: 20 }}
         nothingFound="No options"
+      />
+      <Controlled clearable />
+      <Select
+        clearable
+        label="Controlled (fixed value)"
+        placeholder="Choose value"
+        searchable
+        value="react"
+        data={data}
+        style={{ marginTop: 20 }}
       />
     </div>
   ));

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -141,7 +141,7 @@ export function Select({
   const dropdownRef = useRef<HTMLDivElement>();
   const itemsRefs = useRef<Record<string, HTMLButtonElement>>({});
   const uuid = useId(id);
-  const [_value, handleChange] = useUncontrolled({
+  const [_value, handleChange, inputMode] = useUncontrolled({
     value,
     defaultValue,
     finalValue: null,
@@ -154,21 +154,27 @@ export function Select({
 
   const handleClear = () => {
     handleChange(null);
-    setInputValue('');
+    if (inputMode === 'uncontrolled') {
+      setInputValue('');
+    }
     inputRef.current?.focus();
   };
 
   useEffect(() => {
-    const newSelectedValue = data.find((item) => item.value === value);
+    const newSelectedValue = data.find((item) => item.value === _value);
     if (newSelectedValue) {
       setInputValue(newSelectedValue.label);
+    } else {
+      setInputValue('');
     }
-  }, [value]);
+  }, [_value]);
 
   const handleItemSelect = (item: SelectItem) => {
     handleChange(item.value);
     setHovered(-1);
-    setInputValue(item.label);
+    if (inputMode === 'uncontrolled') {
+      setInputValue(item.label);
+    }
     setDropdownOpened(false);
     inputRef.current.focus();
   };
@@ -267,7 +273,9 @@ export function Select({
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (clearable && event.currentTarget.value === '') {
       handleChange(null);
-      setInputValue('');
+      if (inputMode === 'uncontrolled') {
+        setInputValue('');
+      }
     } else {
       setInputValue(event.currentTarget.value);
     }

--- a/src/mantine-hooks/src/use-uncontrolled/use-uncontrolled.story.tsx
+++ b/src/mantine-hooks/src/use-uncontrolled/use-uncontrolled.story.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { Container } from '@mantine/core';
+import { useUncontrolled } from './use-uncontrolled';
+import { useId } from '../use-id/use-id';
+
+interface CustomInputProps {
+  label: string;
+  value?: string;
+  defaultValue?: string;
+  onChange?: (nextValue: string) => void;
+}
+
+function CustomInput({ label, value, defaultValue, onChange }: CustomInputProps) {
+  const id = useId();
+  const [_value, handleChange] = useUncontrolled({
+    value,
+    defaultValue,
+    finalValue: null,
+    onChange,
+    rule: (val) => typeof val === 'string',
+  });
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <label htmlFor={id}>{label}</label><br />
+      <input id={id} type="text" value={_value} onChange={e => handleChange(e.target.value)} />
+    </div>
+  );
+}
+
+function Example() {
+  const [controlledValue, setControlledValue] = useState('controlled');
+
+  return (
+    <Container size="xs" style={{ padding: 20 }}>
+      <CustomInput label="Uncontrolled" defaultValue="uncontrolled" />
+      <CustomInput label="Controlled" value={controlledValue} onChange={setControlledValue} />
+      <CustomInput label="Controlled (fixed value)" value="fixed" onChange={setControlledValue} />
+    </Container>
+  );
+}
+
+storiesOf('@mantine/hooks/use-uncontrolled', module).add('Usage', () => <Example />);

--- a/src/mantine-hooks/src/use-uncontrolled/use-uncontrolled.test.ts
+++ b/src/mantine-hooks/src/use-uncontrolled/use-uncontrolled.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { act } from 'react-test-renderer';
-import { useUncontrolled } from './use-uncontrolled';
+import { UncontrolledOptions, useUncontrolled } from './use-uncontrolled';
 
 describe('@mantine/hooks/use-uncontrolled', () => {
   it('returns value from configuration object', () => {
@@ -19,20 +19,33 @@ describe('@mantine/hooks/use-uncontrolled', () => {
 
   it('calls onChange handler when setValue is called', () => {
     const spy = jest.fn();
-    const hook = renderHook(() =>
-      useUncontrolled({
-        value: 'test-value',
-        defaultValue: null,
-        finalValue: null,
-        onChange: spy,
-        rule: (f) => !!f,
-      })
+    const hook = renderHook(
+      (props: UncontrolledOptions<string>) => useUncontrolled(props),
+      {
+        initialProps: {
+          value: 'test-value',
+          defaultValue: null,
+          finalValue: null,
+          onChange: spy,
+          rule: (f) => !!f,
+        },
+      }
     );
 
     act(() => hook.result.current[1]('test-value-2'));
+    // simulate receiving the new value from onChange callback
+    hook.rerender({
+      value: 'test-value-2',
+      defaultValue: null,
+      finalValue: null,
+      onChange: spy,
+      rule: (f) => !!f,
+    });
 
+    expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith('test-value-2');
     expect(hook.result.current[0]).toBe('test-value-2');
+    expect(hook.result.current[2]).toBe('controlled');
   });
 
   it('uses defaultValue if value does not meet requirements', () => {
@@ -61,5 +74,39 @@ describe('@mantine/hooks/use-uncontrolled', () => {
     );
 
     expect(hook.result.current[0]).toBe('test-final-value');
+  });
+
+  it('uses finalValue when transitioning to uncontrolled state from controlled state', () => {
+    const spy = jest.fn();
+    const hook = renderHook(
+      (props: UncontrolledOptions<string>) => useUncontrolled(props),
+      {
+        initialProps: {
+          value: 'foo',
+          defaultValue: null,
+          finalValue: 'test-final-value',
+          onChange: spy,
+          rule: (f) => !!f,
+        },
+      }
+    );
+
+    expect(hook.result.current[0]).toBe('foo');
+    expect(hook.result.current[2]).toBe('controlled');
+
+    act(() => hook.result.current[1](null));
+    // simulate receiving the new value from onChange callback
+    hook.rerender({
+      value: null,
+      defaultValue: null,
+      finalValue: 'test-final-value',
+      onChange: spy,
+      rule: (f) => !!f,
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(null);
+    expect(hook.result.current[0]).toBe('test-final-value');
+    expect(hook.result.current[2]).toBe('uncontrolled');
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mantinedev/mantine/issues/154

This has turned out to be bit more complex than originally anticipated because Select has own state as well that needs to be handled, however I believe I have succeeded.

The behavior should be backwards compatible.

I'm not certain what the expectations of `onValueUpdate?(value: T): void;` are since it isn't used anywhere and I fail to see possible use cases, however I tried to keep the behavior same.

The hook now returns third value "mode" that indicates whether it's controlled or uncontrolled currently.