### PR TITLE
[@mantine/demos] Add NotificationProvider to storybook demos

### DIFF
--- a/src/mantine-demos/src/demos/packages/Notifications/autoclose.tsx
+++ b/src/mantine-demos/src/demos/packages/Notifications/autoclose.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Group, Button } from '@mantine/core';
-import { useNotifications } from '@mantine/notifications';
+import { useNotifications, NotificationsProvider } from '@mantine/notifications';
 
 const code = `
 function Demo() {
@@ -89,5 +89,9 @@ function Demo() {
 export const autoclose: MantineDemo = {
   type: 'demo',
   code,
-  component: Demo,
+  component: () => (
+    <NotificationsProvider>
+      <Demo />
+    </NotificationsProvider>
+  ),
 };

--- a/src/mantine-demos/src/demos/packages/Notifications/base.tsx
+++ b/src/mantine-demos/src/demos/packages/Notifications/base.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Group, Button } from '@mantine/core';
-import { useNotifications } from '@mantine/notifications';
+import { useNotifications, NotificationsProvider } from '@mantine/notifications';
 
 const code = `
 import { Group, Button } from '@mantine/core';
@@ -49,5 +49,9 @@ function Demo() {
 export const base: MantineDemo = {
   type: 'demo',
   code,
-  component: Demo,
+  component: () => (
+    <NotificationsProvider>
+      <Demo />
+    </NotificationsProvider>
+  ),
 };

--- a/src/mantine-demos/src/demos/packages/Notifications/clean.tsx
+++ b/src/mantine-demos/src/demos/packages/Notifications/clean.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Group, Button } from '@mantine/core';
-import { useNotifications } from '@mantine/notifications';
+import { useNotifications, NotificationsProvider } from '@mantine/notifications';
 
 const code = `
 import { Group, Button } from '@mantine/core';
@@ -75,5 +75,9 @@ function Demo() {
 export const clean: MantineDemo = {
   type: 'demo',
   code,
-  component: Demo,
+  component: () => (
+    <NotificationsProvider>
+      <Demo />
+    </NotificationsProvider>
+  ),
 };

--- a/src/mantine-demos/src/demos/packages/Notifications/limit.tsx
+++ b/src/mantine-demos/src/demos/packages/Notifications/limit.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Group, Button } from '@mantine/core';
-import { useNotifications } from '@mantine/notifications';
+import { useNotifications, NotificationsProvider } from '@mantine/notifications';
 
 const code = `
 import { Group, Button } from '@mantine/core';
@@ -59,5 +59,9 @@ function Demo() {
 export const limit: MantineDemo = {
   type: 'demo',
   code,
-  component: Demo,
+  component: () => (
+    <NotificationsProvider>
+      <Demo />
+    </NotificationsProvider>
+  ),
 };

--- a/src/mantine-demos/src/demos/packages/Notifications/root.tsx
+++ b/src/mantine-demos/src/demos/packages/Notifications/root.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { CheckIcon } from '@modulz/radix-icons';
 import { Group, Button } from '@mantine/core';
-import { useNotifications } from '@mantine/notifications';
+import { useNotifications, NotificationsProvider } from '@mantine/notifications';
 
 function Demo() {
   const notifications = useNotifications();
@@ -113,5 +113,9 @@ function Demo() {
 
 export const root: MantineDemo = {
   type: 'demo',
-  component: Demo,
+  component: () => (
+    <NotificationsProvider>
+      <Demo />
+    </NotificationsProvider>
+  ),
 };

--- a/src/mantine-demos/src/demos/packages/Notifications/update.tsx
+++ b/src/mantine-demos/src/demos/packages/Notifications/update.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { CheckIcon } from '@modulz/radix-icons';
 import { Group, Button } from '@mantine/core';
-import { useNotifications } from '@mantine/notifications';
+import { useNotifications, NotificationsProvider } from '@mantine/notifications';
 
 const code = `
 import { Group, Button } from '@mantine/core';
@@ -80,5 +80,9 @@ function Demo() {
 export const update: MantineDemo = {
   type: 'demo',
   code,
-  component: Demo,
+  component: () => (
+    <NotificationsProvider>
+      <Demo />
+    </NotificationsProvider>
+  ),
 };


### PR DESCRIPTION
This pr is for fixing storybook demos for Notifications by wrapping the components with NotificationProvider.

**Bug:**

![storybook bug](https://user-images.githubusercontent.com/20839131/159952894-0074a3d8-892b-48a3-811f-b8e09b385319.png)

