### PR TITLE
[docs] Fixed typo

### DIFF
--- a/docs/src/docs/hooks/use-set-state.mdx
+++ b/docs/src/docs/hooks/use-set-state.mdx
@@ -13,7 +13,7 @@ source: 'mantine-hooks/src/use-set-state/use-set-state.ts'
 
 ## Usage
 
-use-state hook works similar to how `this.setState` works in class components – it shallow merges state partial
+use-set-state hook works similar to how `this.setState` works in class components – it shallow merges state partial
 into current state.
 
 ```tsx


### PR DESCRIPTION
Fixed typo in [use-set-state](https://mantine.dev/hooks/use-set-state/) page