### PR TITLE
[docs] Fixed typo in NumberInputDemos.hold

### DIFF
--- a/src/mantine-demos/src/demos/packages/NumberInput/hold.tsx
+++ b/src/mantine-demos/src/demos/packages/NumberInput/hold.tsx
@@ -31,7 +31,7 @@ function Demo() {
       <NumberInput
         mt="md"
         label="Step the value with interval function"
-        description="Ste value will increase incrementally when control is hold"
+        description="Step value will increase incrementally when control is hold"
         placeholder="Hold mouse down on control button"
         stepHoldDelay={500}
         stepHoldInterval={(t) => Math.max(1000 / t ** 2, 25)}

--- a/src/mantine-demos/src/demos/packages/NumberInput/hold.tsx
+++ b/src/mantine-demos/src/demos/packages/NumberInput/hold.tsx
@@ -22,7 +22,7 @@ function Demo() {
   return (
     <div style={{ maxWidth: 420, margin: 'auto' }}>
       <NumberInput
-        label="Ste on hold"
+        label="Step on hold"
         description="Step the value when clicking and holding the arrows"
         placeholder="Hold mouse down on control button"
         stepHoldDelay={500}

--- a/src/mantine-demos/src/demos/packages/NumberInput/hold.tsx
+++ b/src/mantine-demos/src/demos/packages/NumberInput/hold.tsx
@@ -22,7 +22,7 @@ function Demo() {
   return (
     <div style={{ maxWidth: 420, margin: 'auto' }}>
       <NumberInput
-        label="Step on hold"
+        label="Ste on hold"
         description="Step the value when clicking and holding the arrows"
         placeholder="Hold mouse down on control button"
         stepHoldDelay={500}


### PR DESCRIPTION
Fixed a typo in the docs description for the NumberInput hold demo. (Ste -> Step)