### PR TITLE
[docs] Change resize handle location from left to right

### DIFF
--- a/docs/src/demos/hooks/use-resize-observer.tsx
+++ b/docs/src/demos/hooks/use-resize-observer.tsx
@@ -25,7 +25,7 @@ function Demo() {
   return (
     <>
       <Text align="center" size="sm" style={{ marginBottom: theme.spacing.xs }}>
-        Resize textarea by moving its left bottom corner
+        Resize textarea by moving its right bottom corner
       </Text>
 
       <Group position="center">


### PR DESCRIPTION
The resize handle is not located on the bottom left corner, but on the right.

Location on Firefox:
![kuva](https://user-images.githubusercontent.com/38920928/147361221-0ad9f546-739f-4f2a-bb09-dc2e8831183c.png)

Location on Chrome:
![kuva](https://user-images.githubusercontent.com/38920928/147361233-042ef9f7-72f0-4fac-bd44-5c06bc680da1.png)

Location on Edge:
![kuva](https://user-images.githubusercontent.com/38920928/147361259-261e9389-f8dd-418d-911a-0b66e2e7a6b0.png)
