### PR TITLE
[docs] Adds rightSection example for TextInput

### DIFF
--- a/docs/src/docs/core/TextInput.mdx
+++ b/docs/src/docs/core/TextInput.mdx
@@ -48,6 +48,12 @@ You can use any React node as icon:
 
 <Demo data={TextInputDemos.icon} />
 
+## With right section
+
+You can use any React node as right section:
+
+<Demo data={TextInputDemos.rightSection} />
+
 ## Get element ref
 
 You can get input ref with `elementRef` prop:

--- a/src/mantine-core/src/components/TextInput/demos/index.ts
+++ b/src/mantine-core/src/components/TextInput/demos/index.ts
@@ -2,3 +2,4 @@ export { configurator } from './configurator';
 export { validation } from './validation';
 export { disabled } from './disabled';
 export { icon } from './icon';
+export { rightSection } from './rightSection';

--- a/src/mantine-core/src/components/TextInput/demos/rightSection.tsx
+++ b/src/mantine-core/src/components/TextInput/demos/rightSection.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Loader } from '../../Loader/Loader';
+import { TextInput } from '../TextInput';
+
+const code = `
+<TextInput label="Your email" placeholder="Your email" rightSection={<Loader size="xs" />} />
+`;
+
+function Demo() {
+  return (
+    <div style={{ maxWidth: 320, marginLeft: 'auto', marginRight: 'auto' }}>
+      <TextInput label="Your email" placeholder="Your email" rightSection={<Loader size="xs" />} />
+    </div>
+  );
+}
+
+export const rightSection: MantineDemo = {
+  type: 'demo',
+  code,
+  component: Demo,
+};


### PR DESCRIPTION
Adds an example of using `rightSection` to the `TextInput` page. This was one I had to figure out myself so perhaps useful for future visitors. Let me know if you want to change the text.

![image](https://user-images.githubusercontent.com/230500/128356703-ef449dfe-978a-476f-b5c0-2e73d5ce8ace.png)
