### PR TITLE
[@mantine/core] Transferlist: Apply filter on moveAll

### DIFF
--- a/src/mantine-core/src/components/TransferList/RenderList/RenderList.tsx
+++ b/src/mantine-core/src/components/TransferList/RenderList/RenderList.tsx
@@ -25,7 +25,7 @@ export interface RenderListProps extends DefaultProps<RenderListStylesNames> {
   title?: React.ReactNode;
   reversed?: boolean;
   showTransferAll?: boolean;
-  onMoveAll(): void;
+  onMoveAll(query: string): void;
   onMove(): void;
   height: number;
   listComponent?: React.FC<any>;
@@ -220,7 +220,7 @@ export function RenderList({
               radius={0}
               className={classes.transferListControl}
               disabled={data.length === 0}
-              onClick={onMoveAll}
+              onClick={() => onMoveAll(query)}
             >
               {reversed ? <Icons.First /> : <Icons.Last />}
             </ActionIcon>

--- a/src/mantine-core/src/components/TransferList/TransferList.test.tsx
+++ b/src/mantine-core/src/components/TransferList/TransferList.test.tsx
@@ -1,4 +1,6 @@
+import React from 'react';
 import { itSupportsSystemProps } from '@mantine/tests';
+import { render, fireEvent } from '@testing-library/react';
 import { TransferList, TransferListProps } from './TransferList';
 
 const defaultProps: TransferListProps = {
@@ -23,5 +25,62 @@ describe('@mantine/core/TransferList', () => {
     props: defaultProps,
     displayName: '@mantine/core/TransferList',
     refType: HTMLDivElement,
+  });
+
+  it('transfers filtered items', () => {
+    const mockOnChange = jest.fn();
+    const { container } = render(
+      <TransferList
+        {...defaultProps}
+        onChange={mockOnChange}
+        searchPlaceholder="Search..."
+        filterOnTransferAll
+      />
+    );
+    const leftList = container.querySelectorAll('.mantine-TransferList-transferListHeader')[0];
+    const filterInput = leftList.querySelector('input');
+    const transferAllButton = leftList.querySelectorAll('button')[1];
+
+    fireEvent.change(filterInput, { target: { value: 'react' } });
+    fireEvent.click(transferAllButton);
+    expect(mockOnChange).toBeCalledWith([
+      [
+        { value: 'ng', label: 'Angular' },
+        { value: 'next', label: 'Next.js' },
+      ],
+      [
+        { value: 'sv', label: 'Svelte' },
+        { value: 'rw', label: 'Redwood' },
+        { value: 'react', label: 'React' },
+      ],
+    ]);
+  });
+
+  it('transfers all items', () => {
+    const mockOnChange = jest.fn();
+    const { container } = render(
+      <TransferList
+        {...defaultProps}
+        onChange={mockOnChange}
+        searchPlaceholder="Search..."
+        filterOnTransferAll={false}
+      />
+    );
+    const leftList = container.querySelectorAll('.mantine-TransferList-transferListHeader')[0];
+    const filterInput = leftList.querySelector('input');
+    const transferAllButton = leftList.querySelectorAll('button')[1];
+
+    fireEvent.change(filterInput, { target: { value: 'react' } });
+    fireEvent.click(transferAllButton);
+    expect(mockOnChange).toBeCalledWith([
+      [],
+      [
+        { value: 'sv', label: 'Svelte' },
+        { value: 'rw', label: 'Redwood' },
+        { value: 'react', label: 'React' },
+        { value: 'ng', label: 'Angular' },
+        { value: 'next', label: 'Next.js' },
+      ],
+    ]);
   });
 });


### PR DESCRIPTION
As the title says. With these changes, the filter will be applied on the items when moveAll is triggered.  Also added a prop to disable this functionality and move all items even if you have a filter.