### PR TITLE
[@mantine/dates]: Calendar: Fix full width on month view

### DIFF
--- a/src/mantine-dates/src/components/Calendar/Calendar.story.tsx
+++ b/src/mantine-dates/src/components/Calendar/Calendar.story.tsx
@@ -19,6 +19,11 @@ storiesOf('@mantine/dates/Calendar/stories', module)
     </div>
   ))
   .add('Sizes', () => <div style={{ padding: 40 }}>{sizes}</div>)
+  .add('Full width', () => (
+    <div style={{ padding: 40, width: '100%' }}>
+      <WrappedCalendar fullWidth />
+    </div>
+  ))
   .add('First day of the week sunday', () => (
     <div style={{ padding: 40, width: 400 }}>
       <WrappedCalendar minDate={new Date()} firstDayOfWeek="sunday" />

--- a/src/mantine-dates/src/components/CalendarBase/MonthPicker/MonthPicker.styles.ts
+++ b/src/mantine-dates/src/components/CalendarBase/MonthPicker/MonthPicker.styles.ts
@@ -15,7 +15,9 @@ const sizes = {
 export default createStyles((theme, { size }: MonthPickerStyles) => {
   const colors = getSharedColorScheme({ color: theme.primaryColor, theme, variant: 'filled' });
   return {
-    monthPicker: {},
+    monthPicker: {
+      width: '100%',
+    },
 
     monthPickerControls: {
       display: 'flex',


### PR DESCRIPTION
Fixes calendar full width issue when viewing the month.
Before:
<img width="1430" alt="image" src="https://user-images.githubusercontent.com/23553050/157107867-e3dec67b-d4e4-4715-8e7f-31c94007e5af.png">
After:
<img width="1450" alt="image" src="https://user-images.githubusercontent.com/23553050/157107946-b8c60bf8-1355-4178-a9d2-0092be211a3f.png">
