### PR TITLE
[@mantine/dates] Add paginateBy property for Range Calendar

### DIFF
--- a/src/mantine-dates/src/components/CalendarBase/CalendarBase.tsx
+++ b/src/mantine-dates/src/components/CalendarBase/CalendarBase.tsx
@@ -29,6 +29,9 @@ export interface CalendarSharedProps extends DefaultProps<CalendarBaseStylesName
   /** Amount of months */
   amountOfMonths?: number;
 
+  /** Paginate by amount of months */
+  paginateBy?: number;
+
   /** Selected value */
   value?: Date | Date[] | null;
 
@@ -96,6 +99,7 @@ export const CalendarBase = forwardRef<HTMLDivElement, CalendarBaseProps>(
       onMonthChange,
       locale,
       amountOfMonths = 1,
+      paginateBy,
       size = 'sm',
       allowLevelChange = true,
       initialLevel = 'date',
@@ -292,6 +296,7 @@ export const CalendarBase = forwardRef<HTMLDivElement, CalendarBaseProps>(
         {selectionState === 'date' && (
           <MonthsList
             amountOfMonths={amountOfMonths}
+            paginateBy={paginateBy}
             month={_month}
             locale={finalLocale}
             minDate={minDate}

--- a/src/mantine-dates/src/components/CalendarBase/CalendarBase.tsx
+++ b/src/mantine-dates/src/components/CalendarBase/CalendarBase.tsx
@@ -99,7 +99,7 @@ export const CalendarBase = forwardRef<HTMLDivElement, CalendarBaseProps>(
       onMonthChange,
       locale,
       amountOfMonths = 1,
-      paginateBy,
+      paginateBy = amountOfMonths,
       size = 'sm',
       allowLevelChange = true,
       initialLevel = 'date',

--- a/src/mantine-dates/src/components/CalendarBase/MonthsList/MonthsList.test.tsx
+++ b/src/mantine-dates/src/components/CalendarBase/MonthsList/MonthsList.test.tsx
@@ -6,6 +6,7 @@ import { MonthsList, MonthsListProps } from './MonthsList';
 
 const defaultProps: MonthsListProps = {
   amountOfMonths: 1,
+  paginateBy: 1,
   month: new Date(2021, 11, 1),
   locale: 'en',
   allowLevelChange: true,

--- a/src/mantine-dates/src/components/CalendarBase/MonthsList/MonthsList.tsx
+++ b/src/mantine-dates/src/components/CalendarBase/MonthsList/MonthsList.tsx
@@ -72,9 +72,7 @@ export function MonthsList({
             hasPrevious={index === 0 && isMonthInRange({ date: previousMonth, minDate, maxDate })}
             label={formatMonthLabel({ month: monthDate, locale, format: labelFormat })}
             onNext={() => onMonthChange(dayjs(month).add(paginateBy, 'months').toDate())}
-            onPrevious={() =>
-              onMonthChange(dayjs(month).subtract(paginateBy, 'months').toDate())
-            }
+            onPrevious={() => onMonthChange(dayjs(month).subtract(paginateBy, 'months').toDate())}
             onNextLevel={onNextLevel}
             nextLevelDisabled={!allowLevelChange}
             size={size}

--- a/src/mantine-dates/src/components/CalendarBase/MonthsList/MonthsList.tsx
+++ b/src/mantine-dates/src/components/CalendarBase/MonthsList/MonthsList.tsx
@@ -12,6 +12,7 @@ export interface MonthsListProps
   extends DefaultProps<MonthsListStylesNames>,
     Omit<MonthProps, 'styles' | 'classNames' | 'daysRefs' | 'onDayKeyDown'> {
   amountOfMonths: number;
+  paginateBy: number;
   month: Date;
   locale: string;
   allowLevelChange: boolean;
@@ -33,6 +34,7 @@ export interface MonthsListProps
 
 export function MonthsList({
   amountOfMonths,
+  paginateBy,
   month,
   locale,
   minDate,
@@ -69,9 +71,9 @@ export function MonthsList({
             }
             hasPrevious={index === 0 && isMonthInRange({ date: previousMonth, minDate, maxDate })}
             label={formatMonthLabel({ month: monthDate, locale, format: labelFormat })}
-            onNext={() => onMonthChange(dayjs(month).add(amountOfMonths, 'months').toDate())}
+            onNext={() => onMonthChange(dayjs(month).add(paginateBy, 'months').toDate())}
             onPrevious={() =>
-              onMonthChange(dayjs(month).subtract(amountOfMonths, 'months').toDate())
+              onMonthChange(dayjs(month).subtract(paginateBy, 'months').toDate())
             }
             onNextLevel={onNextLevel}
             nextLevelDisabled={!allowLevelChange}

--- a/src/mantine-dates/src/components/RangeCalendar/RangeCalendar.story.tsx
+++ b/src/mantine-dates/src/components/RangeCalendar/RangeCalendar.story.tsx
@@ -14,7 +14,7 @@ function WrappedRangeCalendar(props: Partial<RangeCalendarProps>) {
 storiesOf('RangeCalendar', module)
   .add('First day of the week sunday', () => <WrappedRangeCalendar firstDayOfWeek="sunday" />)
   .add('2 months', () => <WrappedRangeCalendar amountOfMonths={2} />)
-  .add('3 months', () => <WrappedRangeCalendar amountOfMonths={3} />)
+  .add('3 months', () => <WrappedRangeCalendar amountOfMonths={3} paginateBy={1} />)
   .add('Range styles', () => (
     <WrappedRangeCalendar
       month={new Date(2021, 11)}

--- a/src/mantine-dates/src/components/RangeCalendar/RangeCalendar.tsx
+++ b/src/mantine-dates/src/components/RangeCalendar/RangeCalendar.tsx
@@ -32,6 +32,7 @@ export const RangeCalendar = forwardRef<HTMLDivElement, RangeCalendarProps>(
       __staticSelector,
       allowSingleDateInRange,
       amountOfMonths,
+      paginateBy,
       ...others
     } = useMantineDefaultProps('RangeCalendar', defaultProps, props);
 
@@ -115,10 +116,12 @@ export const RangeCalendar = forwardRef<HTMLDivElement, RangeCalendarProps>(
         ref={ref}
         __staticSelector={__staticSelector}
         amountOfMonths={amountOfMonths}
+        paginateBy={paginateBy || amountOfMonths}
         hideOutsideDates={amountOfMonths > 1}
         isDateInRange={shouldHighlightDate}
         isDateFirstInRange={isPickedDateFirstInRange}
         isDateLastInRange={isPickedDateLastInRange}
+
         {...others}
       />
     );

--- a/src/mantine-dates/src/components/RangeCalendar/RangeCalendar.tsx
+++ b/src/mantine-dates/src/components/RangeCalendar/RangeCalendar.tsx
@@ -121,7 +121,6 @@ export const RangeCalendar = forwardRef<HTMLDivElement, RangeCalendarProps>(
         isDateInRange={shouldHighlightDate}
         isDateFirstInRange={isPickedDateFirstInRange}
         isDateLastInRange={isPickedDateLastInRange}
-
         {...others}
       />
     );


### PR DESCRIPTION
Hi, this is my suggestion for the Range calendar to specify how many months are scrolled at a time. Currently when clicking to next or previous months, the amount of months scrolled is decided by the amountOfMonths property. This update would allow the user to specify how many months are "scrolled" at a time. 

PS: Happy to discuss and thanks so much for the great project! 🙏