### PR TITLE
[@mantine/hooks] use-fullscreen: add hook

### DIFF
--- a/docs/src/demos/hooks/use-fullscreen.tsx
+++ b/docs/src/demos/hooks/use-fullscreen.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { useFullscreen } from '@mantine/hooks';
+import { Button, Center, Image, Paper, Text, useMantineTheme } from '@mantine/core';
+
+const code = `
+import { useFullscreen } from '@mantine/hooks';
+import { Button, Center, Paper, Text, useMantineTheme } from '@mantine/core';
+
+function Demo() {
+  const theme = useMantineTheme();
+  const { toggle, fullscreen } = useFullscreen();
+
+  return (
+    <Paper>
+      <Center>
+        <Button
+          onClick={toggle}
+          style={{
+            backgroundColor: fullscreen ? theme.colors.orange[9] : theme.colors.green[9],
+          }}
+        >
+          <Text style={{ color: theme.white }} weight={700}>
+            {fullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen'}
+          </Text>
+        </Button>
+      </Center>
+    </Paper>
+  );
+}
+`;
+
+function Demo() {
+  const theme = useMantineTheme();
+  const { toggle, fullscreen } = useFullscreen();
+
+  return (
+    <Paper>
+      <Center>
+        <Button
+          onClick={toggle}
+          style={{
+            backgroundColor: fullscreen ? theme.colors.orange[9] : theme.colors.green[9],
+          }}
+        >
+          <Text style={{ color: theme.white }} weight={700}>
+            {fullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen'}
+          </Text>
+        </Button>
+      </Center>
+    </Paper>
+  );
+}
+
+const refCode = `
+import { useFullscreen } from '@mantine/hooks';
+import { Button, Image, Paper, Text, useMantineTheme } from '@mantine/core';
+
+function Demo() {
+  const theme = useMantineTheme();
+  const { ref, toggle, fullscreen } = useFullscreen();
+
+  return (
+    <Paper>
+      <Image
+        elementRef={ref}
+        src="https://images.unsplash.com/long-url"
+        alt="Unsplash Image to make Fullscreen"
+      />
+      <Button
+        onClick={toggle}
+        style={{
+          backgroundColor: fullscreen ? theme.colors.orange[9] : theme.colors.green[9],
+        }}
+      >
+        <Text style={{ color: theme.white }} weight={700}>
+          {fullscreen ? 'Exit Fullscreen' : 'Make Image Fullscreen'}
+        </Text>
+      </Button>
+    </Paper>
+  );
+}
+`;
+
+function RefDemo() {
+  const theme = useMantineTheme();
+  const { ref, toggle, fullscreen } = useFullscreen();
+
+  return (
+    <Paper>
+      <Image
+        elementRef={ref}
+        src="https://images.unsplash.com/photo-1545569341-9eb8b30979d9?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80"
+        alt="Unsplash Image to make Fullscreen"
+      />
+      <Button
+        onClick={toggle}
+        style={{
+          backgroundColor: fullscreen ? theme.colors.orange[9] : theme.colors.green[9],
+        }}
+      >
+        <Text style={{ color: theme.white }} weight={700}>
+          {fullscreen ? 'Exit Fullscreen' : 'Make Image Fullscreen'}
+        </Text>
+      </Button>
+    </Paper>
+  );
+}
+
+export const useFullscreenDemo: MantineDemo = {
+  type: 'demo',
+  code,
+  component: Demo,
+};
+
+export const useFullscreenRefDemo: MantineDemo = {
+  type: 'demo',
+  code: refCode,
+  component: RefDemo,
+};

--- a/docs/src/demos/index.ts
+++ b/docs/src/demos/index.ts
@@ -14,6 +14,7 @@ export * from './hooks/use-window-scroll';
 export * from './hooks/use-intersection';
 export * from './hooks/use-hash';
 export * from './hooks/use-hotkeys';
+export * from './hooks/use-fullscreen';
 
 export * from './inputs-guide/color-input';
 export * from './inputs-guide/json-input';

--- a/docs/src/docs/hooks/use-fullscreen.mdx
+++ b/docs/src/docs/hooks/use-fullscreen.mdx
@@ -1,0 +1,39 @@
+---
+group: 'mantine-hooks'
+package: '@mantine/hooks'
+category: 'dom'
+title: 'use-fullscreen'
+order: 1
+slug: /hooks/use-fullscreen/
+description: 'Control fullscreen state'
+import: "import { useFullscreen } from '@mantine/hooks';"
+docs: 'hooks/use-fullscreen.mdx'
+source: 'mantine-hooks/src/use-fullscreen/use-fullscreen.ts'
+---
+
+import { useFullscreenDemo, useFullscreenRefDemo } from '@docs/demos';
+
+## Usage
+
+Use hook to get control the state of fullscreen interations of document or
+of a given element using the [Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API):
+
+<Demo data={useFullscreenDemo} />
+
+## Custom Root
+
+Hook returns an optional ref function that can be passed to an element to act as root.
+
+Be sure to follow best practices to not confuse / trap the end user. [Fullscreen API Guide](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API/Guide#things_your_users_want_to_know):
+
+<Demo data={useFullscreenRefDemo} />
+
+## Definition
+
+```tsx
+function useFullscreen<T extends HTMLElement = any>(): {
+    readonly ref: (element: T | null) => void;
+    readonly toggle: () => Promise<void>;
+    readonly fullscreen: boolean;
+}
+```

--- a/src/mantine-hooks/src/index.ts
+++ b/src/mantine-hooks/src/index.ts
@@ -26,3 +26,4 @@ export { useWindowScroll } from './use-window-scroll/use-window-scroll';
 export { useIntersection } from './use-intersection/use-intersection';
 export { useHash } from './use-hash/use-hash';
 export { useHotkeys, getHotkeyHandler } from './use-hotkey/use-hotkeys';
+export { useFullscreen } from './use-fullscreen/use-fullscreen';

--- a/src/mantine-hooks/src/use-fullscreen/use-fullscreen.ts
+++ b/src/mantine-hooks/src/use-fullscreen/use-fullscreen.ts
@@ -1,0 +1,81 @@
+import { useCallback, useRef, useState, useEffect } from 'react';
+
+function getFullscreenElement(): HTMLElement | null {
+  const _document = window.document as any;
+
+  const fullscreenElement =
+    _document.fullscreenElement ||
+    _document.webkitFullscreenElement ||
+    _document.mozFullScreenElement ||
+    _document.msFullscreenElement;
+
+  return fullscreenElement;
+}
+
+async function exitFullscreen() {
+  const _document = window.document as any;
+
+  if (typeof _document.exitFullscreen === 'function') return _document.exitFullscreen();
+  if (typeof _document.msExitFullscreen === 'function') return _document.msExitFullscreen();
+  if (typeof _document.webkitExitFullscreen === 'function') return _document.webkitExitFullscreen();
+  if (typeof _document.mozCancelFullScreen === 'function') return _document.mozCancelFullScreen();
+
+  return null;
+}
+
+export function useFullscreen<T extends HTMLElement = any>() {
+  const [fullscreen, setFullscreen] = useState<boolean>(false);
+
+  const elementRef = useRef<T>();
+
+  const handleFullscreenChange = useCallback(
+    (event: Event) => {
+      setFullscreen(event.target === getFullscreenElement());
+    },
+    [setFullscreen]
+  );
+
+  const handleFullscreenError = useCallback(
+    (event: Event) => {
+      setFullscreen(false);
+      // eslint-disable-next-line no-console
+      console.error(`Error attempting full-screen mode method: ${event} (${event.target})`);
+    },
+    [setFullscreen]
+  );
+
+  const toggle = useCallback(async () => {
+    if (!getFullscreenElement()) {
+      await elementRef.current.requestFullscreen();
+    } else {
+      await exitFullscreen();
+    }
+  }, []);
+
+  const ref = useCallback((element: T | null) => {
+    if (elementRef.current) {
+      elementRef.current.removeEventListener('fullscreenchange', handleFullscreenChange);
+      elementRef.current.removeEventListener('fullscreenerror', handleFullscreenError);
+      elementRef.current = null;
+    }
+
+    if (element === null) {
+      elementRef.current = window.document.documentElement as T;
+    } else {
+      elementRef.current = element;
+    }
+
+    elementRef.current.addEventListener('fullscreenchange', handleFullscreenChange);
+    elementRef.current.addEventListener('fullscreenerror', handleFullscreenError);
+  }, []);
+
+  useEffect(() => {
+    if (!elementRef.current && window.document) {
+      elementRef.current = window.document.documentElement as T;
+      elementRef.current.addEventListener('fullscreenchange', handleFullscreenChange);
+      elementRef.current.addEventListener('fullscreenerror', handleFullscreenError);
+    }
+  }, []);
+
+  return { ref, toggle, fullscreen } as const;
+}


### PR DESCRIPTION
Adds the use-fullscreen hook.

Attempts to ensure cross browser compatibility and offer a simple to use elementRef for custom root