### PR TITLE
[@mantine/spotlight] Fix registerSpotlightActions and removeSpotlight…

### DIFF
--- a/src/mantine-spotlight/src/events.ts
+++ b/src/mantine-spotlight/src/events.ts
@@ -34,17 +34,17 @@ export function triggerSpotlightAction(actionId: string) {
 }
 
 export function registerSpotlightActions(actions: SpotlightAction[]) {
-  window.dispatchEvent(createEvent(SPOTLIGHT_EVENTS.triggerAction, actions));
+  window.dispatchEvent(createEvent(SPOTLIGHT_EVENTS.registerActions, actions));
 }
 
 export function removeSpotlightActions(actionsIds: string[]) {
-  window.dispatchEvent(createEvent(SPOTLIGHT_EVENTS.triggerAction, actionsIds));
+  window.dispatchEvent(createEvent(SPOTLIGHT_EVENTS.removeActions, actionsIds));
 }
 
 export function useSpotlightEvents(ctx: SpotlightContextValue) {
   const events = {
     registerActions: (event: any) => ctx.registerActions(event.detail),
-    removeActions: (event: any) => ctx.registerActions(event.detail),
+    removeActions: (event: any) => ctx.removeActions(event.detail),
     triggerAction: (event: any) => ctx.triggerAction(event.detail),
     open: ctx.openSpotlight,
     close: ctx.closeSpotlight,


### PR DESCRIPTION
…Actions

Both of these functions were creating trigger events rather than their respective correct ones (registerActions & removeActions).

Tested on my own project and it fixed my issue with registerSpotlightActions seemingly not doing anything.