### PR TITLE
[docs] Fixed typo on Notifications document

### DIFF
--- a/docs/src/docs/others/notifications.mdx
+++ b/docs/src/docs/others/notifications.mdx
@@ -102,7 +102,7 @@ interface NotificationProps {
 
 Notification state item can have these properties:
 
-- **id** – notification id, it is used to update adn remove notification, be default id generates randomly
+- **id** – notification id, it is used to update and remove notification, by default id is randomly generated
 - **disallowClose** – removes close button, notification can be closed only programmatically
 - **onClose** – calls when notification is unmounted
 - **onOpen** – calls when notification is mounted


### PR DESCRIPTION
from: ... update adn remove notification, be default id generates randomly
to : ... update and remove notification, by default id is randomly generated