### PR TITLE
[@mantine/hooks]: add use-viewport-size

### DIFF
--- a/docs/src/demos/hooks/use-viewport-size.tsx
+++ b/docs/src/demos/hooks/use-viewport-size.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useViewportSize } from '@mantine/hooks';
+import { Text, Group } from '@mantine/core';
+
+const code = `
+import { useViewportSize } from '@mantine/hooks';
+import { Text, Group } from '@mantine/core';
+
+function Demo() {
+  const { height, width } = useViewportSize();
+
+  return (
+    <Group position="center">
+      <Text>
+        Viewport width: {width}
+      </Text>
+      <Text>
+        Viewport height: {height}
+      </Text>
+    </Group>
+  );
+}
+`;
+
+function Demo() {
+  const { height, width } = useViewportSize();
+
+  return (
+    <Group position="center">
+      <Text>
+        Viewport width: {width}
+      </Text>
+      <Text>
+        Viewport height: {height}
+      </Text>
+    </Group>
+  );
+}
+
+export const useViewportSizeDemo: MantineDemo = {
+  type: 'demo',
+  code,
+  component: Demo,
+};

--- a/docs/src/demos/index.ts
+++ b/docs/src/demos/index.ts
@@ -11,6 +11,7 @@ export * from './hooks/use-reduced-motion';
 export * from './hooks/use-scroll-lock';
 export * from './hooks/use-force-update';
 export * from './hooks/use-toggle';
+export * from './hooks/use-viewport-size';
 export * from './hooks/use-window-scroll';
 export * from './hooks/use-intersection';
 export * from './hooks/use-hash';

--- a/docs/src/docs/hooks/use-viewport-size.mdx
+++ b/docs/src/docs/hooks/use-viewport-size.mdx
@@ -1,0 +1,31 @@
+---
+group: 'mantine-hooks'
+package: '@mantine/hooks'
+category: 'dom'
+title: 'use-viewport-size'
+order: 1
+slug: /hooks/use-viewport-size/
+description: 'Get information about current viewport size'
+import: "import { useViewportSize } from '@mantine/hooks';"
+docs: 'hooks/use-viewport-size.mdx'
+source: 'mantine-hooks/src/use-viewport-size/use-viewport-size.ts'
+---
+
+import { useViewportSizeDemo } from '@docs/demos';
+
+## Usage
+
+Hook returns current viewport width and height:
+
+<Demo data={useViewportSizeDemo} />
+
+On the first render (as well as during SSR), both width and height are equal to `0`.
+
+## Definition
+
+```tsx
+function useViewportSize(): Readonly<{
+  height: number;
+  width: number;
+}>;
+```

--- a/src/mantine-hooks/src/index.ts
+++ b/src/mantine-hooks/src/index.ts
@@ -25,6 +25,7 @@ export { useScrollLock } from './use-scroll-lock/use-scroll-lock';
 export { useShallowEffect } from './use-shallow-effect/use-shallow-effect';
 export { useToggle, useBooleanToggle } from './use-toggle/use-toggle';
 export { useUncontrolled } from './use-uncontrolled/use-uncontrolled';
+export { useViewportSize } from './use-viewport-size/use-viewport-size';
 export { useWindowEvent } from './use-window-event/use-window-event';
 export { useWindowScroll } from './use-window-scroll/use-window-scroll';
 export { useIntersection } from './use-intersection/use-intersection';

--- a/src/mantine-hooks/src/use-viewport-size/use-viewport-size.ts
+++ b/src/mantine-hooks/src/use-viewport-size/use-viewport-size.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { useWindowEvent } from '../use-window-event/use-window-event';
 
 interface DebouncedWindowSizeOptions {
@@ -25,12 +25,16 @@ export const useViewportSize = ({
   const setSize = useCallback(
     (): void => {
       setWindowSize({
-        width: window.innerWidth,
-        height: window.innerHeight,
+        width: window?.innerWidth ?? initialWidth,
+        height: window?.innerHeight ?? initialWidth,
       });
     },
     [],
   );
+
+  useEffect(() => {
+    setSize();
+  }, []);
 
   useWindowEvent('resize', setSize, eventListerOptions);
 

--- a/src/mantine-hooks/src/use-viewport-size/use-viewport-size.ts
+++ b/src/mantine-hooks/src/use-viewport-size/use-viewport-size.ts
@@ -1,32 +1,24 @@
 import { useCallback, useState, useEffect } from 'react';
 import { useWindowEvent } from '../use-window-event/use-window-event';
 
-interface DebouncedWindowSizeOptions {
-  initialWidth?: number
-  initialHeight?: number
-}
-
 const eventListerOptions = {
   passive: true,
 };
 
-export const useViewportSize = ({
-  initialWidth = 0,
-  initialHeight = 0,
-}: DebouncedWindowSizeOptions): Readonly<{
+export function useViewportSize(): Readonly<{
   width: number;
   height: number;
-}> => {
+}> {
   const [windowSize, setWindowSize] = useState({
-    width: initialWidth,
-    height: initialHeight,
+    width: 0,
+    height: 0,
   });
 
   const setSize = useCallback(
     (): void => {
       setWindowSize({
-        width: window?.innerWidth ?? initialWidth,
-        height: window?.innerHeight ?? initialWidth,
+        width: window?.innerWidth ?? 0,
+        height: window?.innerHeight ?? 0,
       });
     },
     [],
@@ -41,4 +33,4 @@ export const useViewportSize = ({
   useWindowEvent('orientationchange', setSize, eventListerOptions);
 
   return windowSize;
-};
+}

--- a/src/mantine-hooks/src/use-viewport-size/use-viewport-size.ts
+++ b/src/mantine-hooks/src/use-viewport-size/use-viewport-size.ts
@@ -1,0 +1,40 @@
+import { useCallback, useState } from 'react';
+import { useWindowEvent } from '../use-window-event/use-window-event';
+
+interface DebouncedWindowSizeOptions {
+  initialWidth?: number
+  initialHeight?: number
+}
+
+const eventListerOptions = {
+  passive: true,
+};
+
+export const useViewportSize = ({
+  initialWidth = 0,
+  initialHeight = 0,
+}: DebouncedWindowSizeOptions): Readonly<{
+  width: number;
+  height: number;
+}> => {
+  const [windowSize, setWindowSize] = useState({
+    width: initialWidth,
+    height: initialHeight,
+  });
+
+  const setSize = useCallback(
+    (): void => {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    },
+    [],
+  );
+
+  useWindowEvent('resize', setSize, eventListerOptions);
+
+  useWindowEvent('orientationchange', setSize, eventListerOptions);
+
+  return windowSize;
+};


### PR DESCRIPTION
I've prepared a simple version of that hook. Is there a need for a debouncing? If so I think there will be a need for the `useDebouncedCallback` hook due to `useDebouncedValue` won't prevent listeners from 'spam' changing the state. 