### PR TITLE
[@mantine/core] Alert: Add the `radius` prop.

### DIFF
--- a/src/mantine-core/src/components/Alert/Alert.styles.ts
+++ b/src/mantine-core/src/components/Alert/Alert.styles.ts
@@ -1,16 +1,17 @@
-import { createStyles, MantineColor } from '@mantine/styles';
+import { createStyles, MantineColor, MantineNumberSize } from '@mantine/styles';
 
 interface AlertStyles {
   color: MantineColor;
+  radius: MantineNumberSize;
 }
 
-export default createStyles((theme, { color }: AlertStyles) => ({
+export default createStyles((theme, { color, radius }: AlertStyles) => ({
   root: {
     ...theme.fn.fontStyles(),
     position: 'relative',
     overflow: 'hidden',
     padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
-    borderRadius: theme.radius.sm,
+    borderRadius: typeof radius === 'number' ? radius : theme.radius[radius],
     backgroundColor:
       theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.fn.themeColor(color, 0),
   },

--- a/src/mantine-core/src/components/Alert/Alert.styles.ts
+++ b/src/mantine-core/src/components/Alert/Alert.styles.ts
@@ -11,7 +11,7 @@ export default createStyles((theme, { color, radius }: AlertStyles) => ({
     position: 'relative',
     overflow: 'hidden',
     padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
-    borderRadius: typeof radius === 'number' ? radius : theme.radius[radius],
+    borderRadius: theme.fn.size({ size: radius, sizes: theme.radius }),
     backgroundColor:
       theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.fn.themeColor(color, 0),
   },

--- a/src/mantine-core/src/components/Alert/Alert.tsx
+++ b/src/mantine-core/src/components/Alert/Alert.tsx
@@ -30,7 +30,7 @@ export interface AlertProps
   /** Close button aria-label */
   closeButtonLabel?: string;
 
-  /** Alert Radius */
+  /** Radius from theme.radius, or number to set border-radius in px */
   radius?: MantineNumberSize;
 }
 

--- a/src/mantine-core/src/components/Alert/Alert.tsx
+++ b/src/mantine-core/src/components/Alert/Alert.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import { DefaultProps, MantineColor, ClassNames } from '@mantine/styles';
+import { DefaultProps, MantineColor, ClassNames, MantineNumberSize } from '@mantine/styles';
 import { Box } from '../Box';
 import { CloseButton } from '../ActionIcon';
 import useStyles from './Alert.styles';
@@ -29,6 +29,9 @@ export interface AlertProps
 
   /** Close button aria-label */
   closeButtonLabel?: string;
+
+  /** Alert Radius */
+  radius?: MantineNumberSize;
 }
 
 export const Alert = forwardRef<HTMLDivElement, AlertProps>(
@@ -42,12 +45,13 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
       icon,
       styles,
       onClose,
+      radius = 'sm',
       withCloseButton,
       ...others
     }: AlertProps,
     ref
   ) => {
-    const { classes, cx } = useStyles({ color }, { classNames, styles, name: 'Alert' });
+    const { classes, cx } = useStyles({ color, radius }, { classNames, styles, name: 'Alert' });
 
     return (
       <Box className={cx(classes.root, className)} ref={ref} {...others}>


### PR DESCRIPTION
This PR adds the `radius` prop to `Alert` components. This can either be a `MantineNumberSize` or a `number` (which will then set the `border-radius` to that px value). The default value of this is `'sm'` to maintain backwards compatibility.

Fixes #528 