### PR TITLE
[@mantine/modals] ConfirmModal: Add default labels

### DIFF
--- a/src/mantine-modals/src/ConfirmModal.tsx
+++ b/src/mantine-modals/src/ConfirmModal.tsx
@@ -20,7 +20,7 @@ export function ConfirmModal({
   id,
   cancelProps,
   confirmProps,
-  labels,
+  labels = { cancel: '', confirm: '' },
   closeOnConfirm = true,
   closeOnCancel = true,
   groupProps,
@@ -28,6 +28,7 @@ export function ConfirmModal({
   onConfirm,
   children,
 }: ConfirmModalProps) {
+  const { cancel: cancelLabel, confirm: confirmLabel } = labels;
   const ctx = useModals();
 
   const handleCancel = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -48,11 +49,11 @@ export function ConfirmModal({
 
       <Group position="right" {...groupProps}>
         <Button variant="default" {...cancelProps} onClick={handleCancel}>
-          {cancelProps?.children || labels.cancel}
+          {cancelProps?.children || cancelLabel}
         </Button>
 
         <Button {...confirmProps} onClick={handleConfirm}>
-          {confirmProps?.children || labels.confirm}
+          {confirmProps?.children || confirmLabel}
         </Button>
       </Group>
     </>

--- a/src/mantine-modals/src/Modals.story.tsx
+++ b/src/mantine-modals/src/Modals.story.tsx
@@ -4,6 +4,19 @@ import { storiesOf } from '@storybook/react';
 import { Button, Text, Group } from '@mantine/core';
 import { ModalsProvider, useModals, ContextModalProps } from './index';
 
+function DemoWithoutLabels() {
+  const modals = useModals();
+
+  const showConfirmModal = () =>
+    modals.openConfirmModal({
+      title: 'Oh no! No labels!',
+      onCancel: () => console.log('Single confirm modal cancelled'),
+      onConfirm: () => console.log('Single confirm modal confirmed'),
+      onClose: () => console.log('Single confirm modal closed'),
+    });
+  return <Button onClick={showConfirmModal}>Open confirm modal w/o labels</Button>;
+}
+
 function Demo() {
   const modals = useModals();
 
@@ -68,6 +81,9 @@ function Demo() {
       <Button onClick={showContentModal} color="violet">
         Open content modal
       </Button>
+      <ModalsProvider>
+        <DemoWithoutLabels />
+      </ModalsProvider>
     </Group>
   );
 }


### PR DESCRIPTION
Fixes #836 

Sets default confirm modal labels to empty string to avoid browser error (and no modal opening) if the labels are not. Empty string instead of English labels so it is not confusing for non-English development/usage