### PR TITLE
[@mantine/styles] Export MantineThemeOther from package

### DIFF
--- a/src/mantine-styles/src/theme/types/index.ts
+++ b/src/mantine-styles/src/theme/types/index.ts
@@ -5,7 +5,12 @@ export type { MantineGradient } from './MantineGradient';
 export type { MantineMargins, MantineMargin } from './MantineMargins';
 export type { MantineShadow } from './MantineShadow';
 export type { MantineNumberSize, MantineSize, MantineSizes } from './MantineSize';
-export type { MantineTheme, MantineThemeOverride, MantineThemeBase } from './MantineTheme';
+export type {
+  MantineTheme,
+  MantineThemeOverride,
+  MantineThemeBase,
+  MantineThemeOther,
+} from './MantineTheme';
 export type { PolymorphicRef, PolymorphicComponentProps } from './Polymorphic';
 export type { ForwardRefWithStaticComponents } from './ForwardRefWithStaticComponents';
 export type { Tuple } from './Tuple';


### PR DESCRIPTION
A type needs to exist in the `@mantine/core` package to be able to be overwritten as shown in the docs