### PR TITLE
Added zIndex prop to DatePickerBase

### DIFF
--- a/src/mantine-dates/src/components/DatePickerBase/DatePickerBase.tsx
+++ b/src/mantine-dates/src/components/DatePickerBase/DatePickerBase.tsx
@@ -84,6 +84,9 @@ export interface DatePickerBaseSharedProps
 
   /** useEffect dependencies to force update tooltip position */
   positionDependencies?: any[];
+
+  /** Popper zIndex */
+  zIndex?: number;
 }
 
 export interface DatePickerBaseProps extends DatePickerBaseSharedProps {
@@ -141,6 +144,7 @@ export function DatePickerBase({
   clearButtonLabel,
   onClear,
   positionDependencies = [],
+  zIndex = 3,
   ...others
 }: DatePickerBaseProps) {
   const theme = useMantineTheme(themeOverride);
@@ -235,7 +239,7 @@ export function DatePickerBase({
             gutter={0}
             withArrow
             arrowSize={3}
-            zIndex={3}
+            zIndex={zIndex}
           >
             <div
               className={classes.dropdownWrapper}


### PR DESCRIPTION
### Problem
If the DatePicker is used inside a Modal, the DatePicker popover appears behind the Modal, since the zIndex prop of the Popper Component which is used for the DatePicker popover is set to 3.

### Solution
Added zIndex property to DatePickerBase which allows you to modify the z-index attribute of the Popper component. 
The default value is still set to 3.

I don't know if "zIndex" is the correct property name in this case, since it's only for the Popper component and not the DatePicker component itself.