### PR TITLE
[@mantine/core] fix: Invalid background-image property in Button

### DIFF
--- a/src/mantine-core/src/Button/Button.styles.ts
+++ b/src/mantine-core/src/Button/Button.styles.ts
@@ -94,7 +94,6 @@ function getVariantStyles({ variant, theme, color, gradient }: GetVariantStyles)
   return {
     border: `1px solid ${colors.border}`,
     backgroundColor: colors.background,
-    backgroundImage: colors.background,
     color: colors.color,
     ...theme.fn.hover({
       backgroundColor: colors.hover,


### PR DESCRIPTION
#1717 , when a variant is not 'gradient', maybe don't need the 'background-image', which now returns invalid value 'transparent'.
![image](https://user-images.githubusercontent.com/103186898/180772908-350e16fb-4c12-4307-aa91-78f807b24750.png)
