### PR TITLE
[@mantine/dates] Calendar: Added render day and weekday labels

### DIFF
--- a/docs/src/docs/dates/calendar.mdx
+++ b/docs/src/docs/dates/calendar.mdx
@@ -96,6 +96,13 @@ To exclude dates set `excludeDate` prop with function that receives date as an a
 
 <Demo data={CalendarDemos.exclude} />
 
+## Render day as props
+
+You can render a custom component with `renderDay`.
+The function receives one argument:
+
+- `date` – date object which is used to render day component
+
 ## Add styles to days
 
 You can apply styles to any day with `dayStyle` or `dayClassName` callbacks.

--- a/scripts/utils/build-package.ts
+++ b/scripts/utils/build-package.ts
@@ -41,7 +41,7 @@ export async function buildPackage(packageName: string, options?: BuildOptions) 
     }
 
     logger.info(
-      `Package ${chalk.cyan(packageName)} was build in ${chalk.green(
+      `Package ${chalk.cyan(packageName)} was built in ${chalk.green(
         `${((Date.now() - startTime) / 1000).toFixed(2)}s`
       )}`
     );

--- a/src/mantine-dates/src/components/CalendarBase/CalendarBase.tsx
+++ b/src/mantine-dates/src/components/CalendarBase/CalendarBase.tsx
@@ -50,8 +50,8 @@ export interface CalendarSharedProps extends DefaultProps<CalendarBaseStylesName
   /** Selected range */
   range?: [Date, Date];
 
-  /** Function to render an event to date */
-  calendarEvent?(date: Date): React.ReactNode | null;
+  /** Function to render the day */
+  renderDay?(date: Date): React.ReactNode;
 
   /** Called when day is selected */
   onChange?(value: Date): void;
@@ -129,7 +129,7 @@ export const CalendarBase = forwardRef<HTMLDivElement, CalendarBaseProps>(
       isDateInRange,
       isDateFirstInRange,
       isDateLastInRange,
-      calendarEvent,
+      renderDay,
       ...others
     }: CalendarBaseProps,
     ref
@@ -287,7 +287,7 @@ export const CalendarBase = forwardRef<HTMLDivElement, CalendarBaseProps>(
             labelFormat={labelFormat}
             weekdayLabelFormat={weekdayLabelFormat}
             onDayMouseEnter={onDayMouseEnter}
-            calendarEvent={calendarEvent}
+            renderDay={renderDay}
             hideOutsideDates={hideOutsideDates}
             isDateInRange={isDateInRange}
             isDateFirstInRange={isDateFirstInRange}

--- a/src/mantine-dates/src/components/CalendarBase/CalendarBase.tsx
+++ b/src/mantine-dates/src/components/CalendarBase/CalendarBase.tsx
@@ -50,6 +50,9 @@ export interface CalendarSharedProps extends DefaultProps<CalendarBaseStylesName
   /** Selected range */
   range?: [Date, Date];
 
+  /** Function to render an event to date */
+  calendarEvent?(date: Date): React.ReactNode | null;
+
   /** Called when day is selected */
   onChange?(value: Date): void;
 
@@ -76,6 +79,9 @@ export interface CalendarSharedProps extends DefaultProps<CalendarBaseStylesName
 
   /** dayjs label format */
   labelFormat?: string;
+
+  /** dayjs label format for weekday heading */
+  weekdayLabelFormat?: string;
 }
 
 export interface CalendarBaseProps
@@ -118,10 +124,12 @@ export const CalendarBase = forwardRef<HTMLDivElement, CalendarBaseProps>(
       previousMonthLabel,
       previousYearLabel,
       labelFormat = 'MMMM YYYY',
+      weekdayLabelFormat,
       hideOutsideDates,
       isDateInRange,
       isDateFirstInRange,
       isDateLastInRange,
+      calendarEvent,
       ...others
     }: CalendarBaseProps,
     ref
@@ -277,7 +285,9 @@ export const CalendarBase = forwardRef<HTMLDivElement, CalendarBaseProps>(
             nextMonthLabel={nextMonthLabel}
             previousMonthLabel={previousMonthLabel}
             labelFormat={labelFormat}
+            weekdayLabelFormat={weekdayLabelFormat}
             onDayMouseEnter={onDayMouseEnter}
+            calendarEvent={calendarEvent}
             hideOutsideDates={hideOutsideDates}
             isDateInRange={isDateInRange}
             isDateFirstInRange={isDateFirstInRange}

--- a/src/mantine-dates/src/components/CalendarBase/CalendarBase.tsx
+++ b/src/mantine-dates/src/components/CalendarBase/CalendarBase.tsx
@@ -50,7 +50,7 @@ export interface CalendarSharedProps extends DefaultProps<CalendarBaseStylesName
   /** Selected range */
   range?: [Date, Date];
 
-  /** Function to render the day */
+  /** Render day based on the date */
   renderDay?(date: Date): React.ReactNode;
 
   /** Called when day is selected */

--- a/src/mantine-dates/src/components/CalendarBase/MonthsList/MonthsList.tsx
+++ b/src/mantine-dates/src/components/CalendarBase/MonthsList/MonthsList.tsx
@@ -27,6 +27,8 @@ export interface MonthsListProps
   nextMonthLabel?: string;
   previousMonthLabel?: string;
   labelFormat?: string;
+  weekdayLabelFormat?: string;
+  calendarEvent?(date: Date): React.ReactNode | null;
 }
 
 export function MonthsList({
@@ -47,7 +49,9 @@ export function MonthsList({
   nextMonthLabel,
   previousMonthLabel,
   labelFormat,
+  weekdayLabelFormat,
   preventFocus,
+  calendarEvent,
   ...others
 }: MonthsListProps) {
   const nextMonth = dayjs(month).add(amountOfMonths, 'months').toDate();
@@ -94,6 +98,8 @@ export function MonthsList({
             locale={locale}
             focusable={index === 0}
             preventFocus={preventFocus}
+            calendarEvent={calendarEvent}
+            weekdayLabelFormat={weekdayLabelFormat}
             {...others}
           />
         </div>

--- a/src/mantine-dates/src/components/CalendarBase/MonthsList/MonthsList.tsx
+++ b/src/mantine-dates/src/components/CalendarBase/MonthsList/MonthsList.tsx
@@ -28,7 +28,7 @@ export interface MonthsListProps
   previousMonthLabel?: string;
   labelFormat?: string;
   weekdayLabelFormat?: string;
-  calendarEvent?(date: Date): React.ReactNode | null;
+  renderDay?(date: Date): React.ReactNode;
 }
 
 export function MonthsList({
@@ -51,7 +51,7 @@ export function MonthsList({
   labelFormat,
   weekdayLabelFormat,
   preventFocus,
-  calendarEvent,
+  renderDay,
   ...others
 }: MonthsListProps) {
   const nextMonth = dayjs(month).add(amountOfMonths, 'months').toDate();
@@ -98,7 +98,7 @@ export function MonthsList({
             locale={locale}
             focusable={index === 0}
             preventFocus={preventFocus}
-            calendarEvent={calendarEvent}
+            renderDay={renderDay}
             weekdayLabelFormat={weekdayLabelFormat}
             {...others}
           />

--- a/src/mantine-dates/src/components/DatePicker/DatePicker.tsx
+++ b/src/mantine-dates/src/components/DatePicker/DatePicker.tsx
@@ -39,6 +39,9 @@ export interface DatePickerProps
 
   /** Allow free input */
   allowFreeInput?: boolean;
+
+  /** Render day based on the date */
+  renderDay?(date: Date): React.ReactNode;
 }
 
 const defaultProps: Partial<DatePickerProps> = {
@@ -102,6 +105,7 @@ export const DatePicker = forwardRef<HTMLButtonElement, DatePickerProps>(
       onDropdownOpen,
       hideOutsideDates,
       hideWeekdays,
+      renderDay,
       ...others
     } = useMantineDefaultProps('DatePicker', defaultProps, props);
 
@@ -277,6 +281,7 @@ export const DatePicker = forwardRef<HTMLButtonElement, DatePickerProps>(
           initialLevel={initialLevel}
           hideOutsideDates={hideOutsideDates}
           hideWeekdays={hideWeekdays}
+          renderDay={renderDay}
         />
       </DatePickerBase>
     );

--- a/src/mantine-dates/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/src/mantine-dates/src/components/DateRangePicker/DateRangePicker.tsx
@@ -42,6 +42,9 @@ export interface DateRangePickerProps
 
   /** Allows to show multiple months */
   amountOfMonths?: number;
+
+  /** Render day based on the date */
+  renderDay?(date: Date): React.ReactNode;
 }
 
 const validationRule = (val: any) =>
@@ -105,6 +108,7 @@ export const DateRangePicker = forwardRef<HTMLButtonElement, DateRangePickerProp
       onDropdownOpen,
       hideOutsideDates,
       hideWeekdays,
+      renderDay,
       ...others
     } = useMantineDefaultProps('DateRangePicker', defaultProps, props);
 
@@ -204,6 +208,7 @@ export const DateRangePicker = forwardRef<HTMLButtonElement, DateRangePickerProp
           initialLevel={initialLevel}
           hideOutsideDates={hideOutsideDates}
           hideWeekdays={hideWeekdays}
+          renderDay={renderDay}
         />
       </DatePickerBase>
     );

--- a/src/mantine-dates/src/components/Month/Day/Day.test.tsx
+++ b/src/mantine-dates/src/components/Month/Day/Day.test.tsx
@@ -55,4 +55,18 @@ describe('@mantine/core/Month/Day', () => {
   it('has correct displayName', () => {
     expect(Day.displayName).toStrictEqual('@mantine/core/Day');
   });
+
+  it('renders correctly with a renderDay function', () => {
+    const renderDay = (date: Date) => (
+      <div>
+        <span>{date.getDate()}</span>
+        <span>Rendered custom day</span>
+      </div>
+    );
+    render(<Day {...defaultProps} renderDay={renderDay} />);
+
+    const today = new Date().getDate();
+    expect(screen.getByText(today)).toBeInTheDocument();
+    expect(screen.getByText('Rendered custom day')).toBeInTheDocument();
+  });
 });

--- a/src/mantine-dates/src/components/Month/Day/Day.tsx
+++ b/src/mantine-dates/src/components/Month/Day/Day.tsx
@@ -25,7 +25,7 @@ export interface DayProps
   firstInMonth: boolean;
   focusable?: boolean;
   hideOutsideDates?: boolean;
-  calendarEvent?(date: Date): React.ReactNode | null;
+  renderDay?(date: Date): React.ReactNode;
 }
 
 export const Day = forwardRef<HTMLButtonElement, DayProps>(
@@ -49,7 +49,7 @@ export const Day = forwardRef<HTMLButtonElement, DayProps>(
       firstInMonth,
       focusable,
       hideOutsideDates,
-      calendarEvent,
+      renderDay,
       ...others
     }: DayProps,
     ref
@@ -81,8 +81,7 @@ export const Day = forwardRef<HTMLButtonElement, DayProps>(
           className
         )}
       >
-        {value.getDate()}
-        {calendarEvent && calendarEvent(value)}
+        {renderDay ? renderDay(value) : value.getDate()}
       </button>
     );
   }

--- a/src/mantine-dates/src/components/Month/Day/Day.tsx
+++ b/src/mantine-dates/src/components/Month/Day/Day.tsx
@@ -25,6 +25,7 @@ export interface DayProps
   firstInMonth: boolean;
   focusable?: boolean;
   hideOutsideDates?: boolean;
+  calendarEvent?(date: Date): React.ReactNode | null;
 }
 
 export const Day = forwardRef<HTMLButtonElement, DayProps>(
@@ -48,6 +49,7 @@ export const Day = forwardRef<HTMLButtonElement, DayProps>(
       firstInMonth,
       focusable,
       hideOutsideDates,
+      calendarEvent,
       ...others
     }: DayProps,
     ref
@@ -80,6 +82,7 @@ export const Day = forwardRef<HTMLButtonElement, DayProps>(
         )}
       >
         {value.getDate()}
+        {calendarEvent && calendarEvent(value)}
       </button>
     );
   }

--- a/src/mantine-dates/src/components/Month/Day/Day.tsx
+++ b/src/mantine-dates/src/components/Month/Day/Day.tsx
@@ -81,7 +81,7 @@ export const Day = forwardRef<HTMLButtonElement, DayProps>(
           className
         )}
       >
-        {renderDay ? renderDay(value) : value.getDate()}
+        {typeof renderDay === 'function' ? renderDay(value) : value.getDate()}
       </button>
     );
   }

--- a/src/mantine-dates/src/components/Month/Month.test.tsx
+++ b/src/mantine-dates/src/components/Month/Month.test.tsx
@@ -150,4 +150,14 @@ describe('@mantine/dates/Month', () => {
     expect(en.querySelector('th').textContent).toBe('Mo');
     expect(ru.querySelector('th').textContent).toBe('Пн');
   });
+
+  it('renders weekday labels with custom format in given locale', () => {
+    const { container: en } = render(<Month {...defaultProps} weekdayLabelFormat="ddd" />);
+    const { container: ru } = render(
+      <Month {...defaultProps} locale="ru" weekdayLabelFormat="dddd" />
+    );
+
+    expect(en.querySelector('th').textContent).toBe('Mon');
+    expect(ru.querySelector('th').textContent).toBe('Понедельник');
+  });
 });

--- a/src/mantine-dates/src/components/Month/Month.tsx
+++ b/src/mantine-dates/src/components/Month/Month.tsx
@@ -98,6 +98,10 @@ export interface MonthProps
 
   /** Called when keydown event is registered on day */
   onDayKeyDown?(payload: DayKeydownPayload, event: React.KeyboardEvent<HTMLButtonElement>): void;
+
+  calendarEvent?(date: Date): React.ReactNode | null;
+
+  weekdayLabelFormat?: string;
 }
 
 const no = () => false;
@@ -144,6 +148,8 @@ export const Month = forwardRef<HTMLTableElement, MonthProps>((props: MonthProps
     isDateInRange = no,
     isDateFirstInRange = no,
     isDateLastInRange = no,
+    calendarEvent,
+    weekdayLabelFormat,
     ...others
   } = useMantineDefaultProps('Month', defaultProps, props);
 
@@ -154,13 +160,15 @@ export const Month = forwardRef<HTMLTableElement, MonthProps>((props: MonthProps
   const finalLocale = locale || theme.datesLocale;
   const days = getMonthDays(month, firstDayOfWeek);
 
-  const weekdays = getWeekdaysNames(finalLocale, firstDayOfWeek).map((weekday) => (
-    <th className={classes.weekdayCell} key={weekday}>
-      <Text size={size} className={classes.weekday}>
-        {upperFirst(weekday)}
-      </Text>
-    </th>
-  ));
+  const weekdays = getWeekdaysNames(finalLocale, firstDayOfWeek, weekdayLabelFormat).map(
+    (weekday) => (
+      <th className={classes.weekdayCell} key={weekday}>
+        <Text size={size} className={classes.weekday}>
+          {weekday.length >= 2 ? upperFirst(weekday) : weekday}
+        </Text>
+      </th>
+    )
+  );
 
   const hasValue = value instanceof Date;
   const hasValueInMonthRange =
@@ -227,6 +235,7 @@ export const Month = forwardRef<HTMLTableElement, MonthProps>((props: MonthProps
             __staticSelector={__staticSelector}
             styles={styles}
             classNames={classNames}
+            calendarEvent={calendarEvent}
           />
         </td>
       );

--- a/src/mantine-dates/src/components/Month/Month.tsx
+++ b/src/mantine-dates/src/components/Month/Month.tsx
@@ -99,7 +99,7 @@ export interface MonthProps
   /** Called when keydown event is registered on day */
   onDayKeyDown?(payload: DayKeydownPayload, event: React.KeyboardEvent<HTMLButtonElement>): void;
 
-  calendarEvent?(date: Date): React.ReactNode | null;
+  renderDay?(date: Date): React.ReactNode;
 
   weekdayLabelFormat?: string;
 }
@@ -148,7 +148,7 @@ export const Month = forwardRef<HTMLTableElement, MonthProps>((props: MonthProps
     isDateInRange = no,
     isDateFirstInRange = no,
     isDateLastInRange = no,
-    calendarEvent,
+    renderDay,
     weekdayLabelFormat,
     ...others
   } = useMantineDefaultProps('Month', defaultProps, props);
@@ -235,7 +235,7 @@ export const Month = forwardRef<HTMLTableElement, MonthProps>((props: MonthProps
             __staticSelector={__staticSelector}
             styles={styles}
             classNames={classNames}
-            calendarEvent={calendarEvent}
+            renderDay={renderDay}
           />
         </td>
       );

--- a/src/mantine-dates/src/components/Month/Month.tsx
+++ b/src/mantine-dates/src/components/Month/Month.tsx
@@ -99,8 +99,10 @@ export interface MonthProps
   /** Called when keydown event is registered on day */
   onDayKeyDown?(payload: DayKeydownPayload, event: React.KeyboardEvent<HTMLButtonElement>): void;
 
+  /** Render day based on the date */
   renderDay?(date: Date): React.ReactNode;
 
+  /** dayjs label format for weekday heading */
   weekdayLabelFormat?: string;
 }
 

--- a/src/mantine-dates/src/utils/get-weekdays-names/get-weekdays-names.ts
+++ b/src/mantine-dates/src/utils/get-weekdays-names/get-weekdays-names.ts
@@ -2,12 +2,16 @@ import dayjs from 'dayjs';
 import { FirstDayOfWeek } from '../../types';
 import { getStartOfWeek } from '../get-start-of-week/get-start-of-week';
 
-export function getWeekdaysNames(locale: string, firstDayOfWeek: FirstDayOfWeek = 'monday') {
+export function getWeekdaysNames(
+  locale: string,
+  firstDayOfWeek: FirstDayOfWeek = 'monday',
+  format: string = 'dd'
+) {
   const names: string[] = [];
   const date = getStartOfWeek(new Date(), firstDayOfWeek);
 
   for (let i = 0; i < 7; i += 1) {
-    names.push(dayjs(date).locale(locale).format('dd'));
+    names.push(dayjs(date).locale(locale).format(format));
     date.setDate(date.getDate() + 1);
   }
 


### PR DESCRIPTION
Adds a `renderDay` prop to the Calendar which is passed to the Day component that allows a day to be rendered using a custom component.  
Added a weekday label to allow custom labels. Typical in calendars is the use of three-letter weekdays as the size of a calendar grows. Whereas the default in Mantine is two-letter weekdays which works well for a calendar date picker though not so much as an event calendar.