### PR TITLE
[@mantine/core] Box: Remove unnecessary types

### DIFF
--- a/src/mantine-core/src/components/Box/Box.tsx
+++ b/src/mantine-core/src/components/Box/Box.tsx
@@ -5,11 +5,9 @@ import {
   PolymorphicRef,
   extractSystemStyles,
 } from '@mantine/styles';
-import { useSx, BoxSx } from './use-sx/use-sx';
+import { useSx } from './use-sx/use-sx';
 
-interface _BoxProps extends Omit<DefaultProps, 'sx'> {
-  sx?: BoxSx;
-}
+interface _BoxProps extends DefaultProps {}
 
 export type BoxProps<C> = PolymorphicComponentProps<C, _BoxProps>;
 

--- a/src/mantine-core/src/components/Box/use-sx/use-sx.ts
+++ b/src/mantine-core/src/components/Box/use-sx/use-sx.ts
@@ -1,20 +1,17 @@
 import {
-  CSSObject,
   MantineStyleSystemProps,
   MantineTheme,
+  Sx,
   useCss,
   useMantineTheme,
 } from '@mantine/styles';
 import { getSystemStyles } from './get-system-styles/get-system-styles';
 
-type Sx = CSSObject | ((theme: MantineTheme) => CSSObject);
-export type BoxSx = Sx | Sx[];
-
 function extractSx(sx: Sx, theme: MantineTheme) {
   return typeof sx === 'function' ? sx(theme) : sx;
 }
 
-export function useSx(sx: BoxSx, systemProps: MantineStyleSystemProps, className: string) {
+export function useSx(sx: Sx | Sx[], systemProps: MantineStyleSystemProps, className: string) {
   const theme = useMantineTheme();
   const { css, cx } = useCss();
 


### PR DESCRIPTION
Do some clean up by removing unnecessary types from Box component.

This PR is just clean up code.