### PR TITLE
Update use-focus-return.mdx to reflect 5.0.0 changes

### DIFF
--- a/docs/src/docs/hooks/use-focus-return.mdx
+++ b/docs/src/docs/hooks/use-focus-return.mdx
@@ -41,7 +41,6 @@ If `shouldReturnFocus` option is set to `false` you can call returned function t
 ```tsx
 const returnFocus = useFocusReturn({
   opened: false,
-  transitionDuration: 200,
   shouldReturnFocus: false,
 });
 


### PR DESCRIPTION
Update docs to reflect the removal of `transitionDuration` prop due to changes in [use-focus-trap]