### PR TITLE
[@mantine/dates]: TimeField colon centering

### DIFF
--- a/src/mantine-dates/src/components/TimeInput/TimeField/TimeField.tsx
+++ b/src/mantine-dates/src/components/TimeInput/TimeField/TimeField.tsx
@@ -94,7 +94,13 @@ export function TimeField({
       />
 
       {withSeparator && (
-        <Text size={size} style={{ lineHeight: 1, color: 'inherit' }}>
+        <Text
+          size={size}
+          style={{ lineHeight: 1,
+                    color: 'inherit',
+                    position: 'relative',
+                    top: '.1em' }}
+        >
           :
         </Text>
       )}


### PR DESCRIPTION
As colon isn't centered but put above the baseline, thought you would consider this.
references - https://medium.com/@amachino/the-secret-of-san-francisco-fonts-4b5295d9a745.