### PR TITLE
useCookie hook implementation.

### DIFF
--- a/docs/src/demos/hooks/use-cookie.tsx
+++ b/docs/src/demos/hooks/use-cookie.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect } from 'react';
+import { useCookie } from '@mantine/hooks';
+import { Text, Group } from '@mantine/core';
+
+const code = `
+import { useCookie } from '@mantine/hooks';
+
+function Demo(){
+    const [cookie, setCookie] = useCookie('my-cookie');
+
+    useEffect(() => {
+        setCookie('value after http response');
+
+        return () => setCookie();
+    }, []);
+
+    return (
+        <>
+        <Text size="md">Cookie Name: my-cookie</Text>
+        <Text size="md" weight={500}>Cookie Value: {cookie.current} </Text>
+        </>
+    );
+}`;
+
+function Demo() {
+    const [cookie, setCookie] = useCookie('my-cookie');
+
+    useEffect(() => {
+        setCookie('cookie-value');
+
+        return () => setCookie();
+    }, []);
+
+    return (
+        <Group position="center">
+            <Text size="md">Cookie Name: my-cookie</Text>
+            <Text size="md" weight={500}>Cookie Value: {cookie.current} </Text>
+        </Group>
+    );
+}
+
+export const useCookieHook: MantineDemo = {
+    type: 'demo',
+    code,
+    component: Demo,
+};

--- a/docs/src/demos/index.ts
+++ b/docs/src/demos/index.ts
@@ -3,6 +3,7 @@ export * from './hooks/use-form';
 export * from './hooks/use-click-outside';
 export * from './hooks/use-clipboard';
 export * from './hooks/use-color-scheme';
+export * from './hooks/use-cookie';
 export * from './hooks/use-document-title';
 export * from './hooks/use-interval';
 export * from './hooks/use-media-query';

--- a/docs/src/docs/hooks/use-cookie.mdx
+++ b/docs/src/docs/hooks/use-cookie.mdx
@@ -1,0 +1,52 @@
+---
+group: 'mantine-hooks'
+package: '@mantine/hooks'
+title: 'use-cookie'
+category: 'utils'
+order: 1
+slug: /hooks/use-cookie/
+description: 'Access and handle Cookies'
+import: "import { useCookie } from '@mantine/hooks';"
+docs: 'hooks/use-cookie.mdx'
+source: 'mantine-hooks/src/use-cookie/use-cookie.ts'
+---
+
+import { useCookieHook } from '@docs/demos';
+
+## Usage
+
+useCookie hook helps manage cookies easily with a signature similar to useState.
+
+<Demo data={useCookieHook} />
+
+## API
+
+Hook accepts one argument:
+
+- `name` – name of the cookie (cookie key)
+
+Hook returns an array of two elements - 
+1. a ref to access the cookie value. 
+2. a setter function to manipulate the cookie value.
+
+```tsx
+const [cookie, cookie] = useCookie('my-cookie');
+
+setCookie('cookie-value'); // -> cookie.current == 'cookie-value'
+
+//setCookie also accepts a callback to customise the cookie-value
+
+setCookie(() => 'changed-cookie-value; expires=Wed, 05 Aug 2021 23:00:00 UTC'); // -> cookie.current == 'changed-cookie-value; expires=Wed, 05 Aug 2021 23:00:00 UTC'
+
+// To clear the cookie value
+setCookie(); // -> cookie.current = undefined
+```
+
+
+### Definition
+
+```tsx
+function useCookie(
+  name: string
+): readonly [React.MutableRefObject<string>, (value?: React.SetStateAction<T>) => void];
+```

--- a/src/mantine-hooks/README.md
+++ b/src/mantine-hooks/README.md
@@ -24,6 +24,7 @@ npm install @mantine/hooks
 - [use-click-outside](https://mantine.dev/hooks/use-click-outside/) – capture click and touch events from outside of given container
 - [use-clipboard](https://mantine.dev/hooks/use-clipboard/) – provides convenient interface to work with clipboard api
 - [use-color-scheme](https://mantine.dev/hooks/use-color-scheme/) – detect system color scheme
+- [use-cookie](https://mantine.dev/hooks/use-cookie/) - access and handle cookies.
 - [use-debounced-value](https://mantine.dev/hooks/use-debounced-value/) – - debounce value with useEffect
 - [use-document-title](https://mantine.dev/hooks/use-document-title/) - set document.title property
 - [use-focus-trap](https://mantine.dev/hooks/use-focus-trap/) – trap focus at given node

--- a/src/mantine-hooks/src/index.ts
+++ b/src/mantine-hooks/src/index.ts
@@ -3,6 +3,7 @@ export * from './utils';
 export { useClickOutside } from './use-click-outside/use-click-outside';
 export { useClipboard } from './use-clipboard/use-clipboard';
 export { useColorScheme } from './use-color-scheme/use-color-scheme';
+export { useCookie } from './use-cookie/use-cookie';
 export { useDebouncedValue } from './use-debounced-value/use-debounced-value';
 export { useDocumentTitle } from './use-document-title/use-document-title';
 export { useDidUpdate } from './use-did-update/use-did-update';

--- a/src/mantine-hooks/src/use-cookie/use-cookie.test.ts
+++ b/src/mantine-hooks/src/use-cookie/use-cookie.test.ts
@@ -1,0 +1,37 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useCookie } from './use-cookie';
+
+describe('@mantine/hooks/use-cookie', () => {
+  it('returns correct initial state', () => {
+    const hook = renderHook(() => useCookie('cookie'));
+    expect(hook.result.current[0].current).toBe(undefined);
+  });
+  it('allows to set value', () => {
+    const hook = renderHook(() => useCookie('cookie1'));
+    act(() => hook.result.current[1]('cookie-value'));
+    expect(hook.result.current[0].current).toBe('cookie-value');
+    act(() => hook.result.current[1]('cookie-changed'));
+    expect(hook.result.current[0].current).toBe('cookie-changed');
+  });
+  it('allows to set value with callback function, if the returned value has cookie name in it', () => {
+    const hook = renderHook(() => useCookie('cookie2'));
+    act(() => hook.result.current[1](() => 'cookie2=changed it; expires=Wed; 05 Aug 2021 23:00:00 UTC'));
+    expect(hook.result.current[0].current).toBe('changed it; expires=Wed; 05 Aug 2021 23:00:00 UTC');
+  });
+  it('allows to set value with callback function, if the returned value does not have cookie name in it and erase it', () => {
+    const hook = renderHook(() => useCookie('cookie3'));
+    act(() => hook.result.current[1](() => 'no name; expires=Wed; 05 Aug 2021 23:00:00 UTC'));
+    expect(hook.result.current[0].current).toBe('no name; expires=Wed; 05 Aug 2021 23:00:00 UTC');
+    act(() => hook.result.current[1](''));
+    expect(hook.result.current[0].current).toBe('');
+  });
+  it('erase a cookie with callback function and set it again', () => {
+    const hook = renderHook(() => useCookie('cookie3'));
+    act(() => hook.result.current[1](() => 'cookie3-value'));
+    expect(hook.result.current[0].current).toBe('cookie3-value');
+    act(() => hook.result.current[1](''));
+    expect(hook.result.current[0].current).toBe('');
+    act(() => hook.result.current[1](() => 'cookie3-value'));
+    expect(hook.result.current[0].current).toBe('cookie3-value');
+  });
+});

--- a/src/mantine-hooks/src/use-cookie/use-cookie.ts
+++ b/src/mantine-hooks/src/use-cookie/use-cookie.ts
@@ -1,0 +1,49 @@
+import { useRef } from 'react';
+
+function getCookie(name:string) {
+    const cname = `${name}=`;
+    const decoded = decodeURIComponent(document.cookie); //to be careful
+    const arr = decoded.split('; ');
+    let res;
+    arr.forEach(val => {
+        if (val.indexOf(cname) === 0) res = val.substring(cname.length);
+    });
+    return res;
+}
+
+function setCookieUtil(name:string, value:string) {
+    const cname = `${name}=`;
+    let cvalue = '';
+    //if empty erase the cookie
+    if (value === '') {
+        cvalue = `${cname}; Expires=Thu, 01 Jan 1970 00:00:01 GMT`;
+    } else {
+        //if the user forgets to add the cookie-key
+        cvalue = value.indexOf(cname) === 0 ? value.substring(cname.length) : value;
+    }
+    document.cookie = `${cname}${cvalue}`;
+
+    return value === '' ? '' : cvalue;
+}
+
+export function useCookie(name:string) {
+    const cookieValueRef = useRef<string | undefined>(getCookie(name));
+
+    const setCookie = (value?:React.SetStateAction<string>) => {
+        if (typeof value === 'string') {
+            cookieValueRef.current = setCookieUtil(name, value);
+        } else if (typeof value === 'function') {
+            /*
+            Providing a callback to `setCookie` to give the user
+            option to further customise the cookie value with options like - Expire, SameSite or other site specific options.
+             */
+            const cookieValue = value(cookieValueRef.current);
+            cookieValueRef.current = setCookieUtil(name, cookieValue);
+        } else {
+            //default case is to erase the cookie
+            cookieValueRef.current = setCookieUtil(name, '');
+        }
+    };
+
+    return [cookieValueRef, setCookie] as const;
+}


### PR DESCRIPTION
Followed the given signature except the user has to use the cookie.current for accessing the value.
``` 
const [cookie, setCookie] = useCookie('cookie-name');
cookie; // -> current cookie value
setCookie('my-cookie-value'); // -> sets cookie value
```

Used a useRef for persistence and `setCookie` accepts a callback using which user can use for further customisation.