### PR TITLE
[docs] Fix typo in Card section

### DIFF
--- a/docs/src/docs/core/Card.mdx
+++ b/docs/src/docs/core/Card.mdx
@@ -26,7 +26,7 @@ Card component is a wrapper around [Paper](/core/paper/) component with context 
 Card.Section is a special component that is used to remove Card padding from its children while other elements still have horizontal spacing.
 Card.Section works the following way:
 
-- It component is a first child in Card then it has negative top, left and right margins
+- If component is a first child in Card then it has negative top, left and right margins
 - If it is a last child in Card then it has negative bottom, left and right margins
 - If it is in the middle then only left and right margins will be negative
 


### PR DESCRIPTION
Fixes minor typo in `Card.mdx`