### PR TITLE
[docs] Fix props type in `CustomNavbar` and `CustomHeader` examples

### DIFF
--- a/docs/src/docs/core/AppShell.mdx
+++ b/docs/src/docs/core/AppShell.mdx
@@ -150,11 +150,11 @@ To use custom components instead of Navbar or Header:
 ```tsx
 import { AppShell, HeaderProps, Navbar, NavbarProps } from '@mantine/core';
 
-function CustomNavbar(props: NavbarProps) {
+function CustomNavbar(props: Omit<NavbarProps, 'children'>) {
   return <Navbar {...props}>Custom navbar</Navbar>;
 }
 
-function CustomHeader(props: HeaderProps) {
+function CustomHeader(props: Omit<HeaderProps, 'children'>) {
   return <Header {...props}>Custom header</Header>;
 }
 


### PR DESCRIPTION
Hello,

Since your `CustomHeader` and `CustomNavbar` contains it's own children that's not passed as an argument when using in the example, we need to change the props type to remove the children. We could also make the `children` as an optional argument inside `NavbarProps` or `HeaderProps`, but that's probably not the best idea.