### PR TITLE
[@mantine/core] Select: allowDeselect prop

### DIFF
--- a/docs/src/docs/core/Select.mdx
+++ b/docs/src/docs/core/Select.mdx
@@ -113,6 +113,12 @@ When prop is true and value is selected clear button will replace chevron in rig
 
 <Demo data={SelectDemos.clearable} />
 
+## Allow Deselect prop
+
+Set `allowDeselect` prop to enable deselecting value.
+
+<Demo data={SelectDemos.deselectable} />
+
 ## Creatable
 
 Set `creatable` and `getCreateLabel` props to enable creating new select item.

--- a/docs/src/docs/core/Select.mdx
+++ b/docs/src/docs/core/Select.mdx
@@ -116,6 +116,7 @@ When prop is true and value is selected clear button will replace chevron in rig
 ## Allow Deselect prop
 
 Set `allowDeselect` prop to enable deselecting value.
+If `clearable` prop is set, `allowDeselect` defaults to `true`.
 
 <Demo data={SelectDemos.deselectable} />
 

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -185,7 +185,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       zIndex = getDefaultZIndex('popover'),
       name,
       dropdownPosition,
-      allowDeselect = false,
+      allowDeselect,
       ...others
     }: SelectProps,
     ref
@@ -206,7 +206,8 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       cancelable: false,
       isList: true,
     });
-    const isDeselectedValue = useRef<boolean>(false);
+
+    const isDeselectable = allowDeselect === undefined ? clearable : allowDeselect;
 
     const setDropdownOpened = (opened: boolean) => {
       _setDropdownOpened(opened);
@@ -266,9 +267,9 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
     }, [selectedValue?.label]);
 
     const handleItemSelect = (item: SelectItem) => {
-      if (allowDeselect && selectedValue?.value === item.value) {
+      if (isDeselectable && selectedValue?.value === item.value) {
         handleChange(null);
-        isDeselectedValue.current = true;
+        setDropdownOpened(false);
       } else {
         handleChange(item.value);
 
@@ -312,15 +313,13 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
     };
 
     useDidUpdate(() => {
-      if (!isDeselectedValue) {
-        setHovered(
-          getNextIndex(
-            -1,
-            (index) => index + 1,
-            (index) => index < filteredData.length - 1
-          )
-        );
-      } else isDeselectedValue.current = false;
+      setHovered(
+        getNextIndex(
+          -1,
+          (index) => index + 1,
+          (index) => index < filteredData.length - 1
+        )
+      );
     }, [inputValue]);
 
     const selectedItemIndex = _value ? filteredData.findIndex((el) => el.value === _value) : 0;

--- a/src/mantine-core/src/components/Select/demos/deselectable.tsx
+++ b/src/mantine-core/src/components/Select/demos/deselectable.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Select } from '../Select';
+
+const code = `
+<Select
+  label="Your favorite framework/library"
+  placeholder="Pick one"
+  data={[
+    { value: 'react', label: 'React' },
+    { value: 'ng', label: 'Angular' },
+    { value: 'svelte', label: 'Svelte' },
+    { value: 'vue', label: 'Vue' },
+  ]}
+  allowDeselect
+/>
+`;
+
+function Demo() {
+  return (
+    <div style={{ maxWidth: 320, marginLeft: 'auto', marginRight: 'auto' }}>
+      <Select
+        label="Your favorite framework/library"
+        placeholder="Pick one"
+        data={[
+          { value: 'react', label: 'React' },
+          { value: 'ng', label: 'Angular' },
+          { value: 'svelte', label: 'Svelte' },
+          { value: 'vue', label: 'Vue' },
+        ]}
+        allowDeselect
+      />
+    </div>
+  );
+}
+
+export const deselectable: MantineDemo = {
+  type: 'demo',
+  code,
+  component: Demo,
+};

--- a/src/mantine-core/src/components/Select/demos/deselectable.tsx
+++ b/src/mantine-core/src/components/Select/demos/deselectable.tsx
@@ -5,13 +5,13 @@ const code = `
 <Select
   label="Your favorite framework/library"
   placeholder="Pick one"
+  allowDeselect
   data={[
     { value: 'react', label: 'React' },
     { value: 'ng', label: 'Angular' },
     { value: 'svelte', label: 'Svelte' },
     { value: 'vue', label: 'Vue' },
   ]}
-  allowDeselect
 />
 `;
 
@@ -21,13 +21,13 @@ function Demo() {
       <Select
         label="Your favorite framework/library"
         placeholder="Pick one"
+        allowDeselect
         data={[
           { value: 'react', label: 'React' },
           { value: 'ng', label: 'Angular' },
           { value: 'svelte', label: 'Svelte' },
           { value: 'vue', label: 'Vue' },
         ]}
-        allowDeselect
       />
     </div>
   );

--- a/src/mantine-core/src/components/Select/demos/index.ts
+++ b/src/mantine-core/src/components/Select/demos/index.ts
@@ -14,3 +14,4 @@ export { icon } from './icon';
 export { rightSection } from './rightSection';
 export { group } from './group';
 export { scrollbars } from './scrollbars';
+export { deselectable } from './deselectable';

--- a/src/mantine-core/src/components/Select/stories/Select.story.tsx
+++ b/src/mantine-core/src/components/Select/stories/Select.story.tsx
@@ -188,8 +188,7 @@ storiesOf('@mantine/core/Select/stories', module)
         placeholder="Choose value"
         data={[...data, { value: 'lit', label: 'Lit', disabled: true }]}
         style={{ marginTop: 20 }}
-        allowDeselect
-        searchable
+        allowDeselect={false}
       />
     </div>
   ))
@@ -283,9 +282,6 @@ storiesOf('@mantine/core/Select/stories', module)
           { value: 'svelte', label: 'Svelte' },
           { value: 'vue', label: 'Vue' },
         ]}
-        allowDeselect
-        searchable
-        clearable
       />
     </div>
   ));

--- a/src/mantine-core/src/components/Select/stories/Select.story.tsx
+++ b/src/mantine-core/src/components/Select/stories/Select.story.tsx
@@ -181,6 +181,18 @@ storiesOf('@mantine/core/Select/stories', module)
       <Creatable />
     </div>
   ))
+  .add('Deselect item', () => (
+    <div style={{ padding: 40, maxWidth: 400 }}>
+      <Select
+        label="Disabled Elements"
+        placeholder="Choose value"
+        data={[...data, { value: 'lit', label: 'Lit', disabled: true }]}
+        style={{ marginTop: 20 }}
+        allowDeselect
+        searchable
+      />
+    </div>
+  ))
   .add('String as data', () => (
     <div style={{ padding: 40, maxWidth: 400 }}>
       <Select
@@ -271,6 +283,9 @@ storiesOf('@mantine/core/Select/stories', module)
           { value: 'svelte', label: 'Svelte' },
           { value: 'vue', label: 'Vue' },
         ]}
+        allowDeselect
+        searchable
+        clearable
       />
     </div>
   ));


### PR DESCRIPTION
This PR adds `allowDeselect` prop to Select component.

Features - 
- add deselectable feature.
- making sure the dropdown doesn't close on deselecting