### PR TITLE
Option to clear values in select and multiselect when key press escape

### DIFF
--- a/src/mantine-core/src/components/MultiSelect/MultiSelect.story.tsx
+++ b/src/mantine-core/src/components/MultiSelect/MultiSelect.story.tsx
@@ -316,4 +316,16 @@ storiesOf('MultiSelect', module)
         nothingFound="Nothing found"
       />
     </div>
+  ))
+  .add('Escape clear all values when dropdown closed', () => (
+    <div style={{ padding: 40, maxWidth: 400 }}>
+      <MultiSelect
+        label="Multi select"
+        data={data}
+        defaultValue={['react', 'ng']}
+        placeholder="Select items"
+        clearable
+        escapeClearsValue
+      />
+    </div>
   ));

--- a/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
@@ -89,6 +89,9 @@ export interface MultiSelectProps
 
   /** Set the clear button tab index to disabled or default after input field */
   clearButtonTabIndex?: -1 | 0;
+
+  /** Clear all values when the escape key is pressed and the dropdown is closed */
+  escapeClearsValue?: boolean;
 }
 
 export function defaultFilter(value: string, selected: boolean, item: SelectItem) {
@@ -125,6 +128,7 @@ const defaultProps: Partial<MultiSelectProps> = {
   zIndex: getDefaultZIndex('popover'),
   selectOnBlur: false,
   clearButtonTabIndex: 0,
+  escapeClearsValue: false,
 };
 
 export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
@@ -190,6 +194,7 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
       labelProps,
       descriptionProps,
       clearButtonTabIndex,
+      escapeClearsValue,
       ...others
     } = useMantineDefaultProps('MultiSelect', defaultProps, props);
 
@@ -337,6 +342,15 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
       setDropdownOpened(false);
     };
 
+    const handleClear = () => {
+      handleSearchChange('');
+      setValue([]);
+      inputRef.current?.focus();
+      if (maxSelectedValues) {
+        valuesOverflow.current = false;
+      }
+    };
+
     const handleInputKeydown = (event: React.KeyboardEvent<HTMLInputElement>) => {
       if (event.nativeEvent.code !== 'Backspace' && !!maxSelectedValues && valuesOverflow.current) {
         return;
@@ -474,7 +488,11 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
         }
 
         case 'Escape': {
-          setDropdownOpened(false);
+          if (dropdownOpened) {
+            setDropdownOpened(false);
+          } else if (clearable && escapeClearsValue) {
+            handleClear();
+          }
         }
       }
     };
@@ -511,15 +529,6 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
           radius={radius}
         />
       ));
-
-    const handleClear = () => {
-      handleSearchChange('');
-      setValue([]);
-      inputRef.current?.focus();
-      if (maxSelectedValues) {
-        valuesOverflow.current = false;
-      }
-    };
 
     if (isCreatable && shouldCreate(searchValue, sortedData)) {
       createLabel = getCreateLabel(searchValue);

--- a/src/mantine-core/src/components/Select/Select.story.tsx
+++ b/src/mantine-core/src/components/Select/Select.story.tsx
@@ -353,4 +353,15 @@ storiesOf('Select', module)
         clearButtonTabIndex={-1}
       />
     </div>
+  ))
+  .add('Escape clear value when dropdown closed', () => (
+    <div style={{ padding: 40, maxWidth: 400 }}>
+      <Select
+        label="Search in first select"
+        placeholder="Choose value"
+        data={stringData}
+        clearable
+        escapeClearsValue
+      />
+    </div>
   ));

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -134,6 +134,9 @@ export interface SelectProps
 
   /** Set the clear button tab index to disabled or default after input field */
   clearButtonTabIndex?: -1 | 0;
+
+  /** Clear value when the escape key is pressed and the dropdown is closed */
+  escapeClearsValue?: boolean;
 }
 
 export function defaultFilter(value: string, item: SelectItem) {
@@ -165,6 +168,7 @@ const defaultProps: Partial<SelectProps> = {
   filterDataOnExactSearchMatch: false,
   zIndex: getDefaultZIndex('popover'),
   clearButtonTabIndex: 0,
+  escapeClearsValue: false,
 };
 
 export const Select = forwardRef<HTMLInputElement, SelectProps>((props: SelectProps, ref) => {
@@ -225,6 +229,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>((props: SelectPr
     placeholder,
     filterDataOnExactSearchMatch,
     clearButtonTabIndex,
+    escapeClearsValue,
     ...others
   } = useMantineDefaultProps('Select', defaultProps, props);
 
@@ -463,9 +468,13 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>((props: SelectPr
       }
 
       case 'Escape': {
-        event.preventDefault();
-        setDropdownOpened(false);
-        setHovered(-1);
+        if (dropdownOpened) {
+          event.preventDefault();
+          setDropdownOpened(false);
+          setHovered(-1);
+        } else if (clearable && escapeClearsValue) {
+          handleClear();
+        }
         break;
       }
 


### PR DESCRIPTION
Makes it possible to clear the value or all values when the drop down is closed and the escape key is pressed. Requires the clearable property to also be true

- This allow for keyboard interaction only on a select that is also clearable instead of needing mouse click to clear its content.