### PR TITLE
[@mantine/core] RadioGroup: accessible name

### DIFF
--- a/src/mantine-core/src/components/RadioGroup/Radio/Radio.tsx
+++ b/src/mantine-core/src/components/RadioGroup/Radio/Radio.tsx
@@ -88,7 +88,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props: RadioProps
           disabled={disabled}
           {...rest}
         />
-        <Icon className={classes.icon} />
+        <Icon className={classes.icon} aria-hidden />
       </div>
 
       {label && (

--- a/src/mantine-core/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/mantine-core/src/components/RadioGroup/RadioGroup.test.tsx
@@ -50,6 +50,18 @@ describe('@mantine/core/RadioGroup', () => {
     expect(withName.querySelector('input[type="radio"]').getAttribute('name')).toBe('test-name');
   });
 
+  it('has an accessible label', () => {
+    const radioGroup = render(
+      <RadioGroup label="Select a Framework">
+        <Radio value="mantine" label="Mantine" />
+        <Radio value="mui" label="MUI" />
+        <Radio value="chakra" label="ChakraUI" />
+      </RadioGroup>
+    );
+
+    expect(radioGroup.queryByLabelText('Select a Framework')).not.toEqual(null);
+  });
+
   it('supports uncontrolled state', () => {
     render(<RadioGroup {...defaultProps} defaultValue="test-value-1" />);
     expect(screen.getAllByRole('radio')[0]).toBeChecked();

--- a/src/mantine-core/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/mantine-core/src/components/RadioGroup/RadioGroup.tsx
@@ -61,6 +61,7 @@ const defaultProps: Partial<RadioGroupProps> = {
 export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
   (props: RadioGroupProps, ref) => {
     const {
+      id,
       name,
       children,
       value,
@@ -79,6 +80,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
       ...others
     } = useMantineDefaultProps('RadioGroup', defaultProps, props);
 
+    const rootId = useUuid(id);
     const uuid = useUuid(name);
     const [_value, setValue] = useUncontrolled({
       value,
@@ -105,6 +107,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
 
     return (
       <InputWrapper
+        id={rootId}
         labelElement="div"
         size={size}
         __staticSelector="RadioGroup"
@@ -119,6 +122,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
       >
         <Group
           role="radiogroup"
+          aria-labelledby={`${rootId}-label`}
           spacing={spacing}
           direction={orientation === 'horizontal' ? 'row' : 'column'}
           style={{ paddingTop: 5 }}


### PR DESCRIPTION
- Ensure a radio group is labelled
- Hide the styled radio dot