### PR TITLE
[core] Omit "*" from label accessible names

### DIFF
--- a/src/mantine-core/src/components/InputWrapper/InputWrapper.tsx
+++ b/src/mantine-core/src/components/InputWrapper/InputWrapper.tsx
@@ -88,7 +88,11 @@ export const InputWrapper = forwardRef<HTMLDivElement, InputWrapperProps>(
       },
       <>
         {label}
-        {required && <span className={classes.required}> *</span>}
+        {required && (
+          <span className={classes.required} aria-hidden>
+            {' *'}
+          </span>
+        )}
       </>
     );
 

--- a/src/mantine-tests/src/it-supports-input-wrapper-props.tsx
+++ b/src/mantine-tests/src/it-supports-input-wrapper-props.tsx
@@ -14,7 +14,9 @@ export function itSupportsInputWrapperProps<P>(
     const { container } = await renderWithAct(
       <Component {...requiredProps} required id="secret-test-id" label="Test label" />
     );
-    expect(container.querySelector(`.mantine-${name}-required`)).toBeInTheDocument();
+    const requiredGlyph = container.querySelector(`.mantine-${name}-required`);
+    expect(requiredGlyph).toBeInTheDocument();
+    expect(requiredGlyph).toHaveAttribute('aria-hidden');
   });
 
   it('supports description prop', async () => {


### PR DESCRIPTION
Omit the required "*" from the accessible name of labels by using `aria-hidden` on the span.