### PR TITLE
[@mantine/notifications] Fix cleanNotificationsQueue

### DIFF
--- a/src/mantine-demos/src/demos/notifications/Notifications.demo.clean.tsx
+++ b/src/mantine-demos/src/demos/notifications/Notifications.demo.clean.tsx
@@ -11,8 +11,6 @@ import { Group, Button } from '@mantine/core';
 import { showNotification, cleanNotificationsQueue, cleanNotifications } from '@mantine/notifications';
 
 function Demo() {
-  const notifications = useNotifications();
-
   return (
     <Group position="center">
       <Button

--- a/src/mantine-notifications/src/events.ts
+++ b/src/mantine-notifications/src/events.ts
@@ -41,7 +41,7 @@ export function useNotificationsEvents(ctx: NotificationsContextProps) {
     hide: (event: any) => ctx.hideNotification(event.detail),
     update: (event: any) => ctx.updateNotification(event.detail.id, event.detail),
     clean: ctx.clean,
-    cleanQuery: ctx.cleanQueue,
+    cleanQueue: ctx.cleanQueue,
   };
 
   useEffect(() => {


### PR DESCRIPTION
The [`Clean queue` button](https://mantine.dev/others/notifications/#remove-notifications-from-state-and-queue) doesn't work