### PR TITLE
[@mantine/core] Select: only use open/close callback when value changes

### DIFF
--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -214,13 +214,11 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
     const isDeselectable = allowDeselect === undefined ? clearable : allowDeselect;
 
     const setDropdownOpened = (opened: boolean) => {
-      if (dropdownOpened === opened) {
-        return;
+      if (dropdownOpened !== opened) {
+        _setDropdownOpened(opened);
+        const handler = opened ? onDropdownOpen : onDropdownClose;
+        typeof handler === 'function' && handler();
       }
-
-      _setDropdownOpened(opened);
-      const handler = opened ? onDropdownOpen : onDropdownClose;
-      typeof handler === 'function' && handler();
     };
 
     const isCreatable = creatable && typeof getCreateLabel === 'function';

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -214,6 +214,10 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
     const isDeselectable = allowDeselect === undefined ? clearable : allowDeselect;
 
     const setDropdownOpened = (opened: boolean) => {
+      if (dropdownOpened === opened) {
+        return;
+      }
+
       _setDropdownOpened(opened);
       const handler = opened ? onDropdownOpen : onDropdownClose;
       typeof handler === 'function' && handler();


### PR DESCRIPTION
Will only fire the `onDropdownOpen/onDropdownClose` callback if the value actually changes.

Resolves #854 