### PR TITLE
[@mantine/core] TransferList: Add the `showSearch` prop.

### DIFF
--- a/src/mantine-core/src/components/TransferList/RenderList/RenderList.tsx
+++ b/src/mantine-core/src/components/TransferList/RenderList/RenderList.tsx
@@ -21,6 +21,7 @@ interface RenderListProps extends DefaultProps<RenderListStylesNames> {
   nothingFound?: React.ReactNode;
   title?: React.ReactNode;
   reversed?: boolean;
+  showSearch?: boolean;
   onMoveAll(): void;
   onMove(): void;
   height: number;
@@ -38,6 +39,7 @@ export function RenderList({
   filter,
   nothingFound,
   title,
+  showSearch,
   reversed,
   onMoveAll,
   onMove,
@@ -133,20 +135,22 @@ export function RenderList({
 
       <div className={classes.transferListBody}>
         <div className={classes.transferListHeader}>
-          <TextInput
-            value={query}
-            onChange={(event) => {
-              setQuery(event.currentTarget.value);
-              setHovered(0);
-            }}
-            onFocus={() => setHovered(0)}
-            onBlur={() => setHovered(-1)}
-            placeholder={searchPlaceholder}
-            radius={0}
-            onKeyDown={handleSearchKeydown}
-            sx={{ flex: 1 }}
-            classNames={{ input: classes.transferListSearch }}
-          />
+          {showSearch && (
+            <TextInput
+              value={query}
+              onChange={(event) => {
+                setQuery(event.currentTarget.value);
+                setHovered(0);
+              }}
+              onFocus={() => setHovered(0)}
+              onBlur={() => setHovered(-1)}
+              placeholder={searchPlaceholder}
+              radius={0}
+              onKeyDown={handleSearchKeydown}
+              sx={{ flex: 1 }}
+              classNames={{ input: classes.transferListSearch }}
+            />
+          )}
 
           <ActionIcon
             variant="default"
@@ -155,6 +159,7 @@ export function RenderList({
             className={classes.transferListControl}
             disabled={selection.length === 0}
             onClick={onMove}
+            sx={{flex: showSearch ? 0 : 1}}
           >
             {reversed ? <PrevIcon /> : <NextIcon />}
           </ActionIcon>
@@ -166,6 +171,7 @@ export function RenderList({
             className={classes.transferListControl}
             disabled={data.length === 0}
             onClick={onMoveAll}
+            sx={{flex: showSearch ? 0 : 1}}
           >
             {reversed ? <FirstIcon /> : <LastIcon />}
           </ActionIcon>

--- a/src/mantine-core/src/components/TransferList/RenderList/RenderList.tsx
+++ b/src/mantine-core/src/components/TransferList/RenderList/RenderList.tsx
@@ -159,7 +159,7 @@ export function RenderList({
             className={classes.transferListControl}
             disabled={selection.length === 0}
             onClick={onMove}
-            sx={{flex: showSearch ? 0 : 1}}
+            sx={{ flex: showSearch ? 0 : 1 }}
           >
             {reversed ? <PrevIcon /> : <NextIcon />}
           </ActionIcon>
@@ -171,7 +171,7 @@ export function RenderList({
             className={classes.transferListControl}
             disabled={data.length === 0}
             onClick={onMoveAll}
-            sx={{flex: showSearch ? 0 : 1}}
+            sx={{ flex: showSearch ? 0 : 1 }}
           >
             {reversed ? <FirstIcon /> : <LastIcon />}
           </ActionIcon>

--- a/src/mantine-core/src/components/TransferList/TransferList.tsx
+++ b/src/mantine-core/src/components/TransferList/TransferList.tsx
@@ -44,6 +44,9 @@ export interface TransferListProps
 
   /** Breakpoint at which list will collapse to single column layout */
   breakpoint?: MantineNumberSize;
+
+  /** Whether to show the search input field */
+  showSearch?: boolean;
 }
 
 export function defaultFilter(query: string, item: TransferListItem) {
@@ -63,6 +66,7 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>(
       initialSelection,
       listHeight = 150,
       listComponent = SelectScrollArea,
+      showSearch = false,
       breakpoint,
       classNames,
       styles,
@@ -118,6 +122,7 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>(
           title={titles[0]}
           height={listHeight}
           listComponent={listComponent}
+          showSearch={showSearch}
           classNames={classNames}
           styles={styles}
         />
@@ -135,6 +140,7 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>(
           title={titles[1]}
           height={listHeight}
           listComponent={listComponent}
+          showSearch={showSearch}
           classNames={classNames}
           styles={styles}
           reversed

--- a/src/mantine-core/src/components/TransferList/TransferList.tsx
+++ b/src/mantine-core/src/components/TransferList/TransferList.tsx
@@ -66,7 +66,7 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>(
       initialSelection,
       listHeight = 150,
       listComponent = SelectScrollArea,
-      showSearch = false,
+      showSearch = true,
       breakpoint,
       classNames,
       styles,


### PR DESCRIPTION
This PR proposes to add a `showSearch` prop to the `TransferList` component, which controls whether you want to show the search feature of `TransferList`. The motivation is that you may not need a search functionality all the time and a configuration option to turn it off is always nice. The default value for this prop is `true` for backwards compatibility.