### PR TITLE
[@mantine/core] Alert: Fix a11y name without id

### DIFF
--- a/src/mantine-core/src/components/Alert/Alert.test.tsx
+++ b/src/mantine-core/src/components/Alert/Alert.test.tsx
@@ -62,4 +62,10 @@ describe('@mantine/core/Alert', () => {
     const alert = rendered.getByRole('alert');
     expect(alert).toHaveAccessibleName('My Alert');
   });
+
+  it('has an accessible name even when not having an ID', () => {
+    const rendered = render(<Alert title="My Alert">test-alert</Alert>);
+    const alert = rendered.getByRole('alert');
+    expect(alert).toHaveAccessibleName('My Alert');
+  });
 });

--- a/src/mantine-core/src/components/Alert/Alert.tsx
+++ b/src/mantine-core/src/components/Alert/Alert.tsx
@@ -74,7 +74,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>((props: AlertProps, 
 
   const rootId = useUuid(id);
 
-  const titleId = title && id && `${rootId}-title`;
+  const titleId = title && `${rootId}-title`;
   const bodyId = `${rootId}-body`;
 
   return (


### PR DESCRIPTION
Fix label association of alerts when they have no `id`