### PR TITLE
[docs] update package name in `get started with Remix` section

### DIFF
--- a/docs/src/components/GettingStarted/Guides/Guide.tsx
+++ b/docs/src/components/GettingStarted/Guides/Guide.tsx
@@ -134,8 +134,8 @@ function GatsbyGuide({ dependencies }: GuideProps) {
 }
 
 const remixCode = `import { renderToString } from 'react-dom/server';
-import { RemixServer } from 'remix';
-import type { EntryContext } from 'remix';
+import { RemixServer } from '@remix-run/react';
+import type { EntryContext } from '@remix-run/node';
 import { injectStylesIntoStaticMarkup } from '@mantine/ssr';
 
 export default function handleRequest(


### PR DESCRIPTION
Seems like remix updated their package
https://github.com/remix-run/remix/blob/main/examples/mantine/app/entry.server.tsx