### PR TITLE
Use useCallback for notification functions

### DIFF
--- a/src/mantine-notifications/src/NotificationsProvider/use-notifications-state/use-notifications-state.ts
+++ b/src/mantine-notifications/src/NotificationsProvider/use-notifications-state/use-notifications-state.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useQueue, randomId } from '@mantine/hooks';
 import { NotificationProps } from '../../types';
 
@@ -7,7 +8,7 @@ export default function useNotificationsState({ limit }: { limit: number }) {
     limit,
   });
 
-  const showNotification = (notification: NotificationProps) => {
+  const showNotification = useCallback((notification: NotificationProps) => {
     const id = notification.id || randomId();
 
     update((notifications) => {
@@ -19,33 +20,39 @@ export default function useNotificationsState({ limit }: { limit: number }) {
     });
 
     return id;
-  };
+  }, []);
 
-  const updateNotification = (id: string, notification: NotificationProps) =>
-    update((notifications) => {
-      const index = notifications.findIndex((n) => n.id === id);
+  const updateNotification = useCallback(
+    (id: string, notification: NotificationProps) =>
+      update((notifications) => {
+        const index = notifications.findIndex((n) => n.id === id);
 
-      if (index === -1) {
-        return notifications;
-      }
-
-      const newNotifications = [...notifications];
-      newNotifications[index] = notification;
-
-      return newNotifications;
-    });
-
-  const hideNotification = (id: string) =>
-    update((notifications) =>
-      notifications.filter((notification) => {
-        if (notification.id === id) {
-          typeof notification.onClose === 'function' && notification.onClose(notification);
-          return false;
+        if (index === -1) {
+          return notifications;
         }
 
-        return true;
-      })
-    );
+        const newNotifications = [...notifications];
+        newNotifications[index] = notification;
+
+        return newNotifications;
+      }),
+    []
+  );
+
+  const hideNotification = useCallback(
+    (id: string) =>
+      update((notifications) =>
+        notifications.filter((notification) => {
+          if (notification.id === id) {
+            typeof notification.onClose === 'function' && notification.onClose(notification);
+            return false;
+          }
+
+          return true;
+        })
+      ),
+    []
+  );
 
   const clean = () => update(() => []);
 


### PR DESCRIPTION
Currently it is not possible to show a notification from `useEffect` because the `showNotification` function is not referentially equal between renders which results in an infinite loop:

```ts
const { showNotification } = useNotifications();

useEffect(() => {
  showNotification(/* */); // Over and over and over and over again
}, [showNotification, notificationCondition]);
```

Removing `showNotification` triggers `eslint-plugin-react-hooks`. One possible workaround is this:

```ts
const notifications = useNotifications();
const showNotification = useCallback(notifications.showNotification, []);

useEffect(() => {
  showNotification(/* */); // All better :)
}, [showNotification, notificationCondition]);
```

That said, I think it would be nice to make the notification functions referentially equal to begin with.
