### PR TITLE
[@mantine/core] Accordion: Added ability to customize icon

### DIFF
--- a/src/mantine-core/src/components/Accordion/Accordion.story.tsx
+++ b/src/mantine-core/src/components/Accordion/Accordion.story.tsx
@@ -1,23 +1,45 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Accordion, AccordionItem } from './Accordion';
+import { CaretDownIcon } from '@modulz/radix-icons';
 
-storiesOf('@mantine/core/Accordion', module).add('General usage', () => (
-  <div style={{ padding: 40 }}>
-    <Accordion>
-      <AccordionItem label="Customization">
-        Colors, fonts, shadows and many other parts are customizable to fit your design needs
-      </AccordionItem>
+const CustomDownIcon = () => <CaretDownIcon color="red" />;
 
-      <AccordionItem label="Flexibility">
-        Configure components appearance and behavior with vast amount of settings or overwrite any
-        part of component styles
-      </AccordionItem>
+storiesOf('@mantine/core/Accordion', module)
+  .add('General usage', () => (
+    <div style={{ padding: 40 }}>
+      <Accordion>
+        <AccordionItem label="Customization">
+          Colors, fonts, shadows and many other parts are customizable to fit your design needs
+        </AccordionItem>
 
-      <AccordionItem label="No annoying focus ring">
-        With new :focus-visible pseudo-class focus ring appears only when user navigates with
-        keyboard
-      </AccordionItem>
-    </Accordion>
-  </div>
-));
+        <AccordionItem label="Flexibility">
+          Configure components appearance and behavior with vast amount of settings or overwrite any
+          part of component styles
+        </AccordionItem>
+
+        <AccordionItem label="No annoying focus ring">
+          With new :focus-visible pseudo-class focus ring appears only when user navigates with
+          keyboard
+        </AccordionItem>
+      </Accordion>
+    </div>
+  )).add('Custom Icon', () => (
+    <div style={{ padding: 40 }}>
+      <Accordion>
+        <AccordionItem label="Customization" icon={<CustomDownIcon />}>
+          Colors, fonts, shadows and many other parts are customizable to fit your design needs
+        </AccordionItem>
+
+        <AccordionItem label="Flexibility" icon={<CustomDownIcon />}>
+          Configure components appearance and behavior with vast amount of settings or overwrite any
+          part of component styles
+        </AccordionItem>
+
+        <AccordionItem label="No annoying focus ring" icon={<CustomDownIcon />}>
+          With new :focus-visible pseudo-class focus ring appears only when user navigates with
+          keyboard
+        </AccordionItem>
+      </Accordion>
+    </div>
+  ));

--- a/src/mantine-core/src/components/Accordion/Accordion.story.tsx
+++ b/src/mantine-core/src/components/Accordion/Accordion.story.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { Accordion, AccordionItem } from './Accordion';
 import { CaretDownIcon } from '@modulz/radix-icons';
+import { Accordion, AccordionItem } from './Accordion';
 
 const CustomDownIcon = () => <CaretDownIcon color="red" />;
 

--- a/src/mantine-core/src/components/Accordion/AccordionControl/AccordionControl.tsx
+++ b/src/mantine-core/src/components/Accordion/AccordionControl/AccordionControl.tsx
@@ -11,7 +11,7 @@ export type AccordionControlStylesNames = keyof ReturnType<typeof useStyles>;
 
 interface AccordionControlProps
   extends DefaultProps<AccordionControlStylesNames>,
-    AccordionItemProps {
+  AccordionItemProps {
   opened: boolean;
   onToggle(): void;
   transitionDuration: number;
@@ -30,6 +30,7 @@ export function AccordionControl({
   transitionDuration,
   style,
   id,
+  icon,
   ...others
 }: AccordionControlProps) {
   const forceUpdate = useForceUpdate();
@@ -64,7 +65,7 @@ export function AccordionControl({
           {label}
         </div>
         <div className={classes.icon} style={_styles.icon}>
-          <ChevronIcon />
+          {icon ? icon: <ChevronIcon />}
         </div>
       </UnstyledButton>
 

--- a/src/mantine-core/src/components/Accordion/AccordionItem/AccordionItem.tsx
+++ b/src/mantine-core/src/components/Accordion/AccordionItem/AccordionItem.tsx
@@ -4,7 +4,7 @@ export interface AccordionItemProps extends React.ComponentProps<'div'> {
   /** AccordionItem control label */
   label?: React.ReactNode;
 
-  /** Icon on the left side of label */
+  /** AccordionItem indicator label */
   icon?: React.ReactNode;
 
   /** AccordionItem content */

--- a/src/mantine-core/src/components/Accordion/AccordionItem/AccordionItem.tsx
+++ b/src/mantine-core/src/components/Accordion/AccordionItem/AccordionItem.tsx
@@ -4,7 +4,7 @@ export interface AccordionItemProps extends React.ComponentProps<'div'> {
   /** AccordionItem control label */
   label?: React.ReactNode;
 
-  /** AccordionItem indicator label */
+  /** AccordionItem indicator icon */
   icon?: React.ReactNode;
 
   /** AccordionItem content */


### PR DESCRIPTION
Added ability to customize the down icon. This is necessary because the user might want to use a chevron from the icon library of their choice.

I repurposed the icon prop which was currently not being used for anything.