### PR TITLE
[docs] Fix incorrect import in Dark theme docs

### DIFF
--- a/docs/src/docs/theming/dark-theme.mdx
+++ b/docs/src/docs/theming/dark-theme.mdx
@@ -112,7 +112,7 @@ to add `Ctrl/⌘ + J` keyboard shortcut for theme toggle:
 
 ```tsx
 import { MantineProvider, ColorSchemeProvider, ColorScheme } from '@mantine/core';
-import { useWindowEvent, useLocalStorageValue } from '@mantine/hooks';
+import { useHotkeys, useLocalStorageValue } from '@mantine/hooks';
 
 export default function Demo() {
   const [colorScheme, setColorScheme] = useLocalStorageValue<ColorScheme>({


### PR DESCRIPTION
Hello,

This fix an example where `useHotKeys` is used but `useWindowEvent` is imported.