### PR TITLE
[docs] Fix AuthenticationForm path in use-form documentation

### DIFF
--- a/docs/src/docs/hooks/use-form.mdx
+++ b/docs/src/docs/hooks/use-form.mdx
@@ -351,7 +351,7 @@ Submit form with `test@mantine.dev` email to see external validation error:
 
 ### Authentication form
 
-[Browse code on GitHub](https://github.com/mantinedev/mantine/blob/master/src/mantine-demos/src/AuthenticationForm/AuthenticationForm.tsx)
+[Browse code on GitHub](https://github.com/mantinedev/mantine/blob/master/src/mantine-demos/src/shared/AuthenticationForm/AuthenticationForm.tsx)
 
 <HooksDemos.UseFormAuthDemo />
 


### PR DESCRIPTION
Update a code example link after mantine/demos migration