### PR TITLE
Fix MultiSelect

### DIFF
--- a/src/mantine-core/src/components/MultiSelect/MultiSelect.styles.ts
+++ b/src/mantine-core/src/components/MultiSelect/MultiSelect.styles.ts
@@ -27,6 +27,7 @@ export default createStyles((theme, { size, invalid }: MultiSelectStylesParams) 
   },
 
   searchInput: {
+    flex: 1,
     width: 60,
     backgroundColor: 'transparent',
     border: 0,

--- a/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
@@ -302,7 +302,7 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
         valuesOverflow.current = true;
         setDropdownOpened(false);
       }
-    }, [_value]);
+    }, _value);
 
     const handleItemSelect = (item: SelectItem) => {
       clearSearchOnChange && handleSearchChange('');


### PR DESCRIPTION
- Fix search input width #1211 
- Deep compare `value` prop
  sometimes the `value` prop is generated on each render (e.g. `value={users.map(it => it.name)}`) which causes [useDidUpdate](https://github.com/mantinedev/mantine/blob/a51bf44a51347917b797ce5b8f573900a8a780a2/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx#L293) to run at every render