### PR TITLE
[@mantine/core] AppShell: Update docs about wrapped components

### DIFF
--- a/docs/src/docs/core/AppShell.mdx
+++ b/docs/src/docs/core/AppShell.mdx
@@ -144,18 +144,26 @@ To make Navbar fixed (like in Mantine docs) set `fixed` and `position` props:
 ## Wrapping Navbar and Header components
 
 AppShell component requires Navbar and Header components to be direct children at `navbar` and `header` props.
+In addition, `width` and `height` need to be explicitly set on the wrapping `Navbar` or `Header` element respectively.
 To use custom components instead of Navbar or Header:
 
 ```tsx
-import { AppShell, Navbar, NavbarProps } from '@mantine/core';
+import { AppShell, HeaderProps, Navbar, NavbarProps } from '@mantine/core';
 
 function CustomNavbar(props: NavbarProps) {
   return <Navbar {...props}>Custom navbar</Navbar>;
 }
 
+function CustomHeader(props: HeaderProps) {
+  return <Header {...props}>Custom header</Header>;
+}
+
 function App() {
   return (
-    <AppShell navbar={<CustomNavbar width={{ base: 300 }} height={500} padding="xs" />}>
+    <AppShell
+      navbar={<CustomNavbar width={{ base: 300 }} height={500} padding="xs" />}
+      header={<CustomHeader height={70} padding="xs" />}
+    >
       App content
     </AppShell>
   );


### PR DESCRIPTION
Due to how the `AppShell` component is architected, I've noticed that if you are setting a `height` on a `Header` component or a `width` on a `Navbar` component, you need to explicitly set it on the wrapped component, otherwise the layout breaks. It's not enough to just do `{...remainingProps}`