### PR TITLE
[docs] `setCookies` being deprecated

### DIFF
--- a/docs/src/docs/theming/dark-theme.mdx
+++ b/docs/src/docs/theming/dark-theme.mdx
@@ -192,7 +192,7 @@ import { GetServerSidePropsContext } from 'next';
 import { useState } from 'react';
 import { AppProps } from 'next/app';
 // install cookies-next package to manage cookies
-import { getCookie, setCookies } from 'cookies-next';
+import { getCookie, setCookie } from 'cookies-next';
 import { MantineProvider, ColorScheme, ColorSchemeProvider } from '@mantine/core';
 
 export default function App(props: AppProps & { colorScheme: ColorScheme }) {


### PR DESCRIPTION
`setCookies` method is being deprecated in favour of `setCookie` as discussed in PR https://github.com/andreizanik/cookies-next/pull/21

It is giving console warnings, we should better update our code with `setCookie`. It works as expected.