### PR TITLE
[@mantine/demos]: Corrected Typo error on Docs of Form Validation

### DIFF
--- a/src/mantine-demos/src/demos/form/Form.demo.password.tsx
+++ b/src/mantine-demos/src/demos/form/Form.demo.password.tsx
@@ -11,7 +11,7 @@ function Demo() {
   const form = useForm({
     initialValues: {
       password: 'secret',
-      confirmPassword: 'sevret',
+      confirmPassword: 'secret',
     },
 
     validate: {


### PR DESCRIPTION
Typo error on initialValues of useForm() function. Both should be the same value.