### PR TITLE
[NumberInput] Fix late focus when using controls

### DIFF
--- a/src/mantine-core/src/components/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.tsx
@@ -262,11 +262,11 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
     isIncrement: boolean
   ) => {
     event.preventDefault();
+    inputRef.current.focus();
     onStepHandleChange(isIncrement);
     if (shouldUseStepInterval) {
       onStepTimeoutRef.current = window.setTimeout(() => onStepLoop(isIncrement), stepHoldDelay);
     }
-    inputRef.current.focus();
   };
 
   useEffect(() => {


### PR DESCRIPTION
NumberInput does not seem to follow the correct order of the onChange events when using the controls. The blur of other inputs is triggered too late as the focus event is triggered after onChange. This could be resolved by triggering the focus earlier.