### PR TITLE
[@mantine/hooks]: add use-resize-observer

### DIFF
--- a/docs/src/demos/hooks/use-resize-observer.tsx
+++ b/docs/src/demos/hooks/use-resize-observer.tsx
@@ -12,7 +12,7 @@ function Demo() {
 
   return (
     <>
-      <Text align="center" size="sm" style={{ marginBottom: theme.spacing.xs }}>
+      <Text align="center" size="sm">
         Resize current element by moving its left bottom corner
       </Text>
       <Group position="center">
@@ -30,7 +30,7 @@ function Demo() {
           }}
         />
       </Group>
-      <Text align="center" style={{ marginTop: theme.spacing.sm }}>
+      <Text align="center">
         Rect: <Code>{JSON.stringify(rect, null, 2)}</Code>
       </Text>
     </>

--- a/docs/src/demos/hooks/use-resize-observer.tsx
+++ b/docs/src/demos/hooks/use-resize-observer.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { useMantineTheme, Text, Group, Code } from '@mantine/core';
+import { useResizeObserver } from '@mantine/hooks';
+
+const code = `
+import { useMantineTheme, Text, Code, Group } from '@mantine/core';
+import { useResizeObserver } from '@mantine/hooks';
+
+function Demo() {
+  const theme = useMantineTheme();
+  const [ref, rect] = useResizeObserver();
+
+  return (
+    <>
+      <Text align="center" size="sm" style={{ marginBottom: theme.spacing.xs }}>
+        Resize current element by moving its left bottom corner
+      </Text>
+      <Group position="center">
+        <textarea
+          ref={ref}
+          value=""
+          style={{
+            pointerEvents: 'none',
+            width: 400,
+            height: 120,
+            border: \`1px solid \${theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[4]}\`,
+            backgroundColor:
+              theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.gray[2],
+            position: 'relative',
+          }}
+        />
+      </Group>
+      <Text align="center" style={{ marginTop: theme.spacing.sm }}>
+        Rect: <Code>{JSON.stringify(rect, null, 2)}</Code>
+      </Text>
+    </>
+  );
+}`;
+
+function Demo() {
+  const theme = useMantineTheme();
+  const [ref, rect] = useResizeObserver();
+
+  return (
+    <>
+      <Text align="center" size="sm" style={{ marginBottom: theme.spacing.xs }}>
+        Resize current element by moving its left bottom corner
+      </Text>
+      <Group position="center">
+        <textarea
+          ref={ref}
+          value=""
+          style={{
+            pointerEvents: 'none',
+            width: 400,
+            height: 120,
+            border: `1px solid ${theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[4]}`,
+            backgroundColor:
+              theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.gray[2],
+            position: 'relative',
+          }}
+        />
+      </Group>
+      <Text align="center" style={{ marginTop: theme.spacing.sm }}>
+        Rect: <Code>{JSON.stringify(rect, null, 2)}</Code>
+      </Text>
+    </>
+  );
+}
+
+export const useResizeObserverDemo: MantineDemo = {
+  type: 'demo',
+  code,
+  component: Demo,
+};

--- a/docs/src/demos/index.ts
+++ b/docs/src/demos/index.ts
@@ -8,6 +8,7 @@ export * from './hooks/use-idle';
 export * from './hooks/use-interval';
 export * from './hooks/use-media-query';
 export * from './hooks/use-reduced-motion';
+export * from './hooks/use-resize-observer';
 export * from './hooks/use-scroll-lock';
 export * from './hooks/use-force-update';
 export * from './hooks/use-toggle';

--- a/docs/src/docs/hooks/use-resize-observer.mdx
+++ b/docs/src/docs/hooks/use-resize-observer.mdx
@@ -40,7 +40,7 @@ const [ref, rect] = useResizeObserver();
 ## Definition
 
 ```tsx
-function useIntersection<T extends HTMLElement = any>(): [
+function useResizeObserver<T extends HTMLElement = any>(): [
     MutableRefObject<T>,
     {
       readonly x: number;

--- a/docs/src/docs/hooks/use-resize-observer.mdx
+++ b/docs/src/docs/hooks/use-resize-observer.mdx
@@ -1,0 +1,56 @@
+---
+group: 'mantine-hooks'
+package: '@mantine/hooks'
+category: 'dom'
+title: 'use-resize-observer'
+order: 1
+slug: /hooks/use-resize-observer/
+description: 'Get information about element content rect'
+import: "import { useResizeObserver } from '@mantine/hooks';"
+docs: 'hooks/use-resize-observer.mdx'
+source: 'mantine-hooks/src/use-resize-observer/use-resize-observer.ts'
+---
+
+import { useResizeObserverDemo } from '@docs/demos';
+
+## Usage
+
+Use hook to get information about rect informations
+of given element with [Resize Observer API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver):
+
+<Demo data={useResizeObserverDemo} />
+
+## API
+
+Hook returns ref function that should be passed to the observed element, and the current element content rect, as returned by `ResizeObserver`'s callback `entry.contentRect`.
+See [Resize Observer API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) documentation to learn more.
+
+On the first render (as well as during SSR), or when no element is being observed, all of the properties are equal to `0`.
+
+```tsx
+const [ref, rect] = useResizeObserver();
+
+// With regular element:
+<div ref={ref}>Observed</div>
+
+// With Mantine component:
+<Paper elementRef={ref}>Observed</Paper>
+```
+
+## Definition
+
+```tsx
+function useIntersection<T extends HTMLElement = any>(): [
+    MutableRefObject<T>,
+    {
+      readonly x: number;
+      readonly y: number;
+      readonly top: number;
+      readonly left: number;
+      readonly right: number;
+      readonly bottom: number;
+      readonly height: number;
+      readonly width: number;
+  }
+];
+```

--- a/src/mantine-hooks/src/index.ts
+++ b/src/mantine-hooks/src/index.ts
@@ -21,6 +21,7 @@ export { useMergedRef } from './use-merged-ref/use-merged-ref';
 export { useMove, clampUseMovePosition } from './use-move/use-move';
 export { useQueue } from './use-queue/use-queue';
 export { useReducedMotion } from './use-reduced-motion/use-reduced-motion';
+export { useResizeObserver } from './use-resize-observer/use-resize-observer';
 export { useScrollLock } from './use-scroll-lock/use-scroll-lock';
 export { useShallowEffect } from './use-shallow-effect/use-shallow-effect';
 export { useToggle, useBooleanToggle } from './use-toggle/use-toggle';

--- a/src/mantine-hooks/src/use-resize-observer/use-resize-observer.ts
+++ b/src/mantine-hooks/src/use-resize-observer/use-resize-observer.ts
@@ -1,10 +1,6 @@
-import { MutableRefObject, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
-type ObserverRect = Pick<
-  DOMRectReadOnly,
-  'x' | 'y' | 'top' | 'left' | 'right' | 'bottom' | 'height' | 'width'
->;
-type UseResizeObserverResult<T extends HTMLElement = any> = [MutableRefObject<T>, ObserverRect];
+type ObserverRect = Omit<DOMRectReadOnly, 'toJSON'>;
 
 const defaultState: ObserverRect = {
   x: 0,
@@ -17,7 +13,7 @@ const defaultState: ObserverRect = {
   right: 0,
 };
 
-export function useResizeObserver<T extends HTMLElement = any>(): UseResizeObserverResult {
+export function useResizeObserver<T extends HTMLElement = any>() {
   const frameID = useRef(0);
   const ref = useRef<T>(null);
 
@@ -54,5 +50,5 @@ export function useResizeObserver<T extends HTMLElement = any>(): UseResizeObser
     };
   }, [ref.current]);
 
-  return [ref, rect];
+  return [ref, rect] as const;
 }

--- a/src/mantine-hooks/src/use-resize-observer/use-resize-observer.ts
+++ b/src/mantine-hooks/src/use-resize-observer/use-resize-observer.ts
@@ -1,0 +1,58 @@
+import { MutableRefObject, useEffect, useMemo, useRef, useState } from 'react';
+
+type ObserverRect = Pick<
+  DOMRectReadOnly,
+  'x' | 'y' | 'top' | 'left' | 'right' | 'bottom' | 'height' | 'width'
+>;
+type UseResizeObserverResult<T extends HTMLElement = any> = [MutableRefObject<T>, ObserverRect];
+
+const defaultState: ObserverRect = {
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0,
+  top: 0,
+  left: 0,
+  bottom: 0,
+  right: 0,
+};
+
+export function useResizeObserver<T extends HTMLElement = any>(): UseResizeObserverResult {
+  const frameID = useRef(0);
+  const ref = useRef<T>(null);
+
+  const [rect, setRect] = useState<ObserverRect>(defaultState);
+
+  const observer = useMemo(
+    () =>
+      new ResizeObserver((entries) => {
+        const entry = entries[0];
+
+        if (entry) {
+          cancelAnimationFrame(frameID.current);
+
+          frameID.current = requestAnimationFrame(() => {
+            if (ref.current) {
+              setRect(entry.contentRect);
+            }
+          });
+        }
+      }),
+   []);
+
+  useEffect(() => {
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => {
+      observer.disconnect();
+
+      if (frameID.current) {
+        cancelAnimationFrame(frameID.current);
+      }
+    };
+  }, [ref.current]);
+
+  return [ref, rect];
+}


### PR DESCRIPTION
another hook for an initial review - for now, I don't see any necessary options for it for now except something like debounce timing.  Is basic resizeable textarea with no value as demo will be enough for that hook?