### PR TITLE
[@mantine/core] fixed typo `content` attribute to Notification and Switch

### DIFF
--- a/src/mantine-core/src/Notification/Notification.styles.ts
+++ b/src/mantine-core/src/Notification/Notification.styles.ts
@@ -54,7 +54,7 @@ export default createStyles((theme, { color, radius }: NotificationStylesParams,
       }`,
 
       '&::before': {
-        content: "''",
+        content: '""',
         display: 'block',
         position: 'absolute',
         width: 6,

--- a/src/mantine-core/src/Switch/Switch.styles.ts
+++ b/src/mantine-core/src/Switch/Switch.styles.ts
@@ -81,7 +81,7 @@ export default createStyles(
           zIndex: 1,
           borderRadius,
           boxSizing: 'border-box',
-          content: "''",
+          content: '""',
           display: 'block',
           backgroundColor: theme.white,
           height: handleSize,


### PR DESCRIPTION
## Work History

- fixed typo
  It has been modified for consistency with the value of the existing content property.