### PR TITLE
[@mantine/spotlight] Fix keyboard navigation triggering wrong action when using grouping

### DIFF
--- a/src/mantine-core/src/components/Image/BackgroundImage/BackgroundImage.tsx
+++ b/src/mantine-core/src/components/Image/BackgroundImage/BackgroundImage.tsx
@@ -11,6 +11,7 @@ import { Box } from '../../Box';
 interface _BackgroundImageProps extends DefaultProps, React.ComponentPropsWithoutRef<'div'> {
   src: string;
   radius?: MantineNumberSize;
+  padding?: MantineNumberSize;
 }
 
 export type BackgroundImageProps<C> = C extends React.ElementType

--- a/src/mantine-core/src/components/Image/BackgroundImage/BackgroundImage.tsx
+++ b/src/mantine-core/src/components/Image/BackgroundImage/BackgroundImage.tsx
@@ -11,7 +11,6 @@ import { Box } from '../../Box';
 interface _BackgroundImageProps extends DefaultProps, React.ComponentPropsWithoutRef<'div'> {
   src: string;
   radius?: MantineNumberSize;
-  padding?: MantineNumberSize;
 }
 
 export type BackgroundImageProps<C> = C extends React.ElementType

--- a/src/mantine-spotlight/src/ActionsList/ActionsList.tsx
+++ b/src/mantine-spotlight/src/ActionsList/ActionsList.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
-import { DefaultProps, ClassNames, Text, getGroupedOptions } from '@mantine/core';
+import { DefaultProps, ClassNames, Text } from '@mantine/core';
 import type { SpotlightAction } from '../types';
 import type { DefaultActionProps, DefaultActionStylesNames } from '../DefaultAction/DefaultAction';
 import useStyles from './ActionsList.styles';
 
 export type ActionsListStylesNames = ClassNames<typeof useStyles> | DefaultActionStylesNames;
+type GetGroupOptionsItem<T extends any[]> = { type: 'item'; item: T[number]; index: number };
+type GetGroupOptionsLabel = { type: 'label'; label: string };
 
 export interface ActionsListProps extends DefaultProps<ActionsListStylesNames> {
-  actions: SpotlightAction[];
+  actions: (GetGroupOptionsItem<SpotlightAction[]> | GetGroupOptionsLabel)[];
   actionComponent?: React.FC<DefaultActionProps>;
   hovered: number;
   query: string;
@@ -31,7 +33,7 @@ export function ActionsList({
 }: ActionsListProps) {
   const { classes } = useStyles(null, { classNames, styles, name: 'Spotlight' });
 
-  const items = getGroupedOptions(actions).items.map((item) => {
+  const items = actions.map((item) => {
     if (item.type === 'item') {
       return (
         <Action

--- a/src/mantine-spotlight/src/Spotlight.story.tsx
+++ b/src/mantine-spotlight/src/Spotlight.story.tsx
@@ -169,7 +169,7 @@ storiesOf('@mantine/spotlight', module)
       actions={[
         { title: 'Create 1', group: 'Create', onTrigger: () => console.log('Crate') },
         { title: 'Search 1', group: 'Search', onTrigger: () => console.log('Search') },
-        { title: 'No group', onTrigger: () => console.log('Crate') },
+        { title: 'No group', onTrigger: () => console.log('No Group') },
         { title: 'Create 2', group: 'Create', onTrigger: () => console.log('Crate') },
         { title: 'Search 2', group: 'Search', onTrigger: () => console.log('Search') },
         { title: 'Search 3', group: 'Search', onTrigger: () => console.log('Search') },

--- a/src/mantine-spotlight/src/Spotlight/Spotlight.tsx
+++ b/src/mantine-spotlight/src/Spotlight/Spotlight.tsx
@@ -10,6 +10,7 @@ import {
   MantineShadow,
   TextInput,
   getDefaultZIndex,
+  getGroupedOptions,
 } from '@mantine/core';
 import { useScrollLock, useFocusTrap, useDidUpdate, useFocusReturn } from '@mantine/hooks';
 import { DefaultAction, DefaultActionProps } from '../DefaultAction/DefaultAction';
@@ -141,30 +142,34 @@ export function Spotlight({
   useFocusReturn({ transitionDuration: 0, opened });
 
   const filteredActions = filter(query, actions).slice(0, limit);
+  const groupedWithLabels = getGroupedOptions(filteredActions).items;
+  const groupedActions = groupedWithLabels
+    .map((item) => (item.type === 'item' ? item.item : undefined))
+    .filter((item) => item);
 
   useDidUpdate(() => {
-    if (filteredActions.length - 1 < hovered) {
-      setHovered(filteredActions.length - 1);
+    if (groupedActions.length - 1 < hovered) {
+      setHovered(groupedActions.length - 1);
     }
-  }, [filteredActions.length]);
+  }, [groupedActions.length]);
 
   const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     switch (event.code) {
       case 'ArrowDown': {
         event.preventDefault();
-        setHovered((current) => (current < filteredActions.length - 1 ? current + 1 : 0));
+        setHovered((current) => (current < groupedActions.length - 1 ? current + 1 : 0));
         break;
       }
 
       case 'ArrowUp': {
         event.preventDefault();
-        setHovered((current) => (current > 0 ? current - 1 : filteredActions.length - 1));
+        setHovered((current) => (current > 0 ? current - 1 : groupedActions.length - 1));
         break;
       }
 
       case 'Enter': {
         event.preventDefault();
-        const action = filteredActions[hovered];
+        const action = groupedActions[hovered];
         action?.onTrigger?.(action);
         if (closeOnActionTrigger && action?.onTrigger) {
           handleClose();
@@ -227,7 +232,7 @@ export function Spotlight({
                 <ActionsWrapper>
                   <ActionsList
                     highlightQuery={highlightQuery}
-                    actions={filteredActions}
+                    actions={groupedWithLabels}
                     actionComponent={actionComponent}
                     hovered={hovered}
                     query={query}


### PR DESCRIPTION
This pull request is a fix for issue #986.

Grouping is now done in the Spotlight component instead of ActionList in order to keep keyboard navigation consistent with the displayed list. 