### PR TITLE
[@mantine/core] Modal: Prevent top from extending off screen for long centered, overflow outside modals

### DIFF
--- a/src/mantine-core/src/components/Modal/Modal.styles.ts
+++ b/src/mantine-core/src/components/Modal/Modal.styles.ts
@@ -54,6 +54,8 @@ export default createStyles((theme, { overflow, size, centered }: ModalStyles) =
     width: theme.fn.size({ sizes, size }),
     outline: 0,
     backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
+    marginTop: centered ? 'auto' : undefined,
+    marginBottom: centered ? 'auto' : undefined,
   },
 
   header: {


### PR DESCRIPTION
Fixes #927 

Should work w/ long and short modals centered/not centered with overflow outside/inside

Here's a codesandbox that should demo the fix just by applying the styles to the modals directly
https://codesandbox.io/s/mantine-modal-issue-forked-gq49mz?file=/src/App.tsx