### PR TITLE
[docs] Dropzone: strict mode adjustment

### DIFF
--- a/src/mantine-demos/src/demos/dropzone/Dropzone.demo.manual.tsx
+++ b/src/mantine-demos/src/demos/dropzone/Dropzone.demo.manual.tsx
@@ -8,7 +8,7 @@ import { Button, Group } from '@mantine/core';
 import { Dropzone } from '@mantine/dropzone';
 
 function Demo() {
-  const openRef = useRef<() => void>();
+  const openRef = useRef<() => void>(null);
 
   return (
     <>
@@ -25,7 +25,7 @@ function Demo() {
 `;
 
 function Demo() {
-  const openRef = useRef<() => void>();
+  const openRef = useRef<() => void>(null);
 
   return (
     <>


### PR DESCRIPTION
Adding null to useRef so that TypeScript does not throw an error when using this example inside a TS file. 