### PR TITLE
[@mantine/styles] MantineProvider: fix incorrect fontSize naming for body font size theme inheritance

### DIFF
--- a/src/mantine-styles/src/theme/MantineProvider.tsx
+++ b/src/mantine-styles/src/theme/MantineProvider.tsx
@@ -59,7 +59,7 @@ function GlobalStyles() {
           backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
           color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
           lineHeight: theme.lineHeight,
-          fontSizes: theme.fontSizes.md,
+          fontSize: theme.fontSizes.md,
         } as any,
       }}
     />


### PR DESCRIPTION
At https://github.com/mantinedev/mantine/blob/master/src/mantine-styles/src/theme/MantineProvider.tsx#L62

`fontSizes` is transformed into `font-sizes` which is not the right CSS property name. 

With this change it is now `fontSize` which will transform into `font-size`

Cheers!