### PR TITLE
[@mantine/core] Skeleton: Add the `count` prop.

### DIFF
--- a/src/mantine-core/src/components/Skeleton/Skeleton.tsx
+++ b/src/mantine-core/src/components/Skeleton/Skeleton.tsx
@@ -18,6 +18,9 @@ export interface SkeletonProps extends DefaultProps, React.ComponentPropsWithout
 
   /** Radius from theme.radius or number to set border-radius in px */
   radius?: MantineNumberSize;
+
+  /** The number of skeleton elements to render */
+  count?: number;
 }
 
 export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
@@ -29,6 +32,7 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
       className,
       circle,
       radius = 'sm',
+      count = 1,
       classNames,
       styles,
       ...others
@@ -40,13 +44,20 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
       { classNames, styles, name: 'Skeleton' }
     );
 
-    return (
-      <Box
-        className={cx(classes.root, { [classes.visible]: visible }, className)}
-        ref={ref}
-        {...others}
-      />
-    );
+    const skeletonElements = [];
+
+    for (let i = 0; i < count; i += 1) {
+      skeletonElements.push(
+        <Box
+          className={cx(classes.root, { [classes.visible]: visible }, className)}
+          ref={ref}
+          key={i}
+          {...others}
+        />
+      );
+    }
+
+    return <>{skeletonElements.map((element) => element)}</>;
   }
 );
 


### PR DESCRIPTION
This PR proposes to add a `count` prop to the Skeleton component. This will help in quickly generating Skeleton components without having to manually write that many Skeleton components. The default value is `1` to maintain backwards compatibility.


TODO Checklist
---

- [ ] Storybook demos.
- [ ] Documentation.