### PR TITLE
[@mantine/core] SegmentedControl: Add disabled property support for individual options.

### DIFF
--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.story.tsx
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.story.tsx
@@ -62,7 +62,7 @@ function DisabledStates() {
     <div style={{ padding: 40 }}>
       <div>
         <SegmentedControl
-          disabled={true}
+          disabled
           data={[
             { label: 'React', value: 'react' },
             { label: 'Angular', value: 'ng' },

--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.story.tsx
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.story.tsx
@@ -57,6 +57,36 @@ function Conditional(props: Partial<SegmentedControlProps>) {
   );
 }
 
+function DisabledStates() {
+  return (
+    <div style={{ padding: 40 }}>
+      <div>
+        <SegmentedControl
+          disabled={true}
+          data={[
+            { label: 'React', value: 'react' },
+            { label: 'Angular', value: 'ng' },
+            { label: 'Vue', value: 'vue' },
+            { label: 'Very long label', value: 'svelte' },
+          ]}
+        />
+      </div>
+
+      <div style={{ marginTop: 20 }}>
+        <SegmentedControl
+          disabled={false}
+          data={[
+            { label: 'React', value: 'react', disabled: true },
+            { label: 'Angular', value: 'ng' },
+            { label: 'Vue', value: 'vue', disabled: true },
+            { label: 'Very long label', value: 'svelte' },
+          ]}
+        />
+      </div>
+    </div>
+  );
+}
+
 const sizes = (['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
   <div key={size}>
     <Controlled size={size} mt="md" disabled />
@@ -71,6 +101,7 @@ storiesOf('SegmentedControl', module)
     </div>
   ))
   .add('Scaled', () => <Scaled />)
+  .add('Disabled', () => <DisabledStates />)
   .add('Default props on MantineProvider', () => (
     <MantineProvider defaultProps={{ SegmentedControl: { color: 'orange' } }}>
       <Controlled />

--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.story.tsx
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.story.tsx
@@ -74,7 +74,6 @@ function DisabledStates() {
 
       <div style={{ marginTop: 20 }}>
         <SegmentedControl
-          disabled={false}
           data={[
             { label: 'React', value: 'react', disabled: true },
             { label: 'Angular', value: 'ng' },

--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.styles.ts
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.styles.ts
@@ -159,6 +159,7 @@ export default createStyles(
       disabled: {
         '&, &:hover': {
           color: theme.colorScheme === 'dark' ? theme.colors.dark[3] : theme.colors.gray[5],
+          cursor: 'not-allowed',
         },
       },
 

--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.tsx
@@ -20,6 +20,7 @@ import useStyles, { WRAPPER_PADDING } from './SegmentedControl.styles';
 export interface SegmentedControlItem {
   value: string;
   label: React.ReactNode;
+  disabled?: boolean;
 }
 
 export type SegmentedControlStylesNames = ClassNames<typeof useStyles>;
@@ -95,7 +96,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
   } = useMantineDefaultProps('SegmentedControl', defaultProps, props);
 
   const reduceMotion = useReducedMotion();
-  const data = _data.map((item: any) =>
+  const data = _data.map((item: string | SegmentedControlItem): SegmentedControlItem =>
     typeof item === 'string' ? { label: item, value: item } : item
   );
   const mounted = useRef<Boolean>();
@@ -104,7 +105,9 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
   const [_value, handleValueChange] = useUncontrolled({
     value,
     defaultValue,
-    finalValue: Array.isArray(data) ? data[0].value : null,
+    finalValue: Array.isArray(data)
+      ? (data.find(item => !item.disabled)?.value ?? data[0].value)
+      : null,
     onChange,
     rule: (val) => !!val,
   });
@@ -171,7 +174,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
     >
       <input
         className={classes.input}
-        disabled={disabled}
+        disabled={disabled || item.disabled}
         type="radio"
         name={uuid}
         value={item.value}
@@ -183,7 +186,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
       <label
         className={cx(classes.label, {
           [classes.labelActive]: _value === item.value,
-          [classes.disabled]: disabled,
+          [classes.disabled]: disabled || item.disabled,
         })}
         htmlFor={`${uuid}-${item.value}`}
         ref={(node) => {

--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.tsx
@@ -96,8 +96,9 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
   } = useMantineDefaultProps('SegmentedControl', defaultProps, props);
 
   const reduceMotion = useReducedMotion();
-  const data = _data.map((item: string | SegmentedControlItem): SegmentedControlItem =>
-    typeof item === 'string' ? { label: item, value: item } : item
+  const data = _data.map(
+    (item: string | SegmentedControlItem): SegmentedControlItem =>
+      typeof item === 'string' ? { label: item, value: item } : item
   );
   const mounted = useRef<Boolean>();
 
@@ -106,7 +107,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
     value,
     defaultValue,
     finalValue: Array.isArray(data)
-      ? (data.find(item => !item.disabled)?.value ?? data[0].value)
+      ? data.find((item) => !item.disabled)?.value ?? data[0].value
       : null,
     onChange,
     rule: (val) => !!val,

--- a/src/mantine-demos/src/demos/core/SegmentedControl/SegmentedControl.demo.disabled.tsx
+++ b/src/mantine-demos/src/demos/core/SegmentedControl/SegmentedControl.demo.disabled.tsx
@@ -72,8 +72,7 @@ function Demo() {
               },
               {
                 value: 'code',
-                label: 'Code',
-                disabled: false
+                label: 'Code'
               },
               {
                 value: 'export',

--- a/src/mantine-demos/src/demos/core/SegmentedControl/SegmentedControl.demo.disabled.tsx
+++ b/src/mantine-demos/src/demos/core/SegmentedControl/SegmentedControl.demo.disabled.tsx
@@ -36,52 +36,52 @@ function Demo() {
 function Demo() {
   return (
     <Stack align="center">
-        <Box>
-          <Text size="sm" weight={500} mb={3}>
-            Disabled control
-          </Text>
-          <SegmentedControl
-            // disabled={true}
-            disabled
-            data={[
-              {
-                value: 'preview',
-                label: 'Preview',
-              },
-              {
-                value: 'code',
-                label: 'Code',
-              },
-              {
-                value: 'export',
-                label: 'Export',
-              },
-            ]}
-          />
-        </Box>
+      <Box>
+        <Text size="sm" weight={500} mb={3}>
+          Disabled control
+        </Text>
+        <SegmentedControl
+          // disabled={true}
+          disabled
+          data={[
+            {
+              value: 'preview',
+              label: 'Preview',
+            },
+            {
+              value: 'code',
+              label: 'Code',
+            },
+            {
+              value: 'export',
+              label: 'Export',
+            },
+          ]}
+        />
+      </Box>
 
-        <Box>
-          <Text size="sm" weight={500} mb={3}>
-            Disabled options
-          </Text>
-          <SegmentedControl
-            data={[
-              {
-                value: 'preview',
-                label: 'Preview',
-                disabled: true,
-              },
-              {
-                value: 'code',
-                label: 'Code',
-              },
-              {
-                value: 'export',
-                label: 'Export',
-              },
-            ]}
-          />
-        </Box>
+      <Box>
+        <Text size="sm" weight={500} mb={3}>
+          Disabled options
+        </Text>
+        <SegmentedControl
+          data={[
+            {
+              value: 'preview',
+              label: 'Preview',
+              disabled: true,
+            },
+            {
+              value: 'code',
+              label: 'Code',
+            },
+            {
+              value: 'export',
+              label: 'Export',
+            },
+          ]}
+        />
+      </Box>
     </Stack>
   );
 }

--- a/src/mantine-demos/src/demos/core/SegmentedControl/SegmentedControl.demo.disabled.tsx
+++ b/src/mantine-demos/src/demos/core/SegmentedControl/SegmentedControl.demo.disabled.tsx
@@ -35,13 +35,14 @@ function Demo() {
 
 function Demo() {
   return (
-    <Stack align='center'>
+    <Stack align="center">
         <Box>
           <Text size="sm" weight={500} mb={3}>
             Disabled control
           </Text>
           <SegmentedControl
-            disabled={true}
+            // disabled={true}
+            disabled
             data={[
               {
                 value: 'preview',
@@ -68,20 +69,20 @@ function Demo() {
               {
                 value: 'preview',
                 label: 'Preview',
-                disabled: true
+                disabled: true,
               },
               {
                 value: 'code',
-                label: 'Code'
+                label: 'Code',
               },
               {
                 value: 'export',
                 label: 'Export',
-              }
+              },
             ]}
           />
         </Box>
-    </Stack >
+    </Stack>
   );
 }
 

--- a/src/mantine-demos/src/demos/core/SegmentedControl/SegmentedControl.demo.disabled.tsx
+++ b/src/mantine-demos/src/demos/core/SegmentedControl/SegmentedControl.demo.disabled.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { SegmentedControl, Box, Stack, Text } from '@mantine/core';
+
+const code = `
+import { SegmentedControl } from '@mantine/core';
+
+function Demo() {
+  return (
+    <>
+      {/* Disabled control */}
+      <SegmentedControl disabled={true} />
+
+      {/* Disabled options */}
+      <SegmentedControl
+        data={[
+          {
+            value: 'preview',
+            label: 'Preview',
+            disabled: true
+          },
+          {
+            value: 'code',
+            label: 'Code'
+          },
+          {
+            value: 'export',
+            label: 'Export'
+          }
+        ]}
+      />
+    </>
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <Stack align='center'>
+        <Box>
+          <Text size="sm" weight={500} mb={3}>
+            Disabled control
+          </Text>
+          <SegmentedControl
+            disabled={true}
+            data={[
+              {
+                value: 'preview',
+                label: 'Preview',
+              },
+              {
+                value: 'code',
+                label: 'Code',
+              },
+              {
+                value: 'export',
+                label: 'Export',
+              },
+            ]}
+          />
+        </Box>
+
+        <Box>
+          <Text size="sm" weight={500} mb={3}>
+            Disabled options
+          </Text>
+          <SegmentedControl
+            data={[
+              {
+                value: 'preview',
+                label: 'Preview',
+                disabled: true
+              },
+              {
+                value: 'code',
+                label: 'Code',
+                disabled: false
+              },
+              {
+                value: 'export',
+                label: 'Export',
+              }
+            ]}
+          />
+        </Box>
+    </Stack >
+  );
+}
+
+export const disabled: MantineDemo = {
+  type: 'demo',
+  component: Demo,
+  code,
+};

--- a/src/mantine-demos/src/demos/core/SegmentedControl/index.ts
+++ b/src/mantine-demos/src/demos/core/SegmentedControl/index.ts
@@ -5,3 +5,4 @@ export { radius } from './SegmentedControl.demo.radius';
 export { configurator } from './SegmentedControl.demo.configurator';
 export { transitions } from './SegmentedControl.demo.transitions';
 export { labels } from './SegmentedControl.demo.labels';
+export { disabled } from './SegmentedControl.demo.disabled';


### PR DESCRIPTION
Add `disabled` property support for individual options.
Add missing `not-allowed` value for `cursor` for `disabled` state of control and individual options.