### PR TITLE
[@mantine/core] Notification: fix text so large not hidden

### DIFF
--- a/src/mantine-core/src/components/Notification/Notification.story.tsx
+++ b/src/mantine-core/src/components/Notification/Notification.story.tsx
@@ -146,8 +146,33 @@ const demo = (
         doloremque. Cumque.
       </Notification>
 
+      <Notification
+        color="orange"
+        onClose={() => {}}
+        mt="xl"
+        icon={<FaceIcon />}
+        title="NotificationWithIconAndTitleSoLargeThatItWillUseOverflowEllipsisOption"
+      >
+        NotificationWithIconAndDescriptionSoLargeThatItShouldUseOverflowEllipsis
+      </Notification>
+
+      <Notification
+        color="pink"
+        onClose={() => {}}
+        disallowClose
+        mt="xl"
+        icon={<FaceIcon />}
+        title="NotificationWithIconDisallowCloseAndTitleSoLargeThatItWillUseOverflowEllipsisOption"
+      >
+        NotificationWithIconDisallowCloseAndDescriptionSoLargeThatItShouldUseOverflowEllipsis
+      </Notification>
+
       <Notification color="grape" onClose={() => {}} mt="xl">
         Notification without title
+      </Notification>
+
+      <Notification color="grape" onClose={() => {}} mt="xl">
+        NotificationWithoutTitleAndTheDescriptionSoLargeThatItShouldUseOverflowEllipsis
       </Notification>
 
       <Notification color="pink" onClose={() => {}} mt="xl" icon={<CheckIcon />}>

--- a/src/mantine-core/src/components/Notification/Notification.styles.ts
+++ b/src/mantine-core/src/components/Notification/Notification.styles.ts
@@ -5,98 +5,96 @@ export interface NotificationStylesParams {
   radius: MantineNumberSize;
 }
 
-export default createStyles(
-  (theme, { color, radius }: NotificationStylesParams, getRef) => {
-    const _radius = theme.fn.radius(radius) as number;
-    const topBottom = Math.min(Math.max(_radius / 1.2, 4), 30);
+export default createStyles((theme, { color, radius }: NotificationStylesParams, getRef) => {
+  const _radius = theme.fn.radius(radius) as number;
+  const topBottom = Math.min(Math.max(_radius / 1.2, 4), 30);
 
-    return {
-      closeButton: {},
+  return {
+    closeButton: {},
 
-      icon: {
-        ref: getRef('icon'),
-        boxSizing: 'border-box',
-        marginRight: theme.spacing.md,
-        width: 28,
-        height: 28,
-        borderRadius: 28,
-        display: 'flex',
-        flex: 'none',
-        alignItems: 'center',
-        justifyContent: 'center',
+    icon: {
+      ref: getRef('icon'),
+      boxSizing: 'border-box',
+      marginRight: theme.spacing.md,
+      width: 28,
+      height: 28,
+      borderRadius: 28,
+      display: 'flex',
+      flex: 'none',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: theme.white,
+    },
+
+    withIcon: {
+      paddingLeft: theme.spacing.xs,
+
+      '&::before': {
+        display: 'none',
+      },
+    },
+
+    root: {
+      boxSizing: 'border-box',
+      position: 'relative',
+      display: 'flex',
+      alignItems: 'center',
+      paddingLeft: 22,
+      paddingRight: 5,
+      paddingTop: theme.spacing.xs,
+      paddingBottom: theme.spacing.xs,
+      borderRadius: _radius,
+      backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.white,
+      boxShadow: theme.shadows.lg,
+      border: `1px solid ${
+        theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[2]
+      }`,
+
+      '&::before': {
+        content: "''",
+        display: 'block',
+        position: 'absolute',
+        width: 6,
+        top: topBottom,
+        bottom: topBottom,
+        left: 4,
+        borderRadius: _radius,
+        backgroundColor: theme.fn.themeColor(color, theme.colorScheme === 'dark' ? 6 : 7),
+      },
+
+      [`& .${getRef('icon')}`]: {
+        backgroundColor: theme.fn.themeColor(color, theme.colorScheme === 'dark' ? 6 : 7),
         color: theme.white,
       },
+    },
 
-      withIcon: {
-        paddingLeft: theme.spacing.xs,
+    body: {
+      flex: 1,
+      overflow: 'hidden',
+      marginRight: 10,
+    },
 
-        '&::before': {
-          display: 'none',
-        },
+    loader: {
+      marginRight: theme.spacing.md,
+    },
+
+    title: {
+      lineHeight: 1.4,
+      marginBottom: 2,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      color: theme.colorScheme === 'dark' ? theme.white : theme.colors.gray[9],
+    },
+
+    description: {
+      color: theme.colorScheme === 'dark' ? theme.colors.dark[2] : theme.colors.gray[6],
+      lineHeight: 1.4,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+
+      '&:only-child': {
+        color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
       },
-
-      root: {
-        boxSizing: 'border-box',
-        position: 'relative',
-        display: 'flex',
-        alignItems: 'center',
-        paddingLeft: 22,
-        paddingRight: 5,
-        paddingTop: theme.spacing.xs,
-        paddingBottom: theme.spacing.xs,
-        borderRadius: _radius,
-        backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.white,
-        boxShadow: theme.shadows.lg,
-        border: `1px solid ${
-          theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[2]
-        }`,
-
-        '&::before': {
-          content: "''",
-          display: 'block',
-          position: 'absolute',
-          width: 6,
-          top: topBottom,
-          bottom: topBottom,
-          left: 4,
-          borderRadius: _radius,
-          backgroundColor: theme.fn.themeColor(color, theme.colorScheme === 'dark' ? 6 : 7),
-        },
-
-        [`& .${getRef('icon')}`]: {
-          backgroundColor: theme.fn.themeColor(color, theme.colorScheme === 'dark' ? 6 : 7),
-          color: theme.white,
-        },
-      },
-
-      body: {
-        flex: 1,
-        overflow: 'hidden',
-        marginRight: 10,
-      },
-
-      loader: {
-        marginRight: theme.spacing.md,
-      },
-
-      title: {
-        lineHeight: 1.4,
-        marginBottom: 2,
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        color: theme.colorScheme === 'dark' ? theme.white : theme.colors.gray[9],
-      },
-
-      description: {
-        color: theme.colorScheme === 'dark' ? theme.colors.dark[2] : theme.colors.gray[6],
-        lineHeight: 1.4,
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-
-        '&:only-child': {
-          color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
-        },
-      },
-    };
-  }
-);
+    },
+  };
+});

--- a/src/mantine-core/src/components/Notification/Notification.styles.ts
+++ b/src/mantine-core/src/components/Notification/Notification.styles.ts
@@ -3,11 +3,10 @@ import { createStyles, MantineColor, MantineNumberSize } from '@mantine/styles';
 export interface NotificationStylesParams {
   color: MantineColor;
   radius: MantineNumberSize;
-  disallowClose: boolean;
 }
 
 export default createStyles(
-  (theme, { color, radius, disallowClose }: NotificationStylesParams, getRef) => {
+  (theme, { color, radius }: NotificationStylesParams, getRef) => {
     const _radius = theme.fn.radius(radius) as number;
     const topBottom = Math.min(Math.max(_radius / 1.2, 4), 30);
 
@@ -22,6 +21,7 @@ export default createStyles(
         height: 28,
         borderRadius: 28,
         display: 'flex',
+        flex: 'none',
         alignItems: 'center',
         justifyContent: 'center',
         color: theme.white,
@@ -71,7 +71,7 @@ export default createStyles(
 
       body: {
         flex: 1,
-        maxWidth: !disallowClose ? 'calc(100% - 40px)' : '100%', // space for close button and margin
+        overflow: 'hidden',
         marginRight: 10,
       },
 

--- a/src/mantine-core/src/components/Notification/Notification.tsx
+++ b/src/mantine-core/src/components/Notification/Notification.tsx
@@ -64,7 +64,7 @@ export const Notification = forwardRef<HTMLDivElement, NotificationProps>(
     } = useMantineDefaultProps('Notification', {}, props);
 
     const { classes, cx } = useStyles(
-      { color, radius, disallowClose },
+      { color, radius },
       { classNames, styles, name: 'Notification' }
     );
     const withIcon = icon || loading;


### PR DESCRIPTION
while text so large it not hidden.

ps: I am worried about if I should removing the `disallowClose` prop in NotificationStylesParams,  maybe others custom Notification styles  might use this property?

![rk1NkYf2DX](https://user-images.githubusercontent.com/1364025/162583448-0a3bbeb2-400b-4365-a15e-938239f44d4d.png)

