### PR TITLE
[@mantine/tests] conformance test cases type safety

### DIFF
--- a/src/mantine-core/src/components/Popper/PopperContainer/PopperContainer.test.tsx
+++ b/src/mantine-core/src/components/Popper/PopperContainer/PopperContainer.test.tsx
@@ -4,8 +4,8 @@ import { itRendersChildren, itSupportsClassName } from '@mantine/tests';
 import { PopperContainer } from './PopperContainer';
 
 describe('@mantine/core/PopperContainer', () => {
-  itRendersChildren(PopperContainer, { withinPortal: false });
-  itSupportsClassName(PopperContainer, { withinPortal: false });
+  itRendersChildren(PopperContainer, { withinPortal: false, children: undefined });
+  itSupportsClassName(PopperContainer, { withinPortal: false, children: undefined });
 
   it('has correct displayName', () => {
     expect(PopperContainer.displayName).toStrictEqual('@mantine/core/PopperContainer');

--- a/src/mantine-notifications/src/NotificationContainer/NotificationContainer.test.tsx
+++ b/src/mantine-notifications/src/NotificationContainer/NotificationContainer.test.tsx
@@ -5,6 +5,7 @@ const defaultProps = {
   notification: { id: 'test', message: 'test-message' },
   onHide: () => {},
   autoClose: false,
+  innerRef: undefined,
 } as const;
 
 describe('@mantine/notifications/NotificationContainer', () => {

--- a/src/mantine-tests/src/is-supports-input-props.tsx
+++ b/src/mantine-tests/src/is-supports-input-props.tsx
@@ -5,9 +5,9 @@ import { itSupportsInputIcon } from './it-supports-input-icon';
 import { itSupportsInputRightSection } from './it-supports-input-right-section';
 import { renderWithAct } from './render-with-act';
 
-export function itSupportsInputProps(
-  Component: React.ElementType,
-  requiredProps: Record<string, any>,
+export function itSupportsInputProps<P>(
+  Component: React.ComponentType<P>,
+  requiredProps: P,
   name: string
 ) {
   itSupportsWrapperProps(Component, requiredProps);

--- a/src/mantine-tests/src/it-connects-label-and-input.tsx
+++ b/src/mantine-tests/src/it-connects-label-and-input.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { renderWithAct } from './render-with-act';
 
-export function itConnectsLabelAndInput(
-  Component: React.ElementType,
-  requiredProps: Record<string, any>
-) {
+export function itConnectsLabelAndInput<P>(Component: React.ComponentType<P>, requiredProps: P) {
   it('connects label and input with given id', async () => {
     const { container } = await renderWithAct(
       <Component {...requiredProps} id="secret-test-id" label="Test label" />

--- a/src/mantine-tests/src/it-filters-children.tsx
+++ b/src/mantine-tests/src/it-filters-children.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { renderWithAct } from './render-with-act';
 
-export function itFiltersChildren(
-  Component: React.ElementType,
-  requiredProps: Record<string, any>,
+export function itFiltersChildren<P>(
+  Component: React.ComponentType<P>,
+  requiredProps: P,
   childSelector: string,
   children: React.ReactElement[]
 ) {

--- a/src/mantine-tests/src/it-handles-boolean-state.tsx
+++ b/src/mantine-tests/src/it-handles-boolean-state.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-export function itHandlesBooleanState(
-  Component: React.ElementType,
-  requiredProps: Record<string, any>
-) {
+export function itHandlesBooleanState<P>(Component: React.ComponentType<P>, requiredProps: P) {
   it('correctly handles uncontrolled state', () => {
     render(<Component {...requiredProps} />);
     expect(screen.getByRole('checkbox')).not.toBeChecked();

--- a/src/mantine-tests/src/it-is-polymorphic.tsx
+++ b/src/mantine-tests/src/it-is-polymorphic.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
-export function itIsPolymorphic(
-  Component: React.ElementType,
-  requiredProps: Record<string, any>,
+export function itIsPolymorphic<P>(
+  Component: React.ComponentType<P>,
+  requiredProps: P,
   selector?: string
 ) {
   it('is polymorphic', () => {

--- a/src/mantine-tests/src/it-renders-children.tsx
+++ b/src/mantine-tests/src/it-renders-children.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { renderWithAct } from './render-with-act';
 
-export function itRendersChildren(
-  Component: React.ElementType,
-  requiredProps: Record<string, any>
-) {
+export function itRendersChildren<P>(Component: React.ComponentType<P>, requiredProps: P) {
   it('renders children', async () => {
     const { queryAllByText } = await renderWithAct(
       <Component {...requiredProps}>

--- a/src/mantine-tests/src/it-supports-classname.tsx
+++ b/src/mantine-tests/src/it-supports-classname.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { renderWithAct } from './render-with-act';
 
-export function itSupportsClassName(
-  Component: React.ElementType,
-  requiredProps: Record<string, any>
-) {
+export function itSupportsClassName<P>(Component: React.ComponentType<P>, requiredProps: P) {
   it('supports className prop', async () => {
     const { container } = await renderWithAct(
       <Component {...requiredProps} className="test-class-name" />

--- a/src/mantine-tests/src/it-supports-focus-events.tsx
+++ b/src/mantine-tests/src/it-supports-focus-events.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { renderWithAct } from './render-with-act';
 
-export function itSupportsFocusEvents(
-  Component: React.ElementType,
-  requiredProps: Record<string, any>,
-  selector: string
+export function itSupportsFocusEvents<P>(
+  Component: React.ComponentType<P>,
+  requiredProps: P,
+  selector?: string
 ) {
   it('supports focus events', async () => {
     const onFocusSpy = jest.fn();

--- a/src/mantine-tests/src/it-supports-input-icon.tsx
+++ b/src/mantine-tests/src/it-supports-input-icon.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { renderWithAct } from './render-with-act';
 
-export function itSupportsInputIcon(
-  Component: React.ElementType,
-  requiredProps: Record<string, any>
-) {
+export function itSupportsInputIcon<P>(Component: React.ComponentType<P>, requiredProps: P) {
   it('supports input icon', async () => {
     const { getByText } = await renderWithAct(<Component {...requiredProps} icon="Test icon" />);
     expect(getByText('Test icon')).toBeInTheDocument();

--- a/src/mantine-tests/src/it-supports-input-right-section.tsx
+++ b/src/mantine-tests/src/it-supports-input-right-section.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { renderWithAct } from './render-with-act';
 
-export function itSupportsInputRightSection(
-  Component: React.ElementType,
-  requiredProps: Record<string, any>
+export function itSupportsInputRightSection<P>(
+  Component: React.ComponentType<P>,
+  requiredProps: P
 ) {
   it('supports input right section', async () => {
     const { getByText } = await renderWithAct(

--- a/src/mantine-tests/src/it-supports-margins.tsx
+++ b/src/mantine-tests/src/it-supports-margins.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { DEFAULT_THEME } from '@mantine/styles';
 import { renderWithAct } from './render-with-act';
 
-export function itSupportsMargins(
-  Component: React.ElementType,
-  requiredProps: Record<string, any>
-) {
+export function itSupportsMargins<P>(Component: React.ComponentType<P>, requiredProps: P) {
   it('supports m, mx, my, mt, mb, mr and ml props', async () => {
     const { container: m } = await renderWithAct(<Component {...requiredProps} m={45} />);
     const { container: theme } = await renderWithAct(<Component {...requiredProps} m="xl" />);

--- a/src/mantine-tests/src/it-supports-others.tsx
+++ b/src/mantine-tests/src/it-supports-others.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderWithAct } from './render-with-act';
 
-export function itSupportsOthers(Component: React.ElementType, requiredProps: Record<string, any>) {
+export function itSupportsOthers<P>(Component: React.ComponentType<P>, requiredProps: P) {
   it('supports ...others props', async () => {
     const { container } = await renderWithAct(
       <Component {...requiredProps} data-other-attribute="test" />

--- a/src/mantine-tests/src/it-supports-paddings.tsx
+++ b/src/mantine-tests/src/it-supports-paddings.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { DEFAULT_THEME } from '@mantine/styles';
 import { renderWithAct } from './render-with-act';
 
-export function itSupportsPaddings(
-  Component: React.ElementType,
-  requiredProps: Record<string, any>
-) {
+export function itSupportsPaddings<P>(Component: React.ComponentType<P>, requiredProps: P) {
   it('supports p, px, py, pt, pb, pr and pl props', async () => {
     const { container: p } = await renderWithAct(<Component {...requiredProps} p={45} />);
     const { container: theme } = await renderWithAct(<Component {...requiredProps} p="xl" />);

--- a/src/mantine-tests/src/it-supports-ref.tsx
+++ b/src/mantine-tests/src/it-supports-ref.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { renderWithAct } from './render-with-act';
 
-export function itSupportsRef(
-  Component: React.ElementType,
-  requiredProps: Record<string, any>,
+export function itSupportsRef<P>(
+  Component: React.ComponentType<P>,
+  requiredProps: P,
   refType: any,
   refProp: string = 'ref'
 ) {

--- a/src/mantine-tests/src/it-supports-style.tsx
+++ b/src/mantine-tests/src/it-supports-style.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderWithAct } from './render-with-act';
 
-export function itSupportsStyle(Component: React.ElementType, requiredProps: Record<string, any>) {
+export function itSupportsStyle<P>(Component: React.ComponentType<P>, requiredProps: P) {
   it('supports style property', async () => {
     const { container } = await renderWithAct(
       <Component {...requiredProps} style={{ border: '1px solid cyan' }} />

--- a/src/mantine-tests/src/it-supports-sx.tsx
+++ b/src/mantine-tests/src/it-supports-sx.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderWithAct } from './render-with-act';
 
-export function itSupportsSx(Component: React.ElementType, requiredProps: Record<string, any>) {
+export function itSupportsSx<P>(Component: React.ComponentType<P>, requiredProps: P) {
   it('supports sx', async () => {
     const styles = { border: '1px solid aquamarine', background: 'beige' };
     const fn = () => styles;

--- a/src/mantine-tests/src/it-supports-wrapper-props.tsx
+++ b/src/mantine-tests/src/it-supports-wrapper-props.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { renderWithAct } from './render-with-act';
 
-export function itSupportsWrapperProps(
-  Component: React.ElementType,
-  requiredProps: Record<string, any>
-) {
+export function itSupportsWrapperProps<P>(Component: React.ComponentType<P>, requiredProps: P) {
   it('supports wrapperProps prop', async () => {
     const { container } = await renderWithAct(
       <Component {...requiredProps} wrapperProps={{ 'data-test-prop': 'test-prop' }} />


### PR DESCRIPTION
Hi,
Recently I noticed that conformance test cases props aren't safe that much, so I decided to make this PR to add this option to those.

```tsx
itSupportsSx(NotificationContainer, 
  { /* all NotificationContainer component props will be suggested  */ }
);
```