### PR TITLE
[@mantine/dates] Fix capitalization of date input state

### DIFF
--- a/src/mantine-dates/src/components/DatePicker/DatePicker.tsx
+++ b/src/mantine-dates/src/components/DatePicker/DatePicker.tsx
@@ -155,7 +155,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
       }
 
       if (value instanceof Date && !focused) {
-        setInputState(dayjs(value).locale(finalLocale).format(dateFormat));
+        setInputState(upperFirst(dayjs(value).locale(finalLocale).format(dateFormat)));
       }
     }, [value, focused]);
 


### PR DESCRIPTION
Fixes the capitalization issue in #1844 - just one place appeared to be missing the `upperFirst` call.