### PR TITLE
[Docs] Remove form list documentation

### DIFF
--- a/docs/src/docs/form/use-form.mdx
+++ b/docs/src/docs/form/use-form.mdx
@@ -61,7 +61,6 @@ Hook returns an object with the following properties:
 - `onReset` – wrapper function for form `onReset` event handler
 - `reset` – resets `values` to initial state, clears all validation errors
 - `getInputProps` – returns an object with value, onChange and error that should be spread on input
-- `getListInputProps` – returns an object with value, onChange and error that should be spread on input that is used to manage list value
 
 ## UseFormReturnType
 


### PR DESCRIPTION
This prop [has been](https://github.com/mantinedev/mantine/commit/102a62ec48a90857090afc915443ffbecaa249b6#diff-885f0cbfb62b24bda2ed7145a69597b51a67fabc68b78fde5b672962ed97559eL192) removed and should no longer be mentioned in the api overview