### PR TITLE
[@mantine/core] TransferList: Fix incorrect padding

### DIFF
--- a/src/mantine-core/src/components/Checkbox/Checkbox.styles.ts
+++ b/src/mantine-core/src/components/Checkbox/Checkbox.styles.ts
@@ -68,6 +68,7 @@ export default createStyles(
         ...theme.fn.fontStyles(),
         WebkitTapHighlightColor: 'transparent',
         paddingLeft: theme.spacing.sm,
+        paddingRight: theme.spacing.sm,
         fontSize: theme.fn.size({ size, sizes: theme.fontSizes }),
         lineHeight: `${_size}px`,
         color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,


### PR DESCRIPTION
This fixes a bug when TransferList is `RTL`

Before this PR:

![image](https://user-images.githubusercontent.com/49494752/149003676-a61d2176-7f88-45b6-9836-5c92d330a785.png)

After this PR:

![image](https://user-images.githubusercontent.com/49494752/149003626-8ec2b052-5756-470c-ac16-3e10ac5842da.png)
