### PR TITLE
return new value from onCreate

### DIFF
--- a/src/mantine-core/src/components/Select/Select.story.tsx
+++ b/src/mantine-core/src/components/Select/Select.story.tsx
@@ -119,7 +119,53 @@ function DynamicLabels(props: Partial<SelectProps>) {
   );
 }
 
+function CustomValueOnCreate() {
+  const [objectOptions, setObjectOptions] = React.useState([
+    {
+      label: 'AA',
+      value: 'aa',
+    },
+    {
+      label: 'BB',
+      value: 'bb',
+    },
+  ]);
+
+  return (
+    <Select
+      searchable
+      creatable
+      clearable
+      label="Type"
+      placeholder="Pick one"
+      autoComplete="off"
+      nothingFound="No options"
+      name="type"
+      getCreateLabel={(query) => `+ Create ${query}`}
+      onCreate={(d) => {
+        const customValue = Date.now();
+
+        setObjectOptions((items) => [
+          ...items,
+          {
+            label: d,
+            value: customValue,
+          },
+        ]);
+
+        return customValue;
+      }}
+      data={objectOptions}
+    />
+  );
+}
+
 storiesOf('@mantine/core/Select/stories', module)
+  .add('Custom value on create', () => (
+    <div style={{ padding: 40, maxWidth: 400 }}>
+      <CustomValueOnCreate />
+    </div>
+  ))
   .add('Controlled', () => (
     <div style={{ padding: 40, maxWidth: 400 }}>
       <Controlled />

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -118,7 +118,7 @@ export interface SelectProps
   shouldCreate?: (query: string, data: SelectItem[]) => boolean;
 
   /** Called when create option is selected */
-  onCreate?: (query: string) => void;
+  onCreate?: (query: string) => string;
 
   /** Change dropdown component, can be used to add native scrollbars */
   dropdownComponent?: any;
@@ -300,7 +300,12 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>((props: SelectPr
       handleChange(item.value);
 
       if (item.creatable) {
-        typeof onCreate === 'function' && onCreate(item.value);
+        if (typeof onCreate === 'function') {
+          const newValue = onCreate(item.value)
+          if (newValue !== undefined) {
+            handleChange(newValue)
+          }
+        }
       }
 
       if (inputMode === 'uncontrolled') {

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -297,15 +297,16 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>((props: SelectPr
       handleChange(null);
       setDropdownOpened(false);
     } else {
-      handleChange(item.value);
 
       if (item.creatable) {
         if (typeof onCreate === 'function') {
-          const newValue = onCreate(item.value)
+          const newValue = onCreate(item.value);
           if (newValue !== undefined) {
-            handleChange(newValue)
+            handleChange(newValue);
           }
         }
+      } else {
+        handleChange(item.value);
       }
 
       if (inputMode === 'uncontrolled') {


### PR DESCRIPTION
Fixes #980 

This is a proposal to allow the onCreate prop of the Select component to respect a return value.
Currently, the default behavior of onCreate is assuming that the created value is the same as what was inputted.

The use case is using onCreate to specify a custom value that may or may not be derived from the incoming value from input.