### PR TITLE
[@mantine/core] Make Select re-render the input on label change

### DIFF
--- a/src/mantine-core/src/components/MultiSelect/stories/MultiSelect.story.tsx
+++ b/src/mantine-core/src/components/MultiSelect/stories/MultiSelect.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { MANTINE_SIZES } from '@mantine/styles';
 import { WithinOverlays, SubmitForm } from '@mantine/ds/src';
@@ -46,6 +46,41 @@ function Controlled() {
       <MultiSelect
         label="Multi select"
         data={data}
+        value={value}
+        onChange={setValue}
+        placeholder="Select items"
+        nothingFound="Nothing found"
+        searchable
+      />
+      <button type="button" onClick={() => setValue(['react', 'ng'])}>
+        Set value
+      </button>
+    </div>
+  );
+}
+
+function DynamicLabels() {
+  const [value, setValue] = useState([]);
+  const [dynamicData, setDynamicData] = useState(data);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setDynamicData(
+        data.map((d) => ({
+          value: d.value,
+          label: `${d.label}-${Math.floor(Math.random() * 100)}`,
+        }))
+      );
+    }, 1000);
+
+    return () => clearInterval(interval);
+  });
+
+  return (
+    <div style={{ padding: 40, maxWidth: 400 }}>
+      <MultiSelect
+        label="Multi select"
+        data={dynamicData}
         value={value}
         onChange={setValue}
         placeholder="Select items"
@@ -158,6 +193,7 @@ storiesOf('@mantine/core/MultiSelect/stories', module)
     </div>
   ))
   .add('Controlled', () => <Controlled />)
+  .add('Dynamic Labels', () => <DynamicLabels />)
   .add('Searchable', () => (
     <Group style={{ padding: 40, paddingBottom: 0 }} grow align="flex-start">
       <MultiSelect

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -254,6 +254,12 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       }
     }, [_value]);
 
+    useEffect(() => {
+      if (selectedValue && (!searchable || !dropdownOpened)) {
+        handleSearchChange(selectedValue.label);
+      }
+    }, [selectedValue?.label]);
+
     const handleItemSelect = (item: SelectItem) => {
       handleChange(item.value);
 

--- a/src/mantine-core/src/components/Select/stories/Select.story.tsx
+++ b/src/mantine-core/src/components/Select/stories/Select.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { paragraph } from '@mantine/mockdata';
 import { SubmitForm } from '@mantine/ds/src';
@@ -77,6 +77,46 @@ function Creatable() {
   );
 }
 
+function DynamicLabels(props: Partial<SelectProps>) {
+  const [value, setValue] = useState(null);
+  const [dynamicData, setDynamicData] = useState(data);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setDynamicData(
+        data.map((d) => ({
+          value: d.value,
+          label: `${d.label}-${Math.floor(Math.random() * 100)}`,
+        }))
+      );
+    }, 1000);
+
+    return () => clearInterval(interval);
+  });
+
+  return (
+    <div>
+      <Select
+        label="Controlled"
+        placeholder="Controlled"
+        value={value}
+        onChange={setValue}
+        data={dynamicData}
+        mt="md"
+        {...props}
+      />
+      <Group mt="md">
+        <Button variant="outline" onClick={() => setValue(null)}>
+          Set null
+        </Button>
+        <Button variant="outline" onClick={() => setValue('react')}>
+          Set value
+        </Button>
+      </Group>
+    </div>
+  );
+}
+
 storiesOf('@mantine/core/Select/stories', module)
   .add('Controlled', () => (
     <div style={{ padding: 40, maxWidth: 400 }}>
@@ -93,6 +133,16 @@ storiesOf('@mantine/core/Select/stories', module)
         data={data}
         style={{ marginTop: 20 }}
       />
+    </div>
+  ))
+  .add('Dynamic Labels', () => (
+    <div style={{ padding: 40, maxWidth: 400 }}>
+      <DynamicLabels />
+    </div>
+  ))
+  .add('Dynamic Labels (searchable)', () => (
+    <div style={{ padding: 40, maxWidth: 400 }}>
+      <DynamicLabels searchable />
     </div>
   ))
   .add('Disabled items', () => (


### PR DESCRIPTION
Hello!

This PR fixes the fact that Select's input does not re-render if the label of the selected item changes in the `data` array.

I did not have to change MultiSelect which didn't have the issue. I added a story for both Select and MultiSelect to see it in action.