### PR TITLE
[@mantine/core] Select: Home/end keys move focus to start/end of list

### DIFF
--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -419,6 +419,34 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>((props: SelectPr
         break;
       }
 
+      case 'Home': {
+        if (!searchable) {
+          event.preventDefault();
+
+          if (!dropdownOpened) {
+            setDropdownOpened(true);
+          }
+
+          setHovered(0);
+          scrollSelectedItemIntoView();
+        }
+        break;
+      }
+
+      case 'End': {
+        if (!searchable) {
+          event.preventDefault();
+
+          if (!dropdownOpened) {
+            setDropdownOpened(true);
+          }
+
+          setHovered(filteredData.length - 1);
+          scrollSelectedItemIntoView();
+        }
+        break;
+      }
+
       case 'Escape': {
         event.preventDefault();
         setDropdownOpened(false);


### PR DESCRIPTION
Pressing the `Home` or `End` key will move the focus to the start or end of the list, in accordance with WAI-ARIA Authoring practices: https://w3c.github.io/aria-practices/#combobox-keyboard-interaction 

If the list is searchable, default behavior remains (returns focus to the combobox and places the cursor on the first/last character)