### PR TITLE
[@mantine/core] ActionIcon: Transparent bg for disabled State - Skeleton: Safari: Fixed border Radius

### DIFF
--- a/src/mantine-core/src/ActionIcon/ActionIcon.styles.ts
+++ b/src/mantine-core/src/ActionIcon/ActionIcon.styles.ts
@@ -35,6 +35,10 @@ function getVariantStyles({ variant, theme, color }: GetVariantStyles) {
       border: '1px solid transparent',
       color: theme.fn.themeColor(color, theme.colorScheme === 'dark' ? 4 : 7),
       backgroundColor: 'transparent',
+      '&[data-disabled]': {
+        backgroundColor: theme.fn.themeColor('gray', -1),
+        borderColor: theme.fn.themeColor('gray', -1),
+      },
     };
   }
 
@@ -74,6 +78,7 @@ export default createStyles((theme, { color, size, radius, variant }: ActionIcon
       '&:active': {
         transform: 'none',
       },
+      ...getVariantStyles({ variant, theme, color })['&[data-disabled]'],
     },
 
     '&[data-loading]': {

--- a/src/mantine-core/src/Skeleton/Skeleton.styles.ts
+++ b/src/mantine-core/src/Skeleton/Skeleton.styles.ts
@@ -19,6 +19,7 @@ export default createStyles(
       height,
       width: circle ? height : width,
       borderRadius: circle ? height : theme.fn.radius(radius),
+      WebkitTransform: 'translateZ(0)',
       position: 'relative',
       overflow: 'hidden',
     },


### PR DESCRIPTION
Transparent variant now has transparent background color and border color for disabled state (#1883)