### PR TITLE
[@mantine/dropzone] Dropzone: Add name prop 

### DIFF
--- a/src/mantine-dropzone/src/Dropzone/Dropzone.test.tsx
+++ b/src/mantine-dropzone/src/Dropzone/Dropzone.test.tsx
@@ -29,4 +29,12 @@ describe('@mantine/dropzone/Dropzone', () => {
     render(<Dropzone {...defaultProps} openRef={ref} />);
     expect(ref.current).toBeInstanceOf(Function);
   });
+
+  it('has a name attribute on the internal input element', () => {
+    const { container: withName } = render(<Dropzone {...defaultProps} name="a-custom-name" />);
+    const { container: withoutName } = render(<Dropzone {...defaultProps} />);
+
+    expect(withName.querySelector("input[type='file']")).toHaveAttribute('name', 'a-custom-name');
+    expect(withoutName.querySelector("input[type='file']")).not.toHaveAttribute('name');
+  });
 });

--- a/src/mantine-dropzone/src/Dropzone/Dropzone.tsx
+++ b/src/mantine-dropzone/src/Dropzone/Dropzone.tsx
@@ -51,6 +51,9 @@ export interface DropzoneProps extends DefaultProps<DropzoneStylesNames> {
 
   /** Set maximum file size in bytes */
   maxSize?: number;
+
+  /** Name of the form control. Submitted with the form as part of a name/value pair. */
+  name?: string;
 }
 
 const defaultProps: Partial<DropzoneProps> = {
@@ -76,6 +79,7 @@ export const Dropzone = forwardRef<HTMLDivElement, DropzoneProps>((props: Dropzo
     onDrop,
     onReject,
     openRef,
+    name,
     ...others
   } = useMantineDefaultProps('Dropzone', defaultProps, props);
 
@@ -107,7 +111,7 @@ export const Dropzone = forwardRef<HTMLDivElement, DropzoneProps>((props: Dropzo
       )}
     >
       <LoadingOverlay visible={loading} radius={radius} />
-      <input {...getInputProps()} />
+      <input {...getInputProps()} name={name} />
       {children({ accepted: isDragAccept, rejected: isDragReject })}
     </Box>
   );


### PR DESCRIPTION
This PR adds a `name` prop to allow this component to be used in HTML forms, which is being popularized by frameworks like Remix.

Resolves https://github.com/mantinedev/mantine/discussions/1111