### PR TITLE
Avoid manual type annotation for useToggle

### DIFF
--- a/docs/src/docs/hooks/use-toggle.mdx
+++ b/docs/src/docs/hooks/use-toggle.mdx
@@ -42,15 +42,15 @@ toggle('dark'); // -> value == 'dark'
 
 ### Set type
 
-By default, TypeScript will guess your type, but in most cases it's better to set type manually:
+By default, TypeScript will guess your type, but in most cases it's better to use const assertion to prevent type widening:
 
 ```tsx
 const [value, toggle] = useToggle(['light', 'dark']); // value is string
-const [value, toggle] = useToggle<'dark' | 'light'>(['light', 'dark']); // value is 'dark' | 'light'
+const [value, toggle] = useToggle(['light', 'dark'] as const); // value is 'dark' | 'light'
 ```
 
 ### Definition
 
 ```tsx
-function useToggle<T>(options: [T, T]): readonly [T, (value?: React.SetStateAction<T>) => void];
+function useToggle<T>(options: readonly [T, T]): readonly [T, (value?: React.SetStateAction<T>) => void];
 ```

--- a/src/mantine-hooks/src/use-toggle/use-toggle.test.ts
+++ b/src/mantine-hooks/src/use-toggle/use-toggle.test.ts
@@ -3,12 +3,12 @@ import { useToggle } from './use-toggle';
 
 describe('@mantine/hooks/use-toggle', () => {
   it('returns correct initial state', () => {
-    const hook = renderHook(() => useToggle<'dark' | 'light'>(['dark', 'light']));
+    const hook = renderHook(() => useToggle(['dark', 'light'] as const));
     expect(hook.result.current[0]).toBe('dark');
   });
 
   it('correctly toggles value', () => {
-    const hook = renderHook(() => useToggle<'dark' | 'light'>(['dark', 'light']));
+    const hook = renderHook(() => useToggle(['dark', 'light'] as const));
 
     act(() => hook.result.current[1]());
     expect(hook.result.current[0]).toBe('light');
@@ -18,7 +18,7 @@ describe('@mantine/hooks/use-toggle', () => {
   });
 
   it('allows to set value', () => {
-    const hook = renderHook(() => useToggle<'dark' | 'light'>(['dark', 'light']));
+    const hook = renderHook(() => useToggle(['dark', 'light'] as const));
 
     act(() => hook.result.current[1]('dark'));
     expect(hook.result.current[0]).toBe('dark');
@@ -28,7 +28,7 @@ describe('@mantine/hooks/use-toggle', () => {
   });
 
   it('allows to set value with callback function', () => {
-    const hook = renderHook(() => useToggle<'dark' | 'light'>(['dark', 'light']));
+    const hook = renderHook(() => useToggle(['dark', 'light'] as const));
     act(() => hook.result.current[1]((v) => v));
     expect(hook.result.current[0]).toBe('dark');
   });

--- a/src/mantine-hooks/src/use-toggle/use-toggle.ts
+++ b/src/mantine-hooks/src/use-toggle/use-toggle.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-export function useToggle<T>(options: [T, T]) {
+export function useToggle<T>(options: readonly [T, T]) {
   const [state, setState] = useState(options[0]);
 
   const toggle = (value?: React.SetStateAction<T>) => {


### PR DESCRIPTION
Fix #1876.

With this PR, users don't need a type parameter for `useToggle` anymore.

```ts
import { useToggle } from "@mantine/hooks";

const [value] = useToggle(["light", "dark"] as const);  // `value` is inferred as "light" | "dark"
```