### PR TITLE
[@mantine/core] TransferList: Fix border issues.

### DIFF
--- a/src/mantine-core/src/components/TransferList/RenderList/RenderList.styles.ts
+++ b/src/mantine-core/src/components/TransferList/RenderList/RenderList.styles.ts
@@ -61,6 +61,8 @@ export default createStyles((theme, { reversed, native }: RenderListStyles) => (
     borderTopWidth: 0,
     borderRightWidth: 0,
     borderLeftWidth: 0,
+    borderTopLeftRadius: reversed ? 0 : theme.radius.sm,
+    borderTopRightRadius: reversed ? theme.radius.sm : 0,
     display: 'block',
     borderBottomColor: theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[4],
   },
@@ -69,6 +71,8 @@ export default createStyles((theme, { reversed, native }: RenderListStyles) => (
     borderTop: 0,
     borderRightWidth: reversed ? undefined : 0,
     borderLeftWidth: reversed ? 0 : undefined,
+    borderTopLeftRadius: reversed ? theme.radius.sm : 0,
+    borderTopRightRadius: reversed ? 0 : theme.radius.sm,
     borderColor: theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[4],
 
     '&:disabled': {


### PR DESCRIPTION
Reported by user **David** on discord. https://discord.com/channels/854810300876062770/861521000985264138/927839935690604604

This PR fixes a situation where the border radius of the input search and action icons were interfering with the overall border radius of the transfer list body.

So the top left & right border radii of input & icons needs to match that of the body for the radii to be uniform.