### PR TITLE
[@mantine/date]: fix am-pm for android

### DIFF
--- a/src/mantine-dates/src/components/TimeInputBase/AmPmInput/AmPmInput.tsx
+++ b/src/mantine-dates/src/components/TimeInputBase/AmPmInput/AmPmInput.tsx
@@ -32,16 +32,6 @@ export const AmPmInput = forwardRef<HTMLInputElement, AmPmSelectProps>(
         event.preventDefault();
         onChange(value === 'am' ? 'pm' : 'am', true);
       }
-
-      if (event.key === 'p' || event.nativeEvent.code === 'KeyP') {
-        event.preventDefault();
-        onChange('pm', true);
-      }
-
-      if (event.key === 'a' || event.nativeEvent.code === 'KeyA') {
-        event.preventDefault();
-        onChange('am', true);
-      }
     };
 
     /*
@@ -49,7 +39,21 @@ export const AmPmInput = forwardRef<HTMLInputElement, AmPmSelectProps>(
       This way, all key presses focus nextRef and don't steal it back
       Anything beside a or p will leave the value and just move to the next field
     */
-    const handleChange = () => {
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const lastInputVal = event.target.value.slice(-1).toLowerCase();
+
+      if (lastInputVal === 'p') {
+        event.preventDefault();
+        onChange('pm', true);
+        return;
+      }
+
+      if (lastInputVal === 'a') {
+        event.preventDefault();
+        onChange('am', true);
+        return;
+      }
+
       onChange(value.toString(), true);
     };
 

--- a/src/mantine-dates/src/components/TimeInputBase/AmPmInput/AmPmInput.tsx
+++ b/src/mantine-dates/src/components/TimeInputBase/AmPmInput/AmPmInput.tsx
@@ -34,11 +34,6 @@ export const AmPmInput = forwardRef<HTMLInputElement, AmPmSelectProps>(
       }
     };
 
-    /*
-      If the field change is triggered onKeyDown, the keyUp event seems to steal focus back from the nextRef
-      This way, all key presses focus nextRef and don't steal it back
-      Anything beside a or p will leave the value and just move to the next field
-    */
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const lastInputVal = event.target.value.slice(-1).toLowerCase();
 


### PR DESCRIPTION
As android doesn't publish the key code ([issue](https://bugs.chromium.org/p/chromium/issues/detail?id=118639)) and is always undefined. Using `onChange` -> `event.target.value` to toggle am/pm