### PR TITLE
[docs] Removed incorrect argument types for radialGradient

### DIFF
--- a/docs/src/docs/theming/functions.mdx
+++ b/docs/src/docs/theming/functions.mdx
@@ -165,8 +165,8 @@ theme.fn.linearGradient(24, '#000', '#fff'); // -> linear-gradient(24deg, #000 0
 theme.fn.linearGradient(133, 'blue', 'red', 'orange', 'cyan', 'white');
 // -> linear-gradient(133deg, blue 0%, red 25%, orange 50%, cyan 75%, white 100%)'
 
-theme.fn.radialGradient(24, '#000', '#fff'); // -> radial-gradient(circle, #000 0%, #fff 100%)
-theme.fn.radialGradient(133, 'blue', 'red', 'orange', 'cyan', 'white');
+theme.fn.radialGradient('#000', '#fff'); // -> radial-gradient(circle, #000 0%, #fff 100%)
+theme.fn.radialGradient('blue', 'red', 'orange', 'cyan', 'white');
 // -> radial-gradient(circle, blue 0%, red 25%, orange 50%, cyan 75%, white 100%)
 ```
 


### PR DESCRIPTION
`theme.fn.radialGradient` only takes an argument of type `string[]`, which wasn't represented correctly in the documentation.