### PR TITLE
[@mantine/core] & [@mantine/hooks] Replace deprecated String.prototype.substr() 

### DIFF
--- a/src/mantine-core/src/components/ColorPicker/converters/parsers.ts
+++ b/src/mantine-core/src/components/ColorPicker/converters/parsers.ts
@@ -64,7 +64,7 @@ function rgbaToHsva({ r, g, b, a }: RgbaColor): HsvaColor {
 }
 
 export function parseHex(color: string): HsvaColor {
-  const hex = color[0] === '#' ? color.substr(1) : color;
+  const hex = color[0] === '#' ? color.slice(1) : color;
 
   if (hex.length === 3) {
     return rgbaToHsva({
@@ -76,9 +76,9 @@ export function parseHex(color: string): HsvaColor {
   }
 
   return rgbaToHsva({
-    r: parseInt(hex.substr(0, 2), 16),
-    g: parseInt(hex.substr(2, 2), 16),
-    b: parseInt(hex.substr(4, 2), 16),
+    r: parseInt(hex.slice(0, 2), 16),
+    g: parseInt(hex.slice(2, 4), 16),
+    b: parseInt(hex.slice(4, 6), 16),
     a: 1,
   });
 }

--- a/src/mantine-hooks/src/utils/random-id/random-id.ts
+++ b/src/mantine-hooks/src/utils/random-id/random-id.ts
@@ -1,3 +1,3 @@
 export function randomId() {
-  return `mantine-${Math.random().toString(36).substr(2, 9)}`;
+  return `mantine-${Math.random().toString(36).slice(2, 11)}`;
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.