### PR TITLE
SegmentedControl disabled support for individual items.

### DIFF
--- a/docs/src/docs/core/SimpleGrid.mdx
+++ b/docs/src/docs/core/SimpleGrid.mdx
@@ -39,8 +39,8 @@ In this example:
 
 - If screen width is more than 980px then component `cols` and `spacing` is used – 4 columns, lg spacing
 - screen width < 980px and > 755px – cols = 3, spacing = sm
-- screen width < 755px and > 680px – cols = 2, spacing = sm
-- screen width < 680px – cols = 1, spacing = sm
+- screen width < 755px and > 600px – cols = 2, spacing = sm
+- screen width < 600px – cols = 1, spacing = sm
 
 You can also use breakpoints from theme to set `maxWidth`:
 

--- a/docs/src/docs/theming/rtl.mdx
+++ b/docs/src/docs/theming/rtl.mdx
@@ -66,9 +66,11 @@ function App() {
             { key: 'mantine' }
       }
     >
-      <Button onClick={() => setRtl((c) => !c)}>Toggle rtl/ltr</Button>
+      <div dir={rtl ? 'rtl' : 'ltr'}>
+        <Button onClick={() => setRtl((c) => !c)}>Toggle rtl/ltr</Button>
 
-      <YourApp />
+        <YourApp />
+      </div>
     </MantineProvider>
   );
 }

--- a/src/mantine-core/src/components/Modal/Modal.test.tsx
+++ b/src/mantine-core/src/components/Modal/Modal.test.tsx
@@ -18,6 +18,11 @@ describe('@mantine/core/Modal', () => {
   itSupportsSystemProps({ component: Modal, props: defaultProps });
   itRendersChildren(Modal, defaultProps);
 
+  it('uses the provided id prop on the root element', () => {
+    const { container } = render(<Modal {...defaultProps} id="my-modal" />);
+    expect(container.querySelectorAll('#my-modal')).toHaveLength(1);
+  });
+
   it('calls onClose when close button is clicked', () => {
     const spy = jest.fn();
     render(<Modal {...defaultProps} onClose={spy} />);

--- a/src/mantine-core/src/components/Modal/Modal.tsx
+++ b/src/mantine-core/src/components/Modal/Modal.tsx
@@ -191,7 +191,7 @@ export function Modal(props: ModalProps) {
         }}
       >
         {(transitionStyles) => (
-          <Box className={cx(classes.root, className)} {...others}>
+          <Box id={baseId} className={cx(classes.root, className)} {...others}>
             <div
               className={classes.inner}
               onKeyDownCapture={(event) => {

--- a/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/mantine-core/src/components/MultiSelect/MultiSelect.tsx
@@ -118,7 +118,6 @@ const defaultProps: Partial<MultiSelectProps> = {
   clearSearchOnBlur: false,
   disabled: false,
   initiallyOpened: false,
-  radius: 'sm',
   creatable: false,
   shouldCreate: defaultShouldCreate,
   switchDirectionOnFlip: false,

--- a/src/mantine-core/src/components/RadioGroup/Radio/Radio.tsx
+++ b/src/mantine-core/src/components/RadioGroup/Radio/Radio.tsx
@@ -88,7 +88,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props: RadioProps
           disabled={disabled}
           {...rest}
         />
-        <Icon className={classes.icon} />
+        <Icon className={classes.icon} aria-hidden />
       </div>
 
       {label && (

--- a/src/mantine-core/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/mantine-core/src/components/RadioGroup/RadioGroup.test.tsx
@@ -50,6 +50,18 @@ describe('@mantine/core/RadioGroup', () => {
     expect(withName.querySelector('input[type="radio"]').getAttribute('name')).toBe('test-name');
   });
 
+  it('has an accessible label', () => {
+    const radioGroup = render(
+      <RadioGroup label="Select a Framework">
+        <Radio value="mantine" label="Mantine" />
+        <Radio value="mui" label="MUI" />
+        <Radio value="chakra" label="ChakraUI" />
+      </RadioGroup>
+    );
+
+    expect(radioGroup.queryByLabelText('Select a Framework')).not.toEqual(null);
+  });
+
   it('supports uncontrolled state', () => {
     render(<RadioGroup {...defaultProps} defaultValue="test-value-1" />);
     expect(screen.getAllByRole('radio')[0]).toBeChecked();

--- a/src/mantine-core/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/mantine-core/src/components/RadioGroup/RadioGroup.tsx
@@ -61,6 +61,7 @@ const defaultProps: Partial<RadioGroupProps> = {
 export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
   (props: RadioGroupProps, ref) => {
     const {
+      id,
       name,
       children,
       value,
@@ -79,6 +80,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
       ...others
     } = useMantineDefaultProps('RadioGroup', defaultProps, props);
 
+    const rootId = useUuid(id);
     const uuid = useUuid(name);
     const [_value, setValue] = useUncontrolled({
       value,
@@ -105,6 +107,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
 
     return (
       <InputWrapper
+        id={rootId}
         labelElement="div"
         size={size}
         __staticSelector="RadioGroup"
@@ -119,6 +122,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
       >
         <Group
           role="radiogroup"
+          aria-labelledby={`${rootId}-label`}
           spacing={spacing}
           direction={orientation === 'horizontal' ? 'row' : 'column'}
           style={{ paddingTop: 5 }}

--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.story.tsx
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.story.tsx
@@ -57,6 +57,36 @@ function Conditional(props: Partial<SegmentedControlProps>) {
   );
 }
 
+function DisabledStates() {
+  return (
+    <div style={{ padding: 40 }}>
+      <div>
+        <SegmentedControl
+          disabled={true}
+          data={[
+            { label: 'React', value: 'react' },
+            { label: 'Angular', value: 'ng' },
+            { label: 'Vue', value: 'vue' },
+            { label: 'Very long label', value: 'svelte' },
+          ]}
+        />
+      </div>
+
+      <div style={{ marginTop: 20 }}>
+        <SegmentedControl
+          disabled={false}
+          data={[
+            { label: 'React', value: 'react', disabled: true },
+            { label: 'Angular', value: 'ng' },
+            { label: 'Vue', value: 'vue', disabled: true },
+            { label: 'Very long label', value: 'svelte' },
+          ]}
+        />
+      </div>
+    </div>
+  );
+}
+
 const sizes = (['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
   <div key={size}>
     <Controlled size={size} mt="md" disabled />
@@ -71,6 +101,7 @@ storiesOf('SegmentedControl', module)
     </div>
   ))
   .add('Scaled', () => <Scaled />)
+  .add('Disabled', () => <DisabledStates />)
   .add('Default props on MantineProvider', () => (
     <MantineProvider defaultProps={{ SegmentedControl: { color: 'orange' } }}>
       <Controlled />

--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.styles.ts
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.styles.ts
@@ -158,6 +158,7 @@ export default createStyles(
       disabled: {
         '&, &:hover': {
           color: theme.colorScheme === 'dark' ? theme.colors.dark[3] : theme.colors.gray[5],
+          cursor: 'not-allowed',
         },
       },
 

--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useRef, useState, forwardRef, useLayoutEffect } from 'react';
+import React, { useEffect, useRef, useState, forwardRef } from 'react';
 import {
   useReducedMotion,
   useResizeObserver,
   useUncontrolled,
   useUuid,
   useMergedRef,
+  useIsomorphicEffect,
 } from '@mantine/hooks';
 import {
   DefaultProps,
@@ -132,7 +133,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
   const refs = useRef<Record<string, HTMLLabelElement>>({});
   const [observerRef, containerRect] = useResizeObserver();
 
-  useLayoutEffect(() => {
+  useIsomorphicEffect(() => {
     if (!mounted.current) {
       mounted.current = true;
       setShouldAnimate(false);

--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.tsx
@@ -21,6 +21,7 @@ import useStyles, { WRAPPER_PADDING } from './SegmentedControl.styles';
 export interface SegmentedControlItem {
   value: string;
   label: React.ReactNode;
+  disabled?: boolean;
 }
 
 export type SegmentedControlStylesNames = ClassNames<typeof useStyles>;
@@ -96,7 +97,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
   } = useMantineDefaultProps('SegmentedControl', defaultProps, props);
 
   const reduceMotion = useReducedMotion();
-  const data = _data.map((item: any) =>
+  const data = _data.map((item: string | SegmentedControlItem): SegmentedControlItem =>
     typeof item === 'string' ? { label: item, value: item } : item
   );
   const mounted = useRef<Boolean>();
@@ -105,7 +106,9 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
   const [_value, handleValueChange] = useUncontrolled({
     value,
     defaultValue,
-    finalValue: Array.isArray(data) ? data[0].value : null,
+    finalValue: Array.isArray(data)
+      ? (data.find(item => !item.disabled)?.value ?? data[0].value)
+      : null,
     onChange,
     rule: (val) => !!val,
   });
@@ -172,7 +175,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
     >
       <input
         className={classes.input}
-        disabled={disabled}
+        disabled={disabled || item.disabled}
         type="radio"
         name={uuid}
         value={item.value}
@@ -184,7 +187,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
       <label
         className={cx(classes.label, {
           [classes.labelActive]: _value === item.value,
-          [classes.disabled]: disabled,
+          [classes.disabled]: disabled || item.disabled,
         })}
         htmlFor={`${uuid}-${item.value}`}
         ref={(node) => {

--- a/src/mantine-core/src/components/Tooltip/Tooltip.tsx
+++ b/src/mantine-core/src/components/Tooltip/Tooltip.tsx
@@ -167,11 +167,11 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>((props: TooltipP
   return (
     <Box<'div'>
       className={cx(classes.root, className)}
-      onMouseEnter={(event) => {
+      onPointerEnter={(event) => {
         handleOpen();
         typeof onMouseEnter === 'function' && onMouseEnter(event);
       }}
-      onMouseLeave={(event) => {
+      onPointerLeave={(event) => {
         handleClose();
         typeof onMouseLeave === 'function' && onMouseLeave(event);
       }}

--- a/src/mantine-demos/src/demos/core/SegmentedControl/SegmentedControl.demo.disabled.tsx
+++ b/src/mantine-demos/src/demos/core/SegmentedControl/SegmentedControl.demo.disabled.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { SegmentedControl, Box, Stack, Text } from '@mantine/core';
+
+const code = `
+import { SegmentedControl } from '@mantine/core';
+
+function Demo() {
+  return (
+    <>
+      {/* Disabled control */}
+      <SegmentedControl disabled={true} />
+
+      {/* Disabled options */}
+      <SegmentedControl
+        data={[
+          {
+            value: 'preview',
+            label: 'Preview',
+            disabled: true
+          },
+          {
+            value: 'code',
+            label: 'Code'
+          },
+          {
+            value: 'export',
+            label: 'Export'
+          }
+        ]}
+      />
+    </>
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <Stack align='center'>
+        <Box>
+          <Text size="sm" weight={500} mb={3}>
+            Disabled control
+          </Text>
+          <SegmentedControl
+            disabled={true}
+            data={[
+              {
+                value: 'preview',
+                label: 'Preview',
+              },
+              {
+                value: 'code',
+                label: 'Code',
+              },
+              {
+                value: 'export',
+                label: 'Export',
+              },
+            ]}
+          />
+        </Box>
+
+        <Box>
+          <Text size="sm" weight={500} mb={3}>
+            Disabled options
+          </Text>
+          <SegmentedControl
+            data={[
+              {
+                value: 'preview',
+                label: 'Preview',
+                disabled: true
+              },
+              {
+                value: 'code',
+                label: 'Code',
+                disabled: false
+              },
+              {
+                value: 'export',
+                label: 'Export',
+              }
+            ]}
+          />
+        </Box>
+    </Stack >
+  );
+}
+
+export const disabled: MantineDemo = {
+  type: 'demo',
+  component: Demo,
+  code,
+};

--- a/src/mantine-demos/src/demos/core/SegmentedControl/index.ts
+++ b/src/mantine-demos/src/demos/core/SegmentedControl/index.ts
@@ -5,3 +5,4 @@ export { radius } from './SegmentedControl.demo.radius';
 export { configurator } from './SegmentedControl.demo.configurator';
 export { transitions } from './SegmentedControl.demo.transitions';
 export { labels } from './SegmentedControl.demo.labels';
+export { disabled } from './SegmentedControl.demo.disabled';


### PR DESCRIPTION
Introduce `disabled` support for individual options.

Add `not-allowed` cursor state for disabled options and control.