### PR TITLE
[@mantine/core] AppShell/Header: Add withBorder Prop

### DIFF
--- a/src/mantine-core/src/AppShell/Header.story.tsx
+++ b/src/mantine-core/src/AppShell/Header.story.tsx
@@ -26,4 +26,12 @@ storiesOf('AppShell/Header', module)
       </Header>
       <div style={{ paddingTop: 50 }}>{content}</div>
     </>
+  ))
+  .add('Header: Fixed Without border', () => (
+    <>
+      <Header height={50} withBorder={false} fixed>
+        Just a header
+      </Header>
+      <div>{content}</div>
+    </>
   ));

--- a/src/mantine-core/src/AppShell/HorizontalSection/HorizontalSection.styles.ts
+++ b/src/mantine-core/src/AppShell/HorizontalSection/HorizontalSection.styles.ts
@@ -18,12 +18,22 @@ interface HorizontalSectionStyles {
   fixed: boolean;
   zIndex: React.CSSProperties['zIndex'];
   section: 'navbar' | 'aside';
+  withBorder: boolean;
 }
 
 export default createStyles(
   (
     theme,
-    { height, width, fixed, position, hiddenBreakpoint, zIndex, section }: HorizontalSectionStyles
+    {
+      height,
+      width,
+      fixed,
+      position,
+      hiddenBreakpoint,
+      zIndex,
+      section,
+      withBorder,
+    }: HorizontalSectionStyles
   ) => {
     const breakpoints =
       typeof width === 'object' && width !== null
@@ -52,7 +62,7 @@ export default createStyles(
         display: 'flex',
         flexDirection: 'column',
         backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
-        [section === 'navbar' ? 'borderRight' : 'borderLeft']: `1px solid ${
+        [withBorder && section === 'navbar' ? 'borderRight' : 'borderLeft']: `1px solid ${
           theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.gray[2]
         }`,
         ...breakpoints,

--- a/src/mantine-core/src/AppShell/HorizontalSection/HorizontalSection.tsx
+++ b/src/mantine-core/src/AppShell/HorizontalSection/HorizontalSection.tsx
@@ -18,6 +18,9 @@ export interface HorizontalSectionSharedProps extends DefaultProps {
   /** HorizontalSection content */
   children: React.ReactNode;
 
+  /** Border */
+  withBorder?: boolean;
+
   /** Set position to fixed */
   fixed?: boolean;
 
@@ -51,6 +54,7 @@ export const HorizontalSection = forwardRef<HTMLElement, HorizontalSectionProps>
       zIndex = getDefaultZIndex('app'),
       hiddenBreakpoint = 'md',
       hidden = false,
+      withBorder = true,
       className,
       classNames,
       styles,
@@ -73,6 +77,7 @@ export const HorizontalSection = forwardRef<HTMLElement, HorizontalSectionProps>
         hiddenBreakpoint,
         zIndex: ctx.zIndex || zIndex,
         section,
+        withBorder,
       },
       { classNames, styles, name: __staticSelector, unstyled }
     );

--- a/src/mantine-core/src/AppShell/Navbar.story.tsx
+++ b/src/mantine-core/src/AppShell/Navbar.story.tsx
@@ -42,4 +42,12 @@ storiesOf('AppShell/Navbar', module)
     <Navbar style={{ background: 'silver' }} width={{ sm: 300, lg: 400 }}>
       This is navbar
     </Navbar>
+  ))
+  .add('Fixed without Border', () => (
+    <Navbar fixed position={{ top: 60, left: 0 }} width={{ base: 100, sm: 300 }} withBorder={false}>
+      <Navbar.Section>First section</Navbar.Section>
+      <Navbar.Section>Second section</Navbar.Section>
+      <Navbar.Section grow>Grow section</Navbar.Section>
+      <Navbar.Section>Last section</Navbar.Section>
+    </Navbar>
   ));

--- a/src/mantine-core/src/AppShell/VerticalSection/VerticalSection.tsx
+++ b/src/mantine-core/src/AppShell/VerticalSection/VerticalSection.tsx
@@ -11,6 +11,9 @@ export interface VerticalSectionSharedProps extends DefaultProps {
   /** Section height */
   height: number | string;
 
+  /** Border */
+  withBorder?: boolean;
+
   /** Changes position to fixed, controlled by AppShell component if rendered inside */
   fixed?: boolean;
 
@@ -37,6 +40,7 @@ export const VerticalSection = forwardRef<HTMLElement, VerticalSectionProps>(
       styles,
       height,
       fixed = false,
+      withBorder = true,
       position,
       zIndex = getDefaultZIndex('app'),
       section,
@@ -54,7 +58,7 @@ export const VerticalSection = forwardRef<HTMLElement, VerticalSectionProps>(
         fixed: ctx.fixed || fixed,
         position,
         zIndex: ctx.zIndex || zIndex,
-        borderPosition: section === 'header' ? 'bottom' : 'top',
+        borderPosition: withBorder && section === 'header' ? 'bottom' : 'top',
       },
       { name: __staticSelector, classNames, styles, unstyled }
     );


### PR DESCRIPTION
Added an optional `withBorder` prop to the appshell header component. By default, it is set to true.