### PR TITLE
[@mantine/core] allow precision prop for slider

### DIFF
--- a/src/mantine-core/src/components/Slider/RangeSlider/RangeSlider.tsx
+++ b/src/mantine-core/src/components/Slider/RangeSlider/RangeSlider.tsx
@@ -48,6 +48,9 @@ export interface RangeSliderProps
   /** Number by which value will be incremented/decremented with thumb drag and arrows */
   step?: number;
 
+  /** Amount of digits after the decimal point */
+  precision?: number;
+
   /** Current value for controlled slider */
   value?: Value;
 
@@ -126,6 +129,7 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>(
       max,
       minRange,
       step,
+      precision,
       defaultValue,
       name,
       marks,
@@ -204,7 +208,7 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>(
     };
 
     const handleChange = (val: number) => {
-      const nextValue = getChangeValue({ value: val, min, max, step });
+      const nextValue = getChangeValue({ value: val, min, max, step, precision });
       setRangedValue(nextValue, thumbIndex.current, false);
     };
 

--- a/src/mantine-core/src/components/Slider/Slider/Slider.tsx
+++ b/src/mantine-core/src/components/Slider/Slider/Slider.tsx
@@ -42,6 +42,9 @@ export interface SliderProps
   /** Number by which value will be incremented/decremented with thumb drag and arrows */
   step?: number;
 
+  /** Amount of digits after the decimal point */
+  precision?: number;
+
   /** Current value for controlled slider */
   value?: number;
 
@@ -113,6 +116,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props: SliderProp
     min,
     max,
     step,
+    precision,
     defaultValue,
     name,
     marks,
@@ -144,7 +148,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props: SliderProp
   const _label = typeof label === 'function' ? label(_value) : label;
 
   const handleChange = (val: number) => {
-    const nextValue = getChangeValue({ value: val, min, max, step });
+    const nextValue = getChangeValue({ value: val, min, max, step, precision });
     setValue(nextValue);
     valueRef.current = nextValue;
   };

--- a/src/mantine-core/src/components/Slider/utils/get-change-value/get-change-value.test.ts
+++ b/src/mantine-core/src/components/Slider/utils/get-change-value/get-change-value.test.ts
@@ -11,4 +11,13 @@ describe('@mantine/core/Slider/get-change-value', () => {
       80
     );
   });
+
+  it('rounds according to passed precision', () => {
+    expect(getChangeValue({ value: 30, containerWidth: 100, min: 0, max: 1, step: 0.1 })).not.toBe(
+      0.3
+    );
+    expect(
+      getChangeValue({ value: 30, containerWidth: 100, min: 0, max: 1, step: 0.1, precision: 1 })
+    ).toBe(0.3);
+  });
 });

--- a/src/mantine-core/src/components/Slider/utils/get-change-value/get-change-value.ts
+++ b/src/mantine-core/src/components/Slider/utils/get-change-value/get-change-value.ts
@@ -4,12 +4,26 @@ interface GetChangeValue {
   min: number;
   max: number;
   step: number;
+  precision?: number;
 }
 
-export function getChangeValue({ value, containerWidth, min, max, step }: GetChangeValue) {
+export function getChangeValue({
+  value,
+  containerWidth,
+  min,
+  max,
+  step,
+  precision,
+}: GetChangeValue) {
   const left = !containerWidth
     ? value
     : Math.min(Math.max(value, 0), containerWidth) / containerWidth;
   const dx = left * (max - min);
-  return (dx !== 0 ? Math.round(dx / step) * step : 0) + min;
+  const nextValue = (dx !== 0 ? Math.round(dx / step) * step : 0) + min;
+
+  if (precision !== undefined) {
+    return Number(nextValue.toFixed(precision));
+  }
+
+  return nextValue;
 }


### PR DESCRIPTION
As discussed on Discord, this adds the `precision` prop to `Slider` to allow clamping the computed value in case of floating point steps.

Default behavior when `precision` is `undefined` is to keep raw value, as it was the case before.