### PR TITLE
[@mantine/core] Switch: fix on / off label

### DIFF
--- a/src/mantine-core/src/components/Switch/Switch.story.tsx
+++ b/src/mantine-core/src/components/Switch/Switch.story.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
-import { DEFAULT_THEME, MANTINE_SIZES } from '@mantine/styles';
+import { DEFAULT_THEME, MantineSize, MANTINE_SIZES } from '@mantine/styles';
 import { Switch, SwitchProps } from './Switch';
 
 function SwitchWrapper(props: Omit<SwitchProps, 'value' | 'onChange'>) {
@@ -23,7 +23,24 @@ const getThemes = (props?: Partial<SwitchProps>) =>
     <Switch key={color} color={color} {...props} label={color} style={{ marginTop: 15 }} />
   ));
 
+  const switchWithLabels = [
+    { on: 'D', off: 'L', size: 'md' },
+    { on: 'On', off: 'Off', size: 'lg' },
+    { on: 'Dark', off: 'Light', size: 'xl' },
+  ].map((label) => (
+    <Switch
+      color="blue"
+      label={`On: ${label.on} Off: ${label.off}`}
+      key={label.on}
+      size={label.size as MantineSize}
+      onLabel={label.on}
+      offLabel={label.off}
+      style={{ marginTop: 15 }}
+    />
+));
+
 storiesOf('Switch', module)
   .add('Themes', () => <div style={{ padding: 15 }}>{getThemes({ checked: true })}</div>)
   .add('Sizes', () => <div style={{ padding: 15 }}>{sizes}</div>)
+  .add('With on off labels', () => <div style={{ padding: 15 }}>{switchWithLabels}</div>)
   .add('Controlled', () => <SwitchWrapper label="Controlled" style={{ padding: 15 }} />);

--- a/src/mantine-core/src/components/Switch/Switch.story.tsx
+++ b/src/mantine-core/src/components/Switch/Switch.story.tsx
@@ -23,20 +23,20 @@ const getThemes = (props?: Partial<SwitchProps>) =>
     <Switch key={color} color={color} {...props} label={color} style={{ marginTop: 15 }} />
   ));
 
-  const switchWithLabels = [
-    { on: 'D', off: 'L', size: 'md' },
-    { on: 'On', off: 'Off', size: 'lg' },
-    { on: 'Dark', off: 'Light', size: 'xl' },
-  ].map((label) => (
-    <Switch
-      color="blue"
-      label={`On: ${label.on} Off: ${label.off}`}
-      key={label.on}
-      size={label.size as MantineSize}
-      onLabel={label.on}
-      offLabel={label.off}
-      style={{ marginTop: 15 }}
-    />
+const switchWithLabels = [
+  { on: 'D', off: 'L', size: 'md' },
+  { on: 'On', off: 'Off', size: 'lg' },
+  { on: 'Dark', off: 'Light', size: 'xl' },
+].map((label) => (
+  <Switch
+    color="blue"
+    label={`On: ${label.on} Off: ${label.off}`}
+    key={label.on}
+    size={label.size as MantineSize}
+    onLabel={label.on}
+    offLabel={label.off}
+    style={{ marginTop: 15 }}
+  />
 ));
 
 storiesOf('Switch', module)

--- a/src/mantine-core/src/components/Switch/Switch.styles.ts
+++ b/src/mantine-core/src/components/Switch/Switch.styles.ts
@@ -127,9 +127,17 @@ export default createStyles(
           },
 
           '&::after': {
-            transform: 'translateX(-200%)',
+            position: 'absolute',
+            zIndex: 0,
+            display: 'flex',
+            height: '100%',
+            alignItems: 'center',
+            lineHeight: 0,
+            left: '10%',
+            transform: 'translateX(0)',
             content: onLabel ? `'${onLabel}'` : "''",
             color: theme.white,
+            transition: `color 150ms ${theme.transitionTimingFunction}`,
           },
         },
 


### PR DESCRIPTION
Fix issue: https://github.com/mantinedev/mantine/issues/1582

The on label for the switch had incorrect styling resulting in the label not being visible. To fix this I just copied the styles from the off label which was showing correctly. I added some stories as well

<img width="364" alt="image" src="https://user-images.githubusercontent.com/36892129/172516557-270a625f-5d3a-4c8c-b672-575b60489ff7.png">

<img width="421" alt="image" src="https://user-images.githubusercontent.com/36892129/172516634-06ee10b2-8ecf-46d9-9eeb-51bfad8293ed.png">
