### PR TITLE
Added 'exact' prop to Highlight component

### DIFF
--- a/docs/src/docs/core/Highlight.mdx
+++ b/docs/src/docs/core/Highlight.mdx
@@ -33,6 +33,12 @@ You can highlight multiple substrings by providing an array of values:
 
 <Demo data={HighlightDemos.multiple} />
 
+## Highlight only exact strings
+
+You can highlight only exactly matching strings by providing the exact prop:
+
+<Demo data={HighlightDemos.exact} />
+
 ## Text props
 
 Highlight accepts the same props as <GatsbyLink to="/core/text/">Text</GatsbyLink> component:

--- a/src/mantine-core/src/components/Highlight/Highlight.test.tsx
+++ b/src/mantine-core/src/components/Highlight/Highlight.test.tsx
@@ -43,14 +43,14 @@ describe('@mantine/core/Highlight/highlighter', () => {
   const VALUE = 'Hello, World';
 
   it('highlights start of string', () => {
-    expect(highlighter(VALUE, 'Hell')).toEqual([
+    expect(highlighter(VALUE, 'Hell', false)).toEqual([
       { chunk: 'Hell', highlighted: true },
       { chunk: 'o, World', highlighted: false },
     ]);
   });
 
   it('Highlights middle of string', () => {
-    expect(highlighter(VALUE, 'llo, W')).toEqual([
+    expect(highlighter(VALUE, 'llo, W', false)).toEqual([
       { chunk: 'He', highlighted: false },
       { chunk: 'llo, W', highlighted: true },
       { chunk: 'orld', highlighted: false },
@@ -58,7 +58,7 @@ describe('@mantine/core/Highlight/highlighter', () => {
   });
 
   it('Highlights multiple of string', () => {
-    expect(highlighter(VALUE, ['Hell', 'world'])).toEqual([
+    expect(highlighter(VALUE, ['Hell', 'world'], false)).toEqual([
       { chunk: 'Hell', highlighted: true },
       { chunk: 'o, ', highlighted: false },
       { chunk: 'World', highlighted: true },
@@ -66,30 +66,48 @@ describe('@mantine/core/Highlight/highlighter', () => {
   });
 
   it('returns initial string if highlight is empty', () => {
-    expect(highlighter(VALUE, '')).toEqual([{ chunk: VALUE, highlighted: false }]);
-    expect(highlighter(VALUE, [])).toEqual([{ chunk: VALUE, highlighted: false }]);
-    expect(highlighter(VALUE, ['', ''])).toEqual([{ chunk: VALUE, highlighted: false }]);
+    expect(highlighter(VALUE, '', false)).toEqual([{ chunk: VALUE, highlighted: false }]);
+    expect(highlighter(VALUE, [], false)).toEqual([{ chunk: VALUE, highlighted: false }]);
+    expect(highlighter(VALUE, ['', ''], false)).toEqual([{ chunk: VALUE, highlighted: false }]);
   });
 
   it('highlights uppercased value', () => {
-    expect(highlighter(VALUE, 'HELL')).toEqual([
+    expect(highlighter(VALUE, 'HELL', false)).toEqual([
       { chunk: 'Hell', highlighted: true },
       { chunk: 'o, World', highlighted: false },
     ]);
-    expect(highlighter(VALUE, 'Hello,')).toEqual([
+    expect(highlighter(VALUE, 'Hello,', false)).toEqual([
       { chunk: 'Hello,', highlighted: true },
       { chunk: ' World', highlighted: false },
     ]);
   });
 
   it('highlights value with whitespace', () => {
-    expect(highlighter(VALUE, 'Hello  \t')).toEqual([
+    expect(highlighter(VALUE, 'Hello  \t', false)).toEqual([
       { chunk: 'Hello', highlighted: true },
       { chunk: ', World', highlighted: false },
     ]);
   });
 
   it('does not highlight if nothing found', () => {
-    expect(highlighter(VALUE, 'Hi, there')).toEqual([{ chunk: VALUE, highlighted: false }]);
+    expect(highlighter(VALUE, 'Hi, there', false)).toEqual([{ chunk: VALUE, highlighted: false }]);
   });
+
+  it('should only highlight exact matches', () => {
+    const EXACT_VALUE = 'Highlighting is the light of my days without lights';
+    expect(highlighter(EXACT_VALUE, 'light', true)).toEqual([
+      { chunk: "Highlighting is the ", highlighted: false },
+      { chunk: "light", highlighted: true },
+      { chunk: " of my days without lights", highlighted: false }
+    ])
+    expect(highlighter(EXACT_VALUE, 'light', false)).toStrictEqual([
+      { chunk: "High", highlighted: false },
+      { chunk: "light", highlighted: true },
+      { chunk: "ing is the ", highlighted: false },
+      { chunk: "light", highlighted: true },
+      { chunk: " of my days without ", highlighted: false },
+      { chunk: "light", highlighted: true },
+      { chunk: "s", highlighted: false }
+    ])
+  })
 });

--- a/src/mantine-core/src/components/Highlight/Highlight.tsx
+++ b/src/mantine-core/src/components/Highlight/Highlight.tsx
@@ -4,7 +4,7 @@ import { DefaultProps, useMantineTheme, getThemeColor } from '../../theme';
 import { ComponentPassThrough } from '../../types';
 import { Text, TextProps } from '../Text/Text';
 
-export function highlighter(value: string, highlight: string | string[]) {
+export function highlighter(value: string, highlight: string | string[], exact: boolean) {
   const shouldHighlight = Array.isArray(highlight)
     ? highlight.filter((part) => part.trim().length > 0).length > 0
     : highlight.trim() !== '';
@@ -21,13 +21,13 @@ export function highlighter(value: string, highlight: string | string[]) {
           .map((part) => part.trim())
           .join('|');
 
-  const re = new RegExp(`(${matcher})`, 'gi');
-  const chunks = value
+  const pattern = exact ? `\\b(${matcher})\\b` : `(${matcher})`
+
+  const re = new RegExp(pattern, 'gi');
+  return value
     .split(re)
     .map((part) => ({ chunk: part, highlighted: re.test(part) }))
     .filter(({ chunk }) => chunk);
-
-  return chunks;
 }
 
 export interface HighlightProps extends DefaultProps, Omit<TextProps, 'children'> {
@@ -39,6 +39,9 @@ export interface HighlightProps extends DefaultProps, Omit<TextProps, 'children'
 
   /** Full string part of which will be highlighted */
   children: string;
+
+  /** Only highlight when the words are matched exactly */
+  exact?: boolean;
 }
 
 export function Highlight<T extends React.ElementType = 'div'>({
@@ -47,6 +50,7 @@ export function Highlight<T extends React.ElementType = 'div'>({
   component,
   themeOverride,
   highlightColor = 'yellow',
+  exact = false,
   className,
   ...others
 }: ComponentPassThrough<T, HighlightProps>) {
@@ -57,7 +61,7 @@ export function Highlight<T extends React.ElementType = 'div'>({
     shade: theme.colorScheme === 'dark' ? 5 : 2,
   });
 
-  const highlightChunks = highlighter(children, highlight);
+  const highlightChunks = highlighter(children, highlight, exact);
 
   return (
     <Text

--- a/src/mantine-core/src/components/Highlight/demos/configurator.tsx
+++ b/src/mantine-core/src/components/Highlight/demos/configurator.tsx
@@ -25,5 +25,6 @@ export const configurator: MantineDemo = {
       type: 'string',
       initialValue: 'Highlight This, definitely THIS and also this!',
     },
+    { name: 'exact', type: 'boolean', initialValue: false }
   ],
 };

--- a/src/mantine-core/src/components/Highlight/demos/exact.tsx
+++ b/src/mantine-core/src/components/Highlight/demos/exact.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Highlight } from '../Highlight';
+
+const code = `
+<Highlight highlight="light" exact>Highlight this light and not those lights</Highlight>
+`;
+
+function Demo() {
+  return <Highlight highlight="light" exact>Highlight this light and not those lights</Highlight>;
+}
+
+export const exact: MantineDemo = {
+  type: 'demo',
+  code,
+  component: Demo,
+};

--- a/src/mantine-core/src/components/Highlight/demos/index.ts
+++ b/src/mantine-core/src/components/Highlight/demos/index.ts
@@ -1,3 +1,4 @@
 export { configurator } from './configurator';
 export { props } from './props';
 export { multiple } from './multiple';
+export { exact } from './exact';


### PR DESCRIPTION
Adds a prop called "exact" so that only exact matches of words are highlighted.

Ex. "Highlight is my favorite word containing light" will highlight the word "light" twice in this string, once for "highLIGHT" and once for "light". This prop will make sure only the latter is highlighted.