### PR TITLE
Fix DatePicker when type="date"

### DIFF
--- a/src/mantine-dates/src/components/DatePicker/DatePicker.tsx
+++ b/src/mantine-dates/src/components/DatePicker/DatePicker.tsx
@@ -102,12 +102,13 @@ export const DatePicker = forwardRef<HTMLButtonElement, DatePickerProps>(
       onDropdownOpen,
       hideOutsideDates,
       hideWeekdays,
+      type,
       ...others
     } = useMantineDefaultProps('DatePicker', defaultProps, props);
 
     const theme = useMantineTheme();
     const finalLocale = locale || theme.datesLocale;
-    const dateFormat = inputFormat || theme.dateFormat;
+    const dateFormat = type === 'date' ? 'YYYY-MM-DD' : inputFormat || theme.dateFormat;
     const [dropdownOpened, setDropdownOpened] = useState(initiallyOpened);
     const calendarSize = size === 'lg' || size === 'xl' ? 'md' : 'sm';
     const inputRef = useRef<HTMLInputElement>();
@@ -239,7 +240,7 @@ export const DatePicker = forwardRef<HTMLButtonElement, DatePickerProps>(
         inputLabel={inputState}
         __staticSelector="DatePicker"
         dropdownType={dropdownType}
-        clearable={clearable && !!_value && !disabled}
+        clearable={type === 'date' ? false : clearable && !!_value && !disabled}
         clearButtonLabel={clearButtonLabel}
         onClear={handleClear}
         disabled={disabled}
@@ -247,6 +248,7 @@ export const DatePicker = forwardRef<HTMLButtonElement, DatePickerProps>(
         amountOfMonths={amountOfMonths}
         onDropdownClose={onDropdownClose}
         onDropdownOpen={onDropdownOpen}
+        type={type}
         {...others}
       >
         <Calendar


### PR DESCRIPTION
When an input has `type="date"` the `value` read/written to the dom node is a string in the format `YYYY-MM-DD` (the format actually rendered is determined by the browser), so when someone sets `type="date"` on the `DatePicker` component and it attempts to set the value in the dom the value doesn't actually get rendered without a properly set formatting string. Having `type="date"` is preferential when using a framework that ecourages form submissions such as Remix since otherwise the `input` will submit locale-formatted values rather than a timestamp or ISO date (whereas with `type="date"` the value is ISO-formatted).

Additionally, when `type="date"`, there is a browser-supplied clear button, resulting in two clear buttons being rendered. There is no reliable cross-browser way to hide this button, so this PR simply hides mantine's close button when `type="date"`.
