### PR TITLE
Fix input bug with Japanese IME

### DIFF
--- a/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/mantine-core/src/components/Autocomplete/Autocomplete.tsx
@@ -119,6 +119,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
     const [direction, setDirection] = useState<React.CSSProperties['flexDirection']>('column');
     const inputRef = useRef<HTMLInputElement>(null);
     const uuid = useUuid(id);
+    const [IMEOpen, setIMEOpen] = useState(false);
     const [_value, handleChange] = useUncontrolled({
       value,
       defaultValue,
@@ -147,6 +148,10 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
     const filteredData = filterData({ data: formattedData, value: _value, limit, filter });
 
     const handleInputKeydown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (IMEOpen) {
+        return;
+      }
+
       typeof onKeyDown === 'function' && onKeyDown(event);
 
       const isColumn = direction === 'column';
@@ -259,6 +264,8 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
               setDropdownOpened(true);
             }}
             onFocus={handleInputFocus}
+            onCompositionStart={() => setIMEOpen(true)}
+            onCompositionEnd={() => setIMEOpen(false)}
             onBlur={handleInputBlur}
             onClick={handleInputClick}
             aria-autocomplete="list"

--- a/src/mantine-labs/src/TagInput/TagInput.tsx
+++ b/src/mantine-labs/src/TagInput/TagInput.tsx
@@ -157,6 +157,7 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
     const wrapperRef = useRef<HTMLDivElement>();
     const uuid = useUuid(id);
     const [inputValue, setInputValue] = useState('');
+    const [IMEOpen, setIMEOpen] = useState(false);
 
     const [_value, setValue] = useUncontrolled({
       value,
@@ -225,6 +226,10 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
     };
 
     const handleInputKeydown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (IMEOpen) {
+        return;
+      }
+
       switch (event.nativeEvent.code) {
         case 'Enter': {
           if (inputValue) {
@@ -369,6 +374,8 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
                 value={inputValue}
                 onChange={handleInputChange}
                 onFocus={handleInputFocus}
+                onCompositionStart={() => setIMEOpen(true)}
+                onCompositionEnd={() => setIMEOpen(false)}
                 onBlur={handleInputBlur}
                 readOnly={valuesOverflow.current}
                 placeholder={_value.length === 0 ? placeholder : undefined}

--- a/src/mantine-spotlight/src/Spotlight/Spotlight.tsx
+++ b/src/mantine-spotlight/src/Spotlight/Spotlight.tsx
@@ -135,6 +135,7 @@ export function Spotlight({
   ...others
 }: SpotlightProps) {
   const [hovered, setHovered] = useState(-1);
+  const [IMEOpen, setIMEOpen] = useState(false);
   const { classes, cx } = useStyles(
     { centered, maxWidth, topOffset, radius },
     { classNames, styles, name: 'Spotlight' }
@@ -164,6 +165,10 @@ export function Spotlight({
   }, [groupedActions.length]);
 
   const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (IMEOpen) {
+      return;
+    }
+
     switch (event.code) {
       case 'ArrowDown': {
         event.preventDefault();
@@ -234,6 +239,8 @@ export function Spotlight({
                   value={query}
                   onChange={handleInputChange}
                   onKeyDown={handleInputKeyDown}
+                  onCompositionStart={() => setIMEOpen(true)}
+                  onCompositionEnd={() => setIMEOpen(false)}
                   classNames={{ input: classes.searchInput }}
                   size="lg"
                   placeholder={searchPlaceholder}


### PR DESCRIPTION
Relates #1565. I faced the same issue to use Japanese IME (maybe also in Chinese IME?) on Autocomplete, TagInput and SpotLight components. So I apply the same fix of #1570 to these components.
It may relate to the type of IME and IME settings. I tested with the default Japanese IME in macOS Monterey (with enabled the live conversion setting).

## Autocomplete
### Before

https://user-images.githubusercontent.com/62416191/176714240-8a90959d-38f4-48cf-9733-3ffd44e737a2.mov

### Fixed

https://user-images.githubusercontent.com/62416191/176715515-1d209542-1bb6-418f-912a-5ab15f0be84b.mov

## Spotlight

### Before

https://user-images.githubusercontent.com/62416191/176714399-819e39e1-0a22-48df-8f82-579970688705.mov

### Fixed

https://user-images.githubusercontent.com/62416191/176717652-3cb2c738-2c81-41a2-8319-cd8affa17b0b.mov

## TagInput

### Before

https://user-images.githubusercontent.com/62416191/176714485-9a840b36-bb6b-4ba2-87dd-53c37f804005.mov

### Fixed

https://user-images.githubusercontent.com/62416191/176717760-e7f0f18e-9f4f-440e-b6cb-c242594e384d.mov
