### PR TITLE
Feature/hooks/use callback ref

### DIFF
--- a/src/mantine-hooks/src/index.ts
+++ b/src/mantine-hooks/src/index.ts
@@ -48,6 +48,7 @@ export { useEventListener } from './use-event-listener/use-event-listener';
 export { useDisclosure } from './use-disclosure/use-disclosure';
 export { useFocusWithin } from './use-focus-within/use-focus-within';
 export { useNetwork } from './use-network/use-network';
+export { useCallbackRef } from './use-callback-ref/use-callback-ref';
 
 export type { UseMovePosition } from './use-move/use-move';
 export type { OS } from './use-os/use-os';

--- a/src/mantine-hooks/src/use-callback-ref/use-callback-ref.ts
+++ b/src/mantine-hooks/src/use-callback-ref/use-callback-ref.ts
@@ -1,0 +1,11 @@
+import { useLayoutEffect, useRef } from 'react';
+
+export function useCallbackRef<T>(callback: T) {
+  const callbackRef = useRef(callback);
+
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  return callbackRef;
+}

--- a/src/mantine-hooks/src/use-debounced-value/use-debounced-value.ts
+++ b/src/mantine-hooks/src/use-debounced-value/use-debounced-value.ts
@@ -3,7 +3,7 @@ import { useEffect, useState, useRef } from 'react';
 export function useDebouncedValue<T = any>(value: T, wait: number, options = { leading: false }) {
   const [_value, setValue] = useState(value);
   const mountedRef = useRef(false);
-  const timeoutRef = useRef<number>(null);
+  const timeoutRef = useRef<number | null>(null);
   const cooldownRef = useRef(false);
 
   const cancel = () => window.clearTimeout(timeoutRef.current);
@@ -21,7 +21,7 @@ export function useDebouncedValue<T = any>(value: T, wait: number, options = { l
         }, wait);
       }
     }
-  }, [value, options.leading]);
+  }, [value, options.leading, wait]);
 
   useEffect(() => {
     mountedRef.current = true;


### PR DESCRIPTION
[use-callback-ref]: Added new hook useCallbackRef. This helps to create a ref for the incoming props whose references change every time the app re-renders. This can be achieved by useRef but useRef takes the initial value and it does not change. But this hook helps to create a ref which values changes on prop value changes.