### PR TITLE
[@mantine/docs] pages: Fix typo in basics page

### DIFF
--- a/docs/src/docs/pages/basics.mdx
+++ b/docs/src/docs/pages/basics.mdx
@@ -62,7 +62,7 @@ export function Demo() {
 }
 ```
 
-Learn more about [MantineProvider](/theming/mantine-provider/) and [extending theme](/theming/extending-theme/).
+Learn more about [MantineProvider](/theming/mantine-provider/) and [extending theme](/theming/extend-theme/).
 
 ## Dark color scheme
 


### PR DESCRIPTION
Fixes #289.