### PR TITLE
[@mantine/core] Avatar: Add imageProps

### DIFF
--- a/src/mantine-core/src/components/Avatar/Avatar.tsx
+++ b/src/mantine-core/src/components/Avatar/Avatar.tsx
@@ -29,7 +29,7 @@ interface _AvatarProps extends DefaultProps<AvatarStylesNames> {
   /** Color from theme.colors used for letter and icon placeholders */
   color?: MantineColor;
 
-  /** Any additional attribute you want to set on the avatar `img` tag */
+  /** `img` element attributes */
   imageProps?: React.ComponentPropsWithoutRef<'img'>;
 }
 

--- a/src/mantine-core/src/components/Avatar/Avatar.tsx
+++ b/src/mantine-core/src/components/Avatar/Avatar.tsx
@@ -28,6 +28,9 @@ interface _AvatarProps extends DefaultProps<AvatarStylesNames> {
 
   /** Color from theme.colors used for letter and icon placeholders */
   color?: MantineColor;
+
+  /** Any additional attribute you want to set on the avatar `img` tag */
+  imageProps?: React.ComponentPropsWithoutRef<'img'>;
 }
 
 export type AvatarProps<C extends React.ElementType> = PolymorphicComponentProps<C, _AvatarProps>;
@@ -49,6 +52,7 @@ export const Avatar: AvatarComponent = forwardRef(
       color = 'gray',
       classNames,
       styles,
+      imageProps,
       ...others
     }: AvatarProps<C>,
     ref: PolymorphicRef<C>
@@ -75,7 +79,13 @@ export const Avatar: AvatarComponent = forwardRef(
             {children || <AvatarPlaceholderIcon className={classes.placeholderIcon} />}
           </div>
         ) : (
-          <img className={classes.image} src={src} alt={alt} onError={() => setError(true)} />
+          <img
+            {...imageProps}
+            className={classes.image}
+            src={src}
+            alt={alt}
+            onError={() => setError(true)}
+          />
         )}
       </Box>
     );


### PR DESCRIPTION
# Add `imageProps` prop on `Avatar` component

This PR introduces the `imageProps` prop on the `Avatar` component. This allows to pass custom properties to the underlying `img` tag. Here's an example:

```jsx
<Avatar src="example.com/profile-picture.png" referrerPolicy="no-referrer" />
```