### PR TITLE
[@mantine/hooks] use-mouse: Add resetOnExit option

### DIFF
--- a/docs/src/docs/hooks/use-mouse.mdx
+++ b/docs/src/docs/hooks/use-mouse.mdx
@@ -23,6 +23,8 @@ If you do not provide `ref` mouse position will be captured relative to document
 
 ## API
 
+Hook accepts one optional argument `options` in which `resetOnExit` option is defined (defaults to `false`)
+
 Hook returns object with `ref` and `x`, `y` mouse coordinates:
 
 ```tsx
@@ -38,7 +40,9 @@ On the first render (as well as during SSR), both `x` and `y` values are equal t
 ## Definition
 
 ```tsx
-function useMouse<T extends HTMLElement = any>(): {
+function useMouse<T extends HTMLElement = any>(
+  options: { resetOnExit?: boolean } = { resetOnExit: false }
+): {
   x: number;
   y: number;
   ref: React.MutableRefObject<T>;

--- a/docs/src/docs/hooks/use-mouse.mdx
+++ b/docs/src/docs/hooks/use-mouse.mdx
@@ -25,6 +25,10 @@ If you do not provide `ref` mouse position will be captured relative to document
 
 Hook accepts one optional argument `options` in which `resetOnExit` option is defined (defaults to `false`)
 
+```tsx
+useMouse({ resetOnExit: true }); // Will reset mouse position to 0,0 when mouse leaves the element
+```
+
 Hook returns object with `ref` and `x`, `y` mouse coordinates:
 
 ```tsx

--- a/src/mantine-hooks/src/use-mouse/use-mouse.ts
+++ b/src/mantine-hooks/src/use-mouse/use-mouse.ts
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import type { MouseEvent } from 'react';
 
-export function useMouse<T extends HTMLElement = any>(resetOnExit: boolean = false) {
+export function useMouse<T extends HTMLElement = any>(
+  options: { resetOnExit?: boolean } = { resetOnExit: false }
+) {
   const [position, setPosition] = useState({ x: 0, y: 0 });
 
   const ref = useRef<T>();
@@ -31,11 +33,11 @@ export function useMouse<T extends HTMLElement = any>(resetOnExit: boolean = fal
   useEffect(() => {
     const element = ref?.current ? ref.current : document;
     element.addEventListener('mousemove', setMousePosition as any);
-    if (resetOnExit) element.addEventListener('mouseleave', resetMousePosition as any);
+    if (options.resetOnExit) element.addEventListener('mouseleave', resetMousePosition as any);
 
     return () => {
       element.removeEventListener('mousemove', setMousePosition as any);
-      if (resetOnExit) element.removeEventListener('mouseleave', resetMousePosition as any);
+      if (options.resetOnExit) element.removeEventListener('mouseleave', resetMousePosition as any);
     };
   }, [ref.current]);
 

--- a/src/mantine-hooks/src/use-mouse/use-mouse.ts
+++ b/src/mantine-hooks/src/use-mouse/use-mouse.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { MouseEvent } from 'react';
 
-export function useMouse<T extends HTMLElement = any>() {
+export function useMouse<T extends HTMLElement = any>(resetOnExit: boolean = false) {
   const [position, setPosition] = useState({ x: 0, y: 0 });
 
   const ref = useRef<T>();
@@ -26,11 +26,17 @@ export function useMouse<T extends HTMLElement = any>() {
     }
   };
 
+  const resetMousePosition = () => setPosition({ x: 0, y: 0 });
+
   useEffect(() => {
     const element = ref?.current ? ref.current : document;
     element.addEventListener('mousemove', setMousePosition as any);
+    if (resetOnExit) element.addEventListener('mouseleave', resetMousePosition as any);
 
-    return () => element.removeEventListener('mousemove', setMousePosition as any);
+    return () => {
+      element.removeEventListener('mousemove', setMousePosition as any);
+      if (resetOnExit) element.removeEventListener('mouseleave', resetMousePosition as any);
+    };
   }, [ref.current]);
 
   return { ref, ...position };


### PR DESCRIPTION
This PR adds a `resetOnExit` option (false by default for backwards compatibility) to the `useMouse()` hook. When true, the values of x & y will be 0 when the mouse leaves the specified element