### PR TITLE
[@mantine/core] MultiSelect: Fix defaultRadius

### DIFF
--- a/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
@@ -118,7 +118,6 @@ const defaultProps: Partial<MultiSelectProps> = {
   clearSearchOnBlur: false,
   disabled: false,
   initiallyOpened: false,
-  radius: 'sm',
   creatable: false,
   shouldCreate: defaultShouldCreate,
   switchDirectionOnFlip: false,


### PR DESCRIPTION
Currently the defaultRadius is not applied on the MultiSelect