### PR TITLE
Fix typo in `GlobalStyles` fontSize property

### DIFF
--- a/src/mantine-styles/src/theme/GlobalStyles.tsx
+++ b/src/mantine-styles/src/theme/GlobalStyles.tsx
@@ -14,7 +14,7 @@ export function GlobalStyles() {
           backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
           color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
           lineHeight: theme.lineHeight,
-          fontSizes: theme.fontSizes.md,
+          fontSize: theme.fontSizes.md,
         } as any,
       })}
     />


### PR DESCRIPTION
Just noticed that the invalid property `fontSizes` was being added to the css of the document's `body` element when using `GlobalStyles`. I believe this is intended to be `fontSize` instead.

#### Error in Chrome:
![image](https://user-images.githubusercontent.com/19805395/145727701-bdf01c93-8416-4df3-a32e-7263c48f64cf.png)