### PR TITLE
[@mantine/hooks] use-logger: Logging only updated data

### DIFF
--- a/src/mantine-hooks/src/use-logger/use-logger.ts
+++ b/src/mantine-hooks/src/use-logger/use-logger.ts
@@ -10,7 +10,7 @@ export function useLogger(componentName: string, props: any[]) {
 
   useDidUpdate(() => {
     console.log(`${componentName} updated`, ...props);
-  });
+  }, props);
 
   return null;
 }


### PR DESCRIPTION
[Repository to reproduce the bug](https://github.com/fishmandev/react-mantine-demo/blob/main/src/App.tsx):
![Screenshot_2021-10-29_16-41-05](https://user-images.githubusercontent.com/29619660/139445482-ac72fa4d-5e8d-4758-8192-2621522c88f5.png)
![Screenshot_2021-10-29_16-27-22](https://user-images.githubusercontent.com/29619660/139445496-1fed99d1-2465-49b3-b158-9abbe367a349.png)

