### PR TITLE
[docs]  Missing grow prop in example

### DIFF
--- a/docs/src/docs/core/AppShell.mdx
+++ b/docs/src/docs/core/AppShell.mdx
@@ -101,7 +101,7 @@ Navbar can be used outside of AppShell context:
   <Navbar.Section>First section</Navbar.Section>
 
   {/* Grow section will take all available space that is not taken by first and last sections */}
-  <Navbar.Section>Grow section</Navbar.Section>
+  <Navbar.Section grow>Grow section</Navbar.Section>
 
   {/* Last section with normal height (depends on section content) */}
   <Navbar.Section>Last section</Navbar.Section>


### PR DESCRIPTION
Fix: Typo in Navigation.Section example, missing the grow prop that is mentioned in the comment. If I should include all the generated docs in the PR please let me know, thank you!