### PR TITLE
[@mantine/core] Alert: a11y fixes

### DIFF
--- a/src/mantine-core/src/components/Alert/Alert.test.tsx
+++ b/src/mantine-core/src/components/Alert/Alert.test.tsx
@@ -52,4 +52,14 @@ describe('@mantine/core/Alert', () => {
     const { container } = render(<Alert>test-alert</Alert>);
     expect(container.querySelectorAll('.mantine-Alert-title')).toHaveLength(0);
   });
+
+  it('renders with the alert role', () => {
+    const rendered = render(
+      <Alert id="my-alert" title="My Alert">
+        test-alert
+      </Alert>
+    );
+    const alert = rendered.getByRole('alert');
+    expect(alert).toHaveAccessibleName('My Alert');
+  });
 });

--- a/src/mantine-core/src/components/Alert/Alert.tsx
+++ b/src/mantine-core/src/components/Alert/Alert.tsx
@@ -6,8 +6,9 @@ import {
   MantineNumberSize,
   useMantineDefaultProps,
 } from '@mantine/styles';
-import { Box } from '../Box';
+import { useUuid } from '@mantine/hooks';
 import { CloseButton } from '../ActionIcon';
+import { Box } from '../Box';
 import useStyles from './Alert.styles';
 
 export type AlertVariant = 'filled' | 'outline' | 'light';
@@ -50,6 +51,7 @@ const defaultProps: Partial<AlertProps> = {
 
 export const Alert = forwardRef<HTMLDivElement, AlertProps>((props: AlertProps, ref) => {
   const {
+    id,
     className,
     title,
     variant,
@@ -70,15 +72,30 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>((props: AlertProps, 
     { classNames, styles, name: 'Alert' }
   );
 
+  const rootId = useUuid(id);
+
+  const titleId = title && id && `${rootId}-title`;
+  const bodyId = `${rootId}-body`;
+
   return (
-    <Box className={cx(classes.root, classes[variant], className)} ref={ref} {...others}>
+    <Box
+      id={rootId}
+      role="alert"
+      aria-labelledby={titleId}
+      aria-describedby={bodyId}
+      className={cx(classes.root, classes[variant], className)}
+      ref={ref}
+      {...others}
+    >
       <div className={classes.wrapper}>
         {icon && <div className={classes.icon}>{icon}</div>}
 
         <div className={classes.body}>
           {title && (
             <div className={classes.title}>
-              <span className={classes.label}>{title}</span>
+              <span id={titleId} className={classes.label}>
+                {title}
+              </span>
 
               {withCloseButton && (
                 <CloseButton
@@ -93,7 +110,9 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>((props: AlertProps, 
             </div>
           )}
 
-          <div className={classes.message}>{children}</div>
+          <div id={bodyId} className={classes.message}>
+            {children}
+          </div>
         </div>
       </div>
     </Box>


### PR DESCRIPTION
- Add `alert` role to `Alert` components
- Use the title to label alerts
- Use the body to describe alerts