### PR TITLE
[@mantine/core] RingProgress: Add the `capIsRound` prop

### DIFF
--- a/docs/src/docs/core/RingProgress.mdx
+++ b/docs/src/docs/core/RingProgress.mdx
@@ -24,9 +24,9 @@ Set `sections` prop to an array of:
 
 <Demo data={RingProgressDemos.usage} />
 
-## Size and thickness
+## Size, thickness & rounded caps
 
-Use `size` and `thickness` props to configure RingProgress, all values are in px:
+Use `size`, `thickness` & `capIsRound` props to configure RingProgress, size and thickness values are in px:
 
 <Demo data={RingProgressDemos.configurator} />
 

--- a/src/mantine-core/src/components/RingProgress/Curve/Curve.tsx
+++ b/src/mantine-core/src/components/RingProgress/Curve/Curve.tsx
@@ -8,11 +8,21 @@ interface CurveProps {
   offset: number;
   sum: number;
   thickness: number;
+  lineCapIsRound: boolean;
   root?: boolean;
   color?: MantineColor;
 }
 
-export function Curve({ size, value, offset, sum, thickness, root, color }: CurveProps) {
+export function Curve({
+  size,
+  value,
+  offset,
+  sum,
+  thickness,
+  root,
+  color,
+  lineCapIsRound,
+}: CurveProps) {
   const theme = useMantineTheme();
   const stroke = theme.fn.themeColor(
     color || (theme.colorScheme === 'dark' ? 'dark' : 'gray'),
@@ -22,6 +32,7 @@ export function Curve({ size, value, offset, sum, thickness, root, color }: Curv
   return (
     <circle
       fill="none"
+      strokeLinecap={lineCapIsRound ? 'round' : 'butt'}
       stroke={stroke}
       {...getCurveProps({ sum, size, thickness, value, offset, root })}
     />

--- a/src/mantine-core/src/components/RingProgress/RingProgress.tsx
+++ b/src/mantine-core/src/components/RingProgress/RingProgress.tsx
@@ -19,6 +19,9 @@ export interface RingProgressProps
   /** Width and height of the progress ring in px */
   size?: number;
 
+  /** Sets whether the edges of the progress circle are rounded */
+  capIsRound?: boolean;
+
   /** Ring sections */
   sections: { value: number; color: MantineColor }[];
 }
@@ -34,13 +37,19 @@ export const RingProgress = forwardRef<HTMLDivElement, RingProgressProps>(
       thickness = size / 10,
       classNames,
       styles,
+      capIsRound,
       ...others
     }: RingProgressProps,
     ref
   ) => {
     const { classes, cx } = useStyles(null, { classNames, styles, name: 'RingProgress' });
 
-    const curves = getCurves({ size, thickness, sections }).map((curve, index) => (
+    const curves = getCurves({
+      size,
+      thickness,
+      sections,
+      renderRoundedLineCaps: capIsRound,
+    }).map((curve, index) => (
       <Curve
         key={index}
         value={curve.data?.value}
@@ -50,6 +59,7 @@ export const RingProgress = forwardRef<HTMLDivElement, RingProgressProps>(
         offset={curve.offset}
         color={curve.data?.color}
         root={curve.root}
+        lineCapIsRound={curve.lineCapIsRound}
       />
     ));
 

--- a/src/mantine-core/src/components/RingProgress/demos/configurator.tsx
+++ b/src/mantine-core/src/components/RingProgress/demos/configurator.tsx
@@ -34,5 +34,6 @@ export const configurator: MantineDemo = {
   configurator: [
     { name: 'size', type: 'number', initialValue: 120, step: 10, min: 60, max: 400 },
     { name: 'thickness', type: 'number', initialValue: 12, step: 1, min: 1, max: 40 },
+    { name: 'capIsRound', type: 'boolean', initialValue: false },
   ],
 };

--- a/src/mantine-core/src/components/RingProgress/get-curves/get-curves.test.ts
+++ b/src/mantine-core/src/components/RingProgress/get-curves/get-curves.test.ts
@@ -2,19 +2,24 @@ import { getCurves } from './get-curves';
 
 describe('@mantine/core/RingProgress/get-curves', () => {
   it('returns valid curves data', () => {
-    expect(
-      getCurves({
-        size: 350,
-        thickness: 12,
-        sections: [
-          { value: 40, color: 'blue' },
-          { value: 22.345, color: 'red' },
-          { value: 9, color: 'blue' },
-        ],
-        renderRoundedLineCaps: false,
-      })
-    ).toEqual(expect.arrayContaining([
-      { data: { color: 'blue', value: 40 }, offset: 914.2034621946298, root: false, sum: 71.345, lineCapIsRound: false },
+    const curves = getCurves({
+      size: 350,
+      thickness: 12,
+      sections: [
+        { value: 40, color: 'blue' },
+        { value: 22.345, color: 'red' },
+        { value: 9, color: 'blue' },
+      ],
+      renderRoundedLineCaps: false,
+    });
+    const expectedCurves = [
+      {
+        data: { color: 'blue', value: 40 },
+        offset: 914.2034621946298,
+        root: false,
+        sum: 71.345,
+        lineCapIsRound: false,
+      },
       {
         data: { color: 'red', value: 22.345 },
         offset: 548.5220773167778,
@@ -22,8 +27,16 @@ describe('@mantine/core/RingProgress/get-curves', () => {
         sum: 71.345,
         lineCapIsRound: false,
       },
-      { data: { color: 'blue', value: 9 }, offset: 344.2433136893878, root: false, sum: 71.345, lineCapIsRound: false },
+      {
+        data: { color: 'blue', value: 9 },
+        offset: 344.2433136893878,
+        root: false,
+        sum: 71.345,
+        lineCapIsRound: false,
+      },
       { data: null, offset: 261.9650020918711, root: true, sum: 71.345, lineCapIsRound: false },
-    ]));
+    ];
+    expect(curves.length).toEqual(expectedCurves.length);
+    expect(curves).toEqual(expect.arrayContaining(expectedCurves));
   });
 });

--- a/src/mantine-core/src/components/RingProgress/get-curves/get-curves.test.ts
+++ b/src/mantine-core/src/components/RingProgress/get-curves/get-curves.test.ts
@@ -11,17 +11,19 @@ describe('@mantine/core/RingProgress/get-curves', () => {
           { value: 22.345, color: 'red' },
           { value: 9, color: 'blue' },
         ],
+        renderRoundedLineCaps: false,
       })
-    ).toEqual([
-      { data: { color: 'blue', value: 40 }, offset: 914.2034621946298, root: false, sum: 71.345 },
+    ).toEqual(expect.arrayContaining([
+      { data: { color: 'blue', value: 40 }, offset: 914.2034621946298, root: false, sum: 71.345, lineCapIsRound: false },
       {
         data: { color: 'red', value: 22.345 },
         offset: 548.5220773167778,
         root: false,
         sum: 71.345,
+        lineCapIsRound: false,
       },
-      { data: { color: 'blue', value: 9 }, offset: 344.2433136893878, root: false, sum: 71.345 },
-      { data: null, offset: 261.9650020918711, root: true, sum: 71.345 },
-    ]);
+      { data: { color: 'blue', value: 9 }, offset: 344.2433136893878, root: false, sum: 71.345, lineCapIsRound: false },
+      { data: null, offset: 261.9650020918711, root: true, sum: 71.345, lineCapIsRound: false },
+    ]));
   });
 });

--- a/src/mantine-core/src/components/RingProgress/get-curves/get-curves.ts
+++ b/src/mantine-core/src/components/RingProgress/get-curves/get-curves.ts
@@ -9,6 +9,7 @@ interface GetCurves {
   sections: CurveData[];
   size: number;
   thickness: number;
+  renderRoundedLineCaps: boolean;
 }
 
 interface Curve {
@@ -16,13 +17,15 @@ interface Curve {
   offset: number;
   root: boolean;
   data: CurveData;
+  lineCapIsRound?: boolean;
 }
 
-export function getCurves({ size, thickness, sections }: GetCurves) {
+export function getCurves({ size, thickness, sections, renderRoundedLineCaps }: GetCurves) {
   const sum = sections.reduce((acc, current) => acc + current.value, 0);
   const accumulated = Math.PI * ((size * 0.9 - thickness * 2) / 2) * 2;
   let offset = accumulated;
   const curves: Curve[] = [];
+  const curvesInOrder: Curve[] = [];
 
   for (let i = 0; i < sections.length; i += 1) {
     curves.push({ sum, offset, data: sections[i], root: false });
@@ -31,5 +34,18 @@ export function getCurves({ size, thickness, sections }: GetCurves) {
 
   curves.push({ sum, offset, data: null, root: true });
 
-  return curves;
+  // Reorder curves to layer appropriately and selectively set caps to round
+
+  curvesInOrder.push({ ...curves[curves.length - 1], lineCapIsRound: false });
+  if (curves.length > 2) {
+    curvesInOrder.push({ ...curves[0], lineCapIsRound: renderRoundedLineCaps });
+    curvesInOrder.push({ ...curves[curves.length - 2], lineCapIsRound: renderRoundedLineCaps });
+    for (let i = 1; i <= curves.length - 3; i += 1) {
+      curvesInOrder.push({ ...curves[i], lineCapIsRound: false });
+    }
+  } else {
+    curvesInOrder.push({ ...curves[0], lineCapIsRound: renderRoundedLineCaps });
+  }
+
+  return curvesInOrder;
 }


### PR DESCRIPTION
This PR incorporates the `capIsRound` prop on RingProgress, which adds rounded corners appropriately to the circles that compose the component. Closes #397 if merged

- [x] `npm run test` executed successfully
- [x] Documentation and stories updated

Screenshot of the feature in action:
![image](https://user-images.githubusercontent.com/1029727/146056533-610d3141-3d44-4046-a63f-4eb093a243cb.png)
