### PR TITLE
[docs] mantine-core: Fix broken source links

### DIFF
--- a/docs/src/docs/core/Accordion.mdx
+++ b/docs/src/docs/core/Accordion.mdx
@@ -8,7 +8,7 @@ category: 'data-display'
 description: 'Divide content into collapsible sections'
 props: ['Accordion', 'AccordionControl', 'AccordionItem', 'AccordionPanel']
 import: "import { Accordion } from '@mantine/core';"
-source: 'mantine-core/src/components/Accordion/Accordion.tsx'
+source: 'mantine-core/src/Accordion/Accordion.tsx'
 docs: 'core/Accordion.mdx'
 styles: ['Accordion']
 ---

--- a/docs/src/docs/core/ActionIcon.mdx
+++ b/docs/src/docs/core/ActionIcon.mdx
@@ -8,7 +8,7 @@ category: 'buttons'
 description: 'Icon button'
 props: ['ActionIcon']
 import: "import { ActionIcon } from '@mantine/core';"
-source: 'mantine-core/src/components/ActionIcon/ActionIcon.tsx'
+source: 'mantine-core/src/ActionIcon/ActionIcon.tsx'
 docs: 'core/ActionIcon.mdx'
 ---
 

--- a/docs/src/docs/core/Affix.mdx
+++ b/docs/src/docs/core/Affix.mdx
@@ -8,7 +8,7 @@ category: 'overlay'
 description: 'Render react node inside portal at fixed position'
 props: ['Affix']
 import: "import { Affix } from '@mantine/core';"
-source: 'mantine-core/src/components/Affix/Affix.tsx'
+source: 'mantine-core/src/Affix/Affix.tsx'
 docs: 'core/Affix.mdx'
 ---
 

--- a/docs/src/docs/core/Alert.mdx
+++ b/docs/src/docs/core/Alert.mdx
@@ -8,7 +8,7 @@ category: 'feedback'
 description: 'Attract user attention with important static message'
 props: ['Alert']
 import: "import { Alert } from '@mantine/core';"
-source: 'mantine-core/src/components/Alert/Alert.tsx'
+source: 'mantine-core/src/Alert/Alert.tsx'
 docs: 'core/Alert.mdx'
 styles: ['Alert']
 ---

--- a/docs/src/docs/core/Anchor.mdx
+++ b/docs/src/docs/core/Anchor.mdx
@@ -8,7 +8,7 @@ category: 'navigation'
 description: 'Display links with theme styles'
 props: ['Anchor']
 import: "import { Anchor } from '@mantine/core';"
-source: 'mantine-core/src/components/Anchor/Anchor.tsx'
+source: 'mantine-core/src/Anchor/Anchor.tsx'
 docs: 'core/Anchor.mdx'
 ---
 

--- a/docs/src/docs/core/AppShell.mdx
+++ b/docs/src/docs/core/AppShell.mdx
@@ -8,7 +8,7 @@ category: 'layout'
 description: 'Responsive shell for your application with header and navbar'
 props: ['AppShell', 'Navbar', 'Header', 'Aside', 'Footer']
 import: "import { AppShell, Navbar, Header, Aside, Footer } from '@mantine/core';"
-source: 'mantine-core/src/components/AppShell/AppShell.tsx'
+source: 'mantine-core/src/AppShell/AppShell.tsx'
 docs: 'core/AppShell.mdx'
 styles: ['AppShell']
 ---

--- a/docs/src/docs/core/AspectRatio.mdx
+++ b/docs/src/docs/core/AspectRatio.mdx
@@ -8,7 +8,7 @@ category: 'layout'
 description: 'Maintain responsive consistent width/height ratio'
 props: ['AspectRatio']
 import: "import { AspectRatio } from '@mantine/core';"
-source: 'mantine-core/src/components/AspectRatio/AspectRatio.tsx'
+source: 'mantine-core/src/AspectRatio/AspectRatio.tsx'
 docs: 'core/AspectRatio.mdx'
 ---
 

--- a/docs/src/docs/core/Autocomplete.mdx
+++ b/docs/src/docs/core/Autocomplete.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Autocomplete user input with any list of options'
 props: ['Autocomplete']
 import: "import { Autocomplete } from '@mantine/core';"
-source: 'mantine-core/src/components/Autocomplete/Autocomplete.tsx'
+source: 'mantine-core/src/Autocomplete/Autocomplete.tsx'
 docs: 'core/Autocomplete.mdx'
 styles: ['Autocomplete']
 ---

--- a/docs/src/docs/core/Avatar.mdx
+++ b/docs/src/docs/core/Avatar.mdx
@@ -9,7 +9,7 @@ description: 'Display user profile image, initials or fallback icon'
 componentPrefix: 'Avatar'
 props: ['Avatar', 'AvatarGroup']
 import: "import { Avatar } from '@mantine/core';"
-source: 'mantine-core/src/components/Avatar/Avatar.tsx'
+source: 'mantine-core/src/Avatar/Avatar.tsx'
 docs: 'core/Avatar.mdx'
 styles: ['Avatar']
 ---

--- a/docs/src/docs/core/BackgroundImage.mdx
+++ b/docs/src/docs/core/BackgroundImage.mdx
@@ -8,7 +8,7 @@ category: 'data-display'
 description: 'Displays image as background'
 props: ['BackgroundImage']
 import: "import { BackgroundImage } from '@mantine/core';"
-source: 'mantine-core/src/components/BackgroundImage/BackgroundImage.tsx'
+source: 'mantine-core/src/BackgroundImage/BackgroundImage.tsx'
 docs: 'core/BackgroundImage.mdx'
 ---
 

--- a/docs/src/docs/core/Badge.mdx
+++ b/docs/src/docs/core/Badge.mdx
@@ -8,7 +8,7 @@ category: 'data-display'
 description: 'Display badge, pill or tag'
 props: ['Badge']
 import: "import { Badge } from '@mantine/core';"
-source: 'mantine-core/src/components/Badge/Badge.tsx'
+source: 'mantine-core/src/Badge/Badge.tsx'
 docs: 'core/Badge.mdx'
 styles: ['Badge']
 ---

--- a/docs/src/docs/core/Blockquote.mdx
+++ b/docs/src/docs/core/Blockquote.mdx
@@ -8,7 +8,7 @@ category: 'typography'
 description: 'Blockquote with optional cite'
 props: ['Blockquote']
 import: "import { Blockquote } from '@mantine/core';"
-source: 'mantine-core/src/components/Blockquote/Blockquote.tsx'
+source: 'mantine-core/src/Blockquote/Blockquote.tsx'
 docs: 'core/Blockquote.mdx'
 styles: ['Blockquote']
 ---

--- a/docs/src/docs/core/Box.mdx
+++ b/docs/src/docs/core/Box.mdx
@@ -8,7 +8,7 @@ category: 'misc'
 description: 'Add inline styles to any element or component with sx'
 props: ['Box']
 import: "import { Box } from '@mantine/core';"
-source: 'mantine-core/src/components/Box/Box.tsx'
+source: 'mantine-core/src/Box/Box.tsx'
 docs: 'core/Box.mdx'
 ---
 

--- a/docs/src/docs/core/Breadcrumbs.mdx
+++ b/docs/src/docs/core/Breadcrumbs.mdx
@@ -8,7 +8,7 @@ category: 'navigation'
 description: 'Separate list of react nodes with given separator'
 props: ['Breadcrumbs']
 import: "import { Breadcrumbs } from '@mantine/core';"
-source: 'mantine-core/src/components/Breadcrumbs/Breadcrumbs.tsx'
+source: 'mantine-core/src/Breadcrumbs/Breadcrumbs.tsx'
 docs: 'core/Breadcrumbs.mdx'
 styles: ['Breadcrumbs']
 ---

--- a/docs/src/docs/core/Burger.mdx
+++ b/docs/src/docs/core/Burger.mdx
@@ -8,7 +8,7 @@ category: 'navigation'
 description: 'Open/close navigation button'
 props: ['Burger']
 import: "import { Burger } from '@mantine/core';"
-source: 'mantine-core/src/components/Burger/Burger.tsx'
+source: 'mantine-core/src/Burger/Burger.tsx'
 docs: 'core/Burger.mdx'
 styles: ['Burger']
 ---

--- a/docs/src/docs/core/Button.mdx
+++ b/docs/src/docs/core/Button.mdx
@@ -9,7 +9,7 @@ description: 'Render button or link with button styles from mantine theme'
 componentPrefix: 'Button'
 props: ['Button', 'ButtonGroup']
 import: "import { Button } from '@mantine/core';"
-source: 'mantine-core/src/components/Button/Button.tsx'
+source: 'mantine-core/src/Button/Button.tsx'
 docs: 'core/Button.mdx'
 styles: ['Button']
 ---

--- a/docs/src/docs/core/Card.mdx
+++ b/docs/src/docs/core/Card.mdx
@@ -8,7 +8,7 @@ category: 'data-display'
 description: 'Card with context styles for Image and Divider components'
 props: ['Card']
 import: "import { Card } from '@mantine/core';"
-source: 'mantine-core/src/components/Card/Card.tsx'
+source: 'mantine-core/src/Card/Card.tsx'
 docs: 'core/Card.mdx'
 ---
 

--- a/docs/src/docs/core/Center.mdx
+++ b/docs/src/docs/core/Center.mdx
@@ -8,7 +8,7 @@ category: 'layout'
 description: 'Centers content vertically and horizontally'
 props: ['Center']
 import: "import { Center } from '@mantine/core';"
-source: 'mantine-core/src/components/Center/Center.tsx'
+source: 'mantine-core/src/Center/Center.tsx'
 docs: 'core/Center.mdx'
 ---
 

--- a/docs/src/docs/core/Checkbox.mdx
+++ b/docs/src/docs/core/Checkbox.mdx
@@ -9,7 +9,7 @@ description: 'Capture boolean input from user'
 componentPrefix: 'Checkbox'
 props: ['Checkbox', 'CheckboxGroup']
 import: "import { Checkbox } from '@mantine/core';"
-source: 'mantine-core/src/components/Checkbox/Checkbox.tsx'
+source: 'mantine-core/src/Checkbox/Checkbox.tsx'
 docs: 'core/Checkbox.mdx'
 styles: ['Checkbox']
 ---

--- a/docs/src/docs/core/Chip.mdx
+++ b/docs/src/docs/core/Chip.mdx
@@ -9,7 +9,7 @@ description: 'Pick one or multiple values with inline controls'
 componentPrefix: 'Chip'
 props: ['Chip', 'ChipGroup']
 import: "import { Chip } from '@mantine/core';"
-source: 'mantine-core/src/components/Chip/Chip.tsx'
+source: 'mantine-core/src/Chip/Chip.tsx'
 docs: 'core/Chip.mdx'
 styles: ['Chip']
 ---

--- a/docs/src/docs/core/CloseButton.mdx
+++ b/docs/src/docs/core/CloseButton.mdx
@@ -8,7 +8,7 @@ category: 'buttons'
 description: 'ActionIcon with close icon'
 props: ['CloseButton']
 import: "import { CloseButton } from '@mantine/core';"
-source: 'mantine-core/src/components/CloseButton/CloseButton.tsx'
+source: 'mantine-core/src/CloseButton/CloseButton.tsx'
 docs: 'core/ActionIcon.mdx'
 ---
 

--- a/docs/src/docs/core/Code.mdx
+++ b/docs/src/docs/core/Code.mdx
@@ -8,7 +8,7 @@ category: 'typography'
 description: 'Inline or block code without syntax highlight'
 props: ['Code']
 import: "import { Code } from '@mantine/core';"
-source: 'mantine-core/src/components/Code/Code.tsx'
+source: 'mantine-core/src/Code/Code.tsx'
 docs: 'core/Code.mdx'
 ---
 

--- a/docs/src/docs/core/Collapse.mdx
+++ b/docs/src/docs/core/Collapse.mdx
@@ -8,7 +8,7 @@ category: 'misc'
 description: 'Animate presence with slide down transition'
 props: ['Collapse']
 import: "import { Collapse } from '@mantine/core';"
-source: 'mantine-core/src/components/Collapse/Collapse.tsx'
+source: 'mantine-core/src/Collapse/Collapse.tsx'
 docs: 'core/Collapse.mdx'
 ---
 

--- a/docs/src/docs/core/ColorInput.mdx
+++ b/docs/src/docs/core/ColorInput.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Capture color data from user'
 props: ['ColorInput']
 import: "import { ColorInput } from '@mantine/core';"
-source: 'mantine-core/src/components/ColorInput/ColorInput.tsx'
+source: 'mantine-core/src/ColorInput/ColorInput.tsx'
 docs: 'core/ColorInput.mdx'
 styles: ['ColorInput']
 ---

--- a/docs/src/docs/core/ColorPicker.mdx
+++ b/docs/src/docs/core/ColorPicker.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Inline color picker'
 props: ['ColorPicker']
 import: "import { ColorPicker } from '@mantine/core';"
-source: 'mantine-core/src/components/ColorPicker/ColorPicker.tsx'
+source: 'mantine-core/src/ColorPicker/ColorPicker.tsx'
 docs: 'core/ColorPicker.mdx'
 styles: ['ColorPicker']
 ---

--- a/docs/src/docs/core/ColorSwatch.mdx
+++ b/docs/src/docs/core/ColorSwatch.mdx
@@ -8,7 +8,7 @@ category: 'data-display'
 description: 'Display color swatch'
 props: ['ColorSwatch']
 import: "import { ColorSwatch } from '@mantine/core';"
-source: 'mantine-core/src/components/ColorSwatch/ColorSwatch.tsx'
+source: 'mantine-core/src/ColorSwatch/ColorSwatch.tsx'
 docs: 'core/ColorSwatch.mdx'
 ---
 

--- a/docs/src/docs/core/Container.mdx
+++ b/docs/src/docs/core/Container.mdx
@@ -8,7 +8,7 @@ category: 'layout'
 description: 'Center content horizontally with predefined max-width'
 props: ['Container']
 import: "import { Container } from '@mantine/core';"
-source: 'mantine-core/src/components/Container/Container.tsx'
+source: 'mantine-core/src/Container/Container.tsx'
 docs: 'core/Container.mdx'
 ---
 

--- a/docs/src/docs/core/CopyButton.mdx
+++ b/docs/src/docs/core/CopyButton.mdx
@@ -8,7 +8,7 @@ category: 'buttons'
 description: 'Copies given text to clipboard'
 props: ['CopyButton']
 import: "import { CopyButton } from '@mantine/core';"
-source: 'mantine-core/src/components/CopyButton/CopyButton.tsx'
+source: 'mantine-core/src/CopyButton/CopyButton.tsx'
 docs: 'core/CopyButton.mdx'
 ---
 

--- a/docs/src/docs/core/Dialog.mdx
+++ b/docs/src/docs/core/Dialog.mdx
@@ -8,7 +8,7 @@ category: 'overlay'
 description: 'Display fixed overlay at any side of the screen'
 props: ['Dialog']
 import: "import { Dialog } from '@mantine/core';"
-source: 'mantine-core/src/components/Dialog/Dialog.tsx'
+source: 'mantine-core/src/Dialog/Dialog.tsx'
 docs: 'core/Dialog.mdx'
 styles: ['Dialog']
 ---

--- a/docs/src/docs/core/Divider.mdx
+++ b/docs/src/docs/core/Divider.mdx
@@ -8,7 +8,7 @@ category: 'misc'
 description: 'Horizontal line with optional label or vertical divider'
 props: ['Divider']
 import: "import { Divider } from '@mantine/core';"
-source: 'mantine-core/src/components/Divider/Divider.tsx'
+source: 'mantine-core/src/Divider/Divider.tsx'
 docs: 'core/Divider.mdx'
 styles: ['Divider']
 ---

--- a/docs/src/docs/core/Drawer.mdx
+++ b/docs/src/docs/core/Drawer.mdx
@@ -8,7 +8,7 @@ category: 'overlay'
 description: 'Display overlay area at any side of the screen'
 props: ['Drawer']
 import: "import { Drawer } from '@mantine/core';"
-source: 'mantine-core/src/components/Drawer/Drawer.tsx'
+source: 'mantine-core/src/Drawer/Drawer.tsx'
 docs: 'core/Drawer.mdx'
 styles: ['Drawer']
 ---

--- a/docs/src/docs/core/FileButton.mdx
+++ b/docs/src/docs/core/FileButton.mdx
@@ -8,7 +8,7 @@ category: 'buttons'
 description: 'Open file picker with a button click'
 props: ['FileButton']
 import: "import { FileButton } from '@mantine/core';"
-source: 'mantine-core/src/components/FileButton/FileButton.tsx'
+source: 'mantine-core/src/FileButton/FileButton.tsx'
 docs: 'core/FileButton.mdx'
 ---
 

--- a/docs/src/docs/core/FileInput.mdx
+++ b/docs/src/docs/core/FileInput.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Capture files from user'
 props: ['FileInput']
 import: "import { FileInput } from '@mantine/core';"
-source: 'mantine-core/src/components/FileInput/FileInput.tsx'
+source: 'mantine-core/src/FileInput/FileInput.tsx'
 docs: 'core/FileInput.mdx'
 styles: ['FileInput']
 ---

--- a/docs/src/docs/core/FocusTrap.mdx
+++ b/docs/src/docs/core/FocusTrap.mdx
@@ -8,7 +8,7 @@ category: 'misc'
 description: 'Trap focus at child node'
 props: ['FocusTrap']
 import: "import { FocusTrap } from '@mantine/core';"
-source: 'mantine-core/src/components/FocusTrap/FocusTrap.tsx'
+source: 'mantine-core/src/FocusTrap/FocusTrap.tsx'
 docs: 'core/FocusTrap.mdx'
 ---
 

--- a/docs/src/docs/core/Grid.mdx
+++ b/docs/src/docs/core/Grid.mdx
@@ -9,7 +9,7 @@ description: 'Flexbox grid system with variable amount of columns'
 componentPrefix: 'Grid'
 props: ['Grid', 'Col']
 import: "import { Grid } from '@mantine/core';"
-source: 'mantine-core/src/components/Grid/Grid.tsx'
+source: 'mantine-core/src/Grid/Grid.tsx'
 docs: 'core/Grid.mdx'
 ---
 

--- a/docs/src/docs/core/Group.mdx
+++ b/docs/src/docs/core/Group.mdx
@@ -8,7 +8,7 @@ category: 'layout'
 description: 'Compose elements and components in a horizontal flex container'
 props: ['Group']
 import: "import { Group } from '@mantine/core';"
-source: 'mantine-core/src/components/Group/Group.tsx'
+source: 'mantine-core/src/Group/Group.tsx'
 docs: 'core/Group.mdx'
 ---
 

--- a/docs/src/docs/core/Highlight.mdx
+++ b/docs/src/docs/core/Highlight.mdx
@@ -8,7 +8,7 @@ category: 'typography'
 description: 'Highlight given part of a string with mark tag'
 props: ['Highlight']
 import: "import { Highlight } from '@mantine/core';"
-source: 'mantine-core/src/components/Highlight/Highlight.tsx'
+source: 'mantine-core/src/Highlight/Highlight.tsx'
 docs: 'core/Highlight.mdx'
 ---
 

--- a/docs/src/docs/core/HoverCard.mdx
+++ b/docs/src/docs/core/HoverCard.mdx
@@ -9,7 +9,7 @@ description: 'Display popover section when target element is hovered'
 componentPrefix: 'HoverCard'
 props: ['HoverCard', 'HoverCardTarget', 'HoverCardDropdown']
 import: "import { HoverCard } from '@mantine/core';"
-source: 'mantine-core/src/components/HoverCard/HoverCard.tsx'
+source: 'mantine-core/src/HoverCard/HoverCard.tsx'
 docs: 'core/HoverCard.mdx'
 ---
 

--- a/docs/src/docs/core/Image.mdx
+++ b/docs/src/docs/core/Image.mdx
@@ -8,7 +8,7 @@ category: 'data-display'
 description: 'Image with optional placeholder for loading and error state'
 props: ['Image']
 import: "import { Image } from '@mantine/core';"
-source: 'mantine-core/src/components/Image/Image.tsx'
+source: 'mantine-core/src/Image/Image.tsx'
 docs: 'core/Image.mdx'
 styles: ['Image']
 ---

--- a/docs/src/docs/core/Indicator.mdx
+++ b/docs/src/docs/core/Indicator.mdx
@@ -8,7 +8,7 @@ category: 'data-display'
 description: 'Display element at the corner of another element'
 props: ['Indicator']
 import: "import { Indicator } from '@mantine/core';"
-source: 'mantine-core/src/components/Indicator/Indicator.tsx'
+source: 'mantine-core/src/Indicator/Indicator.tsx'
 docs: 'core/Indicator.mdx'
 styles: ['Indicator']
 ---

--- a/docs/src/docs/core/Input.mdx
+++ b/docs/src/docs/core/Input.mdx
@@ -9,7 +9,7 @@ description: 'Base component to create custom inputs'
 componentPrefix: 'Input'
 props: ['Input', 'InputWrapper', 'InputLabel', 'InputDescription', 'InputError']
 import: "import { Input } from '@mantine/core';"
-source: 'mantine-core/src/components/Input/Input.tsx'
+source: 'mantine-core/src/Input/Input.tsx'
 docs: 'core/Input.mdx'
 styles: ['Input', 'Input.Wrapper']
 ---

--- a/docs/src/docs/core/JsonInput.mdx
+++ b/docs/src/docs/core/JsonInput.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Capture json data from user'
 props: ['JsonInput']
 import: "import { JsonInput } from '@mantine/core';"
-source: 'mantine-core/src/components/JsonInput/JsonInput.tsx'
+source: 'mantine-core/src/JsonInput/JsonInput.tsx'
 docs: 'core/JsonInput.mdx'
 styles: ['JsonInput']
 ---

--- a/docs/src/docs/core/Kbd.mdx
+++ b/docs/src/docs/core/Kbd.mdx
@@ -8,7 +8,7 @@ category: 'data-display'
 description: 'Display keyboard button or keys combination'
 props: ['Kbd']
 import: "import { Kbd } from '@mantine/core';"
-source: 'mantine-core/src/components/Kbd/Kbd.tsx'
+source: 'mantine-core/src/Kbd/Kbd.tsx'
 docs: 'core/Kbd.mdx'
 ---
 

--- a/docs/src/docs/core/List.mdx
+++ b/docs/src/docs/core/List.mdx
@@ -9,7 +9,7 @@ description: 'Display ordered or unordered list'
 componentPrefix: 'List'
 props: ['List', 'ListItem']
 import: "import { List } from '@mantine/core';"
-source: 'mantine-core/src/components/List/List.tsx'
+source: 'mantine-core/src/List/List.tsx'
 docs: 'core/List.mdx'
 styles: ['List']
 ---

--- a/docs/src/docs/core/Loader.mdx
+++ b/docs/src/docs/core/Loader.mdx
@@ -8,7 +8,7 @@ category: 'feedback'
 description: 'Indicate loading state'
 props: ['Loader']
 import: "import { Loader } from '@mantine/core';"
-source: 'mantine-core/src/components/Loader/Loader.tsx'
+source: 'mantine-core/src/Loader/Loader.tsx'
 docs: 'core/Loader.mdx'
 ---
 

--- a/docs/src/docs/core/LoadingOverlay.mdx
+++ b/docs/src/docs/core/LoadingOverlay.mdx
@@ -8,7 +8,7 @@ category: 'overlay'
 description: 'Overlay over given container with centered Loader'
 props: ['LoadingOverlay']
 import: "import { LoadingOverlay } from '@mantine/core';"
-source: 'mantine-core/src/components/LoadingOverlay/LoadingOverlay.tsx'
+source: 'mantine-core/src/LoadingOverlay/LoadingOverlay.tsx'
 docs: 'core/LoadingOverlay.mdx'
 ---
 

--- a/docs/src/docs/core/Mark.mdx
+++ b/docs/src/docs/core/Mark.mdx
@@ -8,7 +8,7 @@ category: 'typography'
 description: 'Highlight part of the text'
 props: ['Mark']
 import: "import { Mark } from '@mantine/core';"
-source: 'mantine-core/src/components/Mark/Mark.tsx'
+source: 'mantine-core/src/Mark/Mark.tsx'
 docs: 'core/Mark.mdx'
 ---
 

--- a/docs/src/docs/core/MediaQuery.mdx
+++ b/docs/src/docs/core/MediaQuery.mdx
@@ -8,7 +8,7 @@ category: 'layout'
 description: 'Apply styles to children if media query matches'
 props: ['MediaQuery']
 import: "import { MediaQuery } from '@mantine/core';"
-source: 'mantine-core/src/components/MediaQuery/MediaQuery.tsx'
+source: 'mantine-core/src/MediaQuery/MediaQuery.tsx'
 docs: 'core/MediaQuery.mdx'
 ---
 

--- a/docs/src/docs/core/Menu.mdx
+++ b/docs/src/docs/core/Menu.mdx
@@ -8,7 +8,7 @@ category: 'overlay'
 description: 'Combine a list of secondary actions into single interactive area'
 props: ['Menu', 'MenuItem', 'MenuDropdown', 'MenuTarget']
 import: "import { Menu } from '@mantine/core';"
-source: 'mantine-core/src/components/Menu/Menu.tsx'
+source: 'mantine-core/src/Menu/Menu.tsx'
 docs: 'core/Menu.mdx'
 styles: ['Menu']
 ---

--- a/docs/src/docs/core/Modal.mdx
+++ b/docs/src/docs/core/Modal.mdx
@@ -8,7 +8,7 @@ category: 'overlay'
 description: 'Modal with optional header'
 props: ['Modal']
 import: "import { Modal } from '@mantine/core';"
-source: 'mantine-core/src/components/Modal/Modal.tsx'
+source: 'mantine-core/src/Modal/Modal.tsx'
 docs: 'core/Modal.mdx'
 styles: ['Modal']
 ---

--- a/docs/src/docs/core/MultiSelect.mdx
+++ b/docs/src/docs/core/MultiSelect.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Custom searchable multi select'
 props: ['MultiSelect']
 import: "import { MultiSelect } from '@mantine/core';"
-source: 'mantine-core/src/components/MultiSelect/MultiSelect.tsx'
+source: 'mantine-core/src/MultiSelect/MultiSelect.tsx'
 docs: 'core/MultiSelect.mdx'
 styles: ['MultiSelect']
 ---

--- a/docs/src/docs/core/NativeSelect.mdx
+++ b/docs/src/docs/core/NativeSelect.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Capture user feedback limited to large set of options'
 props: ['NativeSelect']
 import: "import { NativeSelect } from '@mantine/core';"
-source: 'mantine-core/src/components/NativeSelect/NativeSelect.tsx'
+source: 'mantine-core/src/NativeSelect/NativeSelect.tsx'
 docs: 'core/NativeSelect.mdx'
 styles: ['NativeSelect']
 ---

--- a/docs/src/docs/core/NavLink.mdx
+++ b/docs/src/docs/core/NavLink.mdx
@@ -8,7 +8,7 @@ category: 'navigation'
 description: 'Navigation link'
 props: ['NavLink']
 import: "import { NavLink } from '@mantine/core';"
-source: 'mantine-core/src/components/NavLink/NavLink.tsx'
+source: 'mantine-core/src/NavLink/NavLink.tsx'
 docs: 'core/NavLink.mdx'
 styles: ['NavLink']
 ---

--- a/docs/src/docs/core/Notification.mdx
+++ b/docs/src/docs/core/Notification.mdx
@@ -8,7 +8,7 @@ category: 'feedback'
 description: 'Show dynamic notifications and alerts to user, part of notifications system'
 props: ['Notification']
 import: "import { Notification } from '@mantine/core';"
-source: 'mantine-core/src/components/Notification/Notification.tsx'
+source: 'mantine-core/src/Notification/Notification.tsx'
 docs: 'core/Notification.mdx'
 styles: ['Notification']
 ---

--- a/docs/src/docs/core/NumberInput.mdx
+++ b/docs/src/docs/core/NumberInput.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Capture number input from user'
 props: ['NumberInput']
 import: "import { NumberInput } from '@mantine/core';"
-source: 'mantine-core/src/components/NumberInput/NumberInput.tsx'
+source: 'mantine-core/src/NumberInput/NumberInput.tsx'
 docs: 'core/NumberInput.mdx'
 styles: ['NumberInput']
 ---

--- a/docs/src/docs/core/Overlay.mdx
+++ b/docs/src/docs/core/Overlay.mdx
@@ -8,7 +8,7 @@ category: 'overlay'
 description: 'Overlays given element with div element with any color and opacity'
 props: ['Overlay']
 import: "import { Overlay } from '@mantine/core';"
-source: 'mantine-core/src/components/Overlay/Overlay.tsx'
+source: 'mantine-core/src/Overlay/Overlay.tsx'
 docs: 'core/Overlay.mdx'
 ---
 

--- a/docs/src/docs/core/Pagination.mdx
+++ b/docs/src/docs/core/Pagination.mdx
@@ -8,7 +8,7 @@ category: 'navigation'
 description: 'Display active page and navigate between multiple pages'
 props: ['Pagination']
 import: "import { Pagination } from '@mantine/core';"
-source: 'mantine-core/src/components/Pagination/Pagination.tsx'
+source: 'mantine-core/src/Pagination/Pagination.tsx'
 docs: 'core/Pagination.mdx'
 styles: ['Pagination']
 ---

--- a/docs/src/docs/core/Paper.mdx
+++ b/docs/src/docs/core/Paper.mdx
@@ -8,7 +8,7 @@ category: 'misc'
 description: 'Renders white or dark background depending on color scheme'
 props: ['Paper']
 import: "import { Paper } from '@mantine/core';"
-source: 'mantine-core/src/components/Paper/Paper.tsx'
+source: 'mantine-core/src/Paper/Paper.tsx'
 docs: 'core/Paper.mdx'
 ---
 

--- a/docs/src/docs/core/PasswordInput.mdx
+++ b/docs/src/docs/core/PasswordInput.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Capture password from user with option to toggle visibility'
 props: ['PasswordInput']
 import: "import { PasswordInput } from '@mantine/core';"
-source: 'mantine-core/src/components/PasswordInput/PasswordInput.tsx'
+source: 'mantine-core/src/PasswordInput/PasswordInput.tsx'
 docs: 'core/PasswordInput.mdx'
 styles: ['PasswordInput']
 ---

--- a/docs/src/docs/core/Popover.mdx
+++ b/docs/src/docs/core/Popover.mdx
@@ -9,7 +9,7 @@ description: 'Display popover section relative to given target element'
 componentPrefix: 'Popover'
 props: ['Popover', 'PopoverTarget', 'PopoverDropdown']
 import: "import { Popover } from '@mantine/core';"
-source: 'mantine-core/src/components/Popover/Popover.tsx'
+source: 'mantine-core/src/Popover/Popover.tsx'
 docs: 'core/Popover.mdx'
 styles: ['Popover']
 ---

--- a/docs/src/docs/core/Portal.mdx
+++ b/docs/src/docs/core/Portal.mdx
@@ -8,7 +8,7 @@ category: 'misc'
 description: 'Render component outside of current context'
 props: ['Portal']
 import: "import { Portal } from '@mantine/core';"
-source: 'mantine-core/src/components/Portal/Portal.tsx'
+source: 'mantine-core/src/Portal/Portal.tsx'
 docs: 'core/Portal.mdx'
 ---
 

--- a/docs/src/docs/core/Progress.mdx
+++ b/docs/src/docs/core/Progress.mdx
@@ -8,7 +8,7 @@ category: 'feedback'
 description: 'Give user feedback for status of the task'
 props: ['Progress']
 import: "import { Progress } from '@mantine/core';"
-source: 'mantine-core/src/components/Progress/Progress.tsx'
+source: 'mantine-core/src/Progress/Progress.tsx'
 docs: 'core/Progress.mdx'
 styles: ['Progress']
 ---

--- a/docs/src/docs/core/Radio.mdx
+++ b/docs/src/docs/core/Radio.mdx
@@ -9,7 +9,7 @@ description: 'Wrapper for input type radio'
 componentPrefix: 'Radio'
 props: ['Radio', 'RadioGroup']
 import: "import { Radio } from '@mantine/core';"
-source: 'mantine-core/src/components/Radio/Radio.tsx'
+source: 'mantine-core/src/Radio/Radio.tsx'
 docs: 'core/Radio.mdx'
 styles: ['Radio']
 ---

--- a/docs/src/docs/core/RingProgress.mdx
+++ b/docs/src/docs/core/RingProgress.mdx
@@ -8,7 +8,7 @@ category: 'feedback'
 description: 'Give user feedback for status of the task with circle diagram'
 props: ['RingProgress']
 import: "import { RingProgress } from '@mantine/core';"
-source: 'mantine-core/src/components/RingProgress/RingProgress.tsx'
+source: 'mantine-core/src/RingProgress/RingProgress.tsx'
 docs: 'core/RingProgress.mdx'
 styles: ['RingProgress']
 ---

--- a/docs/src/docs/core/ScrollArea.mdx
+++ b/docs/src/docs/core/ScrollArea.mdx
@@ -9,7 +9,7 @@ description: 'Area with custom scrollbars'
 props: ['ScrollArea']
 styles: ['ScrollArea']
 import: "import { ScrollArea } from '@mantine/core';"
-source: 'mantine-core/src/components/ScrollArea/ScrollArea.tsx'
+source: 'mantine-core/src/ScrollArea/ScrollArea.tsx'
 docs: 'core/ScrollArea.mdx'
 ---
 

--- a/docs/src/docs/core/SegmentedControl.mdx
+++ b/docs/src/docs/core/SegmentedControl.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Horizontal control with multiple segments'
 props: ['SegmentedControl']
 import: "import { SegmentedControl } from '@mantine/core';"
-source: 'mantine-core/src/components/SegmentedControl/SegmentedControl.tsx'
+source: 'mantine-core/src/SegmentedControl/SegmentedControl.tsx'
 docs: 'core/SegmentedControl.mdx'
 styles: ['SegmentedControl']
 ---

--- a/docs/src/docs/core/Select.mdx
+++ b/docs/src/docs/core/Select.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Custom searchable select'
 props: ['Select']
 import: "import { Select } from '@mantine/core';"
-source: 'mantine-core/src/components/Select/Select.tsx'
+source: 'mantine-core/src/Select/Select.tsx'
 docs: 'core/Select.mdx'
 styles: ['Select']
 ---

--- a/docs/src/docs/core/SimpleGrid.mdx
+++ b/docs/src/docs/core/SimpleGrid.mdx
@@ -8,7 +8,7 @@ category: 'layout'
 description: 'Responsive grid where each item takes equal amount of space'
 props: ['SimpleGrid']
 import: "import { SimpleGrid } from '@mantine/core';"
-source: 'mantine-core/src/components/SimpleGrid/SimpleGrid.tsx'
+source: 'mantine-core/src/SimpleGrid/SimpleGrid.tsx'
 docs: 'core/SimpleGrid.mdx'
 ---
 

--- a/docs/src/docs/core/Skeleton.mdx
+++ b/docs/src/docs/core/Skeleton.mdx
@@ -8,7 +8,7 @@ category: 'feedback'
 description: 'Indicate content loading state'
 props: ['Skeleton']
 import: "import { Skeleton } from '@mantine/core';"
-source: 'mantine-core/src/components/Skeleton/Skeleton.tsx'
+source: 'mantine-core/src/Skeleton/Skeleton.tsx'
 docs: 'core/Skeleton.mdx'
 ---
 

--- a/docs/src/docs/core/Slider.mdx
+++ b/docs/src/docs/core/Slider.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Capture user feedback from a range of values'
 props: ['Slider', 'RangeSlider']
 import: "import { Slider, RangeSlider } from '@mantine/core';"
-source: 'mantine-core/src/components/Slider'
+source: 'mantine-core/src/Slider'
 docs: 'core/Slider.mdx'
 styles: ['Slider', 'RangeSlider']
 ---

--- a/docs/src/docs/core/Space.mdx
+++ b/docs/src/docs/core/Space.mdx
@@ -8,7 +8,7 @@ category: 'layout'
 description: 'Add horizontal or vertical spacing from theme'
 props: ['Space']
 import: "import { Space } from '@mantine/core';"
-source: 'mantine-core/src/components/Space/Space.tsx'
+source: 'mantine-core/src/Space/Space.tsx'
 docs: 'core/Space.mdx'
 ---
 

--- a/docs/src/docs/core/Spoiler.mdx
+++ b/docs/src/docs/core/Spoiler.mdx
@@ -8,7 +8,7 @@ category: 'data-display'
 description: 'Hide long sections of content under spoiler'
 props: ['Spoiler']
 import: "import { Spoiler } from '@mantine/core';"
-source: 'mantine-core/src/components/Spoiler/Spoiler.tsx'
+source: 'mantine-core/src/Spoiler/Spoiler.tsx'
 docs: 'core/Spoiler.mdx'
 styles: ['Spoiler']
 ---

--- a/docs/src/docs/core/Stack.mdx
+++ b/docs/src/docs/core/Stack.mdx
@@ -8,7 +8,7 @@ category: 'layout'
 description: 'Compose elements and components in vertical flex container'
 props: ['Stack']
 import: "import { Stack } from '@mantine/core';"
-source: 'mantine-core/src/components/Stack/Stack.tsx'
+source: 'mantine-core/src/Stack/Stack.tsx'
 docs: 'core/Stack.mdx'
 ---
 

--- a/docs/src/docs/core/Stepper.mdx
+++ b/docs/src/docs/core/Stepper.mdx
@@ -9,7 +9,7 @@ description: 'Display content divided into a steps sequence'
 componentPrefix: 'Stepper'
 props: ['Stepper', 'Step']
 import: "import { Stepper } from '@mantine/core';"
-source: 'mantine-core/src/components/Stepper/Stepper.tsx'
+source: 'mantine-core/src/Stepper/Stepper.tsx'
 docs: 'core/Stepper.mdx'
 styles: ['Stepper']
 ---

--- a/docs/src/docs/core/Switch.mdx
+++ b/docs/src/docs/core/Switch.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Capture boolean input from user'
 props: ['Switch']
 import: "import { Switch } from '@mantine/core';"
-source: 'mantine-core/src/components/Switch/Switch.tsx'
+source: 'mantine-core/src/Switch/Switch.tsx'
 docs: 'core/Switch.mdx'
 styles: ['Switch']
 ---

--- a/docs/src/docs/core/Table.mdx
+++ b/docs/src/docs/core/Table.mdx
@@ -8,7 +8,7 @@ category: 'typography'
 description: 'Render table with theme styles'
 props: ['Table']
 import: "import { Table } from '@mantine/core';"
-source: 'mantine-core/src/components/Table/Table.tsx'
+source: 'mantine-core/src/Table/Table.tsx'
 docs: 'core/Table.mdx'
 ---
 

--- a/docs/src/docs/core/Tabs.mdx
+++ b/docs/src/docs/core/Tabs.mdx
@@ -9,7 +9,7 @@ description: 'Switch between different views'
 componentPrefix: 'Tabs'
 props: ['Tabs', 'Tab', 'TabsList', 'TabsPanel']
 import: "import { Tabs } from '@mantine/core';"
-source: 'mantine-core/src/components/Tabs/Tabs.tsx'
+source: 'mantine-core/src/Tabs/Tabs.tsx'
 docs: 'core/Tabs.mdx'
 styles: ['Tabs']
 ---

--- a/docs/src/docs/core/Text.mdx
+++ b/docs/src/docs/core/Text.mdx
@@ -8,7 +8,7 @@ category: 'typography'
 description: 'Display text and links with theme styles'
 props: ['Text']
 import: "import { Text } from '@mantine/core';"
-source: 'mantine-core/src/components/Text/Text.tsx'
+source: 'mantine-core/src/Text/Text.tsx'
 docs: 'core/Text.mdx'
 ---
 

--- a/docs/src/docs/core/TextInput.mdx
+++ b/docs/src/docs/core/TextInput.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Capture string input from user'
 props: ['TextInput']
 import: "import { TextInput } from '@mantine/core';"
-source: 'mantine-core/src/components/TextInput/TextInput.tsx'
+source: 'mantine-core/src/TextInput/TextInput.tsx'
 docs: 'core/TextInput.mdx'
 styles: ['TextInput']
 ---

--- a/docs/src/docs/core/Textarea.mdx
+++ b/docs/src/docs/core/Textarea.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Renders textarea with optional autosize variant'
 props: ['Textarea']
 import: "import { Textarea } from '@mantine/core';"
-source: 'mantine-core/src/components/Textarea/Textarea.tsx'
+source: 'mantine-core/src/Textarea/Textarea.tsx'
 docs: 'core/Textarea.mdx'
 styles: ['Textarea']
 ---

--- a/docs/src/docs/core/ThemeIcon.mdx
+++ b/docs/src/docs/core/ThemeIcon.mdx
@@ -8,7 +8,7 @@ category: 'data-display'
 description: 'Render icon inside element with theme colors'
 props: ['ThemeIcon']
 import: "import { ThemeIcon } from '@mantine/core';"
-source: 'mantine-core/src/components/ThemeIcon/ThemeIcon.tsx'
+source: 'mantine-core/src/ThemeIcon/ThemeIcon.tsx'
 docs: 'core/ThemeIcon.mdx'
 ---
 

--- a/docs/src/docs/core/Timeline.mdx
+++ b/docs/src/docs/core/Timeline.mdx
@@ -8,7 +8,7 @@ category: 'data-display'
 description: 'Display list of events in chronological order'
 props: ['Timeline', 'TimelineItem']
 import: "import { Timeline } from '@mantine/core';"
-source: 'mantine-core/src/components/Timeline/Timeline.tsx'
+source: 'mantine-core/src/Timeline/Timeline.tsx'
 docs: 'core/Timeline.mdx'
 styles: ['Timeline']
 ---

--- a/docs/src/docs/core/Title.mdx
+++ b/docs/src/docs/core/Title.mdx
@@ -8,7 +8,7 @@ category: 'typography'
 description: 'h1-h6 headings'
 props: ['Title']
 import: "import { Title } from '@mantine/core';"
-source: 'mantine-core/src/components/Title/Title.tsx'
+source: 'mantine-core/src/Title/Title.tsx'
 docs: 'core/Title.mdx'
 ---
 

--- a/docs/src/docs/core/Tooltip.mdx
+++ b/docs/src/docs/core/Tooltip.mdx
@@ -9,7 +9,7 @@ description: 'Renders tooltip at given element on mouse over or other event'
 componentPrefix: 'Tooltip'
 props: ['Tooltip', 'TooltipFloating', 'TooltipGroup']
 import: "import { Tooltip } from '@mantine/core';"
-source: 'mantine-core/src/components/Tooltip/Tooltip.tsx'
+source: 'mantine-core/src/Tooltip/Tooltip.tsx'
 docs: 'core/Tooltip.mdx'
 styles: ['Tooltip']
 ---

--- a/docs/src/docs/core/TransferList.mdx
+++ b/docs/src/docs/core/TransferList.mdx
@@ -8,7 +8,7 @@ category: 'inputs'
 description: 'Move items between two lists'
 props: ['TransferList']
 import: "import { TransferList } from '@mantine/core';"
-source: 'mantine-core/src/components/TransferList/TransferList.tsx'
+source: 'mantine-core/src/TransferList/TransferList.tsx'
 docs: 'core/TransferList.mdx'
 styles: ['TransferList']
 ---

--- a/docs/src/docs/core/Transition.mdx
+++ b/docs/src/docs/core/Transition.mdx
@@ -8,7 +8,7 @@ category: 'misc'
 description: 'Animate presence of component with premade animations'
 props: ['Transition']
 import: "import { Transition, GroupedTransition } from '@mantine/core';"
-source: 'mantine-core/src/components/Transition/Transition.tsx'
+source: 'mantine-core/src/Transition/Transition.tsx'
 docs: 'core/Transition.mdx'
 ---
 

--- a/docs/src/docs/core/TypographyStylesProvider.mdx
+++ b/docs/src/docs/core/TypographyStylesProvider.mdx
@@ -8,7 +8,7 @@ category: 'typography'
 description: 'Add Mantine typography styles to your html content'
 props: ['TypographyStylesProvider']
 import: "import { TypographyStylesProvider } from '@mantine/core';"
-source: 'mantine-core/src/components/TypographyStylesProvider/TypographyStylesProvider.tsx'
+source: 'mantine-core/src/TypographyStylesProvider/TypographyStylesProvider.tsx'
 docs: 'core/TypographyStylesProvider.mdx'
 ---
 

--- a/docs/src/docs/core/UnstyledButton.mdx
+++ b/docs/src/docs/core/UnstyledButton.mdx
@@ -7,7 +7,7 @@ slug: /core/unstyled-button/
 category: 'buttons'
 description: 'Unstyled polymorphic button'
 import: "import { UnstyledButton } from '@mantine/core';"
-source: 'mantine-core/src/components/UnstyledButton/UnstyledButton.tsx'
+source: 'mantine-core/src/UnstyledButton/UnstyledButton.tsx'
 docs: 'core/UnstyledButton.mdx'
 ---
 


### PR DESCRIPTION
This PR fixes broken source links in docs for all `mantine-core` components. Seems to have been caused by [this commit](https://github.com/mantinedev/mantine/commit/775aa406238d4e76c871f69aab0bbba542cb6734)