### PR TITLE
[@mantine/styles] Fix theme color override

### DIFF
--- a/src/mantine-styles/src/theme/types/MantineColor.ts
+++ b/src/mantine-styles/src/theme/types/MantineColor.ts
@@ -20,7 +20,7 @@ export type DefaultMantineColor =
 export type MantineThemeColorsOverride = Record<string, any>;
 
 export type MantineThemeColors = MantineThemeColorsOverride extends {
-  colors: Record<string, Tuple<string, 10>>;
+  colors: Record<never, Tuple<string, 10>>;
 }
   ? MantineThemeColorsOverride['colors']
   : Record<DefaultMantineColor, Tuple<string, 10>>;


### PR DESCRIPTION
Currently, tested with TypeScript 4.6.2 in VSCode, adding custom colors to the MantineColor type as described [in the docs](https://mantine.dev/theming/extend-theme/#typescript) does not work. Any reference to the type is solely evaluted to `string`, not the intended subset `"colorA" | "colorB" | ...`
This PR fixes this issue with no side effects that I am aware of.

I fail to understand why the change actually works, as `Record<string, Tuple<string, 10>>` does, by my understanding, not extend `Record<never, Tuple<string, 10>>`. If this is an issue in TypeScript instead of Mantine, feel free to comment or close the PR and I will check for issues in the TypeScript repository.