### PR TITLE
Fix typo in Stepper demo

### DIFF
--- a/src/mantine-demos/src/demos/core/Stepper/Stepper.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/core/Stepper/Stepper.demo.usage.tsx
@@ -45,7 +45,7 @@ function Demo() {
   return (
     <>
       <Stepper active={active} onStepClick={setActive} breakpoint="sm">
-        <Stepper.Step label="Fist step" description="Create an account">
+        <Stepper.Step label="First step" description="Create an account">
           <Content>Step 1 content: Create an account</Content>
         </Stepper.Step>
         <Stepper.Step label="Second step" description="Verify email">


### PR DESCRIPTION
This typo is present in the docs too:
![image](https://user-images.githubusercontent.com/1513212/162641915-bdcb72eb-0164-4e3a-8268-ecd4840cdfc2.png)

https://mantine.dev/core/stepper/