### PR TITLE
[@mantine/core] NumberInput: Only fire onChange when value really cha…

### DIFF
--- a/src/mantine-core/src/components/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.tsx
@@ -159,8 +159,10 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
   );
   const inputRef = useRef<HTMLInputElement>();
   const handleValueChange = (val: number | undefined) => {
-    typeof onChange === 'function' && onChange(val);
-    setValue(val);
+    if (val !== _value) {
+      typeof onChange === 'function' && onChange(val);
+      setValue(val);
+    }
   };
 
   const formatNum = (val: string | number = '') => {


### PR DESCRIPTION
I am not completely sure if it would be better to compare against `finalValue`, but maybe it doesn't matter.