### PR TITLE
[@mantine/dates] DateRangePicker: Fix locale

### DIFF
--- a/src/mantine-dates/src/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/src/mantine-dates/src/components/DateRangePicker/DateRangePicker.test.tsx
@@ -1,4 +1,6 @@
+import 'dayjs/locale/ru';
 import React from 'react';
+import { MantineProvider } from '@mantine/core';
 import { render, screen } from '@testing-library/react';
 import { itSupportsSystemProps, itSupportsInputProps, itSupportsFocusEvents } from '@mantine/tests';
 import { DateRangePicker, DateRangePickerProps } from './DateRangePicker';
@@ -21,5 +23,14 @@ describe('@mantine/dates/DateRangePicker', () => {
       <DateRangePicker value={[new Date(2021, 6, 13), new Date(2021, 7, 13)]} inputFormat="MM/YY" />
     );
     expect(screen.getByRole('textbox')).toHaveValue('07/21 – 08/21');
+  });
+
+  it('uses locale provided in theme.datesLocale', () => {
+    render(
+      <MantineProvider theme={{ datesLocale: 'ru' }}>
+        <DateRangePicker value={[new Date(2022, 0, 1), new Date(2022, 1, 20)]} />
+      </MantineProvider>
+    );
+    expect(screen.getByRole('textbox')).toHaveValue('Январь 1, 2022 – Февраль 20, 2022');
   });
 });

--- a/src/mantine-dates/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/src/mantine-dates/src/components/DateRangePicker/DateRangePicker.tsx
@@ -59,7 +59,7 @@ export const DateRangePicker = forwardRef<HTMLButtonElement, DateRangePickerProp
       classNames,
       styles,
       shadow = 'sm',
-      locale = 'en',
+      locale,
       inputFormat,
       transitionDuration = 200,
       transitionTimingFunction,


### PR DESCRIPTION
There is no related issue (at least I can't find it)
I found this defect during development
