### PR TITLE
[@mantine/core]: Changing the Group types to allow 'row-reverse' and 'column-reverse'

### DIFF
--- a/src/mantine-core/src/components/Group/Group.tsx
+++ b/src/mantine-core/src/components/Group/Group.tsx
@@ -18,7 +18,7 @@ export interface GroupProps extends DefaultProps, React.ComponentPropsWithoutRef
   spacing?: MantineNumberSize;
 
   /** Defines flex-direction property, row for horizontal, column for vertical */
-  direction?: 'row' | 'column';
+  direction?: 'row' | 'column' | 'row-reverse' | 'column-reverse';
 
   /** Defines align-items css property */
   align?: React.CSSProperties['alignItems'];


### PR DESCRIPTION
Not much need for an explanation it is a small change.

Stop the Type checking issues when using 'row-reverse' and 'column-reverse', the visual aspect work just fine so only needed to amend the types.