### PR TITLE
[docs] use-element-size: Update source reference.

### DIFF
--- a/docs/src/docs/hooks/use-element-size.mdx
+++ b/docs/src/docs/hooks/use-element-size.mdx
@@ -8,7 +8,7 @@ slug: /hooks/use-element-size/
 description: 'Get element width and height and subscribe to changes'
 import: "import { useElementSize } from '@mantine/hooks';"
 docs: 'hooks/use-element-size.mdx'
-source: 'mantine-hooks/src/use-element-size/use-element-size'
+source: 'mantine-hooks/src/use-resize-observer/use-resize-observer'
 ---
 
 import { HooksDemos } from '@mantine/demos';


### PR DESCRIPTION
`use-element-size` hook is not exported into its own file and is actually located inside `use-resize-observer`'s source.