### PR TITLE
[@mantine/core] Drawer: fix Drawer z-index

### DIFF
--- a/src/mantine-core/src/components/Drawer/Drawer.tsx
+++ b/src/mantine-core/src/components/Drawer/Drawer.tsx
@@ -231,9 +231,12 @@ export function MantineDrawer({
   );
 }
 
-export function Drawer(props: React.ComponentPropsWithoutRef<typeof MantineDrawer>) {
+export function Drawer({
+  zIndex = getDefaultZIndex('modal'),
+  ...props
+}: React.ComponentPropsWithoutRef<typeof MantineDrawer>) {
   return (
-    <Portal zIndex={props.zIndex || 1000}>
+    <Portal zIndex={zIndex}>
       <MantineDrawer {...props} />
     </Portal>
   );


### PR DESCRIPTION
the default z-index of Drawer should be `getDefaultZIndex('modal')` rather than `1000`
issue here #481 