### PR TITLE
[docs] Fix typo in useMemo

### DIFF
--- a/docs/src/docs/others/rte.mdx
+++ b/docs/src/docs/others/rte.mdx
@@ -141,7 +141,7 @@ function Demo() {
       history: { delay: 2500, userOnly: true },
       syntax: true,
     }),
-    {}
+    []
   );
   return <RichTextEditor modules={modules} {...otherProps} />;
 }


### PR DESCRIPTION
The code example is using `{}` instead of `[]` as a dependency list to `useMemo`