### PR TITLE
[@mantine/demos] Badge: Set initial and default value as light

### DIFF
--- a/src/mantine-demos/src/demos/packages/Badge/configurator.tsx
+++ b/src/mantine-demos/src/demos/packages/Badge/configurator.tsx
@@ -30,12 +30,12 @@ export const configurator: MantineDemo = {
     {
       name: 'variant',
       type: 'select',
-      initialValue: 'filled',
-      defaultValue: 'filled',
+      initialValue: 'light',
+      defaultValue: 'light',
       data: [
+        { value: 'light', label: 'Light' },
         { value: 'filled', label: 'Filled' },
         { value: 'outline', label: 'Outline' },
-        { value: 'light', label: 'Light' },
         { value: 'dot', label: 'Dot' },
       ],
     },


### PR DESCRIPTION
Default value of "[@mantine/core] Badge" component is "light" as configured [here](https://github.com/mantinedev/mantine/blob/master/src/mantine-core/src/components/Badge/Badge.tsx#L55).

But, at the "Badge" configurator docs, initial value and default value are set as "filled". This PR includes fix of this issue.