### PR TITLE
[@mantine/dates] Improvements for time inputs

### DIFF
--- a/src/mantine-dates/src/components/TimeInput/TimeInput.test.tsx
+++ b/src/mantine-dates/src/components/TimeInput/TimeInput.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   checkAccessibility,
   itSupportsSystemProps,
@@ -56,5 +57,14 @@ describe('@mantine/dates/TimeInput', () => {
 
     expect(format12.container.querySelectorAll('input')[0].value).toBe('03');
     expect(format24.container.querySelectorAll('input')[0].value).toBe('15');
+  });
+
+  it('automatically moves to the next field', () => {
+    const format24 = render(<TimeInput format="24" />);
+    const inputs = format24.container.querySelectorAll('input');
+
+    userEvent.click(inputs[0]);
+    userEvent.keyboard('00');
+    expect(inputs[1]).toHaveFocus();
   });
 });

--- a/src/mantine-dates/src/components/TimeInput/TimeInput.tsx
+++ b/src/mantine-dates/src/components/TimeInput/TimeInput.tsx
@@ -35,10 +35,10 @@ export interface TimeInputProps
   size?: MantineSize;
 
   /** Controlled input value */
-  value?: Date;
+  value?: Date | null;
 
   /** Uncontrolled input default value */
-  defaultValue?: Date;
+  defaultValue?: Date | null;
 
   /** Controlled input onChange handler */
   onChange?(value: Date): void;
@@ -136,13 +136,18 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
       seconds: string;
       amPm: string;
     }>(getTimeValues(value || defaultValue, format));
-    const [_value, setValue] = useState<Date>(value || defaultValue);
+    const [_value, setValue] = useState<Date | null>(value || defaultValue);
 
     useDidUpdate(() => {
-      if (_value) {
-        setTime(getTimeValues(_value, format));
-      }
+      setTime(getTimeValues(_value, format));
     }, [_value, format]);
+
+    // Allow controlled value prop to override internal _value
+    useDidUpdate(() => {
+      if (value?.getTime() !== _value?.getTime()) {
+        setValue(value);
+      }
+    }, [value]);
 
     const setDate = (change: Partial<typeof time>) => {
       const timeWithChange = { ...time, ...change };
@@ -195,6 +200,7 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
 
     const handleClear = () => {
       setTime({ hours: '', minutes: '', seconds: '', amPm: '' });
+      setValue(null);
       hoursRef.current.focus();
     };
 

--- a/src/mantine-dates/src/components/TimeInput/TimeInput.tsx
+++ b/src/mantine-dates/src/components/TimeInput/TimeInput.tsx
@@ -78,6 +78,9 @@ export interface TimeInputProps
 
   /** Disable field */
   disabled?: boolean;
+
+  /** Ref to focus after final TimeInput field. Used by TimeRangeInput */
+  nextRef?: React.RefObject<HTMLInputElement>;
 }
 
 const RIGHT_SECTION_WIDTH = {
@@ -118,6 +121,7 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
       amPmPlaceholder = 'am',
       disabled = false,
       sx,
+      nextRef,
       ...others
     }: TimeInputProps,
     ref
@@ -179,7 +183,7 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
       min: 0,
       max: 59,
       maxValue: 5,
-      nextRef: !withSeconds ? amPmRef : secondsRef,
+      nextRef: withSeconds ? secondsRef : format === '12' ? amPmRef : nextRef,
     });
 
     const handleSecondsChange = createTimeHandler({
@@ -189,13 +193,14 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
       min: 0,
       max: 59,
       maxValue: 5,
-      nextRef: amPmRef,
+      nextRef: format === '12' ? amPmRef : nextRef,
     });
 
     const handleAmPmChange = createAmPmHandler({
       onChange: (val) => {
         setDate({ amPm: val });
       },
+      nextRef,
     });
 
     const handleClear = () => {

--- a/src/mantine-dates/src/components/TimeInput/TimeInput.tsx
+++ b/src/mantine-dates/src/components/TimeInput/TimeInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, forwardRef, useEffect } from 'react';
+import React, { useState, useRef, forwardRef } from 'react';
 import {
   InputBaseProps,
   InputWrapperBaseProps,
@@ -12,11 +12,10 @@ import {
   CloseButton,
   extractMargins,
 } from '@mantine/core';
-import { useMergedRef, useUuid } from '@mantine/hooks';
+import { useDidUpdate, useMergedRef, useUuid } from '@mantine/hooks';
 import { TimeField } from '../TimeInputBase/TimeField/TimeField';
 import { createTimeHandler } from '../TimeInputBase/create-time-handler/create-time-handler';
 import useStyles from './TimeInput.styles';
-import { padTime } from '../TimeInputBase/pad-time/pad-time';
 import { AmPmInput } from '../TimeInputBase/AmPmInput/AmPmInput';
 import { createAmPmHandler } from '../TimeInputBase/create-amPm-handler/create-amPm-handler';
 import { getDate } from '../TimeInputBase/get-date/get-date';
@@ -131,46 +130,46 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
     const minutesRef = useRef<HTMLInputElement>();
     const secondsRef = useRef<HTMLInputElement>();
     const amPmRef = useRef<HTMLInputElement>();
-    const [amPm, setAmPm] = useState('am');
-    const [time, setTime] = useState<{ hours: string; minutes: string; seconds: string }>(
-      getTimeValues(value || defaultValue)
-    );
+    const [time, setTime] = useState<{
+      hours: string;
+      minutes: string;
+      seconds: string;
+      amPm: string;
+    }>(getTimeValues(value || defaultValue, format));
     const [_value, setValue] = useState<Date>(value || defaultValue);
 
-    useEffect(() => {
-      setValue(getDate(time.hours, time.minutes, time.seconds, format, amPm));
-    }, [time, format, amPm, onChange]);
-
-    useEffect(() => {
-      if (format === '12' && _value) {
-        const _hours = parseInt(time.hours, 10);
-        setAmPm(_hours >= 12 ? 'pm' : 'am');
-
-        if (_hours >= 12) {
-          setTime({ ...time, hours: padTime((_hours - 12).toString()) });
-        }
+    useDidUpdate(() => {
+      if (_value) {
+        setTime(getTimeValues(_value, format));
       }
-    }, [format]);
+    }, [_value, format]);
+
+    const setDate = (change: Partial<typeof time>) => {
+      const timeWithChange = { ...time, ...change };
+      const newDate = getDate(
+        timeWithChange.hours,
+        timeWithChange.minutes,
+        timeWithChange.seconds,
+        format,
+        timeWithChange.amPm
+      );
+      setValue(newDate);
+      typeof onChange === 'function' && onChange(newDate);
+    };
 
     const handleHoursChange = createTimeHandler({
       onChange: (val) => {
-        const newTime = { ...time, hours: padTime(val) };
-        setTime(newTime);
-        typeof onChange === 'function' &&
-          onChange(getDate(newTime.hours, newTime.minutes, newTime.seconds, format, amPm));
+        setDate({ hours: val });
       },
-      min: 0,
-      max: format === '12' ? 11 : 23,
-      maxValue: format === '12' ? 1 : 2,
+      min: format === '12' ? 1 : 0,
+      max: format === '12' ? 12 : 23,
+      maxValue: 2,
       nextRef: minutesRef,
     });
 
     const handleMinutesChange = createTimeHandler({
       onChange: (val) => {
-        const newTime = { ...time, minutes: padTime(val) };
-        setTime(newTime);
-        typeof onChange === 'function' &&
-          onChange(getDate(newTime.hours, newTime.minutes, newTime.seconds, format, amPm));
+        setDate({ minutes: val });
       },
       min: 0,
       max: 59,
@@ -180,10 +179,7 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
 
     const handleSecondsChange = createTimeHandler({
       onChange: (val) => {
-        const newTime = { ...time, seconds: padTime(val) };
-        setTime(newTime);
-        typeof onChange === 'function' &&
-          onChange(getDate(newTime.hours, newTime.minutes, newTime.seconds, format, amPm));
+        setDate({ seconds: val });
       },
       min: 0,
       max: 59,
@@ -193,13 +189,12 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
 
     const handleAmPmChange = createAmPmHandler({
       onChange: (val) => {
-        setAmPm(val);
+        setDate({ amPm: val });
       },
     });
 
     const handleClear = () => {
-      setTime({ hours: '', minutes: '', seconds: '' });
-      setAmPm('');
+      setTime({ hours: '', minutes: '', seconds: '', amPm: '' });
       hoursRef.current.focus();
     };
 
@@ -255,7 +250,7 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
               className={classes.timeInput}
               withSeparator
               size={size}
-              max={format === '12' ? 11 : 23}
+              max={format === '12' ? 12 : 23}
               placeholder={timePlaceholder}
               aria-label={hoursLabel}
               disabled={disabled}
@@ -291,11 +286,8 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
             {format === '12' && (
               <AmPmInput
                 ref={amPmRef}
-                value={amPm}
+                value={time.amPm}
                 onChange={handleAmPmChange}
-                setValue={(val) => {
-                  setAmPm(val);
-                }}
                 placeholder={amPmPlaceholder}
                 size={size}
                 aria-label={amPmLabel}

--- a/src/mantine-dates/src/components/TimeInputBase/AmPmInput/AmPmInput.tsx
+++ b/src/mantine-dates/src/components/TimeInputBase/AmPmInput/AmPmInput.tsx
@@ -8,18 +8,12 @@ interface AmPmSelectProps
   /** Called with onChange event */
   onChange(value: string, triggerShift: boolean): void;
 
-  /** Called when input loses focus, used to format value */
-  setValue(value: string): void;
-
   /** Colon text size */
   size?: MantineSize;
 }
 
 export const AmPmInput = forwardRef<HTMLInputElement, AmPmSelectProps>(
-  (
-    { className, onChange, onFocus, setValue, size = 'sm', value, ...others }: AmPmSelectProps,
-    ref
-  ) => {
+  ({ className, onChange, onFocus, size = 'sm', value, ...others }: AmPmSelectProps, ref) => {
     const { classes, cx } = useStyles({ size, hasValue: !!value });
     const inputRef = useRef<HTMLInputElement>();
 

--- a/src/mantine-dates/src/components/TimeInputBase/AmPmInput/AmPmInput.tsx
+++ b/src/mantine-dates/src/components/TimeInputBase/AmPmInput/AmPmInput.tsx
@@ -30,16 +30,25 @@ export const AmPmInput = forwardRef<HTMLInputElement, AmPmSelectProps>(
     const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
       if (event.nativeEvent.code === 'ArrowUp' || event.nativeEvent.code === 'ArrowDown') {
         event.preventDefault();
-        onChange(value === 'am' ? 'pm' : 'am', false);
+        onChange(value === 'am' ? 'pm' : 'am', true);
       }
 
       if (event.key === 'p' || event.nativeEvent.code === 'KeyP') {
-        onChange('pm', true);
+        onChange('pm', false);
       }
 
       if (event.key === 'a' || event.nativeEvent.code === 'KeyA') {
-        onChange('am', true);
+        onChange('am', false);
       }
+    };
+
+    /*
+      If the field change is triggered onKeyDown, the keyUp event seems to steal focus back from the nextRef
+      This way, all key presses focus nextRef and don't steal it back
+      Anything beside a or p will leave the value and just move to the next field
+    */
+    const handleChange = () => {
+      onChange(value.toString(), true);
     };
 
     return (
@@ -49,7 +58,7 @@ export const AmPmInput = forwardRef<HTMLInputElement, AmPmSelectProps>(
         onClick={handleClick}
         onFocus={handleFocus}
         onKeyDown={handleKeyDown}
-        onChange={() => {}}
+        onChange={handleChange}
         value={value}
         className={cx(classes.timeInput, className)}
         {...others}

--- a/src/mantine-dates/src/components/TimeInputBase/create-amPm-handler/create-amPm-handler.tsx
+++ b/src/mantine-dates/src/components/TimeInputBase/create-amPm-handler/create-amPm-handler.tsx
@@ -12,7 +12,6 @@ export function createAmPmHandler({ onChange, nextRef }: CreateAmPmHandler) {
     if (valLower === 'am' || valLower === 'pm') {
       onChange(valLower);
       triggerShift && nextRef?.current?.focus();
-      triggerShift && nextRef?.current?.select();
       return;
     }
 

--- a/src/mantine-dates/src/components/TimeInputBase/create-amPm-handler/create-amPm-handler.tsx
+++ b/src/mantine-dates/src/components/TimeInputBase/create-amPm-handler/create-amPm-handler.tsx
@@ -12,6 +12,7 @@ export function createAmPmHandler({ onChange, nextRef }: CreateAmPmHandler) {
     if (valLower === 'am' || valLower === 'pm') {
       onChange(valLower);
       triggerShift && nextRef?.current?.focus();
+      triggerShift && nextRef?.current?.select();
       return;
     }
 

--- a/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.ts
@@ -10,21 +10,14 @@ interface CreateTimeHandler {
 }
 
 export function createTimeHandler({ onChange, nextRef, min, max, maxValue }: CreateTimeHandler) {
-  return (value: string, triggerShift: boolean) => {
-    if (value === '00') {
-      onChange('00');
-      triggerShift && nextRef?.current?.focus();
-      triggerShift && nextRef?.current?.select();
-      return;
-    }
-
+  return (value: string, triggerShift: boolean, forceTriggerShift = false) => {
     const parsed = parseInt(value, 10);
 
     if (Number.isNaN(parsed)) {
       return;
     }
 
-    if (parsed > maxValue) {
+    if (parsed > maxValue || forceTriggerShift) {
       onChange(padTime(clamp({ value: parsed, min, max }).toString()));
       triggerShift && nextRef?.current?.focus();
       triggerShift && nextRef?.current?.select();

--- a/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.ts
@@ -20,7 +20,6 @@ export function createTimeHandler({ onChange, nextRef, min, max, maxValue }: Cre
     if (parsed > maxValue || forceTriggerShift) {
       onChange(padTime(clamp({ value: parsed, min, max }).toString()));
       triggerShift && nextRef?.current?.focus();
-      triggerShift && nextRef?.current?.select();
       return;
     }
 

--- a/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.ts
@@ -20,6 +20,7 @@ export function createTimeHandler({ onChange, nextRef, min, max, maxValue }: Cre
     if (parsed > maxValue || forceTriggerShift) {
       onChange(padTime(clamp({ value: parsed, min, max }).toString()));
       triggerShift && nextRef?.current?.focus();
+      triggerShift && nextRef?.current?.select();
       return;
     }
 

--- a/src/mantine-dates/src/components/TimeInputBase/get-date/get-date.test.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/get-date/get-date.test.ts
@@ -19,5 +19,8 @@ describe('@mantine/dates/get-date', () => {
     expect(format12AM.getHours()).toEqual(8);
     expect(format12AM.getMinutes()).toEqual(12);
     expect(format12AM.getSeconds()).toEqual(30);
+
+    expect(getDate('12', '00', '00', '12', 'am').getHours()).toEqual(0);
+    expect(getDate('12', '00', '00', '12', 'pm').getHours()).toEqual(12);
   });
 });

--- a/src/mantine-dates/src/components/TimeInputBase/get-date/get-date.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/get-date/get-date.ts
@@ -16,8 +16,15 @@ export function getDate(
     _hours = 0;
   }
 
+  if (format === '12') {
+    _hours %= 12;
+    if (amPm === 'pm') {
+      _hours += 12;
+    }
+  }
+
   return date
-    .hour(format === '12' && amPm === 'pm' ? (_hours < 12 ? _hours - 12 : _hours) : _hours)
+    .hour(_hours)
     .minute(Number.isNaN(_minutes) ? 0 : _minutes)
     .second(Number.isNaN(_seconds) ? 0 : _seconds)
     .toDate();

--- a/src/mantine-dates/src/components/TimeInputBase/get-time-values/get-time-value.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/get-time-values/get-time-value.ts
@@ -1,13 +1,24 @@
 import { padTime } from '../pad-time/pad-time';
 
-export function getTimeValues(value: Date) {
+export function getTimeValues(value: Date, format: '12' | '24') {
   if (!(value instanceof Date)) {
-    return { hours: '', minutes: '', seconds: '' };
+    return { hours: '', minutes: '', seconds: '', amPm: '' };
+  }
+
+  let _hours = value.getHours();
+
+  const isPm = _hours >= 12;
+  if (format === '12') {
+    _hours %= 12;
+    if (_hours === 0) {
+      _hours += 12;
+    }
   }
 
   return {
-    hours: padTime(value.getHours().toString()),
+    hours: padTime(_hours.toString()),
     minutes: padTime(value.getMinutes().toString()),
     seconds: padTime(value.getSeconds().toString()),
+    amPm: isPm ? 'pm' : 'am',
   };
 }

--- a/src/mantine-dates/src/components/TimeInputBase/get-time-values/get-time-values.test.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/get-time-values/get-time-values.test.ts
@@ -2,10 +2,11 @@ import { getTimeValues } from './get-time-value';
 
 describe('@mantine/dates/get-time-value', () => {
   it('returns correct time values', () => {
-    expect(getTimeValues(new Date(2021, 7, 21, 1, 23, 44))).toEqual({
+    expect(getTimeValues(new Date(2021, 7, 21, 1, 23, 44), '24')).toEqual({
       hours: '01',
       minutes: '23',
       seconds: '44',
+      amPm: 'am',
     });
   });
 });

--- a/src/mantine-dates/src/components/TimeRangeInput/TimeRangeInput.tsx
+++ b/src/mantine-dates/src/components/TimeRangeInput/TimeRangeInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, forwardRef, useEffect } from 'react';
+import React, { useState, useRef, forwardRef } from 'react';
 import {
   InputBaseProps,
   InputWrapperBaseProps,
@@ -12,15 +12,9 @@ import {
   CloseButton,
   extractMargins,
 } from '@mantine/core';
-import { useMergedRef, useUuid } from '@mantine/hooks';
-import { TimeField } from '../TimeInputBase/TimeField/TimeField';
-import { createTimeHandler } from '../TimeInputBase/create-time-handler/create-time-handler';
-import { getTimeValues } from '../TimeInputBase/get-time-values/get-time-value';
+import { useDidUpdate, useMergedRef, useUuid } from '@mantine/hooks';
 import useStyles from './TimeRangeInput.styles';
-import { padTime } from '../TimeInputBase/pad-time/pad-time';
-import { AmPmInput } from '../TimeInputBase/AmPmInput/AmPmInput';
-import { createAmPmHandler } from '../TimeInputBase/create-amPm-handler/create-amPm-handler';
-import { getDate } from '../TimeInputBase/get-date/get-date';
+import { TimeInput } from '../TimeInput';
 
 export type TimeRangeInputStylesNames =
   | Exclude<ClassNames<typeof useStyles>, 'disabled'>
@@ -107,7 +101,7 @@ export const TimeRangeInput = forwardRef<HTMLInputElement, TimeRangeInputProps>(
       styles,
       id,
       value,
-      defaultValue,
+      defaultValue = [null, null],
       onChange,
       withSeconds = false,
       clearable = false,
@@ -134,130 +128,27 @@ export const TimeRangeInput = forwardRef<HTMLInputElement, TimeRangeInputProps>(
     const { margins, rest } = extractMargins(others);
     const uuid = useUuid(id);
 
-    const hoursRef = useRef<HTMLInputElement[]>([]);
-    const minutesRef = useRef<HTMLInputElement[]>([]);
-    const secondsRef = useRef<HTMLInputElement[]>([]);
-    const formatsRef = useRef<HTMLInputElement[]>([]);
-    const [fromTime, setFromTime] = useState<{
-      hours: string;
-      minutes: string;
-      seconds: string;
-      amPm: string;
-    }>(
-      getTimeValues(
-        value ? value[0] : undefined || defaultValue ? defaultValue[0] : undefined,
-        format
-      )
-    );
-    const [toTime, setToTime] = useState<{
-      hours: string;
-      minutes: string;
-      seconds: string;
-      amPm: string;
-    }>(
-      getTimeValues(
-        value ? value[1] : undefined || defaultValue ? defaultValue[1] : undefined,
-        format
-      )
-    );
-    const [selectedFieldIndex, setSelectedFieldIndex] = useState<0 | 1>(0);
+    const fromTimeRef = useRef<HTMLInputElement>();
+    const toTimeRef = useRef<HTMLInputElement>();
     const [_value, setValue] = useState<[Date, Date]>(value ?? defaultValue);
 
-    useEffect(() => {
-      if (_value) {
-        setFromTime(getTimeValues(_value[0], format));
-        setToTime(getTimeValues(_value[1], format));
+    useDidUpdate(() => {
+      typeof onChange === 'function' && onChange(_value);
+    }, [_value]);
+
+    // Allow controlled value prop to override internal _value
+    useDidUpdate(() => {
+      if (
+        value[0]?.getTime() !== _value[0]?.getTime() ||
+        value[1]?.getTime() !== _value[1]?.getTime()
+      ) {
+        setValue(value);
       }
-    }, [_value, format]);
-
-    const setDate = (change: Partial<typeof fromTime>) => {
-      const time = selectedFieldIndex === 0 ? fromTime : toTime;
-      const timeWithChange = { ...time, ...change };
-      const newDate = getDate(
-        timeWithChange.hours,
-        timeWithChange.minutes,
-        timeWithChange.seconds,
-        format,
-        timeWithChange.amPm
-      );
-
-      const newValue: [Date, Date] =
-        selectedFieldIndex === 0 ? [newDate, _value[1]] : [_value[0], newDate];
-      setValue(newValue);
-      typeof onChange === 'function' && onChange(newValue);
-    };
-
-    const nextMinuteRef = () => {
-      if (withSeconds) {
-        return secondsRef.current[selectedFieldIndex];
-      }
-
-      if (format === '12') {
-        return formatsRef.current[selectedFieldIndex];
-      }
-
-      if (format === '24' && selectedFieldIndex === 0) {
-        return hoursRef.current[1];
-      }
-
-      return undefined;
-    };
-
-    const handleHoursChange = createTimeHandler({
-      onChange: (val) => {
-        setDate({ hours: padTime(val) });
-      },
-      min: format === '12' ? 1 : 0,
-      max: format === '12' ? 12 : 23,
-      maxValue: 2,
-      nextRef: {
-        current: minutesRef.current[selectedFieldIndex],
-      },
-    });
-
-    const handleMinutesChange = createTimeHandler({
-      onChange: (val) => {
-        setDate({ minutes: padTime(val) });
-      },
-      min: 0,
-      max: 59,
-      maxValue: 5,
-      nextRef: {
-        current: nextMinuteRef(),
-      },
-    });
-
-    const handleSecondsChange = createTimeHandler({
-      onChange: (val) => {
-        setDate({ seconds: padTime(val) });
-      },
-      min: 0,
-      max: 59,
-      maxValue: 5,
-      nextRef: {
-        current:
-          format === '12'
-            ? formatsRef.current[selectedFieldIndex]
-            : format === '24' && selectedFieldIndex === 0
-            ? hoursRef.current[1]
-            : undefined,
-      },
-    });
-
-    const handleAmPmChange = createAmPmHandler({
-      onChange: (val) => {
-        setDate({ amPm: val });
-      },
-      nextRef: {
-        current: selectedFieldIndex === 0 ? hoursRef.current[1] : undefined,
-      },
-    });
+    }, [value]);
 
     const handleClear = () => {
-      setFromTime({ hours: '', minutes: '', seconds: '', amPm: '' });
-      setToTime({ hours: '', minutes: '', seconds: '', amPm: '' });
-      setSelectedFieldIndex(0);
-      hoursRef.current[0]?.focus();
+      setValue([null, null]);
+      fromTimeRef.current?.focus();
     };
 
     const rightSection =
@@ -269,6 +160,19 @@ export const TimeRangeInput = forwardRef<HTMLInputElement, TimeRangeInputProps>(
           size={size}
         />
       ) : null;
+
+    const forwardProps = {
+      amPmLabel,
+      amPmPlaceholder,
+      disabled,
+      format,
+      hoursLabel,
+      minutesLabel,
+      secondsLabel,
+      size,
+      timePlaceholder,
+      withSeconds,
+    };
 
     return (
       <InputWrapper
@@ -293,8 +197,7 @@ export const TimeRangeInput = forwardRef<HTMLInputElement, TimeRangeInputProps>(
           required={required}
           invalid={!!error}
           onClick={() => {
-            setSelectedFieldIndex(0);
-            hoursRef.current[selectedFieldIndex].focus();
+            fromTimeRef.current?.focus();
           }}
           size={size}
           className={cx({ [classes.disabled]: disabled })}
@@ -306,154 +209,32 @@ export const TimeRangeInput = forwardRef<HTMLInputElement, TimeRangeInputProps>(
           {...rest}
         >
           <div className={classes.inputWrapper}>
-            <TimeField
-              ref={useMergedRef((node: HTMLInputElement) => {
-                hoursRef.current[0] = node;
-              }, ref)}
-              value={fromTime.hours}
-              onChange={handleHoursChange}
-              setValue={(val) => setFromTime((current) => ({ ...current, hours: val }))}
-              id={uuid}
-              className={classes.timeField}
-              withSeparator
-              size={size}
-              max={format === '12' ? 11 : 23}
-              placeholder={timePlaceholder}
-              aria-label={`from ${hoursLabel}`}
-              disabled={disabled}
-              onFocus={() => setSelectedFieldIndex(0)}
+            <TimeInput
+              ref={useMergedRef(fromTimeRef, ref)}
+              variant="unstyled"
+              value={_value[0]}
+              onChange={(date) => setValue([date, _value[1]])}
               name={name}
+              nextRef={toTimeRef}
+              {...forwardProps}
             />
-
-            <TimeField
-              ref={(node) => {
-                minutesRef.current[0] = node;
-              }}
-              value={fromTime.minutes}
-              onChange={handleMinutesChange}
-              setValue={(val) => setFromTime((current) => ({ ...current, minutes: val }))}
-              className={classes.timeField}
-              withSeparator={withSeconds}
-              size={size}
-              max={59}
-              placeholder={timePlaceholder}
-              aria-label={`from ${minutesLabel}`}
-              disabled={disabled}
-              onFocus={() => setSelectedFieldIndex(0)}
-            />
-
-            {withSeconds && (
-              <TimeField
-                ref={(node) => {
-                  secondsRef.current[0] = node;
-                }}
-                value={fromTime.seconds}
-                onChange={handleSecondsChange}
-                setValue={(val) => setFromTime((current) => ({ ...current, seconds: val }))}
-                className={classes.timeField}
-                size={size}
-                max={59}
-                placeholder={timePlaceholder}
-                aria-label={`from ${secondsLabel}`}
-                disabled={disabled}
-                onFocus={() => setSelectedFieldIndex(0)}
-              />
-            )}
-
-            {format === '12' && (
-              <AmPmInput
-                ref={(node) => {
-                  formatsRef.current[0] = node;
-                }}
-                value={fromTime.amPm}
-                onChange={handleAmPmChange}
-                placeholder={amPmPlaceholder}
-                onFocus={() => setSelectedFieldIndex(0)}
-                aria-label={`from ${amPmLabel}`}
-                disabled={disabled}
-              />
-            )}
 
             <span
               className={classes.separator}
               style={{
-                color: toTime?.hours
-                  ? 'inherit'
-                  : theme.colorScheme === 'dark'
-                  ? theme.colors.dark[2]
-                  : theme.colors.gray[7],
+                color: theme.colorScheme === 'dark' ? theme.colors.dark[2] : theme.colors.gray[7],
               }}
             >
               {labelSeparator}
             </span>
 
-            <div className={classes.inputWrapper}>
-              <TimeField
-                ref={(node) => {
-                  hoursRef.current[1] = node;
-                }}
-                value={toTime.hours}
-                onChange={handleHoursChange}
-                setValue={(val) => setToTime((current) => ({ ...current, hours: val }))}
-                className={classes.timeField}
-                withSeparator
-                size={size}
-                max={format === '12' ? 12 : 23}
-                placeholder={timePlaceholder}
-                aria-label={`to ${hoursLabel}`}
-                disabled={disabled}
-                onFocus={() => setSelectedFieldIndex(1)}
-              />
-
-              <TimeField
-                ref={(node) => {
-                  minutesRef.current[1] = node;
-                }}
-                value={toTime.minutes}
-                onChange={handleMinutesChange}
-                setValue={(val) => setToTime((current) => ({ ...current, minutes: val }))}
-                className={classes.timeField}
-                withSeparator={withSeconds}
-                size={size}
-                max={59}
-                placeholder={timePlaceholder}
-                aria-label={`to ${minutesLabel}`}
-                disabled={disabled}
-                onFocus={() => setSelectedFieldIndex(1)}
-              />
-
-              {withSeconds && (
-                <TimeField
-                  ref={(node) => {
-                    secondsRef.current[1] = node;
-                  }}
-                  value={toTime.seconds}
-                  onChange={handleSecondsChange}
-                  setValue={(val) => setToTime((current) => ({ ...current, seconds: val }))}
-                  className={classes.timeField}
-                  size={size}
-                  max={59}
-                  placeholder={timePlaceholder}
-                  aria-label={`to ${secondsLabel}`}
-                  disabled={disabled}
-                  onFocus={() => setSelectedFieldIndex(1)}
-                />
-              )}
-
-              {format === '12' && (
-                <AmPmInput
-                  ref={(node) => {
-                    formatsRef.current[1] = node;
-                  }}
-                  value={toTime.amPm}
-                  onChange={handleAmPmChange}
-                  placeholder={amPmPlaceholder}
-                  onFocus={() => setSelectedFieldIndex(1)}
-                  aria-label={`to ${amPmLabel}`}
-                  disabled={disabled}
-                />
-              )}
-            </div>
+            <TimeInput
+              ref={toTimeRef}
+              variant="unstyled"
+              value={_value[1]}
+              onChange={(date) => setValue([_value[0], date])}
+              {...forwardProps}
+            />
           </div>
         </Input>
       </InputWrapper>

--- a/src/mantine-dates/src/components/TimeRangeInput/TimeRangeInput.tsx
+++ b/src/mantine-dates/src/components/TimeRangeInput/TimeRangeInput.tsx
@@ -216,6 +216,7 @@ export const TimeRangeInput = forwardRef<HTMLInputElement, TimeRangeInputProps>(
               onChange={(date) => setValue([date, _value[1]])}
               name={name}
               nextRef={toTimeRef}
+              id={uuid}
               {...forwardProps}
             />
 

--- a/src/mantine-demos/src/demos/packages/TimeInput/configurator.tsx
+++ b/src/mantine-demos/src/demos/packages/TimeInput/configurator.tsx
@@ -41,6 +41,16 @@ export const configurator: MantineDemo = {
     { name: 'radius', type: 'size', initialValue: 'sm', defaultValue: 'sm' },
     { name: 'size', type: 'size', initialValue: 'sm', defaultValue: 'sm' },
     {
+      name: 'format',
+      type: 'select',
+      data: [
+        { label: '24', value: '24' },
+        { label: '12', value: '12' },
+      ],
+      initialValue: '24',
+      defaultValue: '24',
+    },
+    {
       name: 'withSeconds',
       type: 'boolean',
       initialValue: false,
@@ -51,6 +61,12 @@ export const configurator: MantineDemo = {
       name: 'required',
       type: 'boolean',
       initialValue: true,
+      defaultValue: false,
+    },
+    {
+      name: 'clearable',
+      type: 'boolean',
+      initialValue: false,
       defaultValue: false,
     },
   ],


### PR DESCRIPTION
- 12-hour times are displayed from 01-12 instead of 00-11
- Fixed bug with advancing to next field when entering 00, 01, etc.
- Fixed missing onUpdate calls in certain scenarios
- Add format and clearable to TimeInput configurator
- Fix value prop not overriding TimeInput and TimeRangeInput internal state
- Change TimeRangeInput to use 2 TimeInput fields
- onChange can be called with null to indicate cleared state