### PR TITLE
[@mantine/core] InputNumber: Add props to increment values on holding step arrows

### DIFF
--- a/src/mantine-core/src/components/NumberInput/NumberInput.test.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.test.tsx
@@ -230,7 +230,7 @@ describe('@mantine/core/NumberInput', () => {
     expect(spy).toHaveBeenLastCalledWith(0);
   });
 
-  it('steps value with controls on hold mousedown', async () => {
+  it('steps value with controls on hold mousedown with a millisecond delay value', async () => {
     const spy = jest.fn();
     const element = mount(
       <NumberInput value={0} step={10} onChange={spy} stepHoldDelay={100} stepHoldInterval={100} />
@@ -249,5 +249,32 @@ describe('@mantine/core/NumberInput', () => {
     });
 
     expect(spy).toHaveBeenLastCalledWith(40);
+  });
+
+  it('steps value with controls on hold mousedown with a function delay', async () => {
+    const spy = jest.fn();
+    const element = mount(
+      <NumberInput
+        value={0}
+        step={10}
+        onChange={spy}
+        stepHoldDelay={100}
+        stepHoldInterval={(count) => count > 3 ? 200 : 100}
+      />
+    );
+
+    await act(async () => {
+      element.find('.mantine-NumberInput-controlUp');
+      element.find('.mantine-NumberInput-controlUp').simulate('mousedown');
+
+      await new Promise((resolve) => {
+        setTimeout(() => {
+          element.find('.mantine-NumberInput-controlUp').simulate('mouseup');
+          resolve(null);
+        }, 550);
+      });
+    });
+
+    expect(spy).toHaveBeenLastCalledWith(50);
   });
 });

--- a/src/mantine-core/src/components/NumberInput/NumberInput.test.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.test.tsx
@@ -230,16 +230,10 @@ describe('@mantine/core/NumberInput', () => {
     expect(spy).toHaveBeenLastCalledWith(0);
   });
 
-  it('increments and decrements value with controls on hold mousedown', async () => {
+  it('steps value with controls on hold mousedown', async () => {
     const spy = jest.fn();
     const element = mount(
-      <NumberInput
-        value={0}
-        step={10}
-        onChange={spy}
-        stepIncrementInitialDelay={100}
-        stepIncrementInterval={100}
-      />
+      <NumberInput value={0} step={10} onChange={spy} stepHoldDelay={100} stepHoldInterval={100} />
     );
 
     await act(async () => {

--- a/src/mantine-core/src/components/NumberInput/NumberInput.test.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.test.tsx
@@ -229,4 +229,31 @@ describe('@mantine/core/NumberInput', () => {
     expect(input.getDOMNode().getAttribute('value')).toBe('0');
     expect(spy).toHaveBeenLastCalledWith(0);
   });
+
+  it('increments and decrements value with controls on hold mousedown', async () => {
+    const spy = jest.fn();
+    const element = mount(
+      <NumberInput
+        value={0}
+        step={10}
+        onChange={spy}
+        stepIncrementInitialDelay={100}
+        stepIncrementInterval={100}
+      />
+    );
+
+    await act(async () => {
+      element.find('.mantine-NumberInput-controlUp');
+      element.find('.mantine-NumberInput-controlUp').simulate('mousedown');
+
+      await new Promise((resolve) => {
+        setTimeout(() => {
+          element.find('.mantine-NumberInput-controlUp').simulate('mouseup');
+          resolve(null);
+        }, 350);
+      });
+    });
+
+    expect(spy).toHaveBeenLastCalledWith(40);
+  });
 });

--- a/src/mantine-core/src/components/NumberInput/NumberInput.test.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.test.tsx
@@ -259,7 +259,7 @@ describe('@mantine/core/NumberInput', () => {
         step={10}
         onChange={spy}
         stepHoldDelay={100}
-        stepHoldInterval={(count) => count > 3 ? 200 : 100}
+        stepHoldInterval={(count) => (count > 3 ? 200 : 100)}
       />
     );
 
@@ -276,5 +276,50 @@ describe('@mantine/core/NumberInput', () => {
     });
 
     expect(spy).toHaveBeenLastCalledWith(50);
+  });
+
+  it('steps value with controls on hold keydown and stepHoldInterval', async () => {
+    const spy = jest.fn();
+    const element = mount(
+      <NumberInput value={0} step={10} onChange={spy} stepHoldDelay={100} stepHoldInterval={100} />
+    );
+
+    await act(async () => {
+      const input = element.find('input').at(0);
+      input.simulate('keydown', { key: 'ArrowUp' });
+
+      await new Promise((resolve) => {
+        setTimeout(() => {
+          input.simulate('keyup', { key: 'ArrowUp' });
+          resolve(null);
+        }, 350);
+      });
+    });
+
+    expect(spy).toHaveBeenLastCalledWith(40);
+  });
+
+  it('steps value with controls on hold keydown without stepHoldInterval', async () => {
+    const spy = jest.fn();
+    const element = mount(<NumberInput value={0} step={10} onChange={spy} />);
+
+    const input = element.find('input').at(0);
+    act(() => {
+      input.simulate('keydown', { key: 'ArrowUp' });
+    });
+    act(() => {
+      input.simulate('keydown', { key: 'ArrowUp' });
+    });
+    act(() => {
+      input.simulate('keydown', { key: 'ArrowUp' });
+    });
+    act(() => {
+      input.simulate('keydown', { key: 'ArrowUp' });
+    });
+    act(() => {
+      input.simulate('keyup', { key: 'ArrowUp' });
+    });
+
+    expect(spy).toHaveBeenLastCalledWith(40);
   });
 });

--- a/src/mantine-core/src/components/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.tsx
@@ -188,11 +188,11 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
     const shouldUseStepInterval =
       stepIncrementInitialDelay !== undefined && stepIncrementInterval !== undefined;
 
-    const onStepTimeoutRef = useRef<NodeJS.Timeout>(null);
+    const onStepTimeoutRef = useRef<number>(null);
 
     const onStepDone = () => {
       if (onStepTimeoutRef.current) {
-        clearTimeout(onStepTimeoutRef.current);
+        window.clearTimeout(onStepTimeoutRef.current);
         onStepTimeoutRef.current = null;
       }
     };
@@ -209,7 +209,10 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
       onStepHandleChange(isIncrement);
 
       if (shouldUseStepInterval) {
-        onStepTimeoutRef.current = setTimeout(() => onStepLoop(isIncrement), stepIncrementInterval);
+        onStepTimeoutRef.current = window.setTimeout(
+          () => onStepLoop(isIncrement),
+          stepIncrementInterval
+        );
       }
     };
 
@@ -217,7 +220,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
       event.preventDefault();
       onStepHandleChange(isIncrement);
       if (shouldUseStepInterval) {
-        onStepTimeoutRef.current = setTimeout(
+        onStepTimeoutRef.current = window.setTimeout(
           () => onStepLoop(isIncrement),
           stepIncrementInitialDelay
         );

--- a/src/mantine-core/src/components/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.tsx
@@ -188,15 +188,6 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
     const shouldUseStepInterval =
       stepIncrementInitialDelay !== undefined && stepIncrementInterval !== undefined;
 
-    if (
-      !shouldUseStepInterval &&
-      (stepIncrementInterval !== undefined || stepIncrementInitialDelay !== undefined)
-    ) {
-      console.warn(
-        'stepIncrementInitialDelay and stepIncrementInterval should both be supplied when using either value.'
-      );
-    }
-
     const onStepTimeoutRef = useRef<NodeJS.Timeout>(null);
 
     const onStepDone = () => {

--- a/src/mantine-core/src/components/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.tsx
@@ -48,10 +48,10 @@ export interface NumberInputProps
   step?: number;
 
   /** Delay in milliseconds before incrementing the value on holding the up/down arrows. */
-  stepIncrementInterval?: number;
+  stepHoldInterval?: number;
 
   /** Initial delay in milliseconds before incrementing the value on holding the up/down arrows. */
-  stepIncrementInitialDelay?: number;
+  stepHoldDelay?: number;
 
   /** Removes increment/decrement controls */
   hideControls?: boolean;
@@ -79,8 +79,8 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
       min,
       max,
       step = 1,
-      stepIncrementInterval,
-      stepIncrementInitialDelay,
+      stepHoldInterval,
+      stepHoldDelay,
       onBlur,
       onFocus,
       hideControls = false,
@@ -185,8 +185,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
       }
     }, [value]);
 
-    const shouldUseStepInterval =
-      stepIncrementInitialDelay !== undefined && stepIncrementInterval !== undefined;
+    const shouldUseStepInterval = stepHoldDelay !== undefined && stepHoldInterval !== undefined;
 
     const onStepTimeoutRef = useRef<number>(null);
 
@@ -211,7 +210,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
       if (shouldUseStepInterval) {
         onStepTimeoutRef.current = window.setTimeout(
           () => onStepLoop(isIncrement),
-          stepIncrementInterval
+          stepHoldInterval
         );
       }
     };
@@ -220,10 +219,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
       event.preventDefault();
       onStepHandleChange(isIncrement);
       if (shouldUseStepInterval) {
-        onStepTimeoutRef.current = window.setTimeout(
-          () => onStepLoop(isIncrement),
-          stepIncrementInitialDelay
-        );
+        onStepTimeoutRef.current = window.setTimeout(() => onStepLoop(isIncrement), stepHoldDelay);
       }
       inputRef.current.focus();
     };

--- a/src/mantine-core/src/components/NumberInput/demos/step.tsx
+++ b/src/mantine-core/src/components/NumberInput/demos/step.tsx
@@ -28,7 +28,7 @@ const code = `
 <NumberInput
   label="Step the value with interval function"
   stepHoldDelay={750}
-  stepHoldInterval={(count) => 1000 - count * count}
+  stepHoldInterval={(count) => 1000 - count ** 4}
 />
 `;
 

--- a/src/mantine-core/src/components/NumberInput/demos/step.tsx
+++ b/src/mantine-core/src/components/NumberInput/demos/step.tsx
@@ -20,10 +20,10 @@ const code = `
 />
 <NumberInput
   style={{ marginTop: 15 }}
-  label="Increment on hold"
-  description="Increment the value when clicking and holding the arrows"
-  stepIncrementInitialDelay={750}
-  stepIncrementInterval={100}
+  label="Step on hold"
+  description="Step the value when clicking and holding the arrows"
+  stepHoldDelay={750}
+  stepHoldInterval={100}
 />
 `;
 
@@ -48,10 +48,10 @@ function Demo() {
       />
       <NumberInput
         style={{ marginTop: 15 }}
-        label="Increment on hold"
-        description="Increment the value when clicking and holding the arrows"
-        stepIncrementInitialDelay={750}
-        stepIncrementInterval={100}
+        label="Step on hold"
+        description="Step the value when clicking and holding the arrows"
+        stepHoldDelay={750}
+        stepHoldInterval={100}
       />
     </div>
   );

--- a/src/mantine-core/src/components/NumberInput/demos/step.tsx
+++ b/src/mantine-core/src/components/NumberInput/demos/step.tsx
@@ -18,6 +18,13 @@ const code = `
   step={5}
   min={0}
 />
+<NumberInput
+  style={{ marginTop: 15 }}
+  label="Increment on hold"
+  description="Increment the value when clicking and holding the arrows"
+  stepIncrementInitialDelay={750}
+  stepIncrementInterval={100}
+/>
 `;
 
 function Demo() {
@@ -38,6 +45,13 @@ function Demo() {
         defaultValue={80}
         step={5}
         min={0}
+      />
+      <NumberInput
+        style={{ marginTop: 15 }}
+        label="Increment on hold"
+        description="Increment the value when clicking and holding the arrows"
+        stepIncrementInitialDelay={750}
+        stepIncrementInterval={100}
       />
     </div>
   );

--- a/src/mantine-core/src/components/NumberInput/demos/step.tsx
+++ b/src/mantine-core/src/components/NumberInput/demos/step.tsx
@@ -28,7 +28,7 @@ const code = `
 <NumberInput
   label="Step the value with interval function"
   stepHoldDelay={750}
-  stepHoldInterval={(count) => 1000 - count ** 4}
+  stepHoldInterval={(count) => Math.max(1000 - count ** 4, 0)}
 />
 `;
 
@@ -61,7 +61,7 @@ function Demo() {
       <NumberInput
         label="Step the value with interval function"
         stepHoldDelay={750}
-        stepHoldInterval={(count) => 1000 - count ** 4}
+        stepHoldInterval={(count) => Math.max(1000 - count ** 4, 0)}
       />
     </div>
   );

--- a/src/mantine-core/src/components/NumberInput/demos/step.tsx
+++ b/src/mantine-core/src/components/NumberInput/demos/step.tsx
@@ -25,6 +25,11 @@ const code = `
   stepHoldDelay={750}
   stepHoldInterval={100}
 />
+<NumberInput
+  label="Step the value with interval function"
+  stepHoldDelay={750}
+  stepHoldInterval={(count) => 1000 - count * count}
+/>
 `;
 
 function Demo() {
@@ -52,6 +57,11 @@ function Demo() {
         description="Step the value when clicking and holding the arrows"
         stepHoldDelay={750}
         stepHoldInterval={100}
+      />
+      <NumberInput
+        label="Step the value with interval function"
+        stepHoldDelay={750}
+        stepHoldInterval={(count) => 1000 - count ** 4}
       />
     </div>
   );

--- a/src/mantine-core/src/components/NumberInput/stories/NumberInput.story.tsx
+++ b/src/mantine-core/src/components/NumberInput/stories/NumberInput.story.tsx
@@ -29,17 +29,13 @@ storiesOf('@mantine/core/NumberInput/stories', module)
       </div>
     </RtlProvider>
   ))
-  .add('Incrementing', () => (
+  .add('Step On Hold', () => (
     <>
       <div style={{ padding: 40, maxWidth: 400 }}>
-        <NumberInput
-          label="Increment on hold"
-          stepIncrementInitialDelay={750}
-          stepIncrementInterval={100}
-        />
+        <NumberInput label="Step on hold" stepHoldDelay={750} stepHoldInterval={100} />
       </div>
       <div style={{ padding: 40, maxWidth: 400 }}>
-        <NumberInput label="Don't increment on hold" />
+        <NumberInput label="Don't step on hold" />
       </div>
     </>
   ));

--- a/src/mantine-core/src/components/NumberInput/stories/NumberInput.story.tsx
+++ b/src/mantine-core/src/components/NumberInput/stories/NumberInput.story.tsx
@@ -28,4 +28,18 @@ storiesOf('@mantine/core/NumberInput/stories', module)
         <Controlled />
       </div>
     </RtlProvider>
+  ))
+  .add('Incrementing', () => (
+    <>
+      <div style={{ padding: 40, maxWidth: 400 }}>
+        <NumberInput
+          label="Increment on hold"
+          stepIncrementInitialDelay={750}
+          stepIncrementInterval={100}
+        />
+      </div>
+      <div style={{ padding: 40, maxWidth: 400 }}>
+        <NumberInput label="Don't increment on hold" />
+      </div>
+    </>
   ));

--- a/src/mantine-core/src/components/NumberInput/stories/NumberInput.story.tsx
+++ b/src/mantine-core/src/components/NumberInput/stories/NumberInput.story.tsx
@@ -35,6 +35,13 @@ storiesOf('@mantine/core/NumberInput/stories', module)
         <NumberInput label="Step on hold" stepHoldDelay={750} stepHoldInterval={100} />
       </div>
       <div style={{ padding: 40, maxWidth: 400 }}>
+        <NumberInput
+          label="Step on hold with interval function"
+          stepHoldDelay={750}
+          stepHoldInterval={(count) => 1000 - count * count}
+        />
+      </div>
+      <div style={{ padding: 40, maxWidth: 400 }}>
         <NumberInput label="Don't step on hold" />
       </div>
     </>

--- a/src/mantine-core/src/components/NumberInput/stories/NumberInput.story.tsx
+++ b/src/mantine-core/src/components/NumberInput/stories/NumberInput.story.tsx
@@ -38,7 +38,7 @@ storiesOf('@mantine/core/NumberInput/stories', module)
         <NumberInput
           label="Step on hold with interval function"
           stepHoldDelay={750}
-          stepHoldInterval={(count) => 1000 - count * count}
+          stepHoldInterval={(count) => Math.max(1000 - count * count, 0)}
         />
       </div>
       <div style={{ padding: 40, maxWidth: 400 }}>


### PR DESCRIPTION
Add the ability to automatically increment the value of an InputNumber, by clicking and holding the step arrow buttons.

If either `stepIncrementInterval` or `stepIncrementInitialDelay` are not supplied, then the current functionality is retained and there is not any automatic incrementing.

#525 specifically asks for exponential increase, but I think that a single delay value in milliseconds handles most use cases without much complexity.

If providing something other than a single delay value is required, then I think the type for `stepIncrementInterval` should change and the prop can be a function to calculate the rate.  The type would change from `stepIncrementInterval?: number` to `stepIncrementInterval?: number | (count: number) => number` where count is the current increment count and the return value should be the delay to use.
Example function that could then be provided.
```ts
function calcDelay(count: number): number {
  return 100 * count * count;
}
```

Fixes #525