### PR TITLE
[@mantine/hooks] use-hotkeys: Fix contenteditable event handling

### DIFF
--- a/src/mantine-hooks/src/use-hotkeys/use-hotkeys.ts
+++ b/src/mantine-hooks/src/use-hotkeys/use-hotkeys.ts
@@ -7,7 +7,10 @@ export type HotkeyItem = [string, (event: KeyboardEvent) => void];
 
 function shouldFireEvent(event: KeyboardEvent) {
   if (event.target instanceof HTMLElement) {
-    return !['INPUT', 'TEXTAREA', 'SELECT'].includes(event.target.tagName);
+    return (
+      !event.target.isContentEditable &&
+      !['INPUT', 'TEXTAREA', 'SELECT'].includes(event.target.tagName)
+    );
   }
   return true;
 }


### PR DESCRIPTION
Fixes #1749

### Testing
Tested manually by adding a global hotkey to one of the stories in `RichTextEditor.story.tsx`.

```typescript
// RichTextEditor.story.tsx
export function Usage() {
  const [value, onChange] = useState(html);
  useHotkeys([['shift + b', () => console.log('Triggered')]]);
  return (
    <div style={{ padding: 40, maxWidth: 800, margin: 'auto' }}>
      <RichTextEditor
        value={value}
        onChange={onChange}
        onImageUpload={handleImageUpload}
        stickyOffset={0}
      />
    </div>
  );
}
```

_Note: I'm happy to write unit/integration tests for this if needed!_

### Results
- _Without_ this fix, the hotkey fired while typing within the `RichTextEditor`
- _With_ the fix, the hotkey did not fire, indicating that the bug was fixed
- In addition, all unit tests passed

