### PR TITLE
[@mantine/core] Modal: add id to root element

### DIFF
--- a/src/mantine-core/src/components/Modal/Modal.test.tsx
+++ b/src/mantine-core/src/components/Modal/Modal.test.tsx
@@ -18,6 +18,11 @@ describe('@mantine/core/Modal', () => {
   itSupportsSystemProps({ component: Modal, props: defaultProps });
   itRendersChildren(Modal, defaultProps);
 
+  it('uses the provided id prop on the root element', () => {
+    const { container } = render(<Modal {...defaultProps} id="my-modal" />);
+    expect(container.querySelectorAll('#my-modal')).toHaveLength(1);
+  });
+
   it('calls onClose when close button is clicked', () => {
     const spy = jest.fn();
     render(<Modal {...defaultProps} onClose={spy} />);

--- a/src/mantine-core/src/components/Modal/Modal.tsx
+++ b/src/mantine-core/src/components/Modal/Modal.tsx
@@ -193,6 +193,7 @@ export function Modal(props: ModalProps) {
         {(transitionStyles) => (
           <Box className={cx(classes.root, className)} {...others}>
             <div
+              id={baseId}
               className={classes.inner}
               onKeyDownCapture={(event) => {
                 const shouldTrigger =

--- a/src/mantine-core/src/components/Modal/Modal.tsx
+++ b/src/mantine-core/src/components/Modal/Modal.tsx
@@ -191,9 +191,8 @@ export function Modal(props: ModalProps) {
         }}
       >
         {(transitionStyles) => (
-          <Box className={cx(classes.root, className)} {...others}>
+          <Box id={baseId} className={cx(classes.root, className)} {...others}>
             <div
-              id={baseId}
               className={classes.inner}
               onKeyDownCapture={(event) => {
                 const shouldTrigger =


### PR DESCRIPTION
The `id` prop passed to `<Modal/>` is not being added to the DOM.