### PR TITLE
Allow 3 character hex strings for mantine colors

### DIFF
--- a/src/mantine-styles/src/theme/functions/fns/rgba/rgba.test.ts
+++ b/src/mantine-styles/src/theme/functions/fns/rgba/rgba.test.ts
@@ -5,6 +5,8 @@ describe('@mantine/styles/rgba', () => {
     expect(rgba('#228BE6', 0.74)).toBe('rgba(34, 139, 230, 0.74)');
     expect(rgba('96f2d7', 0.945)).toBe('rgba(150, 242, 215, 0.945)');
     expect(rgba('#000000', 0.333)).toBe('rgba(0, 0, 0, 0.333)');
+    expect(rgba('#000', 0.333)).toBe('rgba(0, 0, 0, 0.333)');
+    expect(rgba('fff', 1)).toBe('rgba(255, 255, 255, 1)');
     expect(rgba('#ffffff', 1)).toBe('rgba(255, 255, 255, 1)');
   });
 

--- a/src/mantine-styles/src/theme/utils/to-rgba/to-rgba.test.ts
+++ b/src/mantine-styles/src/theme/utils/to-rgba/to-rgba.test.ts
@@ -4,6 +4,7 @@ describe('@mantine/styles/to-rgba', () => {
   it('returns the correct rgba values when given a hex string', () => {
     expect(toRgba('#F03E3E')).toStrictEqual({ r: 240, g: 62, b: 62, a: 1 });
     expect(toRgba('#D6336C')).toStrictEqual({ r: 214, g: 51, b: 108, a: 1 });
+    expect(toRgba('#f00')).toStrictEqual({ r: 255, g: 0, b: 0, a: 1 });
     expect(toRgba('#7048E8')).toStrictEqual({ r: 112, g: 72, b: 232, a: 1 });
     expect(toRgba('#1098AD')).toStrictEqual({ r: 16, g: 152, b: 173, a: 1 });
   });

--- a/src/mantine-styles/src/theme/utils/to-rgba/to-rgba.ts
+++ b/src/mantine-styles/src/theme/utils/to-rgba/to-rgba.ts
@@ -14,9 +14,14 @@ function isHexColor(hex: string): boolean {
 }
 
 function hexToRgba(color: string): RGBA {
-  const replaced = color.replace('#', '');
+  let hexString = color.replace('#', '');
 
-  const parsed = parseInt(replaced, 16);
+  if (hexString.length === 3) {
+    let shorthandHex = hexString.split('')
+    hexString = [shorthandHex[0], shorthandHex[0], shorthandHex[1], shorthandHex[1], shorthandHex[2], shorthandHex[2]].join('')
+  }
+
+  const parsed = parseInt(hexString, 16);
   const r = (parsed >> 16) & 255;
   const g = (parsed >> 8) & 255;
   const b = parsed & 255;

--- a/src/mantine-styles/src/theme/utils/to-rgba/to-rgba.ts
+++ b/src/mantine-styles/src/theme/utils/to-rgba/to-rgba.ts
@@ -8,10 +8,9 @@ interface RGBA {
 }
 
 function isHexColor(hex: string): boolean {
-  const replaced = hex.replace('#', '');
-  return (
-    typeof replaced === 'string' && replaced.length === 6 && !Number.isNaN(Number(`0x${replaced}`))
-  );
+  const HEX_REGEXP = /^#+?([0-9A-F]{3}){1,2}$/i
+  
+  return HEX_REGEXP.test(hex)
 }
 
 function hexToRgba(color: string): RGBA {

--- a/src/mantine-styles/src/theme/utils/to-rgba/to-rgba.ts
+++ b/src/mantine-styles/src/theme/utils/to-rgba/to-rgba.ts
@@ -8,17 +8,24 @@ interface RGBA {
 }
 
 function isHexColor(hex: string): boolean {
-  const HEX_REGEXP = /^#+?([0-9A-F]{3}){1,2}$/i
-  
-  return HEX_REGEXP.test(hex)
+  const HEX_REGEXP = /^#?([0-9A-F]{3}){1,2}$/i;
+
+  return HEX_REGEXP.test(hex);
 }
 
 function hexToRgba(color: string): RGBA {
   let hexString = color.replace('#', '');
 
   if (hexString.length === 3) {
-    let shorthandHex = hexString.split('')
-    hexString = [shorthandHex[0], shorthandHex[0], shorthandHex[1], shorthandHex[1], shorthandHex[2], shorthandHex[2]].join('')
+    const shorthandHex = hexString.split('');
+    hexString = [
+      shorthandHex[0],
+      shorthandHex[0],
+      shorthandHex[1],
+      shorthandHex[1],
+      shorthandHex[2],
+      shorthandHex[2],
+    ].join('');
   }
 
   const parsed = parseInt(hexString, 16);


### PR DESCRIPTION
Issue
Using a valid shorthand hex code value for a shade in mantine theme was not being converted to the correct color. For example, #ccc was returning black and not the correct color

Solution
- Update the isHexColor function to accept shorthand hex codes
- if hex is short hand, convert to the long version to be correctly converted to rgba