### PR TITLE
Enable `loading` state for ActionIcon

### DIFF
--- a/src/mantine-core/src/components/ActionIcon/ActionIcon.story.tsx
+++ b/src/mantine-core/src/components/ActionIcon/ActionIcon.story.tsx
@@ -29,6 +29,13 @@ storiesOf('@mantine/core/ActionIcon', module)
       <Group>{getThemes({ disabled: true, variant: 'transparent' })}</Group>
     </>
   ))
+  .add('Loading', () => (
+    <>
+      <Group>{getThemes({ loading: true })}</Group>
+      <Group>{getThemes({ loading: true, variant: 'filled' })}</Group>
+      <Group>{getThemes({ loading: true, variant: 'transparent' })}</Group>
+    </>
+  ))
   .add('Sizes', () => (
     <>
       <Group>{getThemes({ size: 'xs' }, { style: { width: 12, height: 12 } })}</Group>
@@ -74,6 +81,12 @@ storiesOf('@mantine/core/ActionIcon', module)
       </Group>
       <Group style={{ marginTop: 20 }}>
         {getThemes({ disabled: true, variant: 'outline', themeOverride: { colorScheme: 'dark' } })}
+      </Group>
+      <Group style={{ marginTop: 20 }}>
+        {getThemes({ loading: true, variant: 'filled', themeOverride: { colorScheme: 'dark' } })}
+      </Group>
+      <Group style={{ marginTop: 20 }}>
+        {getThemes({ loading: true, variant: 'outline', themeOverride: { colorScheme: 'dark' } })}
       </Group>
     </div>
   ));

--- a/src/mantine-core/src/components/ActionIcon/ActionIcon.styles.ts
+++ b/src/mantine-core/src/components/ActionIcon/ActionIcon.styles.ts
@@ -7,6 +7,7 @@ import {
   getThemeColor,
   createMemoStyles,
   getSharedColorScheme,
+  hexToRgba,
 } from '../../theme';
 
 interface ActionIconStyles {
@@ -25,6 +26,23 @@ export const sizes = {
 };
 
 export default createMemoStyles({
+  loading: (props: ActionIconStyles) => ({
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      top: -1,
+      left: -1,
+      right: -1,
+      bottom: -1,
+      backgroundColor:
+        props.theme.colorScheme === 'dark'
+          ? hexToRgba(props.theme.colors.dark[7], 0.5)
+          : 'rgba(255, 255, 255, .5)',
+      borderRadius: getSizeValue({ size: props.radius, sizes: props.theme.radius }) - 1,
+      cursor: 'not-allowed',
+    },
+  }),
+
   filled: ({ theme, color }: ActionIconStyles) => {
     const colors = getSharedColorScheme({ theme, color, variant: 'filled' });
 
@@ -80,6 +98,7 @@ export default createMemoStyles({
   root: ({ radius, theme, size }: ActionIconStyles) => ({
     ...getFocusStyles(theme),
     ...getFontStyles(theme),
+    position: 'relative',
     appearance: 'none',
     WebkitAppearance: 'none',
     WebkitTapHighlightColor: 'transparent',

--- a/src/mantine-core/src/components/ActionIcon/ActionIcon.tsx
+++ b/src/mantine-core/src/components/ActionIcon/ActionIcon.tsx
@@ -77,7 +77,7 @@ export function ActionIcon<
   const classes = useStyles({ size, radius, color, theme }, null, 'action-icon');
   const Element = component || 'button';
   const colors = getSharedColorScheme({
-    color: 'gray',
+    color,
     theme,
     variant: 'light',
   });

--- a/src/mantine-core/src/components/ActionIcon/ActionIcon.tsx
+++ b/src/mantine-core/src/components/ActionIcon/ActionIcon.tsx
@@ -1,9 +1,24 @@
 import React from 'react';
 import cx from 'clsx';
-import { useMantineTheme, DefaultProps, MantineNumberSize } from '../../theme';
+import {
+  useMantineTheme,
+  DefaultProps,
+  MantineNumberSize,
+  getSizeValue,
+  getSharedColorScheme,
+} from '../../theme';
 import useStyles, { sizes } from './ActionIcon.styles';
+import { Loader } from '../Loader/Loader';
 
 export const ACTION_ICON_SIZES = sizes;
+
+const LOADER_SIZES = {
+  xs: 12,
+  sm: 14,
+  md: 16,
+  lg: 18,
+  xl: 20,
+};
 
 interface _ActionIconProps<C extends React.ElementType, R extends HTMLElement>
   extends DefaultProps {
@@ -27,6 +42,12 @@ interface _ActionIconProps<C extends React.ElementType, R extends HTMLElement>
 
   /** Predefined icon size or number to set width and height in px */
   size?: MantineNumberSize;
+
+  /** Props spread to Loader component */
+  loaderProps?: Record<string, any>;
+
+  /** Indicate loading state */
+  loading?: boolean;
 }
 
 export type ActionIconProps<
@@ -44,6 +65,9 @@ export function ActionIcon<
   radius = 'sm',
   size = 'md',
   variant = 'hover',
+  disabled = false,
+  loaderProps,
+  loading = false,
   themeOverride,
   elementRef,
   component,
@@ -52,6 +76,19 @@ export function ActionIcon<
   const theme = useMantineTheme(themeOverride);
   const classes = useStyles({ size, radius, color, theme }, null, 'action-icon');
   const Element = component || 'button';
+  const colors = getSharedColorScheme({
+    color: 'gray',
+    theme,
+    variant: 'light',
+  });
+
+  const loader = (
+    <Loader
+      color={colors.color}
+      size={getSizeValue({ size, sizes: LOADER_SIZES })}
+      {...loaderProps}
+    />
+  );
 
   return (
     <Element
@@ -59,8 +96,9 @@ export function ActionIcon<
       className={cx(classes.root, classes[variant], className)}
       type="button"
       ref={elementRef as any}
+      disabled={disabled || loading}
     >
-      {children}
+      {loading ? loader : children}
     </Element>
   );
 }

--- a/src/mantine-core/src/components/ActionIcon/ActionIcon.tsx
+++ b/src/mantine-core/src/components/ActionIcon/ActionIcon.tsx
@@ -93,7 +93,7 @@ export function ActionIcon<
   return (
     <Element
       {...others}
-      className={cx(classes.root, classes[variant], className)}
+      className={cx(classes.root, classes[variant], { [classes.loading]: loading }, className)}
       type="button"
       ref={elementRef as any}
       disabled={disabled || loading}

--- a/src/mantine-core/src/components/ActionIcon/demos/configurator.tsx
+++ b/src/mantine-core/src/components/ActionIcon/demos/configurator.tsx
@@ -46,5 +46,7 @@ export const configurator: MantineDemo = {
       initialValue: 'hover',
       defaultValue: 'hover',
     },
+    { name: 'disabled', type: 'boolean', initialValue: false, defaultValue: false },
+    { name: 'loading', type: 'boolean', initialValue: false, defaultValue: false },
   ],
 };


### PR DESCRIPTION
I might have over-simplified how I inject the `Loader` in place of the Icon when in loading state but seems to work fine in the stories.