### PR TITLE
hook/useScrollIntoView

### DIFF
--- a/src/mantine-hooks/src/index.ts
+++ b/src/mantine-hooks/src/index.ts
@@ -22,6 +22,7 @@ export { useMove, clampUseMovePosition } from './use-move/use-move';
 export { usePagination } from './use-pagination/use-pagination';
 export { useQueue } from './use-queue/use-queue';
 export { useReducedMotion } from './use-reduced-motion/use-reduced-motion';
+export { useScrollIntoView } from './use-scroll-into-view/use-scroll-into-view';
 export { useScrollLock } from './use-scroll-lock/use-scroll-lock';
 export { useShallowEffect } from './use-shallow-effect/use-shallow-effect';
 export { useToggle, useBooleanToggle } from './use-toggle/use-toggle';

--- a/src/mantine-hooks/src/use-scroll-into-view/use-scroll-into-view.ts
+++ b/src/mantine-hooks/src/use-scroll-into-view/use-scroll-into-view.ts
@@ -22,6 +22,9 @@ type ScrollIntoViewParams = {
 
   /** axis of scroll */
   axis?: 'x' | 'y'
+
+  /** custom mathematical easing function */
+  easing?: (t: number) => number
 };
 
 export function useScrollIntoView({
@@ -30,6 +33,7 @@ export function useScrollIntoView({
   duration = 1.25,
   axis = 'y',
   onScrollFinish,
+  easing = easeInOutQuad
 }: ScrollIntoViewParams) {
   const forceRerender = useForceUpdate();
   const frameID = useRef(0);
@@ -49,7 +53,7 @@ export function useScrollIntoView({
       // easing timing progress
       const t = elapsed / duration;
 
-      const distance = start + change * easeInOutQuad(t);
+      const distance = start + change * easing(t);
 
       setScrollParam({ parent, axis, distance });
 

--- a/src/mantine-hooks/src/use-scroll-into-view/use-scroll-into-view.ts
+++ b/src/mantine-hooks/src/use-scroll-into-view/use-scroll-into-view.ts
@@ -1,0 +1,84 @@
+/* eslint-disable no-param-reassign */
+import { useForceUpdate } from '@mantine/hooks';
+import { useCallback, useRef, useEffect } from 'react';
+
+import { easeInOutQuad } from './utils/ease-in-out-quad';
+import { getRelativePosition } from './utils/get-relative-position';
+import { getScrollStart } from './utils/get-scroll-start';
+import { setScrollParam } from './utils/set-scroll-param';
+
+type ScrollIntoViewParams = {
+  /** target node to be scrolled yo */
+  target: HTMLElement;
+
+  /** scrollable parent node default to document */
+  parent?: HTMLElement;
+
+  /** callback fired after scroll */
+  onScrollFinish?: () => void;
+
+  /** duration of scroll in seconds */
+  duration?: number;
+
+  /** axis of scroll */
+  axis?: 'x' | 'y'
+};
+
+export function useScrollIntoView({
+  target,
+  parent,
+  duration = 1.25,
+  axis = 'y',
+  onScrollFinish,
+}: ScrollIntoViewParams) {
+  const forceRerender = useForceUpdate();
+  const frameID = useRef(0);
+  const startTime = useRef(0);
+
+  const start = getScrollStart({ parent, axis }) ?? 0;
+  const change = getRelativePosition({ parent, target, axis }) - start;
+
+  const scrollIntoView = useCallback(
+    function animateScroll() {
+      if (startTime.current === 0) {
+        startTime.current = performance.now();
+      }
+      const now = performance.now();
+      const elapsed = (now - startTime.current) / 1000;
+
+      // easing timing progress
+      const t = elapsed / duration;
+
+      const distance = start + change * easeInOutQuad(t);
+
+      setScrollParam({ parent, axis, distance });
+
+      if (t < 1) {
+        frameID.current = requestAnimationFrame(animateScroll);
+      } else {
+        typeof onScrollFinish === 'function' && onScrollFinish();
+        startTime.current = 0;
+        cancelAnimationFrame(frameID.current);
+      }
+    },
+    [parent, target]
+  );
+
+  const cancel = (): void => {
+    cancelAnimationFrame(frameID.current);
+  };
+
+  useEffect(() => {
+    // since that hook doesn't cause any rerenders we need to force
+    // it once to get proper refs for target and parent
+    forceRerender();
+
+    // cleanup RAF
+    return cancel;
+  }, []);
+
+  return {
+    scrollIntoView,
+    cancel,
+  };
+}

--- a/src/mantine-hooks/src/use-scroll-into-view/utils/ease-in-out-quad.ts
+++ b/src/mantine-hooks/src/use-scroll-into-view/utils/ease-in-out-quad.ts
@@ -1,0 +1,1 @@
+export const easeInOutQuad = (t): number => (t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t);

--- a/src/mantine-hooks/src/use-scroll-into-view/utils/get-relative-position.ts
+++ b/src/mantine-hooks/src/use-scroll-into-view/utils/get-relative-position.ts
@@ -1,0 +1,19 @@
+import { getScrollStart } from './get-scroll-start';
+
+export const getRelativePosition = ({ axis, target, parent }) => {
+  if (!target || (!parent && typeof document === 'undefined')) {
+    return 0;
+  }
+  const parentElement = parent || document.body;
+  const parentPosition = parentElement.getBoundingClientRect();
+  const targetPosition = target.getBoundingClientRect();
+
+  const getDiff = (property: 'top' | 'left'): number =>
+    targetPosition[property] - parentPosition[property];
+
+  if (axis === 'y') {
+    return getDiff('top') + getScrollStart({ axis, parent });
+  }
+
+  return getDiff('left');
+};

--- a/src/mantine-hooks/src/use-scroll-into-view/utils/get-scroll-start.ts
+++ b/src/mantine-hooks/src/use-scroll-into-view/utils/get-scroll-start.ts
@@ -1,0 +1,16 @@
+export const getScrollStart = ({ axis, parent }) => {
+  if (!parent && typeof document === 'undefined') {
+    return 0;
+  }
+
+  const method = axis === 'y' ? 'scrollTop' : 'scrollLeft';
+
+  if (parent) {
+    return parent[method];
+  }
+
+  const { body, documentElement } = document;
+
+  // while one of it has a value the second is equal 0
+  return body[method] + documentElement[method];
+};

--- a/src/mantine-hooks/src/use-scroll-into-view/utils/set-scroll-param.ts
+++ b/src/mantine-hooks/src/use-scroll-into-view/utils/set-scroll-param.ts
@@ -1,0 +1,18 @@
+export const setScrollParam = ({ axis, parent, distance }) => {
+  if (!parent && typeof document === 'undefined') {
+    return;
+  }
+
+  const method = axis === 'y' ? 'scrollTop' : 'scrollLeft';
+
+  if (parent) {
+    // eslint-disable-next-line no-param-reassign
+    parent[method] = distance;
+  } else {
+    const { body, documentElement } = document;
+
+    // https://www.w3schools.com/jsref/prop_element_scrolltop.asp
+    body[method] = distance;
+    documentElement[method] = distance;
+  }
+};


### PR DESCRIPTION
That's a proposal version of the `useScrollIntoView` hook, as we've talked about on pm:

It works almost the same as `window.scrollIntoView` but it gives us more control over it. An additional problem with the native approach is that the safari doesn't support `scroll-behavior: smooth` which kinda 'teleports' content. 

features:
- allow configuring `duration` of scroll
- allow configuring `easing function` 
- scrolling on `x` and `y` axis
- `onScrollFinish` callback after scroll animation is finished
- scrolling inside any scrollable HTML node
- works at 60fps by using `requestAnimationFrame` under the mask

hook constructor params:
```
{
  target: HTMLElement;
  parent?: HTMLElement;
  onScrollFinish?: () => void;
  duration?: number;
  axis?: 'x' | 'y'
  easing?: (t: number) => number
};
```

hooks returns: 
```
{
    scrollIntoView: () => void;
    cancel: () => void;
}
```

possible is changing the approach to make the `scrollIntoView` method handle taking `parent` and `target` refs instead of doing this in the constructor.