### PR TITLE
[docs] Use Discord's new blurple for light mode

### DIFF
--- a/docs/src/components/Layout/Header/HeaderControls/HeaderControl.styles.ts
+++ b/docs/src/components/Layout/Header/HeaderControls/HeaderControl.styles.ts
@@ -44,8 +44,7 @@ export default createStyles((theme, { hideOnMobile }: HeaderControlStyles) => ({
     borderColor: '5865f2',
 
     '&:hover': {
-      backgroundColor:
-        theme.fn.lighten('#5865f2', 0.1)
+      backgroundColor: theme.fn.lighten('#5865f2', 0.1),
     },
   },
   twitter: {

--- a/docs/src/components/Layout/Header/HeaderControls/HeaderControl.styles.ts
+++ b/docs/src/components/Layout/Header/HeaderControls/HeaderControl.styles.ts
@@ -40,14 +40,12 @@ export default createStyles((theme, { hideOnMobile }: HeaderControlStyles) => ({
 
   discord: {
     color: theme.white,
-    backgroundColor: theme.colorScheme === 'dark' ? '#5865f2' : '#7289da',
-    borderColor: theme.colorScheme === 'dark' ? '#5865f2' : '#7289da',
+    backgroundColor: '#5865f2',
+    borderColor: '5865f2',
 
     '&:hover': {
       backgroundColor:
-        theme.colorScheme === 'dark'
-          ? theme.fn.lighten('#5865f2', 0.1)
-          : theme.fn.darken('#7289da', 0.1),
+        theme.fn.lighten('#5865f2', 0.1)
     },
   },
   twitter: {

--- a/docs/src/components/SocialButton/SocialButton.tsx
+++ b/docs/src/components/SocialButton/SocialButton.tsx
@@ -25,7 +25,7 @@ function DiscordButton({ style, ...others }: SocialButtonProps) {
       style={{
         ...style,
         ...baseStyles,
-        backgroundColor: theme.colorScheme === 'dark' ? '#5865f2' : '#7289da',
+        backgroundColor: '#5865f2',
       }}
       {...others}
     >


### PR DESCRIPTION
#7289da is used on Mantine's documentation page for Discord's background color; the actual color is #5865f2 which is used on the dark mode version of the page.