### PR TITLE
[@mantine/core] NumberInput: Allows the "-" symbol in an empty NumberInput

### DIFF
--- a/src/mantine-core/src/components/NumberInput/NumberInput.test.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.test.tsx
@@ -151,4 +151,16 @@ describe('@mantine/core/NumberInput', () => {
     expectValue('0');
     expect(spy).toHaveBeenLastCalledWith(0);
   });
+
+  it('allows "-" in an empty NumberInput', () => {
+    const spy = jest.fn();
+    render(<NumberInput onChange={spy} />);
+    enterText('-');
+    expect(spy).toHaveBeenLastCalledWith(undefined);
+    blurInput();
+    expect(getInput()).toHaveValue('');
+    expect(spy).toHaveBeenLastCalledWith(undefined);
+    enterText('-1');
+    expect(spy).toHaveBeenLastCalledWith(-1);
+  });
 });

--- a/src/mantine-core/src/components/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.tsx
@@ -69,12 +69,16 @@ export interface NumberInputProps
   /** Formats the number into the input */
   formatter?: Formatter;
 
-  /** Parsers the value from formatter, should be used with formatter at the same time */
+  /** Parses the value from formatter, should be used with formatter at the same time */
   parser?: Parser;
 }
 
 const defaultFormatter: Formatter = (value) => value || '';
 const defaultParser: Parser = (num) => {
+  if (num === '-') {
+    return num;
+  }
+
   const parsedNum = parseFloat(num);
 
   if (Number.isNaN(parsedNum)) {
@@ -293,7 +297,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
 
       setTempValue(parsed);
 
-      if (val === '') {
+      if (val === '' || val === '-') {
         handleValueChange(undefined);
       } else {
         val.trim() !== '' && !Number.isNaN(parsed) && handleValueChange(parseFloat(parsed));


### PR DESCRIPTION
Fixes the bug in NumberInput raised in the [discord bugs channel](https://discord.com/channels/854810300876062770/972850721244471436/973654286154203156)

> Is NumberInput not allowing the "-" symbol in an empty NumberInput expected behavior? Currently, you are unable to type "-" in an empty NumberInput unless you first put a number then go back and place the "-" before it

Changes:
- You can now type `-` in an empty NumberInput.
- If `-` is the only thing in a NumberInput, the value will remain `undefined`, and the NumberInput will be cleared when the `onBlur` event fires.