### PR TITLE
[@mantine/labs] PinInput calls onChange twice

### DIFF
--- a/src/mantine-labs/src/PinInput/PinInput.tsx
+++ b/src/mantine-labs/src/PinInput/PinInput.tsx
@@ -165,13 +165,6 @@ export const PinInput = forwardRef<HTMLDivElement, PinInputProps>(
       }
     };
 
-    const sendResult = () => {
-      const res = inputsRef.current.map((input) => input.value).join('');
-      if (typeof onChange === 'function') {
-        onChange(res);
-      }
-    };
-
     const setFieldValue = (val: string, index: number) => {
       const values = [..._values];
 
@@ -210,8 +203,6 @@ export const PinInput = forwardRef<HTMLDivElement, PinInputProps>(
         } else {
           focusInputField('prev', index);
         }
-
-        sendResult();
       }
     };
 


### PR DESCRIPTION
Before this PR when you entered 4 numbers and remove one the onChange function is called twice and the second time with the old value so for example `1234` instead of `123` the real value that is display