### PR TITLE
[@mantine/styles] - Fix primaryColor not being a keyof MantineThemeColors

### DIFF
--- a/src/mantine-styles/src/theme/types/MantineTheme.ts
+++ b/src/mantine-styles/src/theme/types/MantineTheme.ts
@@ -41,7 +41,7 @@ export interface MantineTheme {
   lineHeight: CSSProperties['lineHeight'];
   transitionTimingFunction: CSSProperties['transitionTimingFunction'];
   fontFamilyMonospace: CSSProperties['fontFamily'];
-  primaryColor: string;
+  primaryColor: keyof MantineThemeColors;
 
   fontSizes: MantineSizes;
   radius: MantineSizes;


### PR DESCRIPTION
This improves the type for strict mode users so that they no longer get a "possibly undefined" error when using it. 