### PR TITLE
Feature/strict types in public api

### DIFF
--- a/src/mantine-hooks/src/use-merged-ref/use-merged-ref.ts
+++ b/src/mantine-hooks/src/use-merged-ref/use-merged-ref.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import { assignRef } from '../utils';
 
 export function useMergedRef<T = any>(...refs: React.ForwardedRef<T>[]) {
-  return (node: T) => {
+  return (node: T | null) => {
     refs.forEach((ref) => assignRef(ref, node));
   };
 }

--- a/src/mantine-hooks/src/use-uncontrolled/use-uncontrolled.ts
+++ b/src/mantine-hooks/src/use-uncontrolled/use-uncontrolled.ts
@@ -1,14 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
 
-type UncontrolledMode = 'initial' | 'controlled' | 'uncontrolled';
+export type UncontrolledMode = 'initial' | 'controlled' | 'uncontrolled';
 
 export interface UncontrolledOptions<T> {
-  value: T;
-  defaultValue: T;
-  finalValue: T;
-  onChange(value: T): void;
-  onValueUpdate?(value: T): void;
-  rule: (value: T) => boolean;
+  value: T | null | undefined;
+  defaultValue: T | null | undefined;
+  finalValue: T | null;
+  onChange(value: T | null): void;
+  onValueUpdate?(value: T | null): void;
+  rule: (value: T | null | undefined) => boolean;
 }
 
 export function useUncontrolled<T>({
@@ -18,7 +18,7 @@ export function useUncontrolled<T>({
   rule,
   onChange,
   onValueUpdate,
-}: UncontrolledOptions<T>) {
+}: UncontrolledOptions<T>): readonly [T | null, (nextValue: T | null) => void, UncontrolledMode] {
   // determine, whether new props indicate controlled state
   const shouldBeControlled = rule(value);
 
@@ -47,7 +47,7 @@ export function useUncontrolled<T>({
   modeRef.current = shouldBeControlled ? 'controlled' : 'uncontrolled';
   const mode = modeRef.current;
 
-  const handleChange = (nextValue: T) => {
+  const handleChange = (nextValue: T | null) => {
     typeof onChange === 'function' && onChange(nextValue);
 
     // Controlled input only triggers onChange event and expects

--- a/src/mantine-hooks/src/utils/assign-ref/assign-ref.ts
+++ b/src/mantine-hooks/src/utils/assign-ref/assign-ref.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export function assignRef<T = any>(ref: React.ForwardedRef<T>, value: T) {
+export function assignRef<T = any>(ref: React.ForwardedRef<T>, value: T | null) {
   if (typeof ref === 'function') {
     ref(value);
   } else if (typeof ref === 'object' && ref !== null && 'current' in ref) {


### PR DESCRIPTION
Adds strict null annotations to

`assign-ref`
`use-merged-ref`
 - ref value can be always null or whatever type the ref is

`use-uncontrolled`
 - return type needs to be specified otherwise the value type will be coerced to non-null
 - value/default value are optional on inputs, so need to conform to both undefined and null as well as `rule` function
 - the final value and values in callback are always either T or null thanks to finalValue


Note that this is hard to discover and test - we'll have to mostly react to what people find when using the library with strict on.