### PR TITLE
[@mantine/form] add asyncResolver on use-form

### DIFF
--- a/src/mantine-demos/src/demos/form/Form.demo.zod.tsx
+++ b/src/mantine-demos/src/demos/form/Form.demo.zod.tsx
@@ -66,8 +66,7 @@ const schema = z.object({
 
 function Demo() {
   const form = useForm({
-    asyncResolver: true,
-    schema: zodResolver(schema) as any,
+    schema: zodResolver(schema),
     initialValues: {
       name: '',
       email: '',

--- a/src/mantine-demos/src/demos/form/Form.demo.zod.tsx
+++ b/src/mantine-demos/src/demos/form/Form.demo.zod.tsx
@@ -66,7 +66,8 @@ const schema = z.object({
 
 function Demo() {
   const form = useForm({
-    schema: zodResolver(schema),
+    asyncResolver: true,
+    schema: zodResolver(schema) as any,
     initialValues: {
       name: '',
       email: '',

--- a/src/mantine-form/src/resolvers/async-test-resolver.ts
+++ b/src/mantine-form/src/resolvers/async-test-resolver.ts
@@ -1,0 +1,97 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { formList, FormErrors, useForm } from '../index';
+
+export const RESOLVER_ERROR_MESSAGES = {
+  name: 'test-name-error',
+  age: 'test-age-error',
+  fruitName: 'test-fruit-name-error',
+  fruitStock: 'test-fruit-stock-error',
+};
+
+const values = {
+  name: '1',
+  age: 5,
+  fruits: formList([
+    { name: 'banana', stock: -3 },
+    { name: '1', stock: 5 },
+  ]),
+};
+
+const validValues = {
+  name: 'test-name',
+  age: 50,
+  fruits: formList([
+    { name: 'banana', stock: 10 },
+    { name: 'orange', stock: 10 },
+  ]),
+};
+
+const initialValues = {
+  name: '1',
+  age: 5,
+  fruits: formList([
+    { name: 'banana', stock: -3 },
+    { name: '1', stock: 5 },
+  ]),
+};
+
+export function testResolver(schema: (values: Record<string, any>) => Promise<FormErrors>) {
+  // Resolver itself
+
+  it('validates given values', async () => {
+    const asyncValidation = await schema(values);
+    expect(asyncValidation).toStrictEqual({
+      name: RESOLVER_ERROR_MESSAGES.name,
+      age: RESOLVER_ERROR_MESSAGES.age,
+      'fruits.0.stock': RESOLVER_ERROR_MESSAGES.fruitStock,
+      'fruits.1.name': RESOLVER_ERROR_MESSAGES.fruitName,
+    });
+  });
+
+  it('returns empty object if all fields are valid', async () => {
+    const asyncValidation = await schema(validValues);
+    expect(asyncValidation).toStrictEqual({});
+  });
+
+  // use-form integration
+  it('validates regular values', async () => {
+    const hook = renderHook(() =>
+      useForm({ schema: schema as any, initialValues, asyncResolver: true })
+    );
+    expect(hook.result.current.errors).toStrictEqual({});
+    await act(async () => {
+      const results = await hook.result.current.asyncValidate();
+      expect(results).toStrictEqual({
+        hasErrors: true,
+        errors: {
+          name: RESOLVER_ERROR_MESSAGES.name,
+          age: RESOLVER_ERROR_MESSAGES.age,
+          'fruits.0.stock': RESOLVER_ERROR_MESSAGES.fruitStock,
+          'fruits.1.name': RESOLVER_ERROR_MESSAGES.fruitName,
+        },
+      });
+    });
+
+    expect(hook.result.current.errors).toStrictEqual({
+      name: RESOLVER_ERROR_MESSAGES.name,
+      age: RESOLVER_ERROR_MESSAGES.age,
+      'fruits.0.stock': RESOLVER_ERROR_MESSAGES.fruitStock,
+      'fruits.1.name': RESOLVER_ERROR_MESSAGES.fruitName,
+    });
+  });
+
+  it('validates single field with validateField handler', async () => {
+    const hook = renderHook(() =>
+      useForm({ schema: schema as any, initialValues, asyncResolver: true })
+    );
+
+    expect(hook.result.current.errors).toStrictEqual({});
+
+    await act(async () => {
+      const results = await hook.result.current.asyncValidateField('name');
+      expect(results).toStrictEqual({ hasError: true, error: RESOLVER_ERROR_MESSAGES.name });
+    });
+
+    expect(hook.result.current.errors).toStrictEqual({ name: RESOLVER_ERROR_MESSAGES.name });
+  });
+}

--- a/src/mantine-form/src/resolvers/zod-resolver/zod-resolver.test.ts
+++ b/src/mantine-form/src/resolvers/zod-resolver/zod-resolver.test.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { zodResolver } from './zod-resolver';
-import { testResolver, RESOLVER_ERROR_MESSAGES } from '../test-resolver';
+import { testResolver, RESOLVER_ERROR_MESSAGES } from '../async-test-resolver';
 
 describe('@mantine/form zod resolver', () => {
   testResolver(

--- a/src/mantine-form/src/resolvers/zod-resolver/zod-resolver.ts
+++ b/src/mantine-form/src/resolvers/zod-resolver/zod-resolver.ts
@@ -13,15 +13,14 @@ interface ZodResults {
 }
 
 interface ZodSchema {
-  safeParse(values: Record<string, any>): ZodResults;
+  safeParseAsync(values: Record<string, any>): Promise<ZodResults>;
 }
 
 export function zodResolver<T extends Record<string, any>>(schema: any) {
   const _schema: ZodSchema = schema;
 
-  return (values: T): FormErrors => {
-    const parsed = _schema.safeParse(values);
-
+  return async (values: T): Promise<FormErrors> => {
+    const parsed = await _schema.safeParseAsync(values);
     if (parsed.success) {
       return {};
     }

--- a/src/mantine-form/src/types.ts
+++ b/src/mantine-form/src/types.ts
@@ -12,6 +12,7 @@ export type FormRulesRecord<T> = Partial<{
 }>;
 
 export type FormRules<T> = ((values: T) => FormErrors) | FormRulesRecord<T>;
+export type AsyncFormRules<T> = ((values: T) => Promise<FormErrors>) | FormRulesRecord<T>;
 
 export interface FormValidationResult {
   hasErrors: boolean;

--- a/src/mantine-form/src/validate-values/validate-values.ts
+++ b/src/mantine-form/src/validate-values/validate-values.ts
@@ -4,6 +4,7 @@ import type {
   FormRules,
   FormValidationResult,
   FormFieldValidationResult,
+  AsyncFormRules,
 } from '../types';
 import { isFormList } from '../form-list/form-list';
 import { filterErrors } from '../filter-errors/filter-errors';
@@ -45,12 +46,37 @@ export function validateValues(
   return getValidationResults(validateRecordRules(rules, values));
 }
 
+export async function asyncValidateValues(
+  rules: AsyncFormRules<any>,
+  values: Record<string, any>
+): Promise<FormValidationResult> {
+  if (rules === undefined || rules === null) {
+    return { hasErrors: false, errors: {} };
+  }
+
+  if (typeof rules === 'function') {
+    const rulesValues = await rules(values);
+    return getValidationResults(rulesValues);
+  }
+  return getValidationResults(validateRecordRules(rules, values));
+}
+
 export function validateFieldValue(
   field: string,
   rules: FormRules<any>,
   values: Record<string, any>
 ): FormFieldValidationResult {
   const results = validateValues(rules, values);
+  const hasError = field in results.errors;
+  return { hasError, error: hasError ? results.errors[field] : null };
+}
+
+export async function asyncValidateFieldValue(
+  field: string,
+  rules: AsyncFormRules<any>,
+  values: Record<string, any>
+): Promise<FormFieldValidationResult> {
+  const results = await asyncValidateValues(rules, values);
   const hasError = field in results.errors;
   return { hasError, error: hasError ? results.errors[field] : null };
 }


### PR DESCRIPTION
https://github.com/mantinedev/mantine/issues/1100

to check promise need call function ex schema(null) I think there will be performance loss on other resolver ex: yup, zoi. so I decided just use asyncResolver props.

my suggest to make not bigger code should split between async and sync so no hidden bug will occur.
the schema types depend on many place. so I can't change to use Promise<schema>. for now I just bypass it by any when init useForm