### PR TITLE
[@mantine/form] - Export FormList type for explicit TypeScript users

### DIFF
--- a/src/mantine-form/src/index.ts
+++ b/src/mantine-form/src/index.ts
@@ -1,4 +1,4 @@
-export { formList, isFormList } from './form-list/form-list';
+export { formList, isFormList, FormList } from './form-list/form-list';
 export { useForm } from './use-form';
 export { zodResolver } from './resolvers/zod-resolver/zod-resolver';
 export { yupResolver } from './resolvers/yup-resolver/yup-resolver';


### PR DESCRIPTION
Exports FormList type so TS users can use it in their explicit form values definition without breaking `form.getListInputProps`.

Example of the issue:
https://codesandbox.io/s/eloquent-lake-1cb038?file=/src/Registeration.tsx