### PR TITLE
Docs typo fix on MultiSelect page

### DIFF
--- a/docs/src/docs/core/MultiSelect.mdx
+++ b/docs/src/docs/core/MultiSelect.mdx
@@ -191,7 +191,7 @@ Based on this data shape you can create custom `filter` function and `itemCompon
 
 ## Custom label component
 
-Apart from `itemComponent` you can customize appearance of label by providing `labelComponent`:
+Apart from `itemComponent` you can customize appearance of label by providing `valueComponent`:
 
 <Demo data={MultiSelectDemos.countries} />
 


### PR DESCRIPTION
The docs for MultiSelect referenced labelComponent, which is wrong. It should be valueComponent.