### PR TITLE
[@mantine/core] Select: only use open/close callback when value changes

### DIFF
--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -234,6 +234,10 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>((props: SelectPr
   const isDeselectable = allowDeselect === undefined ? clearable : allowDeselect;
 
   const setDropdownOpened = (opened: boolean) => {
+    if (dropdownOpened === opened) {
+      return;
+    }
+
     _setDropdownOpened(opened);
     const handler = opened ? onDropdownOpen : onDropdownClose;
     typeof handler === 'function' && handler();


### PR DESCRIPTION
Will only fire the `onDropdownOpen`/`onDropdownClose` callback if the value actually changes.

Resolves #854 