### PR TITLE
[@mantine/prism] Feature: allow overriding PrismTheme

### DIFF
--- a/docs/src/docs/others/prism.mdx
+++ b/docs/src/docs/others/prism.mdx
@@ -80,6 +80,12 @@ You can force dark/light color scheme by setting `colorScheme` prop:
 
 <Demo data={PrismDemos.colorSchemeOverride} />
 
+## Dynamically override the theme
+
+You can also customize the syntax highlighting rules by setting `getPrismTheme` prop:
+
+<Demo data={PrismDemos.themeOverride} />
+
 ## Languages
 
 Component supports all languages which are supported by [prism-react-renderer](https://github.com/FormidableLabs/prism-react-renderer):

--- a/docs/src/docs/others/prism.mdx
+++ b/docs/src/docs/others/prism.mdx
@@ -78,7 +78,7 @@ To display multiple files use `Prism.Tabs` component, it supports the same props
 
 You can force dark/light color scheme by setting `colorScheme` prop:
 
-<Demo data={PrismDemos.themeOverride} />
+<Demo data={PrismDemos.colorSchemeOverride} />
 
 ## Languages
 

--- a/src/mantine-demos/src/demos/prism/Prism.demo.colorSchemeOverride.tsx
+++ b/src/mantine-demos/src/demos/prism/Prism.demo.colorSchemeOverride.tsx
@@ -25,7 +25,7 @@ function Demo() {
   );
 }
 
-export const themeOverride: MantineDemo = {
+export const colorSchemeOverride: MantineDemo = {
   type: 'demo',
   component: Demo,
   code,

--- a/src/mantine-demos/src/demos/prism/Prism.demo.themeOverride.tsx
+++ b/src/mantine-demos/src/demos/prism/Prism.demo.themeOverride.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Prism, getPrismTheme as defaultGetPrismTheme, PrismThemeSelector } from '@mantine/prism';
+
+const demoCode = `
+export interface MantineProviderProps {
+  theme?: MantineThemeOverride;
+  styles?: ProviderStyles;
+  classNames?: ProviderClassNames;
+  defaultProps?: MantineDefaultProps;
+  emotionOptions?: EmotionCacheOptions;
+  withNormalizeCSS?: boolean;
+  withGlobalStyles?: boolean;
+  withCSSVariables?: boolean;
+  children: React.ReactNode;
+  inherit?: boolean;
+}
+const getPrismTheme = (theme, colorScheme) => {};
+getPrismTheme(mantineTheme, colorScheme);
+`;
+
+const code = `
+import React from 'react';
+import { Prism, getPrismTheme as defaultGetPrismTheme, type PrismThemeSelector } from '@mantine/prism';
+
+const getPrismTheme: PrismThemeSelector = (theme, colorScheme) => {
+  if (colorScheme === 'dark') {
+    // We can chain to the defaults if we want
+    return defaultGetPrismTheme(theme, colorScheme);
+  }
+  // Or completely override the theme to just highlight certain tokens
+  return {
+    plain: {
+      color: theme.colors.gray[9],
+      backgroundColor: theme.colors.gray[0],
+    },
+
+    styles: [
+      {
+        types: ['class-name', 'maybe-class-name'],
+        style: {
+          color: theme.colors.red[9],
+        },
+      },
+    ],
+  };
+};
+
+function Demo() {
+  return (
+    <Prism language="tsx" getPrismTheme={getPrismTheme}>
+      {demoCode}
+    </Prism>
+  );
+}
+`;
+
+const getPrismTheme: PrismThemeSelector = (theme, colorScheme) => {
+  if (colorScheme === 'dark') {
+    // We can chain to the defaults if we want
+    return defaultGetPrismTheme(theme, colorScheme);
+  }
+  // Or completely override the theme to just highlight certain tokens
+  return {
+    plain: {
+      color: theme.colors.gray[9],
+      backgroundColor: theme.colors.gray[0],
+    },
+
+    styles: [
+      {
+        types: ['class-name', 'maybe-class-name'],
+        style: {
+          color: theme.colors.red[9],
+        },
+      },
+    ],
+  };
+};
+
+function Demo() {
+  return (
+    <Prism language="tsx" getPrismTheme={getPrismTheme}>
+      {demoCode}
+    </Prism>
+  );
+}
+
+export const themeOverride: MantineDemo = {
+  type: 'demo',
+  component: Demo,
+  code,
+};

--- a/src/mantine-demos/src/demos/prism/index.ts
+++ b/src/mantine-demos/src/demos/prism/index.ts
@@ -1,6 +1,6 @@
 export { languages } from './Prism.demo.languages';
 export { copyLabel } from './Prism.demo.copyLabel';
-export { themeOverride } from './Prism.demo.themeOverride';
+export { colorSchemeOverride } from './Prism.demo.colorSchemeOverride';
 export { linesHighlight } from './Prism.demo.linesHighlight';
 export { lineNumbers } from './Prism.demo.lineNumbers';
 export { usage } from './Prism.demo.usage';

--- a/src/mantine-demos/src/demos/prism/index.ts
+++ b/src/mantine-demos/src/demos/prism/index.ts
@@ -5,4 +5,5 @@ export { linesHighlight } from './Prism.demo.linesHighlight';
 export { lineNumbers } from './Prism.demo.lineNumbers';
 export { usage } from './Prism.demo.usage';
 export { tabs } from './Prism.demo.tabs';
+export { themeOverride } from './Prism.demo.themeOverride';
 export { scrollbars } from './Prism.demo.scrollbars';

--- a/src/mantine-prism/src/Prism.story.tsx
+++ b/src/mantine-prism/src/Prism.story.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Prism } from './Prism';
+import { getPrismTheme as defaultGetPrismTheme } from './prism-theme';
+import type { PrismThemeSelector } from './types';
 
 const code2 = Array(20)
   .fill(0)
@@ -24,5 +26,51 @@ export const TwoDigitLineNumbers = () => (
 export const ThreeDigitLineNumbers = () => (
   <Prism language="javascript" withLineNumbers>
     {code3}
+  </Prism>
+);
+
+const getPrismTheme: PrismThemeSelector = (theme, colorScheme) => {
+  if (colorScheme === 'dark') {
+    // We can chain to the defaults if we want
+    return defaultGetPrismTheme(theme, colorScheme);
+  }
+  // Or completely override the theme to just highlight certain tokens
+  return {
+    plain: {
+      color: theme.colors.gray[9],
+      backgroundColor: theme.colors.gray[0],
+    },
+
+    styles: [
+      {
+        types: ['class-name', 'maybe-class-name'],
+        style: {
+          color: theme.colors.red[9],
+        },
+      },
+    ],
+  };
+};
+
+const customThemeCode = `
+export interface MantineProviderProps {
+  theme?: MantineThemeOverride;
+  styles?: ProviderStyles;
+  classNames?: ProviderClassNames;
+  defaultProps?: MantineDefaultProps;
+  emotionOptions?: EmotionCacheOptions;
+  withNormalizeCSS?: boolean;
+  withGlobalStyles?: boolean;
+  withCSSVariables?: boolean;
+  children: React.ReactNode;
+  inherit?: boolean;
+}
+const getPrismTheme = (theme, colorScheme) => {};
+getPrismTheme(mantineTheme, colorScheme);
+`;
+
+export const CustomPrismTheme = () => (
+  <Prism language="typescript" withLineNumbers getPrismTheme={getPrismTheme}>
+    {customThemeCode}
   </Prism>
 );

--- a/src/mantine-prism/src/Prism.tsx
+++ b/src/mantine-prism/src/Prism.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { CopyIcon } from './CopyIcon';
-import { getPrismTheme } from './prism-theme';
+import { getPrismTheme as defaultGetPrismTheme } from './prism-theme';
 import { PrismSharedProps } from './types';
 import useStyles from './Prism.styles';
 import useTabsStyles from './PrismTabs.styles';
@@ -41,6 +41,7 @@ const prismDefaultProps: Partial<PrismProps> = {
   trim: true,
   highlightLines: {},
   scrollAreaComponent: ScrollArea,
+  getPrismTheme: defaultGetPrismTheme,
 };
 
 export const Prism: PrismComponent = forwardRef<HTMLDivElement, PrismProps>(
@@ -58,6 +59,7 @@ export const Prism: PrismComponent = forwardRef<HTMLDivElement, PrismProps>(
       highlightLines,
       scrollAreaComponent: ScrollAreaComponent,
       colorScheme,
+      getPrismTheme,
       trim,
       ...others
     } = useMantineDefaultProps('Prism', prismDefaultProps, props);
@@ -100,7 +102,7 @@ export const Prism: PrismComponent = forwardRef<HTMLDivElement, PrismProps>(
 
         <Highlight
           {...defaultProps}
-          theme={getPrismTheme(theme, colorScheme || theme.colorScheme)}
+          theme={(getPrismTheme || defaultGetPrismTheme)(theme, colorScheme || theme.colorScheme)}
           code={code}
           language={language}
         >

--- a/src/mantine-prism/src/index.ts
+++ b/src/mantine-prism/src/index.ts
@@ -8,3 +8,4 @@ export type {
   PrismTabsStylesNames,
 } from './Prism';
 export type { PrismStylesParams } from './Prism.styles';
+export type { PrismThemeSelector } from './types';

--- a/src/mantine-prism/src/prism-theme.ts
+++ b/src/mantine-prism/src/prism-theme.ts
@@ -1,5 +1,6 @@
-import { PrismTheme } from 'prism-react-renderer';
-import { MantineTheme } from '@mantine/core';
+import type { PrismTheme } from 'prism-react-renderer';
+import type { MantineTheme } from '@mantine/core';
+import type { PrismThemeSelector } from './types';
 
 export const dark = (theme: MantineTheme): PrismTheme => ({
   plain: {
@@ -183,5 +184,5 @@ export const light = (theme: MantineTheme): PrismTheme => ({
   ],
 });
 
-export const getPrismTheme = (theme: MantineTheme, colorScheme: 'light' | 'dark') =>
+export const getPrismTheme: PrismThemeSelector = (theme, colorScheme) =>
   colorScheme === 'dark' ? dark(theme) : light(theme);

--- a/src/mantine-prism/src/types.ts
+++ b/src/mantine-prism/src/types.ts
@@ -1,5 +1,5 @@
-import type { Language } from 'prism-react-renderer';
-import type { MantineColor } from '@mantine/core';
+import type { Language, PrismTheme } from 'prism-react-renderer';
+import type { MantineColor, MantineTheme } from '@mantine/core';
 
 export interface PrismSharedProps {
   /** Code which will be highlighted */
@@ -26,9 +26,14 @@ export interface PrismSharedProps {
   /** Force color scheme, defaults to theme.colorScheme */
   colorScheme?: 'dark' | 'light';
 
+  /** Override the PrismTheme syntax rules @see {https://github.com/FormidableLabs/prism-react-renderer#theming} */
+  getPrismTheme?: PrismThemeSelector;
+
   /** Change scroll area component */
   scrollAreaComponent?: any;
 
   /** Defines whether the code should be trimmed, defaults to true */
   trim?: boolean;
 }
+
+export type PrismThemeSelector = (theme: MantineTheme, colorScheme: 'light' | 'dark') => PrismTheme;


### PR DESCRIPTION
PR implementing: https://github.com/mantinedev/mantine/discussions/1528#discussion-4104092
Replaces #1529 (now off of master instead of dev).

## Why

It'd be great if consumers could use @mantine/prism, while customizing the specific colors being selected for different language-tokens to better highlight what the user is trying to focus on.

Generally speaking, I find @mantine's color selections to be very legible, but as a slightly colorblind person, I strongly appreciate the ability to adjust which colors are selected for specific tokens.

By customizing the PrismTheme, a user can make specific tokens pop-out in a rendered code-block.

## How

Expose the call-site of `getPrismTheme` so users can provide their own method matching the same signature.
- https://github.com/mantinedev/mantine/blob/97349accc5632aefabb1a86d91a6f4b221e534cf/src/mantine-prism/src/Prism.tsx#L101-L106
- https://github.com/mantinedev/mantine/blob/97349accc5632aefabb1a86d91a6f4b221e534cf/src/mantine-prism/src/prism-theme.ts#L186-L187