### PR TITLE
Update global-types.d.ts

### DIFF
--- a/configuration/types/global-types.d.ts
+++ b/configuration/types/global-types.d.ts
@@ -22,7 +22,7 @@ interface MantineDemoControlProps {
 
 interface MantineDemoBase {
   component?: React.FC;
-  wrapper?: React.FC;
+  wrapper?: React.FC<{ children: React.ReactNode }>;
   code?: string;
   background?: (colorScheme: 'light' | 'dark') => string;
 }


### PR DESCRIPTION
To avoid this Error "Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes'.ts" providing a prop { children: React.ReactNode }