### PR TITLE
[@mantine/core] Make Accordion heading-level customizable

### DIFF
--- a/src/mantine-core/src/components/Accordion/Accordion.tsx
+++ b/src/mantine-core/src/components/Accordion/Accordion.tsx
@@ -52,6 +52,9 @@ export interface AccordionProps
 
   /** Icon width in px */
   iconSize?: number;
+
+  /** Heading level used for items */
+  order?: 2 | 3 | 4 | 5 | 6;
 }
 
 type AccordionComponent = ForwardRefWithStaticComponents<
@@ -73,6 +76,7 @@ export const Accordion: AccordionComponent = forwardRef<HTMLDivElement, Accordio
       iconPosition = 'left',
       offsetIcon = true,
       iconSize = 24,
+      order = 3,
       icon,
       classNames,
       styles,
@@ -111,6 +115,7 @@ export const Accordion: AccordionComponent = forwardRef<HTMLDivElement, Accordio
         controlRef={mergeRefs(assignControlRef(index), item.props?.controlRef)}
         offsetIcon={offsetIcon}
         iconSize={iconSize}
+        order={order}
       />
     ));
 

--- a/src/mantine-core/src/components/Accordion/AccordionItem/AccordionItem.tsx
+++ b/src/mantine-core/src/components/Accordion/AccordionItem/AccordionItem.tsx
@@ -30,6 +30,7 @@ export interface AccordionItemProps extends PublicAccordionItemProps {
   onControlKeyDown?: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
   offsetIcon?: boolean;
   iconSize?: number;
+  order?: 2 | 3 | 4 | 5 | 6;
 }
 
 export function AccordionItem({
@@ -46,6 +47,7 @@ export function AccordionItem({
   offsetIcon = true,
   iconSize = 24,
   iconPosition = 'left',
+  order = 3,
   id,
   controlRef,
   onControlKeyDown,
@@ -58,9 +60,12 @@ export function AccordionItem({
     { classNames, styles, name: 'Accordion' }
   );
 
+  const cappedOrder = Math.min(6, Math.max(2, order)) as 2 | 3 | 4 | 5 | 6;
+  const Heading = `h${cappedOrder}` as const;
+
   return (
     <Box className={cx(classes.item, { [classes.itemOpened]: opened }, className)} {...others}>
-      <h3 className={classes.itemTitle}>
+      <Heading className={classes.itemTitle}>
         <UnstyledButton
           className={classes.control}
           onClick={onToggle}
@@ -74,7 +79,7 @@ export function AccordionItem({
           <Center className={classes.icon}>{icon}</Center>
           <div className={classes.label}>{label}</div>
         </UnstyledButton>
-      </h3>
+      </Heading>
 
       <Collapse in={opened} transitionDuration={duration}>
         <div className={classes.content} role="region" id={`${id}-body`} aria-labelledby={id}>

--- a/src/mantine-core/src/components/Accordion/stories/Accordion.story.tsx
+++ b/src/mantine-core/src/components/Accordion/stories/Accordion.story.tsx
@@ -83,6 +83,12 @@ storiesOf('@mantine/core/Accordion/stories', module)
       <Accordion.Item label="Second tab">{form}</Accordion.Item>
     </Accordion>
   ))
+  .add('With different heading level', () => (
+    <Accordion mt="xl" mx="auto" sx={{ maxWidth: 400 }} order={2}>
+      <Accordion.Item label="First tab">First tab content</Accordion.Item>
+      <Accordion.Item label="Second tab">Second tab content</Accordion.Item>
+    </Accordion>
+  ))
   .add('Dynamic children', () => <Dynamic />)
   .add('Controlled single', () => <Controlled />)
   .add('Controlled multiple', () => <Controlled multiple />)


### PR DESCRIPTION
As discussed on Discord, allow setting the level for Accordion Item headings.

It still defaults to three, in order not to be breaking.