### PR TITLE
Updated demo and removed `withSeconds` prop

### DIFF
--- a/src/mantine-dates/src/components/TimeRangeInput/demos/usage.tsx
+++ b/src/mantine-dates/src/components/TimeRangeInput/demos/usage.tsx
@@ -23,7 +23,7 @@ function Demo() {
 
   return (
     <div style={{ maxWidth: 340, marginLeft: 'auto', marginRight: 'auto' }}>
-      <TimeRangeInput label="Appointment time" value={value} onChange={setValue} withSeconds />
+      <TimeRangeInput label="Appointment time" value={value} onChange={setValue} />
     </div>
   );
 }


### PR DESCRIPTION
I was checking the new components and noticed this demo was previewing `withSeconds` when it wasn't supposed to.