### PR TITLE
[@mantine/modals] Fix onClose callback not called in closeAll function

### DIFF
--- a/src/mantine-modals/src/ModalsProvider.tsx
+++ b/src/mantine-modals/src/ModalsProvider.tsx
@@ -59,7 +59,10 @@ export function ModalsProvider({ children, modalProps, labels, modals }: ModalsP
     props: null,
     type: 'content',
   });
-  const closeAll = () => handlers.setState([]);
+  const closeAll = () => {
+    state.forEach((modal) => modal.props?.onClose?.());
+    handlers.setState([]);
+  };
 
   const openModal = (props: ModalSettings) => {
     const id = props.id || randomId();


### PR DESCRIPTION
This PR fixes https://github.com/mantinedev/mantine/issues/592