### PR TITLE
[@mantine/core]: Conditional rendering tittle instead of tittleContainer for Alertbox

### DIFF
--- a/src/mantine-core/src/components/Alert/Alert.tsx
+++ b/src/mantine-core/src/components/Alert/Alert.tsx
@@ -91,24 +91,23 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>((props: AlertProps, 
         {icon && <div className={classes.icon}>{icon}</div>}
 
         <div className={classes.body}>
-          {title && (
-            <div className={classes.title}>
+          <div className={classes.title}>
+            {title && (
               <span id={titleId} className={classes.label}>
                 {title}
               </span>
-
-              {withCloseButton && (
-                <CloseButton
-                  className={classes.closeButton}
-                  onClick={() => onClose?.()}
-                  variant="transparent"
-                  size={16}
-                  iconSize={16}
-                  aria-label={closeButtonLabel}
-                />
-              )}
-            </div>
-          )}
+            )}
+            {withCloseButton && (
+              <CloseButton
+                className={classes.closeButton}
+                onClick={() => onClose?.()}
+                variant="transparent"
+                size={16}
+                iconSize={16}
+                aria-label={closeButtonLabel}
+              />
+            )}
+          </div>
 
           <div id={bodyId} className={classes.message}>
             {children}


### PR DESCRIPTION
Issue: [1348](https://github.com/mantinedev/mantine/issues/1348)
withCloseButton will display independent of title now
