### PR TITLE
[@mantine/core] TypographyStylesProvider: Add missing `px`

### DIFF
--- a/src/mantine-core/src/components/TypographyStylesProvider/TypographyStylesProvider.styles.ts
+++ b/src/mantine-core/src/components/TypographyStylesProvider/TypographyStylesProvider.styles.ts
@@ -76,7 +76,7 @@ export default createStyles((theme) => {
 
       '& code': {
         lineHeight: theme.lineHeight,
-        padding: `1px ${theme.spacing.xs / 1}`,
+        padding: `1px ${theme.spacing.xs / 1}px`,
         borderRadius: theme.radius.sm,
         color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
         backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[9] : theme.colors.gray[0],


### PR DESCRIPTION
This PR fixes the missing `px` unit for the TypographyStylesProvider code.

|Screenshot|
|-|
|<img width="183" alt="Screenshot 2022-06-12 at 10 54 45 AM" src="https://user-images.githubusercontent.com/6391763/173217133-8b0bd16f-0a72-4635-b84f-ccf03ce852ee.png">|