### PR TITLE
fix: Gatsby install instructions

### DIFF
--- a/docs/src/components/GettingStarted/Guides/Guide.tsx
+++ b/docs/src/components/GettingStarted/Guides/Guide.tsx
@@ -127,10 +127,11 @@ function NextGuide({ dependencies }: GuideProps) {
 }
 
 function GatsbyGuide({ dependencies }: GuideProps) {
+  dependencies += "gatsby-plugin-mantine"
   return (
     <Guide
       dependencies={dependencies}
-      initScript="npx create-next-app --ts"
+      initScript="npm init gatsby"
       action="Get stared with Gatsby.js Github template"
       actionLink="https://github.com/mantinedev/mantine-gatsby-template"
       withDone


### PR DESCRIPTION
Init a project with `npm init gatsby`, add `gatsby-plugin-mantine` to the dependencies string.