### PR TITLE
[@mantine/hooks] use-idle: Add initialState option to use-idle hook

### DIFF
--- a/docs/src/demos/hooks/use-idle.tsx
+++ b/docs/src/demos/hooks/use-idle.tsx
@@ -31,7 +31,7 @@ function Demo() {
 }
 
 function EventsDemo() {
-  const idle = useIdle(2000, ['click', 'touchstart']);
+  const idle = useIdle(2000, { events: ['click', 'touchstart'] });
 
   return (
     <Group position="center">

--- a/docs/src/demos/hooks/use-idle.tsx
+++ b/docs/src/demos/hooks/use-idle.tsx
@@ -16,7 +16,16 @@ import { Badge } from '@mantine/core';
 import { useIdle } from '@mantine/hooks';
 
 function Demo() {
-  const idleStatus = useIdle(2000, ['click', 'touchstart']);
+  const idleStatus = useIdle(2000, { events: ['click', 'touchstart'] });
+  return <Badge color={idle ? 'blue' : 'teal'}>Current state: {idle ? 'idle' : 'not idle'}</Badge>;
+};`;
+
+const initialStateCode = `
+import { Badge } from '@mantine/core';
+import { useIdle } from '@mantine/hooks';
+
+function Demo() {
+  const idleStatus = useIdle(2000, { initialState: false });
   return <Badge color={idle ? 'blue' : 'teal'}>Current state: {idle ? 'idle' : 'not idle'}</Badge>;
 };`;
 
@@ -40,6 +49,16 @@ function EventsDemo() {
   );
 }
 
+function InitialStateDemo() {
+  const idle = useIdle(2000, { initialState: false });
+
+  return (
+    <Group position="center">
+      <Badge color={idle ? 'blue' : 'teal'}>Current state: {idle ? 'idle' : 'not idle'}</Badge>
+    </Group>
+  );
+}
+
 export const useIdleHook: MantineDemo = {
   type: 'demo',
   code,
@@ -50,4 +69,10 @@ export const useIdleEvents: MantineDemo = {
   type: 'demo',
   code: eventsCode,
   component: EventsDemo,
+};
+
+export const useIdleInitialState: MantineDemo = {
+  type: 'demo',
+  code: initialStateCode,
+  component: InitialStateDemo,
 };

--- a/docs/src/docs/hooks/use-idle.mdx
+++ b/docs/src/docs/hooks/use-idle.mdx
@@ -22,12 +22,22 @@ Hook detect if user does nothing for given time in ms:
 ## Custom events
 
 By default hook will listen to keypress, mousemove, touchmove, click and scroll events to set idle status.
-To change that provide a list of events as second argument:
+To change that provide a list of events in the options argument:
 
 <Demo data={useIdleEvents} />
+
+## Initial state
+
+By default the hook will return an idle state.
+To change that provide an initial state value in the options argument:
+
+<Demo data={useIdleInitialState} />
 
 ### Definition
 
 ```tsx
-function useIdle(timeout: number, events?: string[]): boolean;
+function useIdle(
+  timeout: number,
+  options?: Partial<{ events: string[]; initialState: boolean }>,
+): boolean;
 ```

--- a/docs/src/docs/hooks/use-idle.mdx
+++ b/docs/src/docs/hooks/use-idle.mdx
@@ -38,6 +38,6 @@ To change that provide an initial state value in the options argument:
 ```tsx
 function useIdle(
   timeout: number,
-  options?: Partial<{ events: string[]; initialState: boolean }>,
+  options?: Partial<{ events: string[]; initialState: boolean }>
 ): boolean;
 ```

--- a/src/mantine-hooks/src/use-idle/use-idle.ts
+++ b/src/mantine-hooks/src/use-idle/use-idle.ts
@@ -2,13 +2,13 @@ import { useState, useEffect, useRef } from 'react';
 
 const DEFAULT_EVENTS = ['keypress', 'mousemove', 'touchmove', 'click', 'scroll'];
 const DEFAULT_OPTIONS = {
-    events: DEFAULT_EVENTS,
-    initialState: true,
+  events: DEFAULT_EVENTS,
+  initialState: true,
 };
 
 export function useIdle(
   timeout: number,
-  options?: Partial<{ events: string[]; initialState: boolean }>,
+  options?: Partial<{ events: string[]; initialState: boolean }>
 ) {
   const { events, initialState } = { ...DEFAULT_OPTIONS, ...options };
   const [idle, setIdle] = useState<boolean>(initialState);

--- a/src/mantine-hooks/src/use-idle/use-idle.ts
+++ b/src/mantine-hooks/src/use-idle/use-idle.ts
@@ -1,9 +1,17 @@
 import { useState, useEffect, useRef } from 'react';
 
 const DEFAULT_EVENTS = ['keypress', 'mousemove', 'touchmove', 'click', 'scroll'];
+const DEFAULT_OPTIONS = {
+    events: DEFAULT_EVENTS,
+    initialState: true,
+};
 
-export function useIdle(timeout: number, events: string[] = DEFAULT_EVENTS) {
-  const [idle, setIdle] = useState<boolean>(true);
+export function useIdle(
+  timeout: number,
+  options?: Partial<{ events: string[]; initialState: boolean }>,
+) {
+  const { events, initialState } = { ...DEFAULT_OPTIONS, ...options };
+  const [idle, setIdle] = useState<boolean>(initialState);
   const timer = useRef<number>();
 
   useEffect(() => {


### PR DESCRIPTION
It would useful to be able to set the initialState of `useIdle` (which currently defaults to true).

Currently the following code logs you out the moment you render the component:
```
  // ...

  const shouldLogout = useIdle(logoutSeconds * 1000);

  useEffect(() => {
    if (shouldLogout) {
      logout();
    }
  }, [logout, shouldLogout]);

  // ...
```

With this PR you will be able to set the initial idle state so that it doesn't start off rendering as idle:
```
  // ...

  const shouldLogout = useIdle(logoutSeconds * 1000, { initialState: false });

  useEffect(() => {
    if (shouldLogout) {
      logout();
    }
  }, [logout, shouldLogout]);

  // ...
```

The cleanest way to implement this interface is to move everything after the timeout into an options prop, but unfortunately that is a breaking change so I am open to other ideas.