### PR TITLE
[docs] Update Vite init command

### DIFF
--- a/docs/src/components/GettingStarted/Guides/Guide.tsx
+++ b/docs/src/components/GettingStarted/Guides/Guide.tsx
@@ -93,7 +93,7 @@ function ViteGuide({ dependencies }: GuideProps) {
   return (
     <Guide
       dependencies={dependencies}
-      initScript="yarn create @vitejs/app mantine-vite --template react-ts"
+      initScript="yarn create vite mantine-vite --template react-ts"
       withDone
     />
   );


### PR DESCRIPTION
The `yarn create @vitejs/app` command to create Vite apps has been depracted few months back in favor of `yarn create vite`.

I have updated the docs to accomodate this change.