### PR TITLE
[docs] Fixed typo in Drawer.mdx

### DIFF
--- a/docs/src/docs/core/Drawer.mdx
+++ b/docs/src/docs/core/Drawer.mdx
@@ -43,7 +43,7 @@ Size cannot exceed 100% of width and 100vh of height.
 <Drawer position="right" size="xl" /> // predefined xl width
 <Drawer position="top" size={200} /> // 200px height
 <Drawer position="left" size="75%" /> // 75% width
-<Drawer position="bottom" size="500vh" /> // 100vh height as max-height is 100vh
+<Drawer position="bottom" size="50vh" /> // 100vh height as max-height is 100vh
 ```
 
 <Demo data={DrawerDemos.sizes} />


### PR DESCRIPTION
Fixed a type in Drawer docs which was causing the drawer to cover the whole screen.