### PR TITLE
[docs] Change the order of the ActionIcon variants

### DIFF
--- a/docs/src/docs/core/ActionIcon.mdx
+++ b/docs/src/docs/core/ActionIcon.mdx
@@ -39,7 +39,7 @@ function Demo() {
 
 ## Variants
 
-ActionIcon has 6 variants: hover, default, transparent, filled, light and outline:
+ActionIcon has 6 variants: transparent, hover, default, outline, filled and light:
 
 <Demo data={ActionIconDemos.variants} />
 


### PR DESCRIPTION
Changed the order of the ActionIcon variants so that they match with the order in the demo