### PR TITLE
[@mantine/core] NumberInput: Fixes repeating keys when step on hold is used

### DIFF
--- a/src/mantine-core/src/components/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.tsx
@@ -349,7 +349,11 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
     };
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-      if (event.repeat && shouldUseStepInterval) {
+      if (
+        event.repeat &&
+        shouldUseStepInterval &&
+        (event.key === 'ArrowUp' || event.key === 'ArrowDown')
+      ) {
         event.preventDefault();
         return;
       }


### PR DESCRIPTION
As mentioned on [Discord](https://discord.com/channels/854810300876062770/972850721244471436/993098144067899472). Fixes that NumberField does not respect repeating keys (by holding them long) when "stop on hold" is used.