### PR TITLE
[docs] fix wrong guide link

### DIFF
--- a/docs/src/docs/core/NavLink.mdx
+++ b/docs/src/docs/core/NavLink.mdx
@@ -33,7 +33,7 @@ To create nested links put `NavLink` as children of another `NavLink`:
 
 ## Polymorphic component
 
-`NavLink` is a [polymorphic component](/guide/polymorphic/), by default, its root element is `button`
+`NavLink` is a [polymorphic component](/guides/polymorphic/), by default, its root element is `button`
 you can change that by setting `component` prop:
 
 ```tsx


### PR DESCRIPTION
Fix wrong guide link on NavLink documentation.