### PR TITLE
Update FullScreenDropzone.tsx

### DIFF
--- a/src/mantine-dropzone/src/FullScreenDropzone/FullScreenDropzone.tsx
+++ b/src/mantine-dropzone/src/FullScreenDropzone/FullScreenDropzone.tsx
@@ -16,7 +16,7 @@ export type FullScreenDropzoneStylesNames = Selectors<typeof useStyles>;
 
 export interface FullScreenDropzoneProps
   extends DefaultProps<FullScreenDropzoneStylesNames>,
-    Omit<React.ComponentPropsWithoutRef<'div'>, 'onDrop'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'onDrop' | 'children'> {
   /** Space between dropzone and viewport edges */
   offset?: MantineNumberSize;
 


### PR DESCRIPTION
Notice that children is having a different signature in this case a function that returns React.ReactNode but in React.ComponentPropsWithoutRef<'div'>... is also having a field with that same name, this will result to a conflict so to avoid this, the "children" must not be imported from the upper parent.