### PR TITLE
[@mantine/styles] `sx`: Add `undefined` for array

### DIFF
--- a/src/mantine-styles/src/theme/types/DefaultProps.ts
+++ b/src/mantine-styles/src/theme/types/DefaultProps.ts
@@ -8,7 +8,7 @@ export type Sx = CSSObject | ((theme: MantineTheme) => CSSObject);
 export interface DefaultProps<T extends string = never> extends MantineStyleSystemProps {
   className?: string;
   style?: CSSProperties;
-  sx?: Sx | Sx[];
+  sx?: Sx | (Sx | undefined)[];
   classNames?: Partial<Record<T, string>>;
   styles?: Partial<Record<T, CSSObject>> | ((theme: MantineTheme) => Partial<Record<T, CSSObject>>);
 }


### PR DESCRIPTION
With strictMode, TS will give an error following this use case: https://mantine.dev/theming/sx/#sx-array

This PR add `undefined` to `sx` array's definition.