### PR TITLE
[@mantine/styles] Fix custom color typescript override

### DIFF
--- a/src/mantine-styles/src/theme/types/MantineColor.ts
+++ b/src/mantine-styles/src/theme/types/MantineColor.ts
@@ -17,12 +17,12 @@ export type DefaultMantineColor =
   | 'teal'
   | (string & {});
 
-export type MantineThemeColorsOverride = Record<string, any>;
+export type MantineThemeColorsOverride = {};
 
 export type MantineThemeColors = MantineThemeColorsOverride extends {
-  colors: Record<string, Tuple<string, 10>>;
+  colors: Record<infer CustomColors, Tuple<string, 10>>;
 }
-  ? MantineThemeColorsOverride['colors']
+  ? Record<CustomColors, Tuple<string, 10>>
   : Record<DefaultMantineColor, Tuple<string, 10>>;
 
 export type MantineColor = keyof MantineThemeColors;


### PR DESCRIPTION
Related to #1127 

The current issue is when a user overrides custom color in the method defined in the docs [here](https://mantine.dev/theming/extend-theme/#adding-custom-colors), TS ends up with just `string` as the type for color on something like `<Button color='my-custom-color' />`. Instead, infer the type which lets TS use the string union defined.

Technically a user could say their colors are indexed by objects or something dumb and have runtime issues. That's on the user though. There might be some clever way to revert to the default colors if the user specifies things that aren't string keys, but I don't think it's worth the effort/trickier TS when it's pretty clear to the user that they should be strings