### PR TITLE
[@mantine/dates]: TimeInput: Fix opacity applied twice when disabled

### DIFF
--- a/src/mantine-dates/src/components/TimeInput/TimeInput.styles.ts
+++ b/src/mantine-dates/src/components/TimeInput/TimeInput.styles.ts
@@ -9,7 +9,6 @@ export default createStyles((theme, { size }: TimeInputStylesParams) => ({
   amPmInput: {},
 
   disabled: {
-    opacity: 0.6,
     cursor: 'not-allowed',
   },
 


### PR DESCRIPTION
Disabled time input had opacity set on both the component and wrapper, causing the final opacity to be incorrect.

fix for [#1795](https://github.com/mantinedev/mantine/issues/1795)