### PR TITLE
[docs]: Fix a typo in the Dialog.mdx file

### DIFF
--- a/docs/src/docs/core/Dialog.mdx
+++ b/docs/src/docs/core/Dialog.mdx
@@ -52,7 +52,7 @@ you can customize `shadow`, `padding` and `radius` same way.
 
 ## Change transition
 
-Dialog supports all transition from [Transition](/core/transition/) component.
+Dialog supports all transitions from [Transition](/core/transition/) component.
 To change transition provide following props:
 
 - **transition** – predefined transition name or transition object


### PR DESCRIPTION
Fix a typo