### PR TITLE
[@mantine/hooks] - Renamed HokeyItem type to HotkeyItem | Updated docs to match type definition

### DIFF
--- a/docs/src/docs/hooks/use-hotkeys.mdx
+++ b/docs/src/docs/hooks/use-hotkeys.mdx
@@ -54,5 +54,6 @@ which should be used with `onKeyDown`:
 ## Definition
 
 ```tsx
-function useHotkeys(hotkey: string, handler: (event: KeyboardEvent) => void): void;
+type HotkeyItem = [hotkey: string, handler: (event: KeyboardEvent) => void];
+function useHotkeys(hotkeys: HotkeyItem[]): void;
 ```

--- a/src/mantine-hooks/src/use-hotkeys/use-hotkeys.ts
+++ b/src/mantine-hooks/src/use-hotkeys/use-hotkeys.ts
@@ -3,7 +3,7 @@ import { getHotkeyMatcher, getHotkeyHandler } from './parse-hotkey';
 
 export { getHotkeyHandler };
 
-type HokeyItem = [string, (event: KeyboardEvent) => void];
+type HotkeyItem = [string, (event: KeyboardEvent) => void];
 
 function shouldFireEvent(event: KeyboardEvent) {
   if (event.target instanceof HTMLElement) {
@@ -12,7 +12,7 @@ function shouldFireEvent(event: KeyboardEvent) {
   return true;
 }
 
-export function useHotkeys(hotkeys: HokeyItem[]) {
+export function useHotkeys(hotkeys: HotkeyItem[]) {
   useEffect(() => {
     const keydownListener = (event: KeyboardEvent) => {
       hotkeys.forEach(([hotkey, handler]) => {


### PR DESCRIPTION
This may be a breaking change for people who import the old `HokeyItem` type, but it should be a manageable change.