### PR TITLE
[@mantine/core/select] Select: passed name props to component

### DIFF
--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -604,7 +604,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>((props: SelectPr
           readOnly={!searchable}
           disabled={disabled}
           data-mantine-stop-propagation={shouldShowDropdown}
-          name={null}
+          name={name}
           classNames={{
             ...classNames,
             input: cx({ [classes.input]: !searchable }, classNames?.input),


### PR DESCRIPTION
Explicit transfer of the `props.name` property to the `Input` component, for correct processing of the `onBlur` event.

https://github.com/mantinedev/mantine/discussions/1767