### PR TITLE
Fix useFocusTrap callback signature

### DIFF
--- a/src/mantine-hooks/src/use-focus-trap/use-focus-trap.ts
+++ b/src/mantine-hooks/src/use-focus-trap/use-focus-trap.ts
@@ -9,7 +9,7 @@ import { FOCUS_SELECTOR, focusable, tabbable } from './tabbable';
 import { scopeTab } from './scope-tab';
 import { createAriaHider } from './create-aria-hider';
 
-export function useFocusTrap(active = true): (instance: HTMLElement) => void {
+export function useFocusTrap(active = true): (instance: HTMLElement | null) => void {
   const ref = useRef<HTMLElement | null>();
   const restoreAria = useRef<Function | null>(null);
 


### PR DESCRIPTION
The typed return value of useFocusTrap has been updated to be consistent with the signature in the `setRef` callback.