### PR TITLE
[docs]: Fix a typo in the mantine-dates readme file

### DIFF
--- a/src/mantine-dates/README.md
+++ b/src/mantine-dates/README.md
@@ -11,7 +11,7 @@ Calendars, date and time pickers based on Mantine components
 yarn add @mantine/core @mantine/hooks @mantine/dates dayjs
 
 # With npm
-yarn add @mantine/core @mantine/hooks @mantine/dates dayjs
+npm install @mantine/core @mantine/hooks @mantine/dates dayjs
 
 # With install-peerdeps
 npx install-peerdeps @mantine/dates


### PR DESCRIPTION
Fix a typo