### PR TITLE
[docs] MantineProvider: fix typo `prepend` from `propend`

### DIFF
--- a/docs/src/docs/theming/mantine-provider.mdx
+++ b/docs/src/docs/theming/mantine-provider.mdx
@@ -319,7 +319,7 @@ function App() {
 ## Change styles insertion point
 
 By default, Mantine components styles are prepended to head to allow overrides.
-To make Mantine styles override other styles, set `propend` to `false`.
+To make Mantine styles override other styles, set `prepend` to `false`.
 With this option styles will be added at the end of `head` element:
 
 ```tsx


### PR DESCRIPTION
Small typo fix in [docs: MantineProvider](https://mantine.dev/theming/mantine-provider/#change-styles-insertion-point)