### PR TITLE
[@mantine/core] Autocomplete: make dropdownPosition default to flip

### DIFF
--- a/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
@@ -33,6 +33,9 @@ export interface AutocompleteProps
     InputWrapperBaseProps,
     SelectSharedProps<AutocompleteItem, string>,
     Omit<React.ComponentPropsWithoutRef<'input'>, 'size' | 'onChange' | 'value' | 'defaultValue'> {
+  /** Maximum dropdown height */
+  maxDropdownHeight?: number | string;
+
   /** Called when item from dropdown was selected */
   onItemSubmit?(item: AutocompleteItem): void;
 }
@@ -54,6 +57,7 @@ const defaultProps: Partial<AutocompleteProps> = {
   switchDirectionOnFlip: false,
   zIndex: getDefaultZIndex('popover'),
   dropdownPosition: 'flip',
+  maxDropdownHeight: 'auto',
 };
 
 export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
@@ -94,7 +98,8 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
       withinPortal,
       switchDirectionOnFlip = false,
       zIndex = getDefaultZIndex('popover'),
-      dropdownPosition = 'bottom',
+      dropdownPosition,
+      maxDropdownHeight,
       errorProps,
       labelProps,
       descriptionProps,
@@ -264,7 +269,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
             transitionTimingFunction={transitionTimingFunction}
             uuid={uuid}
             shadow={shadow}
-            maxDropdownHeight="auto"
+            maxDropdownHeight={maxDropdownHeight}
             classNames={classNames}
             styles={styles}
             __staticSelector="Autocomplete"

--- a/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
@@ -53,7 +53,7 @@ const defaultProps: Partial<AutocompleteProps> = {
   filter: defaultFilter,
   switchDirectionOnFlip: false,
   zIndex: getDefaultZIndex('popover'),
-  dropdownPosition: 'bottom',
+  dropdownPosition: 'flip',
 };
 
 export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(


### PR DESCRIPTION
The default dropdownPosition is `bottom`, it not flips to above when there is not enough space. The `Select` component dropdownPosition default also is `flip`, so I did this.

another, i saw the default limit is 5，but i want show large data，when I set limit to  30, the flip is also not work, so I also 
 need to set maxDropdownHeight.

 I hope I did the right thing, Thanks.

https://codesandbox.io/s/adoring-merkle-bffpbm?file=/src/App.tsx