### PR TITLE
[@mantine/rte] fix rte copy paste on highlight

### DIFF
--- a/src/mantine-rte/src/components/RichTextEditor/RichTextEditor.styles.ts
+++ b/src/mantine-rte/src/components/RichTextEditor/RichTextEditor.styles.ts
@@ -150,7 +150,11 @@ export default createStyles(
       },
 
       '& .ql-clipboard': {
-        display: 'none',
+        left: '-100000px',
+        height: '1px',
+        overflowY: 'hidden',
+        position: 'absolute',
+        top: '50%',
       },
 
       '& .ql-align-center': {


### PR DESCRIPTION
copy styles from demo react quill https://codesandbox.io/s/6x93pk4rp3?file=/index.js:70-80

<img width="1117" alt="Screen Shot 2022-04-03 at 23 57 48" src="https://user-images.githubusercontent.com/60646861/161439148-9fbbfcb7-6115-40c5-903d-27a1165268b4.png">

display none make useStyles re-render and caused racing setValue. onChange value from paste and onChange from re-render



https://github.com/mantinedev/mantine/issues/1086