### PR TITLE
Add documentation about dayjs plugins

### DIFF
--- a/docs/src/docs/dates/date-picker.mdx
+++ b/docs/src/docs/dates/date-picker.mdx
@@ -107,6 +107,14 @@ function Demo() {
 `dateParser` function should always return Date object.
 If parsed date is invalid when input is blurred value will be restored to last valid value.
 
+Note that if you use the default dayjs parser, you will need to import and configure the
+`customParseFormat` dayjs plugin:
+
+```tsx
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+dayjs.extend(customParseFormat);
+```
+
 ## Exclude dates
 
 To exclude dates set `excludeDate` prop with function that receives date as an argument and returns


### PR DESCRIPTION
Not being familiar with `dayjs` I spent the better part of an hour trying to figure out why the date parsing wasn't working when using `allowFreeInput` on a `DatePicker`.

I've updated the docs to include the relevant details to get this to work.