### PR TITLE
[@mantine/modals] Add new value to Record type ConfirmLabels

### DIFF
--- a/src/mantine-modals/src/context.ts
+++ b/src/mantine-modals/src/context.ts
@@ -1,10 +1,10 @@
-import { createContext } from 'react';
+import { createContext, ReactNode } from 'react';
 import { ModalProps } from '@mantine/core';
 import type { ConfirmModalProps } from './ConfirmModal';
 
 export type ModalSettings = Partial<Omit<ModalProps, 'opened'>>;
 
-export type ConfirmLabels = Record<'confirm' | 'cancel', string>;
+export type ConfirmLabels = Record<'confirm' | 'cancel', ReactNode>;
 
 export interface OpenConfirmModal extends ModalSettings, ConfirmModalProps {}
 export interface OpenContextModal<CustomProps extends Record<string, unknown> = {}>

--- a/src/mantine-modals/src/use-modals/use-modals.test.tsx
+++ b/src/mantine-modals/src/use-modals/use-modals.test.tsx
@@ -122,6 +122,34 @@ describe('@mantine/modals/use-modals', () => {
     expect(screen.getByText('Cancel')).toBeInTheDocument();
   });
 
+  it('correctly renders a confirm modal with labels as HTMLElement', async () => {
+    const wrapper: WrapperComponent<unknown> = ({ children }) => (
+      <MantineProvider>
+        <ModalsProvider>{children}</ModalsProvider>
+      </MantineProvider>
+    );
+
+    const Component = () => {
+      const modals = useModals();
+
+      useEffect(() => {
+        modals.openConfirmModal({
+          labels: {
+            confirm: <span>Confirm</span>,
+            cancel: <span>Cancel</span>,
+          },
+        });
+      }, []);
+
+      return <div>Empty</div>;
+    };
+
+    render(<Component />, { wrapper });
+
+    expect(screen.getByText('Confirm')).toContainHTML('span');
+    expect(screen.getByText('Cancel')).toContainHTML('span');
+  });
+
   it('correctly renders a regular modal with children and a title', () => {
     const wrapper: WrapperComponent<unknown> = ({ children }) => (
       <MantineProvider>


### PR DESCRIPTION
Replace for `confirm` and `cancel` labels type `string` to `ReactNode`. 

This change will allow to place all valid values of the type `ReactNode` inside the confirm and cancel buttons confirm modal component.

#1286 