### PR TITLE
[@mantine/hooks] usePageLeave: callback calls twice when leaving scrollbar fix

### DIFF
--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -214,13 +214,11 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
     const isDeselectable = allowDeselect === undefined ? clearable : allowDeselect;
 
     const setDropdownOpened = (opened: boolean) => {
-      if (dropdownOpened === opened) {
-        return;
+      if (dropdownOpened !== opened) {
+        _setDropdownOpened(opened);
+        const handler = opened ? onDropdownOpen : onDropdownClose;
+        typeof handler === 'function' && handler();
       }
-
-      _setDropdownOpened(opened);
-      const handler = opened ? onDropdownOpen : onDropdownClose;
-      typeof handler === 'function' && handler();
     };
 
     const isCreatable = creatable && typeof getCreateLabel === 'function';

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -214,6 +214,10 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
     const isDeselectable = allowDeselect === undefined ? clearable : allowDeselect;
 
     const setDropdownOpened = (opened: boolean) => {
+      if (dropdownOpened === opened) {
+        return;
+      }
+
       _setDropdownOpened(opened);
       const handler = opened ? onDropdownOpen : onDropdownClose;
       typeof handler === 'function' && handler();

--- a/src/mantine-hooks/src/use-page-leave/use-page-leave.story.tsx
+++ b/src/mantine-hooks/src/use-page-leave/use-page-leave.story.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { usePageLeave } from './use-page-leave';
+
+const lorem =
+  'Because and pointing threw system for read. That or spot. What stairs nor perfected lead to buttons to here. The in there I attention would left right look such may through they the seven. People, into probably must suppliers, something phase by the every there up rendering it logged although.';
+
+function Example() {
+  const [leftsCount, setLeftsCount] = useState(0);
+  usePageLeave(() => setLeftsCount((p) => p + 1));
+
+  const items = Array(60)
+    .fill(0)
+    .map((_, index) => <p key={index}>{lorem}</p>);
+
+  return (
+    <div style={{ padding: 20 }}>
+      Mouse cursor has left the page {leftsCount} times
+      {items}
+    </div>
+  );
+}
+
+storiesOf('@mantine/hooks/use-page-leave', module).add('Usage', () => <Example />);

--- a/src/mantine-hooks/src/use-page-leave/use-page-leave.ts
+++ b/src/mantine-hooks/src/use-page-leave/use-page-leave.ts
@@ -1,8 +1,8 @@
-import { useWindowEvent } from '../use-window-event/use-window-event';
+import { useEffect } from 'react';
 
 export function usePageLeave(onPageLeave: () => void) {
-  useWindowEvent('mouseout', (event) => {
-    const from = event.relatedTarget || (event as any).toElement;
-    (!from || (from as any).nodeName === 'HTML') && onPageLeave();
-  });
+  useEffect(() => {
+    document.documentElement.addEventListener('mouseleave', onPageLeave);
+    return () => document.documentElement.removeEventListener('mouseleave', onPageLeave);
+  }, []);
 }


### PR DESCRIPTION
The callback will no longer be called twice when leaving the page through the scrollbar.

![otiskbi2P5](https://user-images.githubusercontent.com/9464690/155284376-8173ffea-380b-454f-a9a8-932108d2f6c2.gif)

Resolves #886