### PR TITLE
[@mantine/core] Make direction switch optional on Select

### DIFF
--- a/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
@@ -91,6 +91,9 @@ export interface AutocompleteProps
   /** Whether to render the dropdown in a Portal */
   withinPortal?: boolean;
 
+  /** Whether to switch item order and keyboard navigation on dropdown position flip */
+  switchDirectionOnFlip?: boolean;
+
   /** Dropdown z-index */
   zIndex?: number;
 }
@@ -135,6 +138,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
       onDropdownClose,
       onDropdownOpen,
       withinPortal,
+      switchDirectionOnFlip = true,
       zIndex = getDefaultZIndex('popover'),
       ...others
     }: AutocompleteProps,
@@ -306,6 +310,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
             __staticSelector="Autocomplete"
             direction={direction}
             onDirectionChange={setDirection}
+            switchDirectionOnFlip={switchDirectionOnFlip}
             referenceElement={inputRef.current}
             withinPortal={withinPortal}
             zIndex={zIndex}

--- a/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
@@ -141,6 +141,9 @@ export interface MultiSelectProps extends DefaultProps<MultiSelectStylesNames>, 
   /** Whether to render the dropdown in a Portal */
   withinPortal?: boolean;
 
+  /** Whether to switch item order and keyboard navigation on dropdown position flip */
+  switchDirectionOnFlip?: boolean;
+
   /** Dropdown z-index */
   zIndex?: number;
 }
@@ -210,6 +213,7 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
       onDropdownOpen,
       maxSelectedValues,
       withinPortal,
+      switchDirectionOnFlip = true,
       zIndex = getDefaultZIndex('popover'),
       name,
       ...others
@@ -605,6 +609,7 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
             referenceElement={wrapperRef.current}
             direction={direction}
             onDirectionChange={setDirection}
+            switchDirectionOnFlip={switchDirectionOnFlip}
             withinPortal={withinPortal}
             zIndex={zIndex}
           >

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -108,6 +108,9 @@ export interface SelectProps extends DefaultProps<BaseSelectStylesNames>, BaseSe
   /** Whether to render the dropdown in a Portal */
   withinPortal?: boolean;
 
+  /** Whether to switch item order and keyboard navigation on dropdown position flip */
+  switchDirectionOnFlip?: boolean;
+
   /** Dropdown z-index */
   zIndex?: number;
 }
@@ -167,6 +170,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       onDropdownClose,
       onDropdownOpen,
       withinPortal,
+      switchDirectionOnFlip = true,
       zIndex = getDefaultZIndex('popover'),
       name,
       ...others
@@ -522,6 +526,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
             dropdownComponent={dropdownComponent || SelectScrollArea}
             direction={direction}
             onDirectionChange={setDirection}
+            switchDirectionOnFlip={switchDirectionOnFlip}
             withinPortal={withinPortal}
             zIndex={zIndex}
           >

--- a/src/mantine-core/src/components/Select/SelectDropdown/SelectDropdown.tsx
+++ b/src/mantine-core/src/components/Select/SelectDropdown/SelectDropdown.tsx
@@ -23,6 +23,7 @@ interface SelectDropdownProps extends DefaultProps<SelectDropdownStylesNames> {
   referenceElement?: HTMLElement;
   direction?: React.CSSProperties['flexDirection'];
   onDirectionChange?: (direction: React.CSSProperties['flexDirection']) => void;
+  switchDirectionOnFlip?: boolean;
   zIndex?: number;
 }
 
@@ -44,6 +45,7 @@ export const SelectDropdown = forwardRef<HTMLDivElement, SelectDropdownProps>(
       referenceElement,
       direction = 'column',
       onDirectionChange,
+      switchDirectionOnFlip = true,
       zIndex = getDefaultZIndex('popover'),
       __staticSelector,
     }: SelectDropdownProps,
@@ -95,7 +97,7 @@ export const SelectDropdown = forwardRef<HTMLDivElement, SelectDropdownProps>(
 
                 const nextDirection = state.placement === 'top' ? 'column-reverse' : 'column';
 
-                if (direction !== nextDirection) {
+                if (direction !== nextDirection && switchDirectionOnFlip) {
                   onDirectionChange && onDirectionChange(nextDirection);
                 }
               }

--- a/src/mantine-core/src/components/Select/stories/Select.story.tsx
+++ b/src/mantine-core/src/components/Select/stories/Select.story.tsx
@@ -171,4 +171,16 @@ storiesOf('@mantine/core/Select/stories', module)
       <Select label="Dropdown flip" data={data} placeholder="Select items" />
       {content}
     </div>
+  ))
+  .add('Popper flip (no direction switch)', () => (
+    <div style={{ maxWidth: 600, margin: 'auto' }}>
+      {content}
+      <Select
+        label="Dropdown flip"
+        data={data}
+        placeholder="Select items"
+        switchDirectionOnFlip={false}
+      />
+      {content}
+    </div>
   ));


### PR DESCRIPTION
Implement a `switchDirectionOnFlip` prop for Select, MultiSelect and Autocomplete, allowing to opt out of direction switching.

It simply disables the `onDirectionSwitch` callback, effectively freezing the state into the default direction.