### PR TITLE
[docs] Removed "extend theme" TS section

### DIFF
--- a/docs/src/docs/theming/extend-theme.mdx
+++ b/docs/src/docs/theming/extend-theme.mdx
@@ -176,37 +176,3 @@ You can add any amount of properties using `other`:
   transitionDuration: theme.other.reduceMotion ? '0ms' : '200ms',
 })} />
 ```
-
-## TypeScript
-
-### Adding custom colors
-
-By default TypeScript will only autocomplete Mantine's standard colors when accessing the theme. To add your custom colors to the MantineColor type, you can use TypeScript module declaration:
-```ts
-// ./types.d.ts
-
-declare module "@mantine/core" {
-  export type MantineColor = "myCustomColor"
-}
-
-// or if you want to "extend" standard colors
-import { MantineColor } from '@mantine/core'
-
-declare module "@mantine/core" {
-  export type MantineColor = MantineColor | "myCustomColor"
-}
-```
-
-### Adding custom 'other' properties
-
-Just like with the MantineColor type above, you can add your own properties to the `theme.other` type using TypeScript module declaration:
-```ts
-// ./types.d.ts
-
-declare module "@mantine/core" {
-  export interface MantineThemeOther {
-    myCustomProperty: string
-    myCustomFunction: () => void
-  }
-}
-```


### PR DESCRIPTION
I recently added this section as part of a PR to improve TS support. With those changes being released in `3.6.3` I tried to set it up in our project but found that it doesn't quite work as expected. 

I have not been able to find a solution, as locally I can only get it to work when changing the `node_modules/MantineTheme.d.ts` to import `MantineColor` from `@mantine/core` rather than `./MantineColor`. Obviously this is not possible to do within the actual monorepo as it only gets re-exported on build. 

I tried overwriting `@mantine/styles` using the solution described in these docs, but that doesn't help either. 

The code itself is fine, and does still improve TS support for standard colors, just the overwriting is not currently possible.