### PR TITLE
[@mantine/styles] Any params type to allow specifying styles names

### DIFF
--- a/src/mantine-styles/src/theme/MantineProvider.tsx
+++ b/src/mantine-styles/src/theme/MantineProvider.tsx
@@ -11,8 +11,7 @@ import { NormalizeCSS } from './NormalizeCSS';
 
 type ProviderStyles = Record<
   string,
-  | Record<string, CSSObject>
-  | ((theme: MantineTheme, params: Record<string, any>) => Record<string, CSSObject>)
+  Record<string, CSSObject> | ((theme: MantineTheme, params: any) => Record<string, CSSObject>)
 >;
 
 type ProviderClassNames = Record<string, Record<string, string>>;


### PR DESCRIPTION
```tsx
import tw from 'twin.macro';

export const styles: MantineProviderProps['styles'] = {
  // Specifying `ButtonStylesParams` will report an error
  Button: (theme: MantineTheme, { size }: ButtonStylesParams) => {
    return {
      root: {
        ...tw`transition duration-300`,
        ...(size === 'lg' && tw`text-base`),
        ...(size === 'md' && tw`text-sm`),
      },
      filled: tw`bg-primary-500 hocus:(bg-primary-400) active:(bg-primary-600)`,
      outline: tw`text-primary-500/80 border-primary-500/80`,
    } as Record<ButtonStylesNames, CSSObject>;
  },
};
```
