### PR TITLE
[docs] Fix incorrect source references for hooks.

### DIFF
--- a/docs/src/docs/hooks/use-element-size.mdx
+++ b/docs/src/docs/hooks/use-element-size.mdx
@@ -8,7 +8,7 @@ slug: /hooks/use-element-size/
 description: 'Get element width and height and subscribe to changes'
 import: "import { useElementSize } from '@mantine/hooks';"
 docs: 'hooks/use-element-size.mdx'
-source: 'mantine-hooks/src/use-resize-observer/use-resize-observer'
+source: 'mantine-hooks/src/use-resize-observer/use-resize-observer.ts'
 ---
 
 import { HooksDemos } from '@mantine/demos';

--- a/docs/src/docs/hooks/use-event-listener.mdx
+++ b/docs/src/docs/hooks/use-event-listener.mdx
@@ -8,7 +8,7 @@ slug: /hooks/use-event-listener/
 description: 'Subscribe to events with a ref'
 import: "import { useEventListener } from '@mantine/hooks';"
 docs: 'hooks/use-event-listener.mdx'
-source: 'mantine-hooks/src/use-event-listener/use-event-listener'
+source: 'mantine-hooks/src/use-event-listener/use-event-listener.ts'
 ---
 
 import { HooksDemos } from '@mantine/demos';


### PR DESCRIPTION
Fix missing `.ts` extension for:
1. `use-element-size`.
2. `use-event-listener`.