### PR TITLE
[@mantine/hooks] use-move: fix onScrubEnd on quick tap i.e without any scrubbing

### DIFF
--- a/src/mantine-hooks/src/use-move/use-move.ts
+++ b/src/mantine-hooks/src/use-move/use-move.ts
@@ -78,9 +78,11 @@ export function useMove<T extends HTMLElement = HTMLDivElement>(
     const stopScrubbing = () => {
       if (isSliding.current && mounted.current) {
         isSliding.current = false;
-        typeof handlers?.onScrubEnd === 'function' && handlers.onScrubEnd();
         setActive(false);
         unbindEvents();
+        setTimeout(() => {
+          typeof handlers?.onScrubEnd === 'function' && handlers.onScrubEnd();
+        }, 0);
       }
     };
 


### PR DESCRIPTION
`onScrubEnd` is being called before the `onChange` of parent component like `Slider`, hence a mismatch in the value being passed to `onScrubEnd`. 