### PR TITLE
Update use-debounced-value.mdx

### DIFF
--- a/docs/src/docs/hooks/use-debounced-value.mdx
+++ b/docs/src/docs/hooks/use-debounced-value.mdx
@@ -32,7 +32,7 @@ You can remove immediately update value with first call with `{ leading: true }`
 Hook provides cancel callback, you can use it to cancel update.
 Update cancels automatically on component unmount.
 
-In this example, type in some text and click cancel button within a minute to cancel debounced value change:
+In this example, type in some text and click cancel button within a second to cancel debounced value change:
 
 <HooksDemos.UseDebouncedValueCancelDemo />
 


### PR DESCRIPTION
`const [debounced, cancel] = useDebouncedValue(value, 1000);`
Corrected the description of this line of "minute" to "second"  (1000ms = 1s)