### PR TITLE
[@mantine/core] SegmentedControl: remove initial active tab translation animation

### DIFF
--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.story.tsx
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.story.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { MantineProvider } from '@mantine/styles';
+import { Button } from '../Button/Button';
 import { SegmentedControl, SegmentedControlProps } from './SegmentedControl';
 
 const stringData = ['React', 'Angular', 'Vue', 'Very long label'];
@@ -37,6 +38,25 @@ function Scaled() {
   );
 }
 
+function Conditional(props: Partial<SegmentedControlProps>) {
+  const [visible, setVisible] = useState<Boolean>(false);
+
+  return (
+    <div style={{ padding: 40 }}>
+      <Button onClick={() => setVisible(!visible)}>
+        {!visible ? 'Show' : 'Hide'} Segmented Control
+      </Button>
+      <div
+        style={{
+          paddingTop: 20,
+        }}
+      >
+        {visible && <SegmentedControl {...props} data={stringData} defaultValue="Vue" />}
+      </div>
+    </div>
+  );
+}
+
 const sizes = (['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
   <div key={size}>
     <Controlled size={size} mt="md" disabled />
@@ -59,5 +79,10 @@ storiesOf('SegmentedControl', module)
   .add('Default radius on MantineProvider', () => (
     <MantineProvider theme={{ defaultRadius: 0 }}>
       <Controlled />
+    </MantineProvider>
+  ))
+  .add('Conditional Rendering without initial transition', () => (
+    <MantineProvider theme={{ colorScheme: 'dark' }}>
+      <Conditional />
     </MantineProvider>
   ));

--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.styles.ts
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.styles.ts
@@ -134,6 +134,19 @@ export default createStyles(
           borderLeftColor: 'transparent !important',
           borderTopColor: 'transparent !important',
         },
+        borderRadius: theme.fn.radius(radius),
+        boxShadow: shouldAnimate
+          ? color || theme.colorScheme === 'dark'
+            ? 'none'
+            : theme.shadows.xs
+          : undefined,
+        backgroundColor: shouldAnimate
+          ? color in theme.colors
+            ? theme.fn.themeColor(color, 6)
+            : theme.colorScheme === 'dark'
+            ? theme.colors.dark[5]
+            : theme.white
+          : undefined,
       },
 
       labelActive: {

--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, forwardRef } from 'react';
+import React, { useEffect, useRef, useState, forwardRef, useLayoutEffect } from 'react';
 import {
   useReducedMotion,
   useResizeObserver,
@@ -98,6 +98,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
   const data = _data.map((item: any) =>
     typeof item === 'string' ? { label: item, value: item } : item
   );
+  const mounted = useRef<Boolean>();
 
   const [shouldAnimate, setShouldAnimate] = useState(false);
   const [_value, handleValueChange] = useUncontrolled({
@@ -131,6 +132,15 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
   const refs = useRef<Record<string, HTMLLabelElement>>({});
   const [observerRef, containerRect] = useResizeObserver();
 
+  useLayoutEffect(() => {
+    if (!mounted.current) {
+      mounted.current = true;
+      setShouldAnimate(false);
+    } else {
+      setShouldAnimate(true);
+    }
+  });
+
   useEffect(() => {
     if (_value in refs.current && observerRef.current) {
       const element = refs.current[_value];
@@ -153,10 +163,6 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
       });
     }
   }, [_value, containerRect]);
-
-  useEffect(() => {
-    setShouldAnimate(true);
-  }, []);
 
   const controls = data.map((item) => (
     <div
@@ -191,7 +197,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
 
   return (
     <Box className={cx(classes.root, className)} ref={useMergedRef(observerRef, ref)} {...others}>
-      {!!_value && (
+      {!!_value && shouldAnimate && (
         <Box
           component="span"
           className={classes.active}


### PR DESCRIPTION
#1239 ... assuming we don't want initial transition on render, have done this. If it is to be avoided via a prop, shall do it