### PR TITLE
[@mantine/core] TransferList: Add the `showTransferAll` prop.

### DIFF
--- a/src/mantine-core/src/components/TransferList/RenderList/RenderList.tsx
+++ b/src/mantine-core/src/components/TransferList/RenderList/RenderList.tsx
@@ -22,7 +22,7 @@ interface RenderListProps extends DefaultProps<RenderListStylesNames> {
   title?: React.ReactNode;
   reversed?: boolean;
   showSearch?: boolean;
-  hideTransferAll?: boolean;
+  showTransferAll?: boolean;
   onMoveAll(): void;
   onMove(): void;
   height: number;
@@ -41,7 +41,7 @@ export function RenderList({
   nothingFound,
   title,
   showSearch,
-  hideTransferAll,
+  showTransferAll,
   reversed,
   onMoveAll,
   onMove,
@@ -166,7 +166,7 @@ export function RenderList({
             {reversed ? <PrevIcon /> : <NextIcon />}
           </ActionIcon>
 
-          {!hideTransferAll && (
+          {showTransferAll && (
             <ActionIcon
               variant="default"
               size={36}

--- a/src/mantine-core/src/components/TransferList/RenderList/RenderList.tsx
+++ b/src/mantine-core/src/components/TransferList/RenderList/RenderList.tsx
@@ -22,6 +22,7 @@ interface RenderListProps extends DefaultProps<RenderListStylesNames> {
   title?: React.ReactNode;
   reversed?: boolean;
   showSearch?: boolean;
+  hideTransferAll?: boolean;
   onMoveAll(): void;
   onMove(): void;
   height: number;
@@ -40,6 +41,7 @@ export function RenderList({
   nothingFound,
   title,
   showSearch,
+  hideTransferAll,
   reversed,
   onMoveAll,
   onMove,
@@ -164,17 +166,19 @@ export function RenderList({
             {reversed ? <PrevIcon /> : <NextIcon />}
           </ActionIcon>
 
-          <ActionIcon
-            variant="default"
-            size={36}
-            radius={0}
-            className={classes.transferListControl}
-            disabled={data.length === 0}
-            onClick={onMoveAll}
-            sx={{ flex: showSearch ? 0 : 1 }}
-          >
-            {reversed ? <FirstIcon /> : <LastIcon />}
-          </ActionIcon>
+          {!hideTransferAll && (
+            <ActionIcon
+              variant="default"
+              size={36}
+              radius={0}
+              className={classes.transferListControl}
+              disabled={data.length === 0}
+              onClick={onMoveAll}
+              sx={{ flex: showSearch ? 0 : 1 }}
+            >
+              {reversed ? <FirstIcon /> : <LastIcon />}
+            </ActionIcon>
+          )}
         </div>
 
         <ListComponent

--- a/src/mantine-core/src/components/TransferList/TransferList.tsx
+++ b/src/mantine-core/src/components/TransferList/TransferList.tsx
@@ -49,7 +49,7 @@ export interface TransferListProps
   showSearch?: boolean;
 
   /** Whether to hide the transfer all button */
-  hideTransferAll?: boolean;
+  showTransferAll?: boolean;
 }
 
 export function defaultFilter(query: string, item: TransferListItem) {
@@ -70,7 +70,7 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>(
       listHeight = 150,
       listComponent = SelectScrollArea,
       showSearch = true,
-      hideTransferAll = false,
+      showTransferAll = true,
       breakpoint,
       classNames,
       styles,
@@ -127,7 +127,7 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>(
           height={listHeight}
           listComponent={listComponent}
           showSearch={showSearch}
-          hideTransferAll={hideTransferAll}
+          showTransferAll={showTransferAll}
           classNames={classNames}
           styles={styles}
         />
@@ -146,7 +146,7 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>(
           height={listHeight}
           listComponent={listComponent}
           showSearch={showSearch}
-          hideTransferAll={hideTransferAll}
+          showTransferAll={showTransferAll}
           classNames={classNames}
           styles={styles}
           reversed

--- a/src/mantine-core/src/components/TransferList/TransferList.tsx
+++ b/src/mantine-core/src/components/TransferList/TransferList.tsx
@@ -47,6 +47,9 @@ export interface TransferListProps
 
   /** Whether to show the search input field */
   showSearch?: boolean;
+
+  /** Whether to hide the transfer all button */
+  hideTransferAll?: boolean;
 }
 
 export function defaultFilter(query: string, item: TransferListItem) {
@@ -67,6 +70,7 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>(
       listHeight = 150,
       listComponent = SelectScrollArea,
       showSearch = true,
+      hideTransferAll = false,
       breakpoint,
       classNames,
       styles,
@@ -123,6 +127,7 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>(
           height={listHeight}
           listComponent={listComponent}
           showSearch={showSearch}
+          hideTransferAll={hideTransferAll}
           classNames={classNames}
           styles={styles}
         />
@@ -141,6 +146,7 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>(
           height={listHeight}
           listComponent={listComponent}
           showSearch={showSearch}
+          hideTransferAll={hideTransferAll}
           classNames={classNames}
           styles={styles}
           reversed


### PR DESCRIPTION
This PR adds the `hideTransferAll` prop, which controls whether the Transfer All buttons (`<<` && `>>`) get's shown. The default value for this prop is false to retain backwards compatibility.

Addresses #544 