### PR TITLE
[@mantine/dates] Calendar: Fix bug when all days are excluded:

### DIFF
--- a/src/mantine-dates/src/components/Month/Month.tsx
+++ b/src/mantine-dates/src/components/Month/Month.tsx
@@ -186,51 +186,28 @@ export const Month = forwardRef<HTMLTableElement, MonthProps>((props: MonthProps
     dayjs(value).isAfter(dayjs(month).startOf('month')) &&
     dayjs(value).isBefore(dayjs(month).endOf('month'));
 
-  const firstDayOfMonth = useMemo(() => {
-    let actualFirstDayDisabled = false;
-    let firstDay;
+  const firstIncludedDay = useMemo(
+    () =>
+      days
+        .flatMap((_) => _)
+        .find((date) => {
+          const dayProps = getDayProps({
+            date,
+            month,
+            hasValue,
+            minDate,
+            maxDate,
+            value,
+            excludeDate,
+            disableOutsideEvents,
+            range,
+            weekendDays,
+          });
 
-    for (let i = 0; i < days.length; i += 1) {
-      if (firstDay) {
-        break;
-      }
-
-      const dates = days[i];
-      for (let j = 0; j < dates.length; j += 1) {
-        const date = dates[j];
-        const dayProps = getDayProps({
-          date,
-          month,
-          hasValue,
-          minDate,
-          maxDate,
-          value,
-          excludeDate,
-          disableOutsideEvents,
-          range,
-          weekendDays,
-        });
-
-        if (actualFirstDayDisabled && !dayProps.disabled) {
-          firstDay = date;
-          break;
-        }
-
-        const first = hideOutsideDates
-          ? isSameDate(date, dayjs(month).startOf('month').toDate())
-          : j === 0 && i === 0;
-
-        if (first && !dayProps.disabled) {
-          firstDay = date;
-          break;
-        } else if (first && dayProps.disabled) {
-          actualFirstDayDisabled = true;
-        }
-      }
-    }
-
-    return firstDay;
-  }, []);
+          return !dayProps.disabled && !dayProps.outside;
+        }) || dayjs(month).startOf('month').toDate(),
+    []
+  );
 
   const rows = days.map((row, rowIndex) => {
     const cells = row.map((date, cellIndex) => {
@@ -271,7 +248,7 @@ export const Month = forwardRef<HTMLTableElement, MonthProps>((props: MonthProps
             inRange={dayProps.inRange || isDateInRange(date, dayProps)}
             firstInRange={dayProps.firstInRange || isDateFirstInRange(date, dayProps)}
             lastInRange={dayProps.lastInRange || isDateLastInRange(date, dayProps)}
-            firstInMonth={isSameDate(date, firstDayOfMonth)}
+            firstInMonth={isSameDate(date, firstIncludedDay)}
             selected={dayProps.selected || dayProps.selectedInRange}
             hasValue={hasValueInMonthRange}
             onKeyDown={(event) =>


### PR DESCRIPTION
Bare minimum to re-produce:

```
import React, { useState } from 'react';
import { Calendar } from '@mantine/dates';

function Demo() {
  const [value, setValue] = useState(null);
  
  return (<Calendar
    value={value}
    onChange={setValue}
    excludeDate={() => true}
  />);
}
```

The bug was caused because of a loop to find the first non-excluded date and then used in another function call.
The loop couldn't find a proper day so it was returning undefined, which caused the bug.

Fix for: #1784 