### PR TITLE
[@mantine/dates] TimeInput: Clear milliseconds on input value change.

### DIFF
--- a/src/mantine-dates/src/components/TimeInput/TimeInput.story.tsx
+++ b/src/mantine-dates/src/components/TimeInput/TimeInput.story.tsx
@@ -12,6 +12,7 @@ function Controlled() {
   const [value, onChange] = useState(new Date());
   return (
     <>
+      <p>Time value: {value?.toISOString()}</p>
       <TimeInput value={value} onChange={onChange} label="Controlled" />
       <button type="button" onClick={() => onChange(dayjs(new Date()).add(30, 'minutes').toDate())}>
         set date

--- a/src/mantine-dates/src/components/TimeInputBase/get-date/get-date.test.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/get-date/get-date.test.ts
@@ -7,18 +7,21 @@ describe('@mantine/dates/get-date', () => {
     expect(format24.getHours()).toStrictEqual(20);
     expect(format24.getMinutes()).toStrictEqual(12);
     expect(format24.getSeconds()).toStrictEqual(30);
+    expect(format24.getMilliseconds()).toStrictEqual(0);
 
     const format12PM = getDate('8', '12', '30', '12', 'pm');
 
     expect(format12PM.getHours()).toStrictEqual(20);
     expect(format12PM.getMinutes()).toStrictEqual(12);
     expect(format12PM.getSeconds()).toStrictEqual(30);
+    expect(format12PM.getMilliseconds()).toStrictEqual(0);
 
     const format12AM = getDate('8', '12', '30', '12', 'am');
 
     expect(format12AM.getHours()).toStrictEqual(8);
     expect(format12AM.getMinutes()).toStrictEqual(12);
     expect(format12AM.getSeconds()).toStrictEqual(30);
+    expect(format12AM.getMilliseconds()).toStrictEqual(0);
 
     expect(getDate('12', '00', '00', '12', 'am').getHours()).toStrictEqual(0);
     expect(getDate('12', '00', '00', '12', 'pm').getHours()).toStrictEqual(12);

--- a/src/mantine-dates/src/components/TimeInputBase/get-date/get-date.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/get-date/get-date.ts
@@ -27,5 +27,6 @@ export function getDate(
     .hour(_hours)
     .minute(Number.isNaN(_minutes) ? 0 : _minutes)
     .second(Number.isNaN(_seconds) ? 0 : _seconds)
+    .millisecond(0)
     .toDate();
 }


### PR DESCRIPTION
Fix for #1443.

Outside change through the `onChange` handler in controlled variant still preserves milliseconds.