### PR TITLE
[@mantine/prism] no translate

### DIFF
--- a/src/mantine-prism/src/Prism/Prism.tsx
+++ b/src/mantine-prism/src/Prism/Prism.tsx
@@ -101,7 +101,7 @@ export const Prism = forwardRef<HTMLDivElement, PrismProps>((props: PrismProps, 
   );
 
   return (
-    <Box className={cx(classes.root, className)} ref={ref} {...others}>
+    <Box className={cx(classes.root, className)} ref={ref} {...others} translate="no">
       {!noCopy && (
         <Tooltip
           label={clipboard.copied ? copiedLabel : copyLabel}

--- a/src/mantine-prism/src/PrismTabs/PrismTabs.tsx
+++ b/src/mantine-prism/src/PrismTabs/PrismTabs.tsx
@@ -5,7 +5,7 @@ import useStyles from './PrismTabs.styles';
 
 export function PrismTabs(props: TabsProps) {
   const { classes } = useStyles({ radius: props.radius });
-  return <Tabs {...props} variant="outline" classNames={{ tab: classes.tab }} />;
+  return <Tabs {...props} variant="outline" classNames={{ tab: classes.tab }} translate="no" />;
 }
 
 export function PrismPanel({ language, children, radius, ...others }: PrismProps & TabsPanelProps) {


### PR DESCRIPTION
## How

#1872 

- In the code area of ​​the official documentation, I think it would be better for the translator not to translate.

## Work History

- add `translate="no"` in `Prism` and `PrismTabs`

  ![image](https://user-images.githubusercontent.com/27342882/181239121-bfa3f7d3-9a66-41ea-ac4c-3c8f6fe13476.png)

  In my opinion the tab area should also not be translated. Let me know if you have any other comments!

## Etc

Thanks for the hard work of the mantine development team!
