### PR TITLE
[@mantine/hooks] use-element-size: init hook

### DIFF
--- a/docs/src/demos/hooks/use-element-size.tsx
+++ b/docs/src/demos/hooks/use-element-size.tsx
@@ -1,26 +1,26 @@
 import React from 'react';
 import { useMantineTheme, Text, Group, Code } from '@mantine/core';
-import { useResizeObserver } from '@mantine/hooks';
+import { useElementSize } from '@mantine/hooks';
 
 const code = `
 import { useMantineTheme, Text, Code } from '@mantine/core';
-import { useResizeObserver } from '@mantine/hooks';
+import { useElementSize } from '@mantine/hooks';
 
 function Demo() {
   const theme = useMantineTheme();
-  const [ref, rect] = useResizeObserver();
+  const { ref, ...resolution } = useElementSize();
 
   return (
     <>
       <textarea ref={ref} style={{ pointerEvents: 'none', width: 400, height: 120 }} />
-      <Text align="center">Rect: <Code>{JSON.stringify(rect)}</Code></Text>
+      <Text align="center">Rect: <Code>{JSON.stringify(resolution)}</Code></Text>
     </>
   );
 }`;
 
 function Demo() {
   const theme = useMantineTheme();
-  const [ref, rect] = useResizeObserver();
+  const { ref, ...resolution } = useElementSize();
 
   return (
     <>
@@ -43,13 +43,13 @@ function Demo() {
         />
       </Group>
       <Text align="center" style={{ marginTop: theme.spacing.sm }}>
-        Rect: <Code>{JSON.stringify(rect, null, 2)}</Code>
+        Rect: <Code>{JSON.stringify(resolution, null, 2)}</Code>
       </Text>
     </>
   );
 }
 
-export const useResizeObserverDemo: MantineDemo = {
+export const useElementSizeDemo: MantineDemo = {
   type: 'demo',
   code,
   component: Demo,

--- a/docs/src/demos/index.ts
+++ b/docs/src/demos/index.ts
@@ -4,6 +4,7 @@ export * from './hooks/use-click-outside';
 export * from './hooks/use-clipboard';
 export * from './hooks/use-color-scheme';
 export * from './hooks/use-document-title';
+export * from './hooks/use-element-size';
 export * from './hooks/use-idle';
 export * from './hooks/use-interval';
 export * from './hooks/use-media-query';

--- a/docs/src/docs/hooks/use-element-size.mdx
+++ b/docs/src/docs/hooks/use-element-size.mdx
@@ -1,0 +1,46 @@
+---
+group: 'mantine-hooks'
+package: '@mantine/hooks'
+category: 'dom'
+title: 'use-element-size'
+order: 1
+slug: /hooks/use-element-size/
+description: 'Subscribe to element size'
+import: "import { useElementSize } from '@mantine/hooks';"
+docs: 'hooks/use-element-size.mdx'
+source: 'mantine-hooks/src/use-element-size/use-element-size'
+---
+
+import { useElementSizeDemo } from '@docs/demos';
+
+## Usage
+
+<Demo data={useElementSizeDemo} />
+
+## API
+
+A hook based on `useResizeObserver` to observe element's width and height.
+
+Hook returns ref function that should be passed to the observed element, and the element's height and width.
+
+On the first render (as well as during SSR), or when no element is being observed, all of the properties are equal to `0`.
+
+```tsx
+const {ref, width, height} = useElementSize();
+
+// With regular element:
+<div ref={ref}>Observed</div>
+
+// With Mantine component:
+<Paper ref={ref}>Observed</Paper>
+```
+
+## Definition
+
+```tsx
+function useElementSize<T extends HTMLElement = any>(): {
+  MutableRefObject<T>,
+  width: number,
+  height: number
+};
+```

--- a/src/mantine-hooks/src/index.ts
+++ b/src/mantine-hooks/src/index.ts
@@ -43,6 +43,7 @@ export { useUuid } from './use-uuid/use-uuid';
 export { useOs } from './use-os/use-os';
 export { useSetState } from './use-set-state/use-set-state';
 export { useInputState } from './use-input-state/use-input-state';
+export { useElementSize } from './use-element-size/use-element-size';
 
 export type { UseMovePosition } from './use-move/use-move';
 export type { OS } from './use-os/use-os';

--- a/src/mantine-hooks/src/use-element-size/use-element-size.ts
+++ b/src/mantine-hooks/src/use-element-size/use-element-size.ts
@@ -1,5 +1,7 @@
-//import { useRef } from 'react';
+import { useResizeObserver } from '../use-resize-observer/use-resize-observer';
 
 export function useElementSize<T extends HTMLElement = any>() {
-  //const ref = useRef<T>(null);
+  const [ref, { width, height }] = useResizeObserver<T>();
+
+  return { ref, width, height } as const;
 }

--- a/src/mantine-hooks/src/use-element-size/use-element-size.ts
+++ b/src/mantine-hooks/src/use-element-size/use-element-size.ts
@@ -1,0 +1,5 @@
+//import { useRef } from 'react';
+
+export function useElementSize<T extends HTMLElement = any>() {
+  //const ref = useRef<T>(null);
+}


### PR DESCRIPTION
This PR implements the simpler use-element-size hook.