### PR TITLE
[@mantine/core] Group: Fix position and align for column direction

### DIFF
--- a/src/mantine-core/src/components/Group/Group.styles.ts
+++ b/src/mantine-core/src/components/Group/Group.styles.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createStyles, MantineNumberSize } from '@mantine/styles';
 
-export type GroupPosition = 'right' | 'center' | 'left' | 'apart';
+export type GroupPosition = 'right' | 'center' | 'left' | 'apart' | 'top' | 'bottom';
 
 export interface GroupStylesParams {
   position: GroupPosition;
@@ -14,8 +14,10 @@ export interface GroupStylesParams {
 }
 
 const POSITIONS = {
+  top: 'flex-start',
   left: 'flex-start',
   center: 'center',
+  bottom: 'flex-end',
   right: 'flex-end',
   apart: 'space-between',
 };
@@ -26,17 +28,9 @@ export default createStyles(
       boxSizing: 'border-box',
       display: 'flex',
       flexDirection: direction,
-      alignItems:
-        align ||
-        (direction === 'row'
-          ? 'center'
-          : grow
-          ? 'stretch'
-          : position === 'apart'
-          ? 'flex-start'
-          : POSITIONS[position]),
+      alignItems: align,
       flexWrap: noWrap ? 'nowrap' : 'wrap',
-      justifyContent: direction === 'row' ? POSITIONS[position] : undefined,
+      justifyContent: POSITIONS[position],
       gap: theme.fn.size({ size: spacing, sizes: theme.spacing }),
     },
 

--- a/src/mantine-core/src/components/Group/Group.tsx
+++ b/src/mantine-core/src/components/Group/Group.tsx
@@ -26,6 +26,7 @@ export interface GroupProps extends DefaultProps, React.ComponentPropsWithoutRef
 
 const defaultProps: Partial<GroupProps> = {
   position: 'left',
+  align: 'center',
   spacing: 'md',
   direction: 'row',
 };

--- a/src/mantine-demos/src/demos/packages/Group/configurator.tsx
+++ b/src/mantine-demos/src/demos/packages/Group/configurator.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
-import { Group, GroupProps, Button } from '@mantine/core';
+import { Group, GroupProps, Button, Card } from '@mantine/core';
 
 function Wrapper(props: GroupProps) {
   return (
-    <Group {...props}>
-      <Button variant="outline">1</Button>
-      <Button variant="outline">2</Button>
-      <Button variant="outline">3</Button>
-    </Group>
+    <Card withBorder p={0} sx={{ height: '250px' }}>
+      <Group {...props} sx={{ width: '100%', height: '100%' }}>
+        <Button variant="outline">1</Button>
+        <Button variant="outline" size="xl">
+          2
+        </Button>
+        <Button variant="outline">3</Button>
+      </Group>
+    </Card>
   );
 }
 
@@ -18,7 +22,7 @@ function Demo() {
   return (
     <Group${props}>
       <Button variant="outline">1</Button>
-      <Button variant="outline">2</Button>
+      <Button variant="outline" size="xl">2</Button>
       <Button variant="outline">3</Button>
     </Group>
   );
@@ -38,9 +42,23 @@ export const configurator: MantineDemo = {
         { label: 'center', value: 'center' },
         { label: 'right', value: 'right' },
         { label: 'apart', value: 'apart' },
+        { label: 'top', value: 'top' },
+        { label: 'bottom', value: 'bottom' },
       ],
       initialValue: 'left',
       defaultValue: 'left',
+    },
+    {
+      name: 'align',
+      type: 'select',
+      data: [
+        { label: 'center', value: 'center' },
+        { label: 'flex-start', value: 'flex-start' },
+        { label: 'flex-end', value: 'flex-end' },
+        { label: 'baseline', value: 'baseline' },
+      ],
+      initialValue: 'center',
+      defaultValue: 'center',
     },
     {
       name: 'direction',


### PR DESCRIPTION
Fixes #745 

alignItems (align) and justifyContent (position) now works properly for both row and column Groups
Added top/bottom as position properties for flex-start and flex-end
Adjusted demo so it better shows the effects of the properties