### PR TITLE
[@mantine/core] Autocomplete: Fix enter not submitting form

### DIFF
--- a/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
@@ -139,11 +139,8 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
         }
 
         case 'Enter': {
-          if (dropdownOpened) {
-            event.preventDefault();
-          }
-
           if (filteredData[hovered] && dropdownOpened) {
+            event.preventDefault();
             handleChange(filteredData[hovered].value);
             typeof onItemSubmit === 'function' && onItemSubmit(filteredData[hovered]);
             setDropdownOpened(false);


### PR DESCRIPTION
Fixes #1360

Now pressing enter when there are no filtered items doesn't call event.preventDefault(), so a parent form will be submitted now. Try the Autocomplete -> Within form story to test the changes.