### PR TITLE
[@mantine-dropzone] Add support for React 18

### DIFF
--- a/docs/src/docs/others/dropzone.mdx
+++ b/docs/src/docs/others/dropzone.mdx
@@ -73,7 +73,28 @@ To open files browser from outside of component use `openRef` prop to get functi
 
 ## Mime types
 
-To specify specific file types provide an array of mime types to `accept` prop:
+To specify file types provide an object with the keys set to the [mime type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)
+and the values as an array of file extensions. Find more examples of accepting specific file types
+in the [react-dropzone docs](https://react-dropzone.js.org/#section-accepting-specific-file-types).
+
+```tsx
+import { Dropzone } from '@mantine/dropzone';
+
+function Demo() {
+  return (
+    <Dropzone
+      accept={{
+        'image/*': [], // All images
+        'text/html': ['.html', '.htm'],
+      }}
+    >
+      {/* children */}
+    </Dropzone>
+  );
+}
+```
+
+You can also specify file types by providing an array of mime types to `accept` prop:
 
 ```tsx
 import { Dropzone } from '@mantine/dropzone';

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "prism-react-renderer": "^1.2.1",
     "quill-mention": "^3.0.8",
     "react": "^17.0.2",
-    "react-dropzone": "^11.4.2",
+    "react-dropzone": "^14.1.1",
     "react-feather": "^2.0.9",
     "react-popper": "^2.2.5",
     "react-quill": "2.0.0-beta.4",

--- a/src/mantine-dropzone/package.json
+++ b/src/mantine-dropzone/package.json
@@ -34,7 +34,7 @@
     "react-dom": ">=16.8.0"
   },
   "dependencies": {
-    "react-dropzone": "^11.4.2"
+    "react-dropzone": "^14.1.1"
   },
   "devDependencies": {}
 }

--- a/src/mantine-dropzone/src/Dropzone/Dropzone.tsx
+++ b/src/mantine-dropzone/src/Dropzone/Dropzone.tsx
@@ -41,7 +41,7 @@ export interface DropzoneProps extends DefaultProps<DropzoneStylesNames> {
   loading?: boolean;
 
   /** File types to accept  */
-  accept?: string[];
+  accept?: { [key: string]: string[] } | string[];
 
   /** Get open function as ref */
   openRef?: React.ForwardedRef<() => void | undefined>;
@@ -89,7 +89,7 @@ export const Dropzone = forwardRef<HTMLDivElement, DropzoneProps>((props: Dropzo
     onDropAccepted: (files) => onDrop(files),
     onDropRejected: (fileRejections) => onReject(fileRejections),
     disabled: disabled || loading,
-    accept,
+    accept: Array.isArray(accept) ? accept.reduce((r, key) => ({ ...r, [key]: [] }), {}) : accept,
     multiple,
     maxSize,
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4204,7 +4204,7 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-attr-accept@^2.2.1:
+attr-accept@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
   integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
@@ -6879,10 +6879,10 @@ file-loader@^6.2.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-file-selector@^0.2.2:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.2.4.tgz#7b98286f9dbb9925f420130ea5ed0a69238d4d80"
-  integrity sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==
+file-selector@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.5.0.tgz#21c7126dc9728b31a2742d91cab20d55e67e4fb4"
+  integrity sha512-s8KNnmIDTBoD0p9uJ9uD0XY38SCeBOtj0UMXyQSLg1Ypfrfj8+dAvwsLjYQkQ2GjhVtp2HrnF5cJzMhBjfD8HA==
   dependencies:
     tslib "^2.0.3"
 
@@ -11010,14 +11010,14 @@ react-draggable@^4.4.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-dropzone@^11.4.2:
-  version "11.4.2"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-11.4.2.tgz#1eb99e9def4cc7520f4f58e85c853ce52c483d56"
-  integrity sha512-ocYzYn7Qgp0tFc1gQtUTOaHHSzVTwhWHxxY+r7cj2jJTPfMTZB5GWSJHdIVoxsl+EQENpjJ/6Zvcw0BqKZQ+Eg==
+react-dropzone@^14.1.1:
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-14.1.1.tgz#44ef66b8806bab7e3e39a4b089e73145de038482"
+  integrity sha512-JYavQrxU66hBHwDAXCMoHNvhMonKDA0VQ8ouJi8Ouxgz9lmtA4OGVBXgOTCq4vCbwTTDT9synvNUCIpT6zWWow==
   dependencies:
-    attr-accept "^2.2.1"
-    file-selector "^0.2.2"
-    prop-types "^15.7.2"
+    attr-accept "^2.2.2"
+    file-selector "^0.5.0"
+    prop-types "^15.8.1"
 
 react-error-boundary@^3.1.0:
   version "3.1.3"


### PR DESCRIPTION
I struggled with docs a bit. I wasn't sure where to add the example since using an array is so simple and intuitive, it's nice having it right at the top so it's the first thing users see. At the same time, the two current examples flow so nicely into the mime types table that I didn't want to disrupt the flow. Anyway, I'm happy to make any changes.