### PR TITLE
[@mantine/core] Alert: Add a `variant` prop.

### DIFF
--- a/src/mantine-core/src/components/Alert/Alert.styles.ts
+++ b/src/mantine-core/src/components/Alert/Alert.styles.ts
@@ -1,69 +1,94 @@
-import { createStyles, MantineColor, MantineNumberSize } from '@mantine/styles';
+import {
+  createStyles,
+  MantineColor,
+  MantineNumberSize,
+  getSharedColorScheme,
+} from '@mantine/styles';
 
 interface AlertStyles {
   color: MantineColor;
   radius: MantineNumberSize;
 }
 
-export default createStyles((theme, { color, radius }: AlertStyles) => ({
-  root: {
-    ...theme.fn.fontStyles(),
-    position: 'relative',
-    overflow: 'hidden',
-    padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
-    borderRadius: theme.fn.size({ size: radius, sizes: theme.radius }),
-    backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.fn.themeColor(color, 0),
-  },
+export default createStyles((theme, { color, radius }: AlertStyles) => {
+  const lightColors = getSharedColorScheme({ color, theme, variant: 'light' });
+  const filledColors = getSharedColorScheme({ theme, color, variant: 'filled' });
+  const outlineColors = getSharedColorScheme({ theme, color, variant: 'outline' });
 
-  wrapper: {
-    display: 'flex',
-  },
+  return {
+    root: {
+      ...theme.fn.fontStyles(),
+      position: 'relative',
+      overflow: 'hidden',
+      padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
+      borderRadius: theme.fn.size({ size: radius, sizes: theme.radius }),
+    },
 
-  body: {
-    flex: 1,
-  },
+    wrapper: {
+      display: 'flex',
+    },
 
-  title: {
-    boxSizing: 'border-box',
-    color: theme.fn.themeColor(color, theme.colorScheme === 'dark' ? 5 : 7),
-    margin: 0,
-    marginBottom: 7,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    lineHeight: theme.lineHeight,
-    fontSize: theme.fontSizes.sm,
-    fontWeight: 700,
-  },
+    body: {
+      flex: 1,
+    },
 
-  label: {
-    display: 'block',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
+    title: {
+      boxSizing: 'border-box',
+      margin: 0,
+      marginBottom: 7,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      lineHeight: theme.lineHeight,
+      fontSize: theme.fontSizes.sm,
+      fontWeight: 700,
+    },
 
-  icon: {
-    color: theme.fn.themeColor(color, theme.colorScheme === 'dark' ? 5 : 7),
-    lineHeight: 1,
-    width: 20,
-    height: 20,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-start',
-    marginRight: theme.spacing.md,
-    marginTop: 1,
-  },
+    label: {
+      display: 'block',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    },
 
-  message: {
-    ...theme.fn.fontStyles(),
-    lineHeight: theme.lineHeight,
-    textOverflow: 'ellipsis',
-    overflow: 'hidden',
-    fontSize: theme.fontSizes.sm,
-    color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
-  },
+    light: {
+      backgroundColor: lightColors.background,
+      color: lightColors.color,
+      border: '1px solid transparent',
+    },
 
-  closeButton: {
-    marginTop: 2,
-  },
-}));
+    filled: {
+      backgroundColor: filledColors.background,
+      color: filledColors.color,
+      border: '1px solid transparent',
+    },
+
+    outline: {
+      backgroundColor: outlineColors.background,
+      color: outlineColors.color,
+      border: `1px solid ${outlineColors.border}`,
+    },
+
+    icon: {
+      lineHeight: 1,
+      width: 20,
+      height: 20,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+      marginRight: theme.spacing.md,
+      marginTop: 1,
+    },
+
+    message: {
+      ...theme.fn.fontStyles(),
+      lineHeight: theme.lineHeight,
+      textOverflow: 'ellipsis',
+      overflow: 'hidden',
+      fontSize: theme.fontSizes.sm,
+    },
+
+    closeButton: {
+      marginTop: 2,
+    },
+  };
+});

--- a/src/mantine-core/src/components/Alert/Alert.styles.ts
+++ b/src/mantine-core/src/components/Alert/Alert.styles.ts
@@ -13,12 +13,21 @@ export default createStyles((theme, { color, radius, outline }: AlertStyles) => 
     overflow: 'hidden',
     padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
     borderRadius: theme.fn.size({ size: radius, sizes: theme.radius }),
-    backgroundColor: outline ?
-      'transparent' : theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.fn.themeColor(color, 0),
-    borderColor: outline ?
-      theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.fn.themeColor(color, 0) : 'initial',
-    border: outline ?
-      `3px solid ${theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.fn.themeColor(color, 0)}` : 'initial',
+    backgroundColor: outline
+      ? 'transparent'
+      : theme.colorScheme === 'dark'
+      ? theme.colors.dark[5]
+      : theme.fn.themeColor(color, 0),
+    borderColor: outline
+      ? theme.colorScheme === 'dark'
+        ? theme.colors.dark[5]
+        : theme.fn.themeColor(color, 0)
+      : 'initial',
+    border: outline
+      ? `3px solid ${
+          theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.fn.themeColor(color, 0)
+        }`
+      : 'initial',
   },
 
   wrapper: {

--- a/src/mantine-core/src/components/Alert/Alert.styles.ts
+++ b/src/mantine-core/src/components/Alert/Alert.styles.ts
@@ -3,17 +3,22 @@ import { createStyles, MantineColor, MantineNumberSize } from '@mantine/styles';
 interface AlertStyles {
   color: MantineColor;
   radius: MantineNumberSize;
+  outline: boolean;
 }
 
-export default createStyles((theme, { color, radius }: AlertStyles) => ({
+export default createStyles((theme, { color, radius, outline }: AlertStyles) => ({
   root: {
     ...theme.fn.fontStyles(),
     position: 'relative',
     overflow: 'hidden',
     padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
     borderRadius: theme.fn.size({ size: radius, sizes: theme.radius }),
-    backgroundColor:
-      theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.fn.themeColor(color, 0),
+    backgroundColor: outline ?
+      'transparent' : theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.fn.themeColor(color, 0),
+    borderColor: outline ?
+      theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.fn.themeColor(color, 0) : 'initial',
+    border: outline ?
+      `3px solid ${theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.fn.themeColor(color, 0)}` : 'initial',
   },
 
   wrapper: {

--- a/src/mantine-core/src/components/Alert/Alert.styles.ts
+++ b/src/mantine-core/src/components/Alert/Alert.styles.ts
@@ -3,31 +3,16 @@ import { createStyles, MantineColor, MantineNumberSize } from '@mantine/styles';
 interface AlertStyles {
   color: MantineColor;
   radius: MantineNumberSize;
-  outline: boolean;
 }
 
-export default createStyles((theme, { color, radius, outline }: AlertStyles) => ({
+export default createStyles((theme, { color, radius }: AlertStyles) => ({
   root: {
     ...theme.fn.fontStyles(),
     position: 'relative',
     overflow: 'hidden',
     padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
     borderRadius: theme.fn.size({ size: radius, sizes: theme.radius }),
-    backgroundColor: outline
-      ? 'transparent'
-      : theme.colorScheme === 'dark'
-      ? theme.colors.dark[5]
-      : theme.fn.themeColor(color, 0),
-    borderColor: outline
-      ? theme.colorScheme === 'dark'
-        ? theme.colors.dark[5]
-        : theme.fn.themeColor(color, 0)
-      : 'initial',
-    border: outline
-      ? `3px solid ${
-          theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.fn.themeColor(color, 0)
-        }`
-      : 'initial',
+    backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.fn.themeColor(color, 0),
   },
 
   wrapper: {

--- a/src/mantine-core/src/components/Alert/Alert.styles.ts
+++ b/src/mantine-core/src/components/Alert/Alert.styles.ts
@@ -8,12 +8,13 @@ import {
 interface AlertStyles {
   color: MantineColor;
   radius: MantineNumberSize;
+  variant: 'filled' | 'outline' | 'light';
 }
 
-export default createStyles((theme, { color, radius }: AlertStyles) => {
-  const lightColors = getSharedColorScheme({ color, theme, variant: 'light' });
-  const filledColors = getSharedColorScheme({ theme, color, variant: 'filled' });
-  const outlineColors = getSharedColorScheme({ theme, color, variant: 'outline' });
+export default createStyles((theme, { color, radius, variant }: AlertStyles) => {
+  const lightColors = getSharedColorScheme({ color, theme, variant });
+  const filledColors = getSharedColorScheme({ theme, color, variant });
+  const outlineColors = getSharedColorScheme({ theme, color, variant });
 
   return {
     root: {
@@ -51,8 +52,8 @@ export default createStyles((theme, { color, radius }: AlertStyles) => {
     },
 
     light: {
-      backgroundColor: lightColors.background,
-      color: lightColors.color,
+      backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[5] : lightColors.background,
+      color: theme.fn.themeColor(color, theme.colorScheme === 'dark' ? 5 : 7),
       border: '1px solid transparent',
     },
 
@@ -85,6 +86,12 @@ export default createStyles((theme, { color, radius }: AlertStyles) => {
       textOverflow: 'ellipsis',
       overflow: 'hidden',
       fontSize: theme.fontSizes.sm,
+      color:
+        variant === 'filled'
+          ? filledColors.color
+          : theme.colorScheme === 'dark'
+          ? theme.colors.dark[0]
+          : theme.black,
     },
 
     closeButton: {

--- a/src/mantine-core/src/components/Alert/Alert.tsx
+++ b/src/mantine-core/src/components/Alert/Alert.tsx
@@ -4,8 +4,8 @@ import { Box } from '../Box';
 import { CloseButton } from '../ActionIcon';
 import useStyles from './Alert.styles';
 
-export type AlertStylesNames = ClassNames<typeof useStyles>;
 export type AlertVariant = 'filled' | 'outline' | 'light';
+export type AlertStylesNames = ClassNames<typeof useStyles>;
 
 export interface AlertProps
   extends DefaultProps<AlertStylesNames>,
@@ -56,7 +56,10 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
     }: AlertProps,
     ref
   ) => {
-    const { classes, cx } = useStyles({ color, radius }, { classNames, styles, name: 'Alert' });
+    const { classes, cx } = useStyles(
+      { color, radius, variant },
+      { classNames, styles, name: 'Alert' }
+    );
 
     return (
       <Box className={cx(classes[variant], classes.root, className)} ref={ref} {...others}>

--- a/src/mantine-core/src/components/Alert/Alert.tsx
+++ b/src/mantine-core/src/components/Alert/Alert.tsx
@@ -55,7 +55,10 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
     }: AlertProps,
     ref
   ) => {
-    const { classes, cx } = useStyles({ color, radius, outline }, { classNames, styles, name: 'Alert' });
+    const { classes, cx } = useStyles(
+      { color, radius, outline },
+      { classNames, styles, name: 'Alert' }
+    );
 
     return (
       <Box className={cx(classes.root, className)} ref={ref} {...others}>

--- a/src/mantine-core/src/components/Alert/Alert.tsx
+++ b/src/mantine-core/src/components/Alert/Alert.tsx
@@ -32,6 +32,9 @@ export interface AlertProps
 
   /** Radius from theme.radius, or number to set border-radius in px */
   radius?: MantineNumberSize;
+
+  /** Show an outline instead of filling the alert container */
+  outline?: boolean;
 }
 
 export const Alert = forwardRef<HTMLDivElement, AlertProps>(
@@ -46,12 +49,13 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
       styles,
       onClose,
       radius = 'sm',
+      outline = false,
       withCloseButton,
       ...others
     }: AlertProps,
     ref
   ) => {
-    const { classes, cx } = useStyles({ color, radius }, { classNames, styles, name: 'Alert' });
+    const { classes, cx } = useStyles({ color, radius, outline }, { classNames, styles, name: 'Alert' });
 
     return (
       <Box className={cx(classes.root, className)} ref={ref} {...others}>

--- a/src/mantine-core/src/components/Alert/Alert.tsx
+++ b/src/mantine-core/src/components/Alert/Alert.tsx
@@ -13,6 +13,9 @@ export interface AlertProps
   /** Alert title */
   title?: React.ReactNode;
 
+  /** Controls Alert background, color and border styles */
+  variant?: AlertVariant;
+
   /** Alert message */
   children: React.ReactNode;
 
@@ -40,6 +43,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
     {
       className,
       title,
+      variant = 'light',
       children,
       color,
       classNames,
@@ -52,13 +56,10 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
     }: AlertProps,
     ref
   ) => {
-    const { classes, cx } = useStyles(
-      { color, radius },
-      { classNames, styles, name: 'Alert' }
-    );
+    const { classes, cx } = useStyles({ color, radius }, { classNames, styles, name: 'Alert' });
 
     return (
-      <Box className={cx(classes.root, className)} ref={ref} {...others}>
+      <Box className={cx(classes[variant], classes.root, className)} ref={ref} {...others}>
         <div className={classes.wrapper}>
           {icon && <div className={classes.icon}>{icon}</div>}
 

--- a/src/mantine-core/src/components/Alert/Alert.tsx
+++ b/src/mantine-core/src/components/Alert/Alert.tsx
@@ -33,9 +33,6 @@ export interface AlertProps
 
   /** Radius from theme.radius, or number to set border-radius in px */
   radius?: MantineNumberSize;
-
-  /** Show an outline instead of filling the alert container */
-  outline?: boolean;
 }
 
 export const Alert = forwardRef<HTMLDivElement, AlertProps>(
@@ -50,14 +47,13 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
       styles,
       onClose,
       radius = 'sm',
-      outline = false,
       withCloseButton,
       ...others
     }: AlertProps,
     ref
   ) => {
     const { classes, cx } = useStyles(
-      { color, radius, outline },
+      { color, radius },
       { classNames, styles, name: 'Alert' }
     );
 

--- a/src/mantine-core/src/components/Alert/Alert.tsx
+++ b/src/mantine-core/src/components/Alert/Alert.tsx
@@ -5,6 +5,7 @@ import { CloseButton } from '../ActionIcon';
 import useStyles from './Alert.styles';
 
 export type AlertStylesNames = ClassNames<typeof useStyles>;
+export type AlertVariant = 'filled' | 'outline' | 'light';
 
 export interface AlertProps
   extends DefaultProps<AlertStylesNames>,

--- a/src/mantine-core/src/components/Alert/demos/configurator.tsx
+++ b/src/mantine-core/src/components/Alert/demos/configurator.tsx
@@ -32,5 +32,16 @@ export const configurator: MantineDemo = {
     { name: 'color', type: 'color', initialValue: 'red', defaultValue: 'blue' },
     { name: 'radius', type: 'size', initialValue: 'sm', defaultValue: 'sm' },
     { name: 'withCloseButton', type: 'boolean', initialValue: false, defaultValue: false },
+    {
+      name: 'variant',
+      type: 'segmented',
+      data: [
+        { label: 'light', value: 'light' },
+        { label: 'filled', value: 'filled' },
+        { label: 'outline', value: 'outline' },
+      ],
+      initialValue: 'light',
+      defaultValue: 'light',
+    },
   ],
 };

--- a/src/mantine-core/src/components/Alert/demos/configurator.tsx
+++ b/src/mantine-core/src/components/Alert/demos/configurator.tsx
@@ -32,6 +32,5 @@ export const configurator: MantineDemo = {
     { name: 'color', type: 'color', initialValue: 'red', defaultValue: 'blue' },
     { name: 'radius', type: 'size', initialValue: 'sm', defaultValue: 'sm' },
     { name: 'withCloseButton', type: 'boolean', initialValue: false, defaultValue: false },
-    { name: 'outline', type: 'boolean', initialValue: false, defaultValue: false },
   ],
 };

--- a/src/mantine-core/src/components/Alert/demos/configurator.tsx
+++ b/src/mantine-core/src/components/Alert/demos/configurator.tsx
@@ -32,5 +32,6 @@ export const configurator: MantineDemo = {
     { name: 'color', type: 'color', initialValue: 'red', defaultValue: 'blue' },
     { name: 'radius', type: 'size', initialValue: 'sm', defaultValue: 'sm' },
     { name: 'withCloseButton', type: 'boolean', initialValue: false, defaultValue: false },
+    { name: 'outline', type: 'boolean', initialValue: false, defaultValue: false },
   ],
 };

--- a/src/mantine-core/src/components/Alert/styles.api.ts
+++ b/src/mantine-core/src/components/Alert/styles.api.ts
@@ -3,6 +3,9 @@ import type { AlertStylesNames } from './Alert';
 export const Alert: Record<AlertStylesNames, string> = {
   root: 'Root element',
   wrapper: 'Wraps body and icon',
+  light: 'Light variant root element modifier',
+  filled: 'Filed variant root element modifier',
+  outline: 'Outline variant root element modifier',
   body: 'Body element, wraps title and message',
   title: 'Title element, contains label and icon',
   label: 'Title label',


### PR DESCRIPTION
This PR proposes to add an `outline` prop to the `Alert` component to show an outline instead of filling the Alert container with the chosen color.

Reference: https://mui.com/components/alert/#outlined