### PR TITLE
[@mantine/core] AppShell: Fix responsive layout bug

### DIFF
--- a/src/mantine-core/src/components/AppShell/AppShell.styles.ts
+++ b/src/mantine-core/src/components/AppShell/AppShell.styles.ts
@@ -53,7 +53,7 @@ export default createStyles((theme, props: AppShellStyles) => ({
 
   main: {
     flex: 1,
-    width: 100vw,
+    width: '100vw',
     boxSizing: 'border-box',
     ...getPositionStyles(props, theme),
   },

--- a/src/mantine-core/src/components/AppShell/AppShell.styles.ts
+++ b/src/mantine-core/src/components/AppShell/AppShell.styles.ts
@@ -53,6 +53,7 @@ export default createStyles((theme, props: AppShellStyles) => ({
 
   main: {
     flex: 1,
+    width: 100vw,
     boxSizing: 'border-box',
     ...getPositionStyles(props, theme),
   },


### PR DESCRIPTION
Before applying `100vw`:
<img width="400" alt="Screen Shot 2022-01-08 at 2 20 55 PM" src="https://user-images.githubusercontent.com/361348/148661940-e21dfd69-a3b4-4c27-b581-821384a25c74.png">

After applying `100vw` (also had to add a div with `margin-right: 16px`, but at least it works here):
<img width="402" alt="Screen Shot 2022-01-08 at 2 21 31 PM" src="https://user-images.githubusercontent.com/361348/148661941-7a343d3f-13ac-45ab-89cc-58cb51be071d.png">

Can also consider adding `height: 100vh`, but I'm not an expert at CSS and don't want to fix something that doesn't seem broken.