### PR TITLE
[@mantine/hooks] use-network: Include all properties and remove dummy object.

### DIFF
--- a/docs/src/docs/hooks/use-network.mdx
+++ b/docs/src/docs/hooks/use-network.mdx
@@ -27,10 +27,12 @@ import { HooksDemos } from '@mantine/demos';
 
 ```tsx
 function useNetwork(): {
-  downlink: number;
-  effectiveType: 'slow-2g' | '2g' | '3g' | '4g';
-  saveData: boolean;
-  rtt: number;
   online: boolean;
+  downlink?: number;
+  downlinkMax?: number;
+  effectiveType?: 'slow-2g' | '2g' | '3g' | '4g';
+  rtt?: number;
+  saveData?: boolean;
+  type?: 'bluetooth' | 'cellular' | 'ethernet' | 'wifi' | 'wimax' | 'none' | 'other' | 'unknown';
 };
 ```

--- a/src/mantine-hooks/src/use-network/use-network.ts
+++ b/src/mantine-hooks/src/use-network/use-network.ts
@@ -2,22 +2,17 @@ import { useState, useEffect, useCallback } from 'react';
 import { useWindowEvent } from '../use-window-event/use-window-event';
 
 interface NetworkStatus {
-  downlink: number;
-  effectiveType: 'slow-2g' | '2g' | '3g' | '4g';
-  saveData: boolean;
-  rtt: number;
+  downlink?: number;
+  downlinkMax?: number;
+  effectiveType?: 'slow-2g' | '2g' | '3g' | '4g';
+  rtt?: number;
+  saveData?: boolean;
+  type?: 'bluetooth' | 'cellular' | 'ethernet' | 'wifi' | 'wimax' | 'none' | 'other' | 'unknown';
 }
-
-const defaultValue: NetworkStatus = {
-  downlink: 10,
-  effectiveType: '4g',
-  saveData: false,
-  rtt: 50,
-};
 
 function getConnection(): NetworkStatus {
   if (typeof navigator === 'undefined') {
-    return defaultValue;
+    return {};
   }
 
   const _navigator = navigator as any;
@@ -25,14 +20,16 @@ function getConnection(): NetworkStatus {
     _navigator.connection || _navigator.mozConnection || _navigator.webkitConnection;
 
   if (!connection) {
-    return defaultValue;
+    return {};
   }
 
   return {
     downlink: connection?.downlink,
+    downlinkMax: connection?.downlinkMax,
     effectiveType: connection?.effectiveType,
-    saveData: connection?.saveData,
     rtt: connection?.rtt,
+    saveData: connection?.saveData,
+    type: connection?.type,
   };
 }
 
@@ -47,7 +44,7 @@ export function useNetwork() {
   useWindowEvent('offline', () => setStatus({ online: false, ...getConnection() }));
 
   useEffect(() => {
-    if (navigator.connection) {
+    if (navigator?.connection) {
       navigator.connection.addEventListener('change', handleConnectionChange);
       return () => navigator.connection.removeEventListener('change', handleConnectionChange);
     }

--- a/src/mantine-hooks/src/use-network/use-network.ts
+++ b/src/mantine-hooks/src/use-network/use-network.ts
@@ -44,7 +44,7 @@ export function useNetwork() {
   useWindowEvent('offline', () => setStatus({ online: false, ...getConnection() }));
 
   useEffect(() => {
-    if (navigator?.connection) {
+    if (navigator.connection) {
       navigator.connection.addEventListener('change', handleConnectionChange);
       return () => navigator.connection.removeEventListener('change', handleConnectionChange);
     }


### PR DESCRIPTION
Yeah, the support is truly terrible.

TypeScript types i.e. `NetworkInformation`, `ConnectionType` and such are incomplete and don't reflect the MDN docs as well so I didn't use them.