### PR TITLE
[@mantine/dates] Improve the UX of the TimeInput component

### DIFF
--- a/src/mantine-dates/src/components/TimeInput/TimeInput.tsx
+++ b/src/mantine-dates/src/components/TimeInput/TimeInput.tsx
@@ -176,6 +176,7 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
       min: format === '12' ? 1 : 0,
       max: format === '12' ? 12 : 23,
       nextRef: minutesRef,
+      nextMax: 59,
     });
 
     const handleMinutesChange = createTimeHandler({
@@ -188,6 +189,7 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
       min: 0,
       max: 59,
       nextRef: withSeconds ? secondsRef : format === '12' ? amPmRef : nextRef,
+      nextMax: 59,
     });
 
     const handleSecondsChange = createTimeHandler({

--- a/src/mantine-dates/src/components/TimeInput/TimeInput.tsx
+++ b/src/mantine-dates/src/components/TimeInput/TimeInput.tsx
@@ -189,7 +189,7 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
       min: 0,
       max: 59,
       nextRef: withSeconds ? secondsRef : format === '12' ? amPmRef : nextRef,
-      nextMax: 59,
+      nextMax: withSeconds ? 59 : undefined,
     });
 
     const handleSecondsChange = createTimeHandler({

--- a/src/mantine-dates/src/components/TimeInput/TimeInput.tsx
+++ b/src/mantine-dates/src/components/TimeInput/TimeInput.tsx
@@ -167,22 +167,26 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
     };
 
     const handleHoursChange = createTimeHandler({
-      onChange: (val) => {
-        setDate({ hours: val });
+      onChange: (val, carryOver) => {
+        setDate({
+          hours: val,
+          minutes: carryOver ?? time.minutes,
+        });
       },
       min: format === '12' ? 1 : 0,
       max: format === '12' ? 12 : 23,
-      maxValue: 2,
       nextRef: minutesRef,
     });
 
     const handleMinutesChange = createTimeHandler({
-      onChange: (val) => {
-        setDate({ minutes: val });
+      onChange: (val, carryOver) => {
+        setDate({
+          minutes: val,
+          seconds: carryOver ?? time.seconds,
+        });
       },
       min: 0,
       max: 59,
-      maxValue: 5,
       nextRef: withSeconds ? secondsRef : format === '12' ? amPmRef : nextRef,
     });
 
@@ -192,7 +196,6 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
       },
       min: 0,
       max: 59,
-      maxValue: 5,
       nextRef: format === '12' ? amPmRef : nextRef,
     });
 

--- a/src/mantine-dates/src/components/TimeInputBase/create-time-handler/all-but-last-digit/all-but-last-digit.test.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/create-time-handler/all-but-last-digit/all-but-last-digit.test.ts
@@ -1,0 +1,7 @@
+import { allButLastDigit } from './all-but-last-digit';
+
+it('Correctly trims last digit', () => {
+  expect(allButLastDigit(0)).toBe(0);
+  expect(allButLastDigit(28)).toBe(2);
+  expect(allButLastDigit(123)).toBe(12);
+});

--- a/src/mantine-dates/src/components/TimeInputBase/create-time-handler/all-but-last-digit/all-but-last-digit.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/create-time-handler/all-but-last-digit/all-but-last-digit.ts
@@ -1,0 +1,3 @@
+export function allButLastDigit(value: number) {
+  return Math.floor(value / 10);
+}

--- a/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.test.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.test.ts
@@ -28,7 +28,7 @@ describe('@mantine/dates/create-time-handler', () => {
 
     handler('6', true);
 
-    expect(spy).toHaveBeenCalledWith('06');
+    expect(spy).toHaveBeenCalledWith('06', undefined);
     expect(ref.current.focus).toHaveBeenCalledTimes(1);
     expect(ref.current.select).toHaveBeenCalledTimes(1);
   });

--- a/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.test.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.test.ts
@@ -8,7 +8,6 @@ describe('@mantine/dates/create-time-handler', () => {
       onChange: spy,
       min: 0,
       max: 23,
-      maxValue: 2,
       nextRef: ref as any,
     });
 
@@ -17,14 +16,13 @@ describe('@mantine/dates/create-time-handler', () => {
     expect(spy).toHaveBeenCalledTimes(0);
   });
 
-  it('calls onChange with padded value when value is more than maxValue', () => {
+  it('calls onChange with padded value when value is more than Math.floor(max / 10)', () => {
     const ref = { current: { focus: jest.fn(), select: jest.fn() } };
     const spy = jest.fn();
     const handler = createTimeHandler({
       onChange: spy,
       min: 0,
       max: 23,
-      maxValue: 2,
       nextRef: ref as any,
     });
 
@@ -35,14 +33,13 @@ describe('@mantine/dates/create-time-handler', () => {
     expect(ref.current.select).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onChange with value when value is less than maxValue', () => {
+  it('calls onChange with value when value is less than Math.floor(max / 10)', () => {
     const ref = { current: { focus: jest.fn(), select: jest.fn() } };
     const spy = jest.fn();
     const handler = createTimeHandler({
       onChange: spy,
       min: 0,
       max: 59,
-      maxValue: 5,
       nextRef: ref as any,
     });
 

--- a/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.ts
@@ -25,7 +25,7 @@ export function createTimeHandler({ onChange, nextRef, min, max, nextMax }: Crea
           1. The number starts with the last digit of the current value.
           2. The number is less than the next field's maximum value constraint.
       */
-      if (parsed > max && lastDigit <= Math.floor(nextMax / 10)) {
+      if (nextMax && parsed > max && lastDigit <= Math.floor(nextMax / 10)) {
         onChange(padTime(Math.floor(parsed / 10).toString()), padTime(lastDigit.toString()));
       } else {
         onChange(padTime(clamp({ value: parsed, min, max }).toString()));

--- a/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.ts
@@ -1,5 +1,6 @@
 import { clamp } from '@mantine/hooks';
 import { padTime } from '../pad-time/pad-time';
+import { allButLastDigit } from './all-but-last-digit/all-but-last-digit';
 
 interface CreateTimeHandler {
   onChange(value: string, carryOver?: string): void;
@@ -17,20 +18,25 @@ export function createTimeHandler({ onChange, nextRef, min, max, nextMax }: Crea
       return;
     }
 
-    if (parsed > Math.floor(max / 10) || forceTriggerShift) {
+    if (parsed > allButLastDigit(max) || forceTriggerShift) {
       const lastDigit = parsed % 10;
+
+      let updatedValue: string;
+      let carryOver: string | undefined;
 
       /*
         Check if it is possible to construct a number that satisfies the following conditions:
           1. The number starts with the last digit of the current value.
           2. The number is less than the next field's maximum value constraint.
       */
-      if (nextMax && parsed > max && lastDigit <= Math.floor(nextMax / 10)) {
-        onChange(padTime(Math.floor(parsed / 10).toString()), padTime(lastDigit.toString()));
+      if (parsed > max && nextMax && lastDigit <= allButLastDigit(nextMax)) {
+        updatedValue = padTime(allButLastDigit(parsed).toString());
+        carryOver = padTime(lastDigit.toString());
       } else {
-        onChange(padTime(clamp({ value: parsed, min, max }).toString()));
+        updatedValue = padTime(clamp({ value: parsed, min, max }).toString());
       }
 
+      onChange(updatedValue, carryOver);
       triggerShift && nextRef?.current?.focus();
       triggerShift && nextRef?.current?.select();
       return;

--- a/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.ts
@@ -2,14 +2,13 @@ import { clamp } from '@mantine/hooks';
 import { padTime } from '../pad-time/pad-time';
 
 interface CreateTimeHandler {
-  onChange(value: string): void;
+  onChange(value: string, carryOver?: string): void;
   nextRef?: React.RefObject<HTMLInputElement>;
   min: number;
   max: number;
-  maxValue: number;
 }
 
-export function createTimeHandler({ onChange, nextRef, min, max, maxValue }: CreateTimeHandler) {
+export function createTimeHandler({ onChange, nextRef, min, max }: CreateTimeHandler) {
   return (value: string, triggerShift: boolean, forceTriggerShift = false) => {
     const parsed = parseInt(value, 10);
 
@@ -17,8 +16,13 @@ export function createTimeHandler({ onChange, nextRef, min, max, maxValue }: Cre
       return;
     }
 
-    if (parsed > maxValue || forceTriggerShift) {
-      onChange(padTime(clamp({ value: parsed, min, max }).toString()));
+    if (parsed > Math.floor(max / 10) || forceTriggerShift) {
+      if (parsed > max) {
+        onChange(padTime(Math.floor(parsed / 10).toString()), padTime((parsed % 10).toString()));
+      } else {
+        onChange(padTime(clamp({ value: parsed, min, max }).toString()));
+      }
+
       triggerShift && nextRef?.current?.focus();
       triggerShift && nextRef?.current?.select();
       return;

--- a/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/create-time-handler/create-time-handler.ts
@@ -6,9 +6,10 @@ interface CreateTimeHandler {
   nextRef?: React.RefObject<HTMLInputElement>;
   min: number;
   max: number;
+  nextMax?: number;
 }
 
-export function createTimeHandler({ onChange, nextRef, min, max }: CreateTimeHandler) {
+export function createTimeHandler({ onChange, nextRef, min, max, nextMax }: CreateTimeHandler) {
   return (value: string, triggerShift: boolean, forceTriggerShift = false) => {
     const parsed = parseInt(value, 10);
 
@@ -17,8 +18,15 @@ export function createTimeHandler({ onChange, nextRef, min, max }: CreateTimeHan
     }
 
     if (parsed > Math.floor(max / 10) || forceTriggerShift) {
-      if (parsed > max) {
-        onChange(padTime(Math.floor(parsed / 10).toString()), padTime((parsed % 10).toString()));
+      const lastDigit = parsed % 10;
+
+      /*
+        Check if it is possible to construct a number that satisfies the following conditions:
+          1. The number starts with the last digit of the current value.
+          2. The number is less than the next field's maximum value constraint.
+      */
+      if (parsed > max && lastDigit <= Math.floor(nextMax / 10)) {
+        onChange(padTime(Math.floor(parsed / 10).toString()), padTime(lastDigit.toString()));
       } else {
         onChange(padTime(clamp({ value: parsed, min, max }).toString()));
       }


### PR DESCRIPTION
This PR aims to improve the UX of the TimeInput component by advancing the user's focus to the next input field when we can infer their intent. If we can't deduce anything useful, then it falls back to the existing logic. The additional logic is only used when entering times that require a leading zero (e.g. `1:45`).

Here are a few examples demonstrating the difference:

### Example 1

**TimeInput props**: 12 hour time format without seconds
**Desired time (What the user is trying to enter)**: `1:30`
**User keystrokes (What the user types in the input)**: `1`, `3`, `0`

**Result (with current implementation)**: `12:00` (incorrect)
**Result (with this PR)**: `1:30` (correct)

### Example 2

**TimeInput props**: 24 hour time format without seconds
**Desired time (What the user is trying to enter)**: `2:45`
**User keystrokes (What the user types in the input)**: `2`, `4`, `5`

**Result (with current implementation)**: `23:05` (incorrect)
**Result (with this PR)**: `2:45` (correct)

### Example 3

**TimeInput props**: 12 hour time format without seconds
**Desired time (What the user is trying to enter)**: `12:30`
**User keystrokes (What the user types in the input)**: `1`, `6` (incorrect keystroke), `3`, `0`

**Result (with current implementation)**: `12:30` (correct)
**Result (with this PR)**: `12:30` (correct)
