### PR TITLE
Fix typo

### DIFF
--- a/docs/src/docs/hooks/use-input-state.mdx
+++ b/docs/src/docs/hooks/use-input-state.mdx
@@ -13,7 +13,7 @@ source: 'mantine-hooks/src/use-input-state/use-input-state.ts'
 
 ## Usage
 
-use-list-state hook handles state of native inputs (with event in `onChange` handler) and custom inputs (with value in `onChange` handler).
+use-input-state hook handles state of native inputs (with event in `onChange` handler) and custom inputs (with value in `onChange` handler).
 Hook works with all Mantine and native inputs:
 
 ```tsx


### PR DESCRIPTION
Should be *use-**input**-state* instead of *use-**list**-state*