### PR TITLE
[@mantine/hooks] use-form: Change UseForm type to return value of use…

### DIFF
--- a/src/mantine-hooks/src/use-form/use-form.ts
+++ b/src/mantine-hooks/src/use-form/use-form.ts
@@ -9,17 +9,41 @@ export type UseFormErrors<T> = {
   readonly [P in keyof T]?: React.ReactNode | null;
 };
 
-export interface UseForm<T> {
+interface UseFormInput<T> {
   validationRules?: ValidationRule<T>;
   errorMessages?: UseFormErrors<T>;
   initialValues: T;
+}
+
+export interface UseForm<T> {
+  values: T;
+  errors: Record<keyof T, React.ReactNode>;
+  validate: () => boolean;
+  reset: () => void;
+  setErrors: React.Dispatch<React.SetStateAction<Record<keyof T, React.ReactNode>>>;
+  setValues: React.Dispatch<React.SetStateAction<T>>;
+  setFieldValue: <K extends keyof T, U extends T[K]>(field: K, value: U) => void;
+  setFieldError: (field: keyof T, error: React.ReactNode) => void;
+  validateField: (field: keyof T) => void;
+  resetErrors: () => void;
+  onSubmit: (handleSubmit: (values: T) => any) => (event?: React.FormEvent) => void;
+  getInputProps: <K extends keyof T>(
+    field: K,
+    options?: {
+      type?: 'checkbox' | 'default';
+    }
+  ) => {
+    [x: string]: any;
+    onChange: any;
+    error: Record<keyof T, React.ReactNode>[K];
+  };
 }
 
 export function useForm<T extends { [key: string]: any }>({
   initialValues,
   validationRules = {},
   errorMessages = {},
-}: UseForm<T>) {
+}: UseFormInput<T>): UseForm<T> {
   type ValidationErrors = Record<keyof T, React.ReactNode>;
 
   const initialErrors = Object.keys(initialValues).reduce((acc, field) => {


### PR DESCRIPTION
As discussed in Discord, I am proposing this change to make re-use of `use-form` easier in components getting the return value of `useForm` passed.

Example:

``` tsx
const EventEditor = (event: Event) => {
    const eventForm = useForm({ initialValues: event })
    return <>
        <EventEditorFinancialDetails eventForm={eventForm}>
        <EventEditorRegistrationDetails eventForm={eventForm}>
    </>
}

const EventEditorFinancialDetails(props: { eventForm: UseForm<Event> }) => {
    // ...
}

```

Note: `UseForm` is not documented, but could potentially cause breaking changes, when users depend on the type. Please keep that in mind when updating. @rtivital agreed to rename the type.

Thank you!