### PR TITLE
[@mantine/rte] Change the display property of the mention to `inline-block`

### DIFF
--- a/src/mantine-rte/src/components/RichTextEditor/RichTextEditor.styles.ts
+++ b/src/mantine-rte/src/components/RichTextEditor/RichTextEditor.styles.ts
@@ -197,12 +197,11 @@ export default createStyles(
       },
 
       '& .mention': {
+        display: 'inline-block',
         color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
         backgroundColor:
           theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors[theme.primaryColor][0],
         padding: '3px 5px',
-        height: 24,
-        width: 65,
         marginRight: 2,
         borderRadius: theme.radius.sm,
         userSelect: 'all',


### PR DESCRIPTION
## Package

Rich text editor

## Example Docs

https://mantine.dev/others/rte/#mentions

## Description

- Mention has width and height properties, but the actual size is not applied because it is an inline property.

![image](https://user-images.githubusercontent.com/27342882/182142339-ad8641ef-7647-44af-a5c0-09008d560ab7.png)


- If the Mention has inline-block properties, width, height, margin, padding can be set, so I think it is very useful.
- Even for inline block properties, the width (65px) and height (24px) currently specified are too small, so I thought it would be better to delete them.

## Suggest

![image](https://user-images.githubusercontent.com/27342882/182141964-a57d80c1-3831-4935-a8c4-31333d20c96c.png)

- If there are several lines of mentions, it would be better to see if there is a margin-bottom. What do you think?

![image](https://user-images.githubusercontent.com/27342882/182142198-cef838f9-25cc-4e56-85dc-00d5111467de.png)

If you agree with this, I'll add a commit.
