### PR TITLE
[@mantine/core] Table: Add a `border` prop.

### DIFF
--- a/src/mantine-core/src/components/Table/Table.styles.ts
+++ b/src/mantine-core/src/components/Table/Table.styles.ts
@@ -2,9 +2,10 @@ import { createStyles } from '@mantine/styles';
 
 interface TableStyles {
   captionSide: 'top' | 'bottom';
+  border: boolean;
 }
 
-export default createStyles((theme, { captionSide }: TableStyles, getRef) => {
+export default createStyles((theme, { captionSide, border }: TableStyles, getRef) => {
   const striped = { ref: getRef('striped') };
   const hover = { ref: getRef('hover') };
 
@@ -19,6 +20,14 @@ export default createStyles((theme, { captionSide }: TableStyles, getRef) => {
       captionSide,
       color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
       lineHeight: theme.lineHeight,
+
+      '& thead th, & tbody td, & tfoot td': {
+        border: border
+          ? `1px solid ${
+              theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
+            }`
+          : 'initial',
+      },
 
       '& caption': {
         marginTop: captionSide === 'top' ? 0 : theme.spacing.xs,
@@ -56,7 +65,11 @@ export default createStyles((theme, { captionSide }: TableStyles, getRef) => {
       },
 
       '& tbody tr:last-of-type td': {
-        borderBottom: 'none',
+        borderBottom: border
+          ? `1px solid ${
+              theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
+            }`
+          : 'none',
       },
 
       [`&.${striped.ref} tbody tr:nth-of-type(odd)`]: {

--- a/src/mantine-core/src/components/Table/Table.styles.ts
+++ b/src/mantine-core/src/components/Table/Table.styles.ts
@@ -21,7 +21,7 @@ export default createStyles((theme, { captionSide, border }: TableStyles, getRef
       color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
       lineHeight: theme.lineHeight,
 
-      '& thead th, & tbody td, & tfoot td': {
+      '& thead th, & tbody td, & tfoot th': {
         border: border
           ? `1px solid ${
               theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]

--- a/src/mantine-core/src/components/Table/Table.tsx
+++ b/src/mantine-core/src/components/Table/Table.tsx
@@ -12,6 +12,9 @@ export interface TableProps extends DefaultProps, React.ComponentPropsWithoutRef
 
   /** Table caption position */
   captionSide?: 'top' | 'bottom';
+
+  /** If true, render border on all cells */
+  border?: boolean;
 }
 
 export const Table = forwardRef<HTMLTableElement, TableProps>(
@@ -21,12 +24,13 @@ export const Table = forwardRef<HTMLTableElement, TableProps>(
       children,
       striped = false,
       highlightOnHover = false,
+      border = false,
       captionSide = 'top',
       ...others
     }: TableProps,
     ref
   ) => {
-    const { classes, cx } = useStyles({ captionSide }, { name: 'Table' });
+    const { classes, cx } = useStyles({ captionSide, border }, { name: 'Table' });
 
     return (
       <Box

--- a/src/mantine-core/src/components/Table/demos/configurator.tsx
+++ b/src/mantine-core/src/components/Table/demos/configurator.tsx
@@ -57,5 +57,6 @@ export const configurator: MantineDemo = {
   configurator: [
     { name: 'striped', type: 'boolean', defaultValue: false },
     { name: 'highlightOnHover', type: 'boolean', defaultValue: false },
+    { name: 'border', type: 'boolean', defaultValue: false },
   ],
 };


### PR DESCRIPTION
This PR adds a `border` prop to the `Table` component to render border to the table and all the table cells.

Reference: https://getbootstrap.com/docs/5.1/content/tables/#bordered-tables