### PR TITLE
[@mantine/core] Fix useTransition.ts not correctly emit duration

### DIFF
--- a/src/mantine-core/src/components/Transition/use-transition.ts
+++ b/src/mantine-core/src/components/Transition/use-transition.ts
@@ -34,7 +34,7 @@ export function useTransition({
   const theme = useMantineTheme();
   const reduceMotion = useReducedMotion();
   const [transitionStatus, setStatus] = useState<TransitionStatus>(mounted ? 'entered' : 'exited');
-  const [transitionDuration, setTransitionDuration] = useState(reduceMotion ? 0 : duration);
+  let transitionDuration = reduceMotion ? 0 : duration;
   const timeoutRef = useRef<number>(-1);
 
   const handleStateChange = (shouldMount: boolean) => {
@@ -43,10 +43,9 @@ export function useTransition({
 
     setStatus(shouldMount ? 'pre-entering' : 'pre-exiting');
     window.clearTimeout(timeoutRef.current);
-    const _duration = reduceMotion ? 0 : shouldMount ? duration : exitDuration;
-    setTransitionDuration(_duration);
+    transitionDuration = reduceMotion ? 0 : shouldMount ? duration : exitDuration;
 
-    if (_duration === 0) {
+    if (transitionDuration === 0) {
       typeof preHandler === 'function' && preHandler();
       typeof handler === 'function' && handler();
       setStatus(shouldMount ? 'entered' : 'exited');
@@ -60,7 +59,7 @@ export function useTransition({
         window.clearTimeout(preStateTimeout);
         typeof handler === 'function' && handler();
         setStatus(shouldMount ? 'entered' : 'exited');
-      }, _duration);
+      }, transitionDuration);
     }
   };
 


### PR DESCRIPTION
Hi, this is my suggestion to fix the transition duration (possible temporary until the hook is also fixed) application in dev mode. It more or less is just a deletion of the useState which causes a side effect in the useDidUpdate hook where the transition duration is not correctly returned (probably cause the hook fired twice in the new React 18 strict mode). Please refer to the issue I created for a description of the faced error. #1686 

Happy to discuss