### PR TITLE
fix checkout on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Force LF on text files for windows with autocrlf=true. This avoids having issues with lint requiring LF endings. 

Note that for the change to take place people on windows will need to save their changes and rebuild the repository:

**Running commands below remove all local changes**
```
git rm --cached -r . 
git reset --hard
```