### PR TITLE
[@mantine/hooks] use-interval: handle dynamic functions with a ref

### DIFF
--- a/src/mantine-hooks/src/use-interval/use-interval.ts
+++ b/src/mantine-hooks/src/use-interval/use-interval.ts
@@ -1,13 +1,18 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export function useInterval(fn: () => void, interval: number) {
   const [active, setActive] = useState(false);
   const intervalRef = useRef<number>();
+  const fnRef = useRef<() => void>();
+
+  useEffect(() => {
+    fnRef.current = fn;
+  }, [fn]);
 
   const start = () => {
     setActive((old) => {
       if (!old) {
-        intervalRef.current = window.setInterval(fn, interval);
+        intervalRef.current = window.setInterval(fnRef.current, interval);
       }
       return true;
     });


### PR DESCRIPTION
## Issue
The use case I ran into is polling a status api for long running reports. When I generate the report it returns the taskId and I need to poll with that taskId. This doesn't currently work with the existing hook because taskId isn't defined until the user clicks a button to generate a report.

## Solution
* Use a ref to `fn` and update the ref if the `fn` changes
* [Article that references a similar issue]( https://overreacted.io/making-setinterval-declarative-with-react-hooks/) by Dan Abramov

This now works 🎉 
```tsx
const pollingInterval = useInterval(() => {
    checkStatus({ taskId: taskIdState });
}, 1000);
```