### PR TITLE
[docs] fixed typo in Image Placeholders

### DIFF
--- a/docs/src/docs/core/Image.mdx
+++ b/docs/src/docs/core/Image.mdx
@@ -33,7 +33,7 @@ In case you want to show the image with its original proportions and want it to 
 
 ## Placeholder
 
-By default, placeholders image placeholders are disabled.
+By default, image placeholders are disabled.
 Image placeholder is displayed in these cases:
 
 - `withPlaceholder` prop is set to true


### PR DESCRIPTION
[docs] fixed typo in Image Placeholders
been using mantine a lot, found this small typo