### PR TITLE
[@mantine/core] MultiSelect - fix dropdown and clearable issues

### DIFF
--- a/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
@@ -313,6 +313,11 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
       );
     }, [searchValue]);
 
+    useDidUpdate(() => {
+      //using greater than equal to take into account creatable type.
+      if (!disabled && _value.length >= data.length) setDropdownOpened(false);
+    }, [_value]);
+
     const handleItemSelect = (item: SelectItem) => {
       setTimeout(() => {
         clearSearchOnChange && handleSearchChange('');
@@ -439,7 +444,13 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
           {...item}
           disabled={disabled}
           className={classes.value}
-          onRemove={() => handleValueRemove(item.value)}
+          onRemove={(e) => {
+            if (dropdownOpened) {
+              e.preventDefault();
+              e.stopPropagation();
+            }
+            handleValueRemove(item.value);
+          }}
           key={item.value}
           size={size}
           styles={styles}
@@ -518,7 +529,7 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
               rightSectionWidth,
               styles,
               size,
-              shouldClear: clearable && _value.length > 0,
+              shouldClear: !disabled && clearable && _value.length > 0,
               clearButtonLabel,
               onClear: handleClear,
               error,


### PR DESCRIPTION
This PR fixes the following -
- prevent from clearing when disabled
- when all items are selected, removing the last item doesn't open the drop down
- removing items shouldn't close the dropdown but just open it.