### PR TITLE
Fix checkbox icon size issue before CSS page load

### DIFF
--- a/src/mantine-core/src/components/Chips/Chip/Chip.tsx
+++ b/src/mantine-core/src/components/Chips/Chip/Chip.tsx
@@ -130,7 +130,7 @@ export const Chip = forwardRef<HTMLInputElement, ChipProps>((props: ChipProps, r
       >
         {value && (
           <span className={classes.iconWrapper}>
-            <CheckboxIcon indeterminate={false} className={classes.checkIcon} />
+            <CheckboxIcon indeterminate={false} className={classes.checkIcon} width={(size === "xs" && 10) || (size === "sm" && 12) || (size === "md" && 14) || (size === "lg" && 16) || (size === "xl" && 18)} />
           </span>
         )}
         {children}


### PR DESCRIPTION
This fixes the large checkbox icon issue before CSS page load. Sets the width directly on the SVG element based on the size of chip selected.