### PR TITLE
[docs] Fix incorrect link in Box docs

### DIFF
--- a/docs/src/docs/core/Box.mdx
+++ b/docs/src/docs/core/Box.mdx
@@ -17,7 +17,7 @@ import { BoxDemos } from '@demos/core';
 
 ## Usage
 
-Box allows you to use [sx prop](/theming/create-styles/#sx-prop) with any element or component.
+Box allows you to use [sx prop](/theming/sx) with any element or component.
 Box itself does not include any styles.
 
 <Demo data={BoxDemos.usage} />


### PR DESCRIPTION
Fixed a wrong link :shaved_ice: 