### PR TITLE
[@mantine/styles]: Fix radius function type, to be optional

### DIFF
--- a/src/mantine-styles/src/theme/functions/fns/radius/radius.ts
+++ b/src/mantine-styles/src/theme/functions/fns/radius/radius.ts
@@ -1,7 +1,7 @@
 import type { MantineThemeBase, MantineNumberSize } from '../../../types';
 
 export function radius(theme: MantineThemeBase) {
-  return (size: MantineNumberSize | (string & {})): string | number => {
+  return (size?: MantineNumberSize | (string & {})): string | number => {
     if (typeof size === 'number') {
       return size;
     }


### PR DESCRIPTION
Made the `size` parameter optional, since the function already defaults to the `defaultRadius` from line 9-12.