### PR TITLE
[@mantine/core] NumberInput: Allow user to pass inputMode

### DIFF
--- a/src/mantine-core/src/components/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.tsx
@@ -122,6 +122,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
       rightSectionWidth,
       formatter,
       parser,
+      inputMode,
       ...others
     } = useMantineDefaultProps('NumberInput', defaultProps, props);
 
@@ -371,7 +372,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
         size={size}
         styles={styles}
         classNames={classNames}
-        inputMode={getInputMode(step, precision, useOs())}
+        inputMode={inputMode || getInputMode(step, precision, useOs())}
         __staticSelector="NumberInput"
       />
     );


### PR DESCRIPTION
The current logic to determine the NumberInput `inputMode` prop checks various combinations of the `step` and `precision` props to make that determination. I'm proposing that users should be allowed to supply their own `inputMode` prop in the event that the logic in `mantine/src/mantine-core/src/utils/get-input-mode` doesn't account for their needs.