### PR TITLE
[@mantine/core] Added inputMode for NumberInput

### DIFF
--- a/src/mantine-core/src/components/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.tsx
@@ -359,6 +359,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
         size={size}
         styles={styles}
         classNames={classNames}
+        inputMode={Number.isInteger(step) && precision === 0 ? 'numeric' : 'decimal'}
         __staticSelector="NumberInput"
       />
     );


### PR DESCRIPTION
These changes add `inputMode` to [NumberInput](https://mantine.dev/core/number-input/) component. 

If `step` and `precision` properties are set, `inputMode` is set to 'decimal' and on mobile devices, a keyboard looks like:
![IMG_7429](https://user-images.githubusercontent.com/65853205/153649250-faebb472-d8f2-4e25-8fc2-75a626135fe7.jpg)

Without properties  `step` and `precision` `inputMode` is set to 'decimal' and keyboard looks like:

![IMG_7430](https://user-images.githubusercontent.com/65853205/153649151-b6724f2d-ed0a-4cee-8c43-e0e01f4d6cb2.jpg)
 