### PR TITLE
[@mantine/hooks] use-page-leave

### DIFF
--- a/docs/src/demos/hooks/use-page-leave.tsx
+++ b/docs/src/demos/hooks/use-page-leave.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { usePageLeave } from '@mantine/hooks';
+import { Text } from '@mantine/core';
+
+const code = `
+import { useState } from 'react';
+import { usePageLeave } from '@mantine/hooks';
+import { Text } from '@mantine/core';
+
+function Demo() {
+  const [leftsCount, setLeftsCount] = useState(0);
+
+  usePageLeave(() => setLeftsCount((p) => p + 1));
+
+  return (
+    <Text align="center">
+      Your mouse has left page {leftsCount} times.
+    </Text>
+  );
+}
+`;
+
+function Demo() {
+  const [leftsCount, setLeftsCount] = useState(0);
+
+  usePageLeave(() => setLeftsCount((p) => p + 1));
+
+  return <Text align="center">Your mouse has left page {leftsCount} times.</Text>;
+}
+
+export const usePageLeaveDemo: MantineDemo = {
+  type: 'demo',
+  component: Demo,
+  code,
+};

--- a/docs/src/demos/index.ts
+++ b/docs/src/demos/index.ts
@@ -7,6 +7,7 @@ export * from './hooks/use-document-title';
 export * from './hooks/use-idle';
 export * from './hooks/use-interval';
 export * from './hooks/use-media-query';
+export * from './hooks/use-page-leave';
 export * from './hooks/use-reduced-motion';
 export * from './hooks/use-scroll-into-view';
 export * from './hooks/use-resize-observer';

--- a/docs/src/docs/hooks/use-page-leave.mdx
+++ b/docs/src/docs/hooks/use-page-leave.mdx
@@ -1,0 +1,27 @@
+---
+group: 'mantine-hooks'
+package: '@mantine/hooks'
+category: 'utils'
+title: 'use-page-leave'
+order: 1
+slug: /hooks/use-page-leave/
+description: 'Monitor when user leaves page'
+import: "import { useOs } from '@mantine/hooks';"
+docs: 'hooks/use-page-leave.mdx'
+source: 'mantine-hooks/src/use-page-leave/use-page-leave.ts'
+---
+
+import { usePageLeaveDemo } from '@docs/demos';
+
+## Usage
+
+Hook detect event when mouse leaves current page.
+It accepts function as an argument that is fired each time mouse leaves page.
+
+<Demo data={usePageLeaveDemo} />
+
+## Definition
+
+```tsx
+function usePageLeave(onPageLeave: () => void): void;
+```

--- a/src/mantine-hooks/src/index.ts
+++ b/src/mantine-hooks/src/index.ts
@@ -22,6 +22,7 @@ export { useMouse } from './use-mouse/use-mouse';
 export { useMove, clampUseMovePosition } from './use-move/use-move';
 export { usePagination } from './use-pagination/use-pagination';
 export { useQueue } from './use-queue/use-queue';
+export { usePageLeave } from './use-page-leave/use-page-leave';
 export { useReducedMotion } from './use-reduced-motion/use-reduced-motion';
 export { useScrollIntoView } from './use-scroll-into-view/use-scroll-into-view';
 export { useResizeObserver } from './use-resize-observer/use-resize-observer';

--- a/src/mantine-hooks/src/use-page-leave/use-page-leave.ts
+++ b/src/mantine-hooks/src/use-page-leave/use-page-leave.ts
@@ -1,6 +1,6 @@
 import { useWindowEvent } from '../use-window-event/use-window-event';
 
-export function usePageLeave(onPageLeave) {
+export function usePageLeave(onPageLeave: () => void) {
   const handler = (event: MouseEvent) => {
     // http://help.dottoro.com/ljltrsom.php
     const from = event.relatedTarget || (event as any).toElement;

--- a/src/mantine-hooks/src/use-page-leave/use-page-leave.ts
+++ b/src/mantine-hooks/src/use-page-leave/use-page-leave.ts
@@ -1,0 +1,14 @@
+import { useWindowEvent } from '../use-window-event/use-window-event';
+
+export function usePageLeave(onPageLeave) {
+  const handler = (event: MouseEvent) => {
+    // http://help.dottoro.com/ljltrsom.php
+    const from = event.relatedTarget || (event as any).toElement;
+
+    if (!from || (from as any).nodeName === 'HTML') {
+      onPageLeave();
+    }
+  };
+
+  useWindowEvent('mouseout', handler);
+}


### PR DESCRIPTION
as potential improvement and extendable future we can:

return a boolean variable that indicates if mouse is out of page. 

accept `onReturn` function callback - left a comment with similar implementation 