### PR TITLE
Fix for overflow of Paper children elements

### DIFF
--- a/src/mantine-core/src/components/Paper/Paper.styles.ts
+++ b/src/mantine-core/src/components/Paper/Paper.styles.ts
@@ -12,6 +12,7 @@ export default createStyles((theme, { radius, shadow, padding, withBorder }: Pap
     ...theme.fn.focusStyles(),
     WebkitTapHighlightColor: 'transparent',
     display: 'block',
+    overflow: 'hidden',
     textDecoration: 'none',
     color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
     backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,


### PR DESCRIPTION
This fixes the issue of children elements (like the `Table` component with rows on hover in the attached video) overflowing the corner radius of`Paper` parent.


https://user-images.githubusercontent.com/44101337/151796010-c636cb93-5707-4476-aafb-0c8055b4ed48.mov



