### PR TITLE
[@mantine/styles] Improve MantineTheme['colors'] TS type

### DIFF
--- a/src/mantine-styles/src/theme/types/MantineTheme.ts
+++ b/src/mantine-styles/src/theme/types/MantineTheme.ts
@@ -3,6 +3,7 @@ import type { MantineSizes, MantineSize, MantineNumberSize } from './MantineSize
 import type { Tuple } from './Tuple';
 import type { DeepPartial } from './DeepPartial';
 import { CSSObject } from '../../tss';
+import { MantineColor } from './MantineColor';
 
 export type LoaderType = 'bars' | 'oval' | 'dots';
 
@@ -33,7 +34,7 @@ export interface MantineTheme {
   colorScheme: 'light' | 'dark';
   white: string;
   black: string;
-  colors: Record<string, Tuple<string, 10>>;
+  colors: Record<MantineColor, Tuple<string, 10>>;
   fontFamily: CSSProperties['fontFamily'];
   lineHeight: CSSProperties['lineHeight'];
   transitionTimingFunction: CSSProperties['transitionTimingFunction'];


### PR DESCRIPTION
This small change improves the TS type for `MantineTheme['colors']`. This should have two major improvements:

1. Autocomplete on the `colors` property should work now
```ts
const theme = useMantineTheme()
theme.colors. // This should now autocomplete showing all the default Mantine colors

const useStyles = createStyles(theme => ({
 root: {
   color: theme.colors. // This should now autocomplete showing all the default Mantine colors
 }
})
```

2. TS users will now be able to overwrite the `MantineColor` type to include their custom color names, like so:
```ts
// ./types.ts

declare module "@mantine/core" {
  export type MantineColor = "myColorName"
}

// or extend
import { MantineColor } from '@mantine/core'

declare module "@mantine/core" {
  export type MantineColor =  MantineColor | "myColorName"
}
```