### PR TITLE
[@mantine/next] Avoid page double render

### DIFF
--- a/src/mantine-next/src/create-get-initial-props.tsx
+++ b/src/mantine-next/src/create-get-initial-props.tsx
@@ -6,14 +6,13 @@ export function createGetInitialProps() {
   const stylesServer = createStylesServer();
 
   return async function getInitialProps(ctx: DocumentContext) {
-    const page = await ctx.renderPage();
     const initialProps = await NextDocument.getInitialProps(ctx);
     return {
       ...initialProps,
       styles: (
         <>
           {initialProps.styles}
-          <ServerStyles html={page.html} server={stylesServer} />
+          <ServerStyles html={initialProps.html} server={stylesServer} />
         </>
       ),
     };


### PR DESCRIPTION
Based on https://github.com/vercel/next.js/blob/v12.0.1/packages/next/server/render.tsx#L522-L532, this avoids the need for double page render. After investigation, the potential unneeded render has been introduced in the official [example](https://github.com/vercel/next.js/pull/20228/files#diff-3976da223aaf15067ecdd0734ca277ebf4629c46d62f89d732ab392752d3572dR6) but does not exist in the earlier proposed [solution](https://gist.github.com/colinhacks/c40519a6a050a99091862319151377ec). There might a reason (layered override?) for it but I am unable to find relevant explanation.