### PR TITLE
[@mantine/core] NumberInput: Preserve cursor selection on format/parse

### DIFF
--- a/src/mantine-core/src/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.tsx
@@ -176,6 +176,12 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
       parsedStr = parsedStr.replace(/\./g, decimalSeparator);
     }
 
+    // save the current selection position to restore it after the formatting
+    const selectionStart = inputRef.current?.selectionStart;
+    requestAnimationFrame(() => {
+      inputRef.current?.setSelectionRange(selectionStart, selectionStart);
+    });
+
     return formatter(parsedStr);
   };
 


### PR DESCRIPTION
Related issue: https://github.com/mantinedev/mantine/issues/1905

Before:
https://user-images.githubusercontent.com/22859283/181459033-21669098-e90c-4173-9e60-677fbdc75a23.mov


After:
https://user-images.githubusercontent.com/22859283/181459057-3de74e75-c259-4f90-9f2c-69990f35af0d.mov


