### PR TITLE
[@mantine/prism] Fix prism number spacing

### DIFF
--- a/src/mantine-prism/src/Prism.styles.ts
+++ b/src/mantine-prism/src/Prism.styles.ts
@@ -42,8 +42,9 @@ export default createStyles((theme, { colorScheme, native }: PrismStylesParams) 
   lineNumber: {
     color: colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[4],
     textAlign: 'right',
-    paddingRight: theme.dir === 'ltr' ? theme.spacing.xl : undefined,
-    paddingLeft: theme.dir === 'rtl' ? theme.spacing.xl : undefined,
+    minWidth: 43,
+    paddingRight: theme.dir === 'ltr' ? theme.spacing.xs : undefined,
+    paddingLeft: theme.dir === 'rtl' ? theme.spacing.xs : undefined,
     userSelect: 'none',
   },
 

--- a/src/mantine-prism/src/Prism.styles.ts
+++ b/src/mantine-prism/src/Prism.styles.ts
@@ -42,9 +42,9 @@ export default createStyles((theme, { colorScheme, native }: PrismStylesParams) 
   lineNumber: {
     color: colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[4],
     textAlign: 'right',
-    minWidth: 43,
-    paddingRight: theme.dir === 'ltr' ? theme.spacing.xs : undefined,
-    paddingLeft: theme.dir === 'rtl' ? theme.spacing.xs : undefined,
+    width: 43,
+    marginRight: theme.dir === 'ltr' ? theme.spacing.xs : undefined,
+    marginLeft: theme.dir === 'rtl' ? theme.spacing.xs : undefined,
     userSelect: 'none',
   },
 


### PR DESCRIPTION
use min-width of max lines 65535 like VSCode.

user can easy override with styles. if they want smaller space caused only small lines code