### PR TITLE
[@mantine/hooks] use-cookie: fix document not available in ssr

### DIFF
--- a/src/mantine-hooks/src/use-cookie/use-cookie.ts
+++ b/src/mantine-hooks/src/use-cookie/use-cookie.ts
@@ -1,6 +1,8 @@
 import { useRef } from 'react';
 
 function getCookie(name: string) {
+  if (typeof document === 'undefined') return null;
+
   const cookie = `${name}=`;
   const decoded = decodeURIComponent(document.cookie);
   const arr = decoded.split('; ');


### PR DESCRIPTION
Noticed that build failed for SSR Gatsby. This small change fixes it.