### PR TITLE
[@mantine/core] Timeline: Allow manually overriding of active state

### DIFF
--- a/src/mantine-core/src/components/Timeline/Timeline.test.tsx
+++ b/src/mantine-core/src/components/Timeline/Timeline.test.tsx
@@ -14,6 +14,17 @@ const defaultProps = {
   ],
 };
 
+const manualActiveStates = {
+  children: [
+    <Timeline.Item key="1" title="Hello" bullet="$">
+      1
+    </Timeline.Item>,
+    <Timeline.Item key="2">2</Timeline.Item>,
+    <Timeline.Item key="3" active={false} lineActive={false}>3</Timeline.Item>,
+    <Timeline.Item key="4" active={true}>4</Timeline.Item>,
+  ],
+};
+
 describe('@mantine/core/Timeline', () => {
   itSupportsSystemProps({
     component: Timeline,
@@ -28,7 +39,7 @@ describe('@mantine/core/Timeline', () => {
     <Timeline.Item>Child 2</Timeline.Item>,
   ]);
 
-  it('handles active item correctly', () => {
+  it('handles active item correctly on Timeline', () => {
     const { container: secondActive } = render(<Timeline {...defaultProps} active={1} />);
     const { container: thirdActive } = render(<Timeline {...defaultProps} active={2} />);
 
@@ -37,6 +48,21 @@ describe('@mantine/core/Timeline', () => {
 
     expect(thirdActive.querySelectorAll('.mantine-Timeline-itemActive')).toHaveLength(3);
     expect(thirdActive.querySelectorAll('.mantine-Timeline-itemLineActive')).toHaveLength(2);
+  });
+
+  it('handles active item correctly on Timeline.Item', () => {
+    const { container: fourthActive } = render(<Timeline {...manualActiveStates} active={-1} />);
+    const { container: toSecondAndFourthActive } = render(<Timeline {...manualActiveStates} active={1} />);
+    const { container: thirdNotActive } = render(<Timeline {...manualActiveStates} active={3} />);
+
+    expect(fourthActive.querySelectorAll('.mantine-Timeline-itemActive')).toHaveLength(1);
+    expect(fourthActive.querySelectorAll('.mantine-Timeline-itemLineActive')).toHaveLength(0);
+
+    expect(toSecondAndFourthActive.querySelectorAll('.mantine-Timeline-itemActive')).toHaveLength(3);
+    expect(toSecondAndFourthActive.querySelectorAll('.mantine-Timeline-itemLineActive')).toHaveLength(1);
+
+    expect(thirdNotActive.querySelectorAll('.mantine-Timeline-itemActive')).toHaveLength(3);
+    expect(thirdNotActive.querySelectorAll('.mantine-Timeline-itemLineActive')).toHaveLength(2);
   });
 
   it('exposes TimelineItem as Timeline.Item', () => {

--- a/src/mantine-core/src/components/Timeline/Timeline.tsx
+++ b/src/mantine-core/src/components/Timeline/Timeline.tsx
@@ -81,10 +81,10 @@ export const Timeline: TimelineComponent = forwardRef<HTMLDivElement, TimelinePr
         color: item.props.color || color,
         bulletSize: item.props.bulletSize || bulletSize,
         active:
-          item.props.active ||
+          item.props.active ??
           (reverseActive ? active >= _children.length - index - 1 : active >= index),
         lineActive:
-          item.props.lineActive ||
+          item.props.lineActive ??
           (reverseActive ? active >= _children.length - index - 1 : active - 1 >= index),
       })
     );


### PR DESCRIPTION
I was surprised that I was able to set `active={true}` (or just `active`) on a `Timeline.Item` to turn on the active presentation of an item, but if it was covered by `Timeline`’s `active` I was unable to set `active={false}` to turn off the active presentation.

Turns out falsy values for `active` were being ignored and always turned the element over to `Timeline`’s control. I propose to only let `Timeline` handle active state in case of `undefined`.

I am not too happy with the test, but it seems to confirm my fix. Not sure how deep Mantine usually goes with tests. Let me know if there is anything there you would want me to tweak!

Thanks for the awesome UI project ❤️ 