### PR TITLE
Fixed useHash not getting initial value

### DIFF
--- a/src/mantine-hooks/src/use-hash/use-hash.ts
+++ b/src/mantine-hooks/src/use-hash/use-hash.ts
@@ -4,7 +4,7 @@ import { useWindowEvent } from '../use-window-event/use-window-event';
 const browser = typeof window !== 'undefined';
 
 export function useHash(): readonly [string | null, (hash: string) => void] {
-  const [hash, setHashValue] = useState<string>(browser ? window.location.hash : "");
+  const [hash, setHashValue] = useState<string>(browser ? window.location?.hash : "");
 
   const setHash = (value: string) => {
     window.location.hash = value;

--- a/src/mantine-hooks/src/use-hash/use-hash.ts
+++ b/src/mantine-hooks/src/use-hash/use-hash.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useWindowEvent } from '../use-window-event/use-window-event';
 
 export function useHash(): readonly [string | null, (hash: string) => void] {
-  const [hash, setHashValue] = useState<string>(null);
+  const [hash, setHashValue] = useState<string>(window.location.hash);
 
   const setHash = (value: string) => {
     window.location.hash = value;

--- a/src/mantine-hooks/src/use-hash/use-hash.ts
+++ b/src/mantine-hooks/src/use-hash/use-hash.ts
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { useWindowEvent } from '../use-window-event/use-window-event';
 
+const browser = typeof window !== 'undefined';
+
 export function useHash(): readonly [string | null, (hash: string) => void] {
-  const [hash, setHashValue] = useState<string>(window.location.hash);
+  const [hash, setHashValue] = useState<string>(browser ? window.location.hash : "");
 
   const setHash = (value: string) => {
     window.location.hash = value;


### PR DESCRIPTION
The hashchange event is not firing on initial load, adding window.location.hash directly to the useState would solve this.
Tried it locally and these changes make it work.

Let me know if something is wrong.