### PR TITLE
[@mantine/core] Switch: Add the `(on|off)Label` props.

### DIFF
--- a/docs/src/docs/core/Switch.mdx
+++ b/docs/src/docs/core/Switch.mdx
@@ -50,6 +50,17 @@ Alternatively, you can use a number to set radius in px:
 
 <Demo data={SwitchDemos.radius} />
 
+## Inner Labels
+
+Use the `onLabel` & `offLabel` props to render text within the Switch box in the checked and unchecked states
+respectively.
+
+```tsx
+<Switch radius="xl" color="green" onLabel="On" offLabel="Off" />
+```
+
+<Demo data={SwitchDemos.labels} />
+
 ## Get input ref
 
 ```tsx

--- a/src/mantine-core/src/components/Switch/Switch.styles.ts
+++ b/src/mantine-core/src/components/Switch/Switch.styles.ts
@@ -4,6 +4,8 @@ interface SwitchStyles {
   color: MantineColor;
   size: MantineSize;
   radius: MantineNumberSize;
+  offLabel: string;
+  onLabel: string;
 }
 
 const switchHeight = {
@@ -35,7 +37,7 @@ export const sizes = Object.keys(switchHeight).reduce((acc, size) => {
   return acc;
 }, {} as Record<MantineSize, { width: number; height: number }>);
 
-export default createStyles((theme, { size, radius, color }: SwitchStyles) => {
+export default createStyles((theme, { size, radius, color, offLabel, onLabel }: SwitchStyles) => {
   const handleSize = theme.fn.size({ size, sizes: handleSizes });
   const borderRadius = theme.fn.size({ size: radius, sizes: theme.radius });
 
@@ -65,6 +67,8 @@ export default createStyles((theme, { size, radius, color }: SwitchStyles) => {
       appearance: 'none',
       display: 'flex',
       alignItems: 'center',
+      fontSize: handleSize * 0.55,
+      fontWeight: 600,
 
       '&::before': {
         borderRadius,
@@ -83,6 +87,14 @@ export default createStyles((theme, { size, radius, color }: SwitchStyles) => {
         },
       },
 
+      '&::after': {
+        position: 'absolute',
+        top: '30%',
+        right: '10%',
+        content: offLabel ? `'${offLabel}'` : '',
+        color: theme.white,
+      },
+
       '&:checked': {
         backgroundColor: theme.fn.themeColor(color, 6),
         borderColor: theme.fn.themeColor(color, 6),
@@ -94,6 +106,14 @@ export default createStyles((theme, { size, radius, color }: SwitchStyles) => {
             (size === 'xs' ? 3 : 4) // borderWidth: 2 + padding: 2 * 2
           }px)`,
           borderColor: theme.white,
+        },
+
+        '&::after': {
+          position: 'absolute',
+          top: '30%',
+          left: '10%',
+          content: onLabel ? `'${onLabel}'` : '',
+          color: theme.white,
         },
       },
 

--- a/src/mantine-core/src/components/Switch/Switch.styles.ts
+++ b/src/mantine-core/src/components/Switch/Switch.styles.ts
@@ -91,7 +91,7 @@ export default createStyles((theme, { size, radius, color, offLabel, onLabel }: 
         position: 'absolute',
         top: '30%',
         right: '10%',
-        content: offLabel ? `'${offLabel}'` : '',
+        content: offLabel ? `'${offLabel}'` : "''",
         color: theme.white,
       },
 
@@ -112,7 +112,7 @@ export default createStyles((theme, { size, radius, color, offLabel, onLabel }: 
           position: 'absolute',
           top: '30%',
           left: '10%',
-          content: onLabel ? `'${onLabel}'` : '',
+          content: onLabel ? `'${onLabel}'` : "''",
           color: theme.white,
         },
       },

--- a/src/mantine-core/src/components/Switch/Switch.tsx
+++ b/src/mantine-core/src/components/Switch/Switch.tsx
@@ -22,6 +22,12 @@ export interface SwitchProps
   /** Switch label */
   label?: React.ReactNode;
 
+  /** The inner label to be set when Switch is in an unchecked state */
+  offLabel?: string;
+
+  /** The inner label to be set when Switch is in the checked state */
+  onLabel?: string;
+
   /** Switch checked state color from theme.colors, defaults to theme.primaryColor */
   color?: MantineColor;
 
@@ -41,6 +47,8 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
       className,
       color,
       label,
+      offLabel = '',
+      onLabel = '',
       id,
       style,
       size = 'sm',
@@ -55,7 +63,7 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
     ref
   ) => {
     const { classes, cx } = useStyles(
-      { size, color, radius },
+      { size, color, radius, offLabel, onLabel },
       { classNames, styles, name: 'Switch' }
     );
     const { margins, rest } = extractMargins(others);

--- a/src/mantine-core/src/components/Switch/demos/configurator.tsx
+++ b/src/mantine-core/src/components/Switch/demos/configurator.tsx
@@ -20,7 +20,5 @@ export const configurator: MantineDemo = {
     { name: 'radius', type: 'size', initialValue: 'xl', defaultValue: 'xl' },
     { name: 'color', type: 'color', initialValue: 'blue', defaultValue: 'blue' },
     { name: 'disabled', type: 'boolean', initialValue: false, defaultValue: false },
-    { name: 'onLabel', type: 'string', initialValue: '', defaultValue: '' },
-    { name: 'offLabel', type: 'string', initialValue: '', defaultValue: '' },
   ],
 };

--- a/src/mantine-core/src/components/Switch/demos/configurator.tsx
+++ b/src/mantine-core/src/components/Switch/demos/configurator.tsx
@@ -20,5 +20,7 @@ export const configurator: MantineDemo = {
     { name: 'radius', type: 'size', initialValue: 'xl', defaultValue: 'xl' },
     { name: 'color', type: 'color', initialValue: 'blue', defaultValue: 'blue' },
     { name: 'disabled', type: 'boolean', initialValue: false, defaultValue: false },
+    { name: 'onLabel', type: 'string', initialValue: '', defaultValue: '' },
+    { name: 'offLabel', type: 'string', initialValue: '', defaultValue: '' },
   ],
 };

--- a/src/mantine-core/src/components/Switch/demos/index.ts
+++ b/src/mantine-core/src/components/Switch/demos/index.ts
@@ -1,3 +1,4 @@
 export { configurator } from './configurator';
 export { radius } from './radius';
 export { sizes } from './sizes';
+export { labels } from './labels';

--- a/src/mantine-core/src/components/Switch/demos/labels.tsx
+++ b/src/mantine-core/src/components/Switch/demos/labels.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Switch } from '../Switch';
+
+const code = `
+  <Switch
+    size="lg"
+    color="green"
+    onLabel="On"
+    offLabel="Off"
+  />
+`;
+
+function Label() {
+  return (
+    <>
+      <Switch size="lg" color="green" onLabel="On" offLabel="Off" />
+    </>
+  );
+}
+
+export const labels: MantineDemo = {
+  type: 'demo',
+  component: Label,
+};

--- a/src/mantine-core/src/components/Switch/demos/labels.tsx
+++ b/src/mantine-core/src/components/Switch/demos/labels.tsx
@@ -1,15 +1,6 @@
 import React from 'react';
 import { Switch } from '../Switch';
 
-const code = `
-  <Switch
-    size="lg"
-    color="green"
-    onLabel="On"
-    offLabel="Off"
-  />
-`;
-
 function Label() {
   return (
     <>


### PR DESCRIPTION
This PR adds the `onLabel` & `offLabel` props to control the text that gets shown in a `Switch` component in the checked/unchecked state respectively.