### PR TITLE
[@mantine/hooks] use-scroll-lock: migrate to internal state

### DIFF
--- a/docs/src/components/HomePage/Explore/demos/Hooks.tsx
+++ b/docs/src/components/HomePage/Explore/demos/Hooks.tsx
@@ -6,13 +6,11 @@ import { LockClosedIcon, LockOpen2Icon } from '@modulz/radix-icons';
 import { LinkTitle } from './LinkTitle';
 
 const lockCode = `
-import { useState } from 'react';
 import { useScrollLock } from '@mantine/hooks';
 import { Button } from '@mantine/core';
 
 function Demo() {
-  const [lockScroll, setLockScroll] = useState(false);
-  useScrollLock(lockScroll);
+  const [lockScroll, setLockScroll] = useScrollLock();
   const label = lockScroll ? 'Unlock scroll' : 'Lock scroll';
   return <Button onClick={() => setLockScroll((c) => !c)}>{label}</Button>;
 }
@@ -36,10 +34,9 @@ function Demo() {
 `.trim();
 
 export function HooksDemo() {
-  const [lockScroll, setLockScroll] = useState(false);
+  const [lockScroll, setLockScroll] = useScrollLock();
   const [opened, setOpened] = useState(false);
   const ref = useClickOutside(() => setOpened(false));
-  useScrollLock(lockScroll);
 
   return (
     <>

--- a/docs/src/demos/hooks/use-scroll-lock.tsx
+++ b/docs/src/demos/hooks/use-scroll-lock.tsx
@@ -1,16 +1,14 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useScrollLock } from '@mantine/hooks';
 import { LockClosedIcon, LockOpen2Icon } from '@modulz/radix-icons';
 import { Group, Button } from '@mantine/core';
 
-const code = `import React, { useState } from 'react';
-import { useScrollLock } from '@mantine/hooks';
+const code = `import { useScrollLock } from '@mantine/hooks';
 import { Button } from '@mantine/core';
 import { LockClosedIcon, LockOpen2Icon } from '@modulz/radix-icons';
 
 export function Demo() {
-  const [lockScroll, setLockScroll] = useState(false);
-  useScrollLock(lockScroll);
+  const [lockScroll, setLockScroll] = useScrollLock();
 
   return (
     <Button
@@ -24,8 +22,7 @@ export function Demo() {
 }`;
 
 function Demo() {
-  const [lockScroll, setLockScroll] = useState(false);
-  useScrollLock(lockScroll);
+  const [lockScroll, setLockScroll] = useScrollLock();
 
   return (
     <Group position="center">

--- a/docs/src/docs/hooks/use-scroll-lock.mdx
+++ b/docs/src/docs/hooks/use-scroll-lock.mdx
@@ -48,23 +48,10 @@ example with <GatsbyLink to="/core/modal/">Modal</GatsbyLink> component:
 
 <Demo data={ModalDemos.usage} />
 
-## Disable touch events
-
-To prevent scroll on mobile devices use `disableTouchEvents` option.
-**Warning** that this will prevent scroll in all all elements,
-e.g. user will not be able to scroll modal content with overflow.
-
-```tsx
-useScrollLock(true, { disableTouchEvents: true });
-```
-
 ## Definition
 
 ```tsx
 function useScrollLock(
-  lock: boolean,
-  options?: {
-    disableTouchEvents: boolean;
-  }
-): void;
+  lock?: boolean
+): readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>]
 ```

--- a/src/mantine-hooks/src/use-scroll-lock/use-scroll-lock.story.tsx
+++ b/src/mantine-hooks/src/use-scroll-lock/use-scroll-lock.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Container, Text, Button, Group } from '@mantine/core';
 import { LockClosedIcon, LockOpen2Icon } from '@modulz/radix-icons';
@@ -8,7 +8,8 @@ const lorem =
   'Because and pointing threw system for read. That or spot. What stairs nor perfected lead to buttons to here. The in there I attention would left right look such may through they the seven. People, into probably must suppliers, something phase by the every there up rendering it logged although.';
 
 function Example() {
-  const [lockScroll, setLockScroll] = useState(false);
+  const [lockScroll, setLockScroll] = useScrollLock();
+
   const items = Array(10)
     .fill(0)
     .map((_, index) => (
@@ -16,8 +17,6 @@ function Example() {
         {lorem}
       </Text>
     ));
-
-  useScrollLock(lockScroll);
 
   return (
     <Container size="xs" style={{ padding: 20 }}>

--- a/src/mantine-hooks/src/use-scroll-lock/use-scroll-lock.test.ts
+++ b/src/mantine-hooks/src/use-scroll-lock/use-scroll-lock.test.ts
@@ -15,7 +15,7 @@ describe('@mantine/hooks/use-scroll-lock', () => {
 
   it('does not change overflow if called with false', () => {
     document.body.style.overflow = 'visible';
-    renderHook(() => useScrollLock(false));
+    renderHook(() => useScrollLock());
     expect(document.body.style.overflow).toBe('visible');
   });
 });


### PR DESCRIPTION
Migrate to internal state handling.

Changed the API to maintain custom init state handling, please let me know if the naming and API is as intended or not.

Once I know what the API looks like I will update the docs accordingly