### PR TITLE
Autocomplete and Select allow strings

### DIFF
--- a/src/mantine-core/src/components/Autocomplete/Autocomplete.story.tsx
+++ b/src/mantine-core/src/components/Autocomplete/Autocomplete.story.tsx
@@ -50,4 +50,13 @@ storiesOf('@mantine/core/Autocomplete', module)
     <div style={{ padding: 40, maxWidth: 300 }}>
       <DynamicData />
     </div>
+  ))
+  .add('Strings as data', () => (
+    <div style={{ padding: 40, maxWidth: 300 }}>
+      <Autocomplete
+        label="Choose your favorite library/framework"
+        placeholder="Choose value"
+        data={['React', 'Angular', 'Svelte', 'Vue']}
+      />
+    </div>
   ));

--- a/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
@@ -23,6 +23,11 @@ export interface AutocompleteItem {
   [key: string]: any;
 }
 
+export type AutocompleteDataProp = string | {
+  value: string;
+  [key: string]: any;
+};
+
 export interface AutocompleteProps
   extends DefaultProps<AutocompleteStylesNames>,
     InputBaseProps,
@@ -35,7 +40,7 @@ export interface AutocompleteProps
   elementRef?: React.ForwardedRef<HTMLInputElement>;
 
   /** Autocomplete data used to renderer items in dropdown */
-  data: AutocompleteItem[];
+  data: AutocompleteDataProp[];
 
   /** Change item renderer */
   itemComponent?: React.FC<any>;
@@ -137,7 +142,9 @@ export function Autocomplete({
     inputRef.current.focus();
   };
 
-  const filteredData = data.filter((item) => filter(_value, item)).slice(0, limit);
+  const formattedData = data.map((item) => typeof item === 'string' ? ({ value: item }) : item);
+
+  const filteredData = formattedData.filter((item) => filter(_value, item)).slice(0, limit);
 
   const items = filteredData.map((item, index) => (
     <Item

--- a/src/mantine-core/src/components/Select/Select.story.tsx
+++ b/src/mantine-core/src/components/Select/Select.story.tsx
@@ -9,6 +9,13 @@ const data = [
   { value: 'vue', label: 'Vue' },
 ];
 
+const stringData = [
+  'React',
+  'Angular',
+  'Svelte',
+  'Vue',
+];
+
 const largeData = Array(50)
   .fill(0)
   .map((_, index) => ({
@@ -101,6 +108,58 @@ storiesOf('@mantine/core/Select', module)
         searchable
         value="react"
         data={data}
+        style={{ marginTop: 20 }}
+      />
+    </div>
+  )).add('String as data', () => (
+    <div style={{ padding: 40, maxWidth: 300 }}>
+      <Select
+        label="Choose your favorite library/framework"
+        placeholder="Choose value"
+        data={stringData}
+      />
+      <Select
+        searchable
+        label="Choose your favorite library/framework"
+        placeholder="Choose value"
+        limit={2}
+        data={stringData}
+        style={{ marginTop: 20 }}
+        nothingFound="No options"
+      />
+      <Select
+        label="Controlled (fixed value)"
+        placeholder="Choose value"
+        searchable
+        value="react"
+        data={stringData}
+        style={{ marginTop: 20 }}
+      />
+      <Select
+        size="xl"
+        searchable
+        clearable
+        label="Choose your favorite library/framework"
+        placeholder="Choose value"
+        data={stringData}
+        style={{ marginTop: 20 }}
+        nothingFound="No options"
+      />
+      <Select
+        clearable
+        label="Choose your favorite library/framework"
+        placeholder="Choose value"
+        data={stringData}
+        style={{ marginTop: 20 }}
+        nothingFound="No options"
+      />
+      <Select
+        clearable
+        label="Controlled (fixed value)"
+        placeholder="Choose value"
+        searchable
+        value="React"
+        data={stringData}
         style={{ marginTop: 20 }}
       />
     </div>

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -29,6 +29,12 @@ export interface SelectItem {
   [key: string]: any;
 }
 
+export type SelectItemDataProp = string | {
+  value: string;
+  label: string;
+  [key: string]: any;
+};
+
 export interface SelectProps
   extends DefaultProps<SelectStylesNames>,
     InputBaseProps,
@@ -41,7 +47,7 @@ export interface SelectProps
   elementRef?: React.ForwardedRef<HTMLInputElement>;
 
   /** Select data used to renderer items in dropdown */
-  data: SelectItem[];
+  data: SelectItemDataProp[];
 
   /** Change item renderer */
   itemComponent?: React.FC<any>;
@@ -149,7 +155,9 @@ export function Select({
     rule: (val) => typeof val === 'string',
   });
 
-  const selectedValue = data.find((item) => item.value === _value);
+  const formattedData = data.map((item) => typeof item === 'string' ? ({ label: item, value: item }) : item);
+
+  const selectedValue = formattedData.find((item) => item.value === _value);
   const [inputValue, setInputValue] = useState(selectedValue?.label || '');
 
   const handleClear = () => {
@@ -161,7 +169,7 @@ export function Select({
   };
 
   useEffect(() => {
-    const newSelectedValue = data.find((item) => item.value === _value);
+    const newSelectedValue = formattedData.find((item) => item.value === _value);
     if (newSelectedValue) {
       setInputValue(newSelectedValue.label);
     } else {
@@ -179,10 +187,10 @@ export function Select({
     inputRef.current.focus();
   };
 
-  const shouldFilter = searchable && data.every((item) => item.label !== inputValue);
+  const shouldFilter = searchable && formattedData.every((item) => item.label !== inputValue);
   const filteredData = shouldFilter
-    ? data.filter((item) => filter(inputValue, item)).slice(0, limit)
-    : data;
+    ? formattedData.filter((item) => filter(inputValue, item)).slice(0, limit)
+    : formattedData;
 
   const items = filteredData.map((item, index) => (
     <Item
@@ -266,7 +274,7 @@ export function Select({
 
   const handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     typeof onBlur === 'function' && onBlur(event);
-    const selected = data.find((item) => item.value === _value);
+    const selected = formattedData.find((item) => item.value === _value);
     setInputValue(selected?.label || '');
     setDropdownOpened(false);
   };


### PR DESCRIPTION
Update to allow data prop to be string for both Autocomplete and Select.

This works by mapping over the `data` and formatting correctly and ensuring all future references to data refer to the `formattedData` variable.

Included storybook for both components.

Needed to create a new Type for the data prop as there were warnings suggesting that `item.value` doesn't exist on a `string`.