### PR TITLE
[@mantine/core] Divider: Fixed labels demo when `RTL` is enabled

### DIFF
--- a/src/mantine-core/src/components/Divider/demos/labels.tsx
+++ b/src/mantine-core/src/components/Divider/demos/labels.tsx
@@ -14,7 +14,7 @@ const code = `
   label={
     <>
       <MagnifyingGlassIcon style={{ width: 12, height: 12 }} />
-      <span style={{ marginLeft: 5 }}>Search results</span>
+      <span style={{ marginLeft: 5, marginRight: 5 }}>Search results</span>
     </>
   }
 />
@@ -39,7 +39,7 @@ function Demo() {
         label={
           <>
             <MagnifyingGlassIcon style={{ width: 12, height: 12 }} />
-            <span style={{ marginLeft: 5 }}>Search results</span>
+            <span style={{ marginLeft: 5, marginRight: 5 }}>Search results</span>
           </>
         }
       />


### PR DESCRIPTION
Before this PR:

![image](https://user-images.githubusercontent.com/49494752/149007287-6491ef03-071c-499f-a0e7-936267a7915b.png)

After this PR:

![image](https://user-images.githubusercontent.com/49494752/149007244-b17d06e7-73c8-43a6-a6f8-673738918892.png)