### PR TITLE
[mantine/hooks] use-focus-trap: fix unfocusing current element

### DIFF
--- a/src/mantine-hooks/src/use-focus-trap/use-focus-trap.ts
+++ b/src/mantine-hooks/src/use-focus-trap/use-focus-trap.ts
@@ -11,12 +11,11 @@ import { createAriaHider } from './create-aria-hider';
 
 export function useFocusTrap(active = true): (instance: HTMLElement | null) => void {
   const ref = useRef<HTMLElement | null>();
-  const isTrapped = useRef(false);
   const restoreAria = useRef<Function | null>(null);
 
   const setRef = useCallback(
     (node: HTMLElement | null) => {
-      if (isTrapped.current || !active) {
+      if (!active) {
         return;
       }
 
@@ -46,7 +45,6 @@ export function useFocusTrap(active = true): (instance: HTMLElement | null) => v
 
           if (focusElement) {
             focusElement.focus();
-            isTrapped.current = true;
           } else if (process.env.NODE_ENV === 'development') {
             // eslint-disable-next-line no-console
             console.warn(
@@ -69,7 +67,6 @@ export function useFocusTrap(active = true): (instance: HTMLElement | null) => v
         ref.current = node;
       } else {
         ref.current = null;
-        isTrapped.current = false;
       }
     },
     [active]

--- a/src/mantine-hooks/src/use-merged-ref/use-merged-ref.ts
+++ b/src/mantine-hooks/src/use-merged-ref/use-merged-ref.ts
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { assignRef } from '../utils';
 
 type Ref<T> = React.Dispatch<React.SetStateAction<T>> | React.ForwardedRef<T>;
 
 export function useMergedRef<T = any>(...refs: Ref<T>[]) {
-  return (node: T | null) => {
+  return useCallback((node: T | null) => {
     refs.forEach((ref) => assignRef(ref, node));
-  };
+  }, refs);
 }


### PR DESCRIPTION
A fix for [issue#330](https://github.com/mantinedev/mantine/issues/330)

`setRef` function was re-executing with every re-render which was causing a focus on the element with `data-autofocus` attribute. I've attached an internal state if the focus was already trapped, that covers this issue.