### PR TITLE
Feature: Popper without Portal

### DIFF
--- a/docs/src/docs/core/Popper.mdx
+++ b/docs/src/docs/core/Popper.mdx
@@ -121,6 +121,13 @@ After each placement change `onPlacementChange` which takes current placement as
 />
 ```
 
+## Portal
+
+By default, Popper content will be rendered inside a [Portal](/core/portal) component.
+
+You can opt-out of this behavior through the `withinPortal` prop, setting it to `false`. Other Mantine components
+relying on Popper expose this prop too.
+
 ## TypeScript
 
 ```tsx

--- a/docs/src/docs/core/Popper.mdx
+++ b/docs/src/docs/core/Popper.mdx
@@ -123,7 +123,7 @@ After each placement change `onPlacementChange` which takes current placement as
 
 ## Portal
 
-By default, Popper content will be rendered inside a [Portal](/core/portal) component.
+By default, Popper content will be rendered inside a [Portal](/core/portal/) component.
 
 You can opt-out of this behavior through the `withinPortal` prop, setting it to `false`. Other Mantine components
 relying on Popper expose this prop too.

--- a/src/mantine-core/src/components/Autocomplete/Autocomplete.story.tsx
+++ b/src/mantine-core/src/components/Autocomplete/Autocomplete.story.tsx
@@ -59,4 +59,14 @@ storiesOf('@mantine/core/Autocomplete', module)
         data={['React', 'Angular', 'Svelte', 'Vue']}
       />
     </div>
+  ))
+  .add('Without Portal', () => (
+    <div style={{ padding: 40, maxWidth: 300 }}>
+      <Autocomplete
+        label="Choose your favorite library/framework"
+        placeholder="Choose value"
+        data={['React', 'Angular', 'Svelte', 'Vue']}
+        withinPortal={false}
+      />
+    </div>
   ));

--- a/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
@@ -86,6 +86,9 @@ export interface AutocompleteProps
 
   /** Called when dropdown is closed */
   onDropdownClose?(): void;
+
+  /** Whether to render the target element in a Portal */
+  withinPortal?: boolean;
 }
 
 export function defaultFilter(value: string, item: AutocompleteItem) {
@@ -127,6 +130,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
       nothingFound,
       onDropdownClose,
       onDropdownOpen,
+      withinPortal,
       ...others
     }: AutocompleteProps,
     ref
@@ -297,6 +301,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
             direction={direction}
             onDirectionChange={setDirection}
             referenceElement={inputRef.current}
+            withinPortal={withinPortal}
           >
             <SelectItems
               data={filteredData}

--- a/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
@@ -87,7 +87,7 @@ export interface AutocompleteProps
   /** Called when dropdown is closed */
   onDropdownClose?(): void;
 
-  /** Whether to render the target element in a Portal */
+  /** Whether to render the dropdown in a Portal */
   withinPortal?: boolean;
 }
 

--- a/src/mantine-core/src/components/ColorInput/ColorInput.story.tsx
+++ b/src/mantine-core/src/components/ColorInput/ColorInput.story.tsx
@@ -74,6 +74,14 @@ function BaseStory() {
         dropdownZIndex={1000}
       />
       <ControlledInput />
+      <ColorInput
+        label="Without Portal"
+        placeholder="Pick color"
+        format="hsla"
+        withinPortal={false}
+        style={{ marginTop: 15 }}
+        dropdownZIndex={10}
+      />
     </div>
   );
 }

--- a/src/mantine-core/src/components/ColorInput/ColorInput.tsx
+++ b/src/mantine-core/src/components/ColorInput/ColorInput.tsx
@@ -52,7 +52,7 @@ export interface ColorInputProps
   /** Dropdown transition timing function, defaults to theme.transitionTimingFunction */
   transitionTimingFunction?: string;
 
-  /** Whether to render the target element in a Portal */
+  /** Whether to render the dropdown in a Portal */
   withinPortal?: boolean;
 }
 

--- a/src/mantine-core/src/components/ColorInput/ColorInput.tsx
+++ b/src/mantine-core/src/components/ColorInput/ColorInput.tsx
@@ -51,6 +51,9 @@ export interface ColorInputProps
 
   /** Dropdown transition timing function, defaults to theme.transitionTimingFunction */
   transitionTimingFunction?: string;
+
+  /** Whether to render the target element in a Portal */
+  withinPortal?: boolean;
 }
 
 const SWATCH_SIZES = {
@@ -97,6 +100,7 @@ export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
       dropdownZIndex = 1,
       transitionDuration = 0,
       transitionTimingFunction,
+      withinPortal,
       className,
       style,
       swatches,
@@ -205,6 +209,7 @@ export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
           zIndex={dropdownZIndex}
           arrowClassName={classes.arrow}
           arrowStyle={{ left: theme.fn.size({ size, sizes: ARROW_OFFSET }) }}
+          withinPortal={withinPortal}
         >
           <div style={{ pointerEvents: 'all' }}>
             <Paper<'div'>

--- a/src/mantine-core/src/components/Menu/Menu.story.tsx
+++ b/src/mantine-core/src/components/Menu/Menu.story.tsx
@@ -40,4 +40,11 @@ storiesOf('@mantine/core/Menu', module)
         <Menu>{menuItems}</Menu>
       </div>
     </DarkStory>
+  ))
+  .add('Without Portal', () => (
+    <div style={{ padding: 60 }}>
+      <Menu position="right" withArrow closeOnItemClick withinPortal={false}>
+        {menuItems}
+      </Menu>
+    </div>
   ));

--- a/src/mantine-core/src/components/Menu/Menu.tsx
+++ b/src/mantine-core/src/components/Menu/Menu.tsx
@@ -81,7 +81,7 @@ export interface MenuProps
   /** Trap focus inside menu */
   trapFocus?: boolean;
 
-  /** Whether to render the target element in a Portal */
+  /** Whether to render the dropdown in a Portal */
   withinPortal?: boolean;
 }
 

--- a/src/mantine-core/src/components/Menu/Menu.tsx
+++ b/src/mantine-core/src/components/Menu/Menu.tsx
@@ -80,6 +80,9 @@ export interface MenuProps
 
   /** Trap focus inside menu */
   trapFocus?: boolean;
+
+  /** Whether to render the target element in a Portal */
+  withinPortal?: boolean;
 }
 
 const defaultControl = (
@@ -121,6 +124,7 @@ export const Menu: MenuComponent = forwardRef<HTMLButtonElement, MenuProps>(
       radius = 'sm',
       delay = 0,
       zIndex = 1,
+      withinPortal = true,
       classNames,
       styles,
       closeOnScroll = true,
@@ -230,6 +234,7 @@ export const Menu: MenuComponent = forwardRef<HTMLButtonElement, MenuProps>(
           arrowSize={3}
           zIndex={zIndex}
           arrowClassName={classes.arrow}
+          withinPortal={withinPortal}
         >
           <MenuBody
             {...menuBodyProps}

--- a/src/mantine-core/src/components/MultiSelect/MultiSelect.story.tsx
+++ b/src/mantine-core/src/components/MultiSelect/MultiSelect.story.tsx
@@ -298,4 +298,30 @@ storiesOf('@mantine/core/MultiSelect', module)
         maxSelectedValues={5}
       />
     </Group>
+  ))
+  .add('Without Portal', () => (
+    <>
+      <Group style={{ padding: 40, paddingBottom: 0 }} grow align="flex-start">
+        <MultiSelect
+          label="Multi select"
+          data={data}
+          defaultValue={['react', 'ng']}
+          placeholder="Select items"
+          nothingFound="Nothing found"
+          withinPortal={false}
+        />
+        <TextInput label="Text input" placeholder="Select items" />
+      </Group>
+      <Group style={{ padding: 40, paddingTop: 0 }} grow align="flex-start">
+        <TextInput label="Text input" placeholder="Select items" />
+        <MultiSelect
+          label="Multi select with separator and disabled items"
+          data={[...data, { label: 'Lit', value: 'lit', disabled: true }]}
+          defaultValue={['react', 'ng']}
+          placeholder="Select items"
+          nothingFound="Nothing found"
+          withinPortal={false}
+        />
+      </Group>
+    </>
   ));

--- a/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
@@ -136,7 +136,7 @@ export interface MultiSelectProps extends DefaultProps<MultiSelectStylesNames>, 
   /** Limit amount of items selected */
   maxSelectedValues?: number;
 
-  /** Whether to render the target element in a Portal */
+  /** Whether to render the dropdown in a Portal */
   withinPortal?: boolean;
 }
 

--- a/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
@@ -135,6 +135,9 @@ export interface MultiSelectProps extends DefaultProps<MultiSelectStylesNames>, 
 
   /** Limit amount of items selected */
   maxSelectedValues?: number;
+
+  /** Whether to render the target element in a Portal */
+  withinPortal?: boolean;
 }
 
 export function defaultFilter(value: string, selected: boolean, item: SelectItem) {
@@ -201,6 +204,7 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
       onDropdownClose,
       onDropdownOpen,
       maxSelectedValues,
+      withinPortal,
       ...others
     }: MultiSelectProps,
     ref
@@ -579,6 +583,7 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
             referenceElement={wrapperRef.current}
             direction={direction}
             onDirectionChange={setDirection}
+            withinPortal={withinPortal}
           >
             <SelectItems
               data={filteredData}

--- a/src/mantine-core/src/components/Popover/Popover.story.tsx
+++ b/src/mantine-core/src/components/Popover/Popover.story.tsx
@@ -88,4 +88,17 @@ storiesOf('@mantine/core/Popover', module)
         />
       </div>
     </MantineProvider>
+  ))
+  .add('Without Portal', () => (
+    <div style={{ padding: 400 }}>
+      <Wrapper
+        withArrow
+        position="top"
+        placement="center"
+        title="Hello!"
+        transition="slide-up"
+        withCloseButton
+        withinPortal={false}
+      />
+    </div>
   ));

--- a/src/mantine-core/src/components/Popover/Popover.tsx
+++ b/src/mantine-core/src/components/Popover/Popover.tsx
@@ -68,7 +68,7 @@ export interface PopoverProps
   /** useEffect dependencies to force update tooltip position */
   positionDependencies?: any[];
 
-  /** Whether to render the target element in a Portal */
+  /** Whether to render the popover in a Portal */
   withinPortal?: boolean;
 }
 

--- a/src/mantine-core/src/components/Popover/Popover.tsx
+++ b/src/mantine-core/src/components/Popover/Popover.tsx
@@ -67,6 +67,9 @@ export interface PopoverProps
 
   /** useEffect dependencies to force update tooltip position */
   positionDependencies?: any[];
+
+  /** Whether to render the target element in a Portal */
+  withinPortal?: boolean;
 }
 
 export function Popover({
@@ -95,6 +98,7 @@ export function Popover({
   shadow = 'sm',
   closeButtonLabel,
   positionDependencies = [],
+  withinPortal = true,
   id,
   classNames,
   styles,
@@ -142,6 +146,7 @@ export function Popover({
         zIndex={zIndex}
         arrowClassName={classes.arrow}
         forceUpdateDependencies={[radius, shadow, spacing, ...positionDependencies]}
+        withinPortal={withinPortal}
       >
         <PopoverBody
           shadow={shadow}

--- a/src/mantine-core/src/components/Popper/Popper.tsx
+++ b/src/mantine-core/src/components/Popper/Popper.tsx
@@ -2,9 +2,9 @@ import React, { useMemo, useState, useRef } from 'react';
 import { usePopper, StrictModifier } from 'react-popper';
 import type { Placement } from '@popperjs/core';
 import { useDidUpdate } from '@mantine/hooks';
-import { Portal } from '../Portal';
 import { Transition, MantineTransition } from '../Transition';
 import { parsePopperPosition } from './parse-popper-position/parse-popper-position';
+import { PopperContainer } from './PopperContainer/PopperContainer';
 import useStyles from './Popper.styles';
 
 export interface SharedPopperProps {
@@ -69,6 +69,9 @@ export interface PopperProps<T extends HTMLElement> extends SharedPopperProps {
 
   /** Called when popper changes its placement */
   onPlacementChange?(placement: Placement): void;
+
+  /** Whether to render the target element in a Portal */
+  withinPortal?: boolean;
 }
 
 export function Popper<T extends HTMLElement = HTMLDivElement>({
@@ -92,6 +95,7 @@ export function Popper<T extends HTMLElement = HTMLDivElement>({
   allowPlacementChange = true,
   placementFallbacks = ['bottom'],
   onPlacementChange,
+  withinPortal = true,
 }: PopperProps<T>) {
   const padding = withArrow ? gutter + arrowSize : gutter;
   const { classes, cx } = useStyles({ arrowSize }, { name: 'Popper' });
@@ -157,7 +161,7 @@ export function Popper<T extends HTMLElement = HTMLDivElement>({
     >
       {(transitionStyles) => (
         <div>
-          <Portal zIndex={zIndex}>
+          <PopperContainer withinPortal={withinPortal} zIndex={zIndex}>
             <div
               ref={setPopperElement}
               style={{ ...styles.popper, pointerEvents: 'none' }}
@@ -178,7 +182,7 @@ export function Popper<T extends HTMLElement = HTMLDivElement>({
                 )}
               </div>
             </div>
-          </Portal>
+          </PopperContainer>
         </div>
       )}
     </Transition>

--- a/src/mantine-core/src/components/Popper/PopperContainer/PopperContainer.test.tsx
+++ b/src/mantine-core/src/components/Popper/PopperContainer/PopperContainer.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { itRendersChildren, itSupportsClassName } from '@mantine/tests';
+import { PopperContainer } from './PopperContainer';
+
+describe('@mantine/core/PopperContainer', () => {
+  // Clean up dom as jest does not do this automatically
+  afterEach(() => {
+    document.getElementsByTagName('body')[0].innerHTML = '';
+  });
+
+  itRendersChildren(PopperContainer, {});
+  itSupportsClassName(PopperContainer, {});
+
+  it('has correct displayName', () => {
+    expect(PopperContainer.displayName).toEqual('@mantine/core/PopperContainer');
+  });
+
+  it('adds z-index styles from prop', () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+
+    mount(
+      <PopperContainer className="test-popper-container" zIndex={1543}>
+        test-popper-container
+      </PopperContainer>,
+      { attachTo: target },
+    );
+
+    const container = document.querySelector('.test-popper-container');
+    expect(window.getComputedStyle(container).zIndex).toBe('1543');
+  });
+
+  it('supports rendering inside its virtual DOM parent', () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+
+    mount(
+      <div className="virtual-dom-parent">
+        <PopperContainer className="test-in-parent">test-in-parent</PopperContainer>
+      </div>,
+      { attachTo: target },
+    );
+
+    const container = document.querySelector('.test-in-parent');
+    const parent = document.querySelector('.virtual-dom-parent');
+
+    expect(container.parentNode).toEqual(parent);
+    expect(parent.childNodes).toHaveLength(1);
+  });
+
+  it('supports rendering inside a portal', () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+
+    mount(
+      <div className="virtual-dom-parent">
+        <PopperContainer className="test-in-portal" withinPortal>test-in-portal</PopperContainer>
+      </div>,
+      { attachTo: target },
+    );
+
+    const container = document.querySelector('.test-in-portal');
+    const parent = document.querySelector('.virtual-dom-parent');
+
+    expect(container.parentNode).not.toEqual(parent);
+    expect(parent.childNodes).toHaveLength(0);
+  });
+});

--- a/src/mantine-core/src/components/Popper/PopperContainer/PopperContainer.test.tsx
+++ b/src/mantine-core/src/components/Popper/PopperContainer/PopperContainer.test.tsx
@@ -24,7 +24,7 @@ describe('@mantine/core/PopperContainer', () => {
       <PopperContainer className="test-popper-container" zIndex={1543}>
         test-popper-container
       </PopperContainer>,
-      { attachTo: target },
+      { attachTo: target }
     );
 
     const container = document.querySelector('.test-popper-container');
@@ -39,7 +39,7 @@ describe('@mantine/core/PopperContainer', () => {
       <div className="virtual-dom-parent">
         <PopperContainer className="test-in-parent">test-in-parent</PopperContainer>
       </div>,
-      { attachTo: target },
+      { attachTo: target }
     );
 
     const container = document.querySelector('.test-in-parent');
@@ -55,9 +55,11 @@ describe('@mantine/core/PopperContainer', () => {
 
     mount(
       <div className="virtual-dom-parent">
-        <PopperContainer className="test-in-portal" withinPortal>test-in-portal</PopperContainer>
+        <PopperContainer className="test-in-portal" withinPortal>
+          test-in-portal
+        </PopperContainer>
       </div>,
-      { attachTo: target },
+      { attachTo: target }
     );
 
     const container = document.querySelector('.test-in-portal');

--- a/src/mantine-core/src/components/Popper/PopperContainer/PopperContainer.tsx
+++ b/src/mantine-core/src/components/Popper/PopperContainer/PopperContainer.tsx
@@ -19,7 +19,7 @@ export function PopperContainer({
   children,
   zIndex = 1,
   className,
-  withinPortal,
+  withinPortal = false,
 }: PopperContainerProps) {
   if (withinPortal) {
     return (

--- a/src/mantine-core/src/components/Popper/PopperContainer/PopperContainer.tsx
+++ b/src/mantine-core/src/components/Popper/PopperContainer/PopperContainer.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Portal } from '../../Portal';
+
+export interface PopperContainerProps {
+  /** PopperContainer children, for example, modal or popover */
+  children: React.ReactNode;
+
+  /** Root element z-index property */
+  zIndex?: number;
+
+  /** Root element className */
+  className?: string;
+
+  /** Whether to render the target element in a Portal */
+  withinPortal?: boolean;
+}
+
+export function PopperContainer({
+  children,
+  zIndex = 1,
+  className,
+  withinPortal,
+}: PopperContainerProps) {
+  if (withinPortal) {
+    return (
+      <Portal className={className} zIndex={zIndex}>
+        {children}
+      </Portal>
+    );
+  }
+
+  return (
+    <div className={className} style={{ position: 'relative', zIndex }}>
+      {children}
+    </div>
+  );
+}
+
+PopperContainer.displayName = '@mantine/core/PopperContainer';

--- a/src/mantine-core/src/components/Select/Select.story.tsx
+++ b/src/mantine-core/src/components/Select/Select.story.tsx
@@ -134,6 +134,13 @@ storiesOf('@mantine/core/Select', module)
         data={largeData}
         style={{ marginTop: 20 }}
       />
+      <Select
+        label="Without Portal"
+        placeholder="Choose value"
+        data={data}
+        withinPortal={false}
+        style={{ marginTop: 20 }}
+      />
     </div>
   ))
   .add('With custom scrollbars', () => (

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -98,6 +98,9 @@ export interface SelectProps extends DefaultProps<BaseSelectStylesNames>, BaseSe
 
   /** Called when dropdown is closed */
   onDropdownClose?(): void;
+
+  /** Whether to render the target element in a Portal */
+  withinPortal?: boolean;
 }
 
 export function defaultFilter(value: string, item: SelectItem) {
@@ -154,6 +157,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       dropdownComponent,
       onDropdownClose,
       onDropdownOpen,
+      withinPortal,
       ...others
     }: SelectProps,
     ref
@@ -483,6 +487,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
             dropdownComponent={dropdownComponent}
             direction={direction}
             onDirectionChange={setDirection}
+            withinPortal={withinPortal}
           >
             <SelectItems
               data={filteredData}

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -99,7 +99,7 @@ export interface SelectProps extends DefaultProps<BaseSelectStylesNames>, BaseSe
   /** Called when dropdown is closed */
   onDropdownClose?(): void;
 
-  /** Whether to render the target element in a Portal */
+  /** Whether to render the dropdown in a Portal */
   withinPortal?: boolean;
 }
 

--- a/src/mantine-core/src/components/Select/SelectDropdown/SelectDropdown.tsx
+++ b/src/mantine-core/src/components/Select/SelectDropdown/SelectDropdown.tsx
@@ -15,6 +15,7 @@ interface SelectDropdownProps extends DefaultProps<SelectDropdownStylesNames> {
   uuid: string;
   shadow: MantineShadow;
   maxDropdownHeight?: number | string;
+  withinPortal?: boolean;
   children: React.ReactNode;
   __staticSelector: string;
   dropdownComponent?: React.FC<any>;
@@ -33,6 +34,7 @@ export const SelectDropdown = forwardRef<HTMLDivElement, SelectDropdownProps>(
       uuid,
       shadow,
       maxDropdownHeight,
+      withinPortal = true,
       children,
       classNames,
       styles,
@@ -54,6 +56,7 @@ export const SelectDropdown = forwardRef<HTMLDivElement, SelectDropdownProps>(
         transitionDuration={transitionDuration}
         transitionTimingFunction={transitionTimingFunction}
         position="bottom"
+        withinPortal={withinPortal}
         placementFallbacks={['top']}
         onPlacementChange={(placement: string) => {
           const nextDirection = placement === 'top' ? 'column-reverse' : 'column';

--- a/src/mantine-core/src/components/Tooltip/Tooltip.story.tsx
+++ b/src/mantine-core/src/components/Tooltip/Tooltip.story.tsx
@@ -47,4 +47,11 @@ storiesOf('@mantine/core/Tooltip', module)
         <Button>Button</Button>
       </Tooltip>
     </div>
+  ))
+  .add('Without Portal', () => (
+    <div style={{ padding: 100 }}>
+      <Tooltip label="tooltip" withinPortal={false}>
+        <Button>Button</Button>
+      </Tooltip>
+    </div>
   ));

--- a/src/mantine-core/src/components/Tooltip/Tooltip.tsx
+++ b/src/mantine-core/src/components/Tooltip/Tooltip.tsx
@@ -47,6 +47,9 @@ export interface TooltipProps
 
   /** useEffect dependencies to force update tooltip position */
   positionDependencies?: any[];
+
+  /** Whether to render the target element in a Portal */
+  withinPortal?: boolean;
 }
 
 export function Tooltip({
@@ -70,6 +73,7 @@ export function Tooltip({
   wrapLines = false,
   allowPointerEvents = false,
   positionDependencies = [],
+  withinPortal = true,
   tooltipRef,
   tooltipId,
   classNames,
@@ -113,6 +117,7 @@ export function Tooltip({
         zIndex={zIndex}
         arrowClassName={classes.arrow}
         forceUpdateDependencies={[color, ...positionDependencies]}
+        withinPortal={withinPortal}
       >
         <div
           className={classes.body}

--- a/src/mantine-dates/src/components/DatePicker/DatePicker.story.tsx
+++ b/src/mantine-dates/src/components/DatePicker/DatePicker.story.tsx
@@ -152,4 +152,9 @@ storiesOf('@mantine/dates/DatePicker', module)
     <MantineProvider theme={{ dateFormat: 'MM YYYY DD' }}>
       <DatePicker label="One month" />
     </MantineProvider>
+  ))
+  .add('Without Portal', () => (
+    <div style={{ padding: 40, maxWidth: 300 }}>
+      <DatePicker placeholder="Pick date" label="Date picker" withinPortal={false} />
+    </div>
   ));

--- a/src/mantine-dates/src/components/DatePicker/DatePicker.tsx
+++ b/src/mantine-dates/src/components/DatePicker/DatePicker.tsx
@@ -75,6 +75,7 @@ export const DatePicker = forwardRef<HTMLButtonElement, DatePickerProps>(
       clearButtonLabel,
       fixOnBlur = true,
       allowFreeInput,
+      withinPortal = true,
       dateParser,
       firstDayOfWeek = 'monday',
       onFocus,
@@ -188,6 +189,7 @@ export const DatePicker = forwardRef<HTMLButtonElement, DatePickerProps>(
         clearButtonLabel={clearButtonLabel}
         onClear={handleClear}
         disabled={disabled}
+        withinPortal={withinPortal}
         {...others}
       >
         <Calendar

--- a/src/mantine-dates/src/components/DatePickerBase/DatePickerBase.tsx
+++ b/src/mantine-dates/src/components/DatePickerBase/DatePickerBase.tsx
@@ -85,6 +85,9 @@ export interface DatePickerBaseSharedProps
 
   /** call onChange with last valid value onBlur */
   fixOnBlur?: boolean;
+
+  /** Whether to render the dropdown in a Portal */
+  withinPortal?: boolean;
 }
 
 export interface DatePickerBaseProps extends DatePickerBaseSharedProps {
@@ -147,6 +150,7 @@ export const DatePickerBase = forwardRef<HTMLInputElement, DatePickerBaseProps>(
       onClear,
       positionDependencies = [],
       zIndex = 3,
+      withinPortal = true,
       onBlur,
       onFocus,
       onChange,
@@ -282,6 +286,7 @@ export const DatePickerBase = forwardRef<HTMLInputElement, DatePickerBaseProps>(
               position="bottom"
               placement="start"
               gutter={10}
+              withinPortal={withinPortal}
               withArrow
               arrowSize={3}
               zIndex={zIndex}

--- a/src/mantine-dates/src/components/DateRangePicker/DateRangePicker.story.tsx
+++ b/src/mantine-dates/src/components/DateRangePicker/DateRangePicker.story.tsx
@@ -66,4 +66,22 @@ storiesOf('@mantine/dates/DateRangePicker', module)
     <MantineProvider theme={{ dateFormat: 'MM YYYY DD' }}>
       <DateRangePicker label="First" />
     </MantineProvider>
+  ))
+  .add('Without Portal', () => (
+    <div style={{ padding: 40 }}>
+      <DateRangePicker
+        label="Pick dates"
+        placeholder="Dates range"
+        defaultValue={[new Date(), new Date()]}
+        withinPortal={false}
+      />
+      <DateRangePicker
+        label="First day of the week - sunday"
+        placeholder="Dates range"
+        defaultValue={[new Date(), new Date()]}
+        firstDayOfWeek="sunday"
+        style={{ paddingTop: '10px' }}
+        withinPortal={false}
+      />
+    </div>
   ));

--- a/src/mantine-dates/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/src/mantine-dates/src/components/DateRangePicker/DateRangePicker.tsx
@@ -84,6 +84,7 @@ export const DateRangePicker = forwardRef<HTMLButtonElement, DateRangePickerProp
       firstDayOfWeek = 'monday',
       allowSingleDateInRange = false,
       amountOfMonths = 1,
+      withinPortal = true,
       ...others
     }: DateRangePickerProps,
     ref
@@ -140,6 +141,7 @@ export const DateRangePicker = forwardRef<HTMLButtonElement, DateRangePickerProp
           clearable={clearable && valueValid}
           clearButtonLabel={clearButtonLabel}
           onClear={handleClear}
+          withinPortal={withinPortal}
           {...others}
         >
           <RangeCalendar


### PR DESCRIPTION
This MR follows up the conversation #435, and enables Popper and all Popper-related components to be used without Portals, through an opt-out prop `withinPortal` which defaults to `true`.

I've added a `Without Portal` story to all related components Storybook, and added a section about Portal in the `Popper` documentation.

Tell me if anything is missing or if you see anything wrong in my implementation 👍 