### PR TITLE
[@mantine/core] Skeleton: Add the `showAnimation` prop.

### DIFF
--- a/src/mantine-core/src/components/Skeleton/Skeleton.styles.ts
+++ b/src/mantine-core/src/components/Skeleton/Skeleton.styles.ts
@@ -5,6 +5,7 @@ interface SkeletonStylesProps {
   width: number | string;
   circle: boolean;
   radius: MantineNumberSize;
+  showAnimation: boolean;
 }
 
 export const fade = keyframes({
@@ -12,37 +13,39 @@ export const fade = keyframes({
   '50%': { opacity: 1 },
 });
 
-export default createStyles((theme, { height, width, radius, circle }: SkeletonStylesProps) => ({
-  root: {
-    height,
-    width: circle ? height : width,
-    borderRadius: circle ? height : theme.fn.size({ size: radius, sizes: theme.radius }),
-    position: 'relative',
-    overflow: 'hidden',
-  },
-
-  visible: {
-    '&::before': {
-      content: '""',
-      position: 'absolute',
-      background: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
-      top: 0,
-      bottom: 0,
-      left: 0,
-      right: 0,
-      zIndex: 10,
+export default createStyles(
+  (theme, { height, width, radius, circle, showAnimation }: SkeletonStylesProps) => ({
+    root: {
+      height,
+      width: circle ? height : width,
+      borderRadius: circle ? height : theme.fn.size({ size: radius, sizes: theme.radius }),
+      position: 'relative',
+      overflow: 'hidden',
     },
 
-    '&::after': {
-      content: '""',
-      position: 'absolute',
-      background: theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3],
-      top: 0,
-      bottom: 0,
-      left: 0,
-      right: 0,
-      animation: `${fade} 1500ms linear infinite`,
-      zIndex: 11,
+    visible: {
+      '&::before': {
+        content: '""',
+        position: 'absolute',
+        background: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: 10,
+      },
+
+      '&::after': {
+        content: '""',
+        position: 'absolute',
+        background: theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3],
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        animation: showAnimation ? `${fade} 1500ms linear infinite` : 'none',
+        zIndex: 11,
+      },
     },
-  },
-}));
+  })
+);

--- a/src/mantine-core/src/components/Skeleton/Skeleton.styles.ts
+++ b/src/mantine-core/src/components/Skeleton/Skeleton.styles.ts
@@ -5,7 +5,7 @@ interface SkeletonStylesProps {
   width: number | string;
   circle: boolean;
   radius: MantineNumberSize;
-  showAnimation: boolean;
+  animate: boolean;
 }
 
 export const fade = keyframes({
@@ -14,7 +14,7 @@ export const fade = keyframes({
 });
 
 export default createStyles(
-  (theme, { height, width, radius, circle, showAnimation }: SkeletonStylesProps) => ({
+  (theme, { height, width, radius, circle, animate }: SkeletonStylesProps) => ({
     root: {
       height,
       width: circle ? height : width,
@@ -43,7 +43,7 @@ export default createStyles(
         bottom: 0,
         left: 0,
         right: 0,
-        animation: showAnimation ? `${fade} 1500ms linear infinite` : 'none',
+        animation: animate ? `${fade} 1500ms linear infinite` : 'none',
         zIndex: 11,
       },
     },

--- a/src/mantine-core/src/components/Skeleton/Skeleton.tsx
+++ b/src/mantine-core/src/components/Skeleton/Skeleton.tsx
@@ -20,7 +20,7 @@ export interface SkeletonProps extends DefaultProps, React.ComponentPropsWithout
   radius?: MantineNumberSize;
 
   /** Whether to show the animation effect */
-  showAnimation?: boolean;
+  animate?: boolean;
 }
 
 export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
@@ -29,7 +29,7 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
       height = 'auto',
       width = '100%',
       visible = true,
-      showAnimation = true,
+      animate = true,
       className,
       circle,
       radius = 'sm',
@@ -40,7 +40,7 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
     ref
   ) => {
     const { classes, cx } = useStyles(
-      { height, width, circle, radius, showAnimation },
+      { height, width, circle, radius, animate },
       { classNames, styles, name: 'Skeleton' }
     );
 

--- a/src/mantine-core/src/components/Skeleton/Skeleton.tsx
+++ b/src/mantine-core/src/components/Skeleton/Skeleton.tsx
@@ -18,6 +18,9 @@ export interface SkeletonProps extends DefaultProps, React.ComponentPropsWithout
 
   /** Radius from theme.radius or number to set border-radius in px */
   radius?: MantineNumberSize;
+
+  /** Whether to show the animation effect */
+  showAnimation?: boolean;
 }
 
 export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
@@ -26,6 +29,7 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
       height = 'auto',
       width = '100%',
       visible = true,
+      showAnimation = true,
       className,
       circle,
       radius = 'sm',
@@ -36,7 +40,7 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
     ref
   ) => {
     const { classes, cx } = useStyles(
-      { height, width, circle, radius },
+      { height, width, circle, radius, showAnimation },
       { classNames, styles, name: 'Skeleton' }
     );
 


### PR DESCRIPTION
This commit proposes to add a `showAnimation` prop to the `Skeleton` component. This can be used to disable skeleton animation. It's default value is `true` to maintain backwards compatibility.

References:
-------------
1. https://mui.com/api/skeleton/
2. https://ant.design/components/skeleton/#API