### PR TITLE
[@mantine/core] PasswordInput: Make input respect theme default radius

### DIFF
--- a/src/mantine-core/src/components/PasswordInput/PasswordInput.story.tsx
+++ b/src/mantine-core/src/components/PasswordInput/PasswordInput.story.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
-import { MANTINE_SIZES } from '@mantine/styles';
+import { MantineProvider, MANTINE_SIZES } from '@mantine/styles';
 import { PasswordInput, PasswordInputProps } from './PasswordInput';
 
 const sizes = MANTINE_SIZES.map((size) => (
@@ -25,4 +25,9 @@ function Controlled(props: Partial<PasswordInputProps>) {
 storiesOf('@mantine/core/PasswordInput/stories', module)
   .add('Controlled', () => <Controlled />)
   .add('Sizes', () => <div style={{ width: 400, padding: 20 }}>{sizes}</div>)
-  .add('Invalid', () => <Controlled error="error" />);
+  .add('Invalid', () => <Controlled error="error" />)
+  .add('Default radius on MantineProvider', () => (
+    <MantineProvider theme={{ defaultRadius: 'lg' }}>
+      <Controlled />
+    </MantineProvider>
+  ));

--- a/src/mantine-core/src/components/PasswordInput/PasswordInput.tsx
+++ b/src/mantine-core/src/components/PasswordInput/PasswordInput.tsx
@@ -51,7 +51,6 @@ const rightSectionSizes = {
 };
 
 const defaultProps: Partial<PasswordInputProps> = {
-  radius: 'sm',
   size: 'sm',
   toggleTabIndex: -1,
   visibilityToggleIcon: PasswordToggleIcon,


### PR DESCRIPTION
Previously the PasswordInput did not respect the default radius set in the theme, due to overwriting it with its own default props.