### PR TITLE
[docs] Add pnpm to package installation component

### DIFF
--- a/docs/src/components/PackagesInstallation/PackagesInstallation.tsx
+++ b/docs/src/components/PackagesInstallation/PackagesInstallation.tsx
@@ -1,13 +1,19 @@
 import React, { useState } from 'react';
 import { Table, Checkbox, Code, Text, Box } from '@mantine/core';
 import { Prism } from '@mantine/prism';
-import { NpmIcon, YarnIcon } from '@mantine/ds';
+import { NpmIcon, YarnIcon, PnpmIcon } from '@mantine/ds';
 import { PACKAGES_DATA } from './data';
+
+const packageManagers = {
+  yarn: 'yarn add',
+  npm: 'npm install',
+  pnpm: 'pnpm add',
+};
 
 function getInstallationCommand(
   selection: string[],
   extraPackages: string[],
-  type: 'yarn' | 'npm'
+  type: 'yarn' | 'npm' | 'pnpm'
 ) {
   const packages = selection.reduce<string[]>((acc, item) => {
     acc.push(...PACKAGES_DATA.find((i) => i.package === item).dependencies);
@@ -17,7 +23,7 @@ function getInstallationCommand(
   const unique = Array.from(
     new Set(['@mantine/core', '@mantine/hooks', ...packages, ...extraPackages, '@emotion/react'])
   );
-  const prefix = type === 'yarn' ? 'yarn add' : 'npm install';
+  const prefix = packageManagers[type];
   return `${prefix} ${unique.join(' ')}`;
 }
 
@@ -96,6 +102,9 @@ export function PackagesInstallation({ extraPackages = [] }: PackagesInstallatio
           <Prism.Tab value="npm" icon={<NpmIcon size={16} />}>
             npm
           </Prism.Tab>
+          <Prism.Tab value="pnpm" icon={<PnpmIcon size={16} />}>
+            pnpm
+          </Prism.Tab>
         </Prism.TabsList>
 
         <Prism.Panel value="yarn" language="bash">
@@ -103,6 +112,9 @@ export function PackagesInstallation({ extraPackages = [] }: PackagesInstallatio
         </Prism.Panel>
         <Prism.Panel value="npm" language="bash">
           {getInstallationCommand(selection, extraPackages, 'npm')}
+        </Prism.Panel>
+        <Prism.Panel value="pnpm" language="bash">
+          {getInstallationCommand(selection, extraPackages, 'pnpm')}
         </Prism.Panel>
       </Prism.Tabs>
     </>

--- a/src/mantine-ds/src/Icons/Icons.story.tsx
+++ b/src/mantine-ds/src/Icons/Icons.story.tsx
@@ -4,6 +4,7 @@ import { GithubIcon } from './GithubIcon';
 import { TwitterIcon } from './TwitterIcon';
 import { NpmIcon } from './NpmIcon';
 import { YarnIcon } from './YarnIcon';
+import { PnpmIcon } from './PnpmIcon';
 
 export default { title: 'DS/Icons' };
 
@@ -15,6 +16,7 @@ export function Usage() {
       <TwitterIcon size={40} />
       <NpmIcon size={40} />
       <YarnIcon size={40} />
+      <PnpmIcon size={40} />
     </div>
   );
 }

--- a/src/mantine-ds/src/Icons/PnpmIcon.tsx
+++ b/src/mantine-ds/src/Icons/PnpmIcon.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface PnpmIconProps extends React.ComponentPropsWithoutRef<'svg'> {
+  size?: number;
+}
+
+export function PnpmIcon({ size, ...others }: PnpmIconProps) {
+  return (
+    <svg
+      {...others}
+      viewBox="76.59 44 164.01 164"
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+    >
+      <path fill="#f9ad00" d="m237.6 95h-50v-50h50v50z" />
+      <path fill="#f9ad00" d="m182.59 95h-50v-50h50v50z" />
+      <path fill="#f9ad00" d="m127.59 95h-50v-50h50v50z" />
+      <path fill="#f9ad00" d="m237.6 150h-50v-50h50v50z" />
+      <path fill="#4e4e4e" d="m182.59 150h-50v-50h50v50z" />
+      <path fill="#4e4e4e" d="m182.59 205h-50v-50h50v50z" />
+      <path fill="#4e4e4e" d="m237.6 205h-50v-50h50v50z" />
+      <path fill="#4e4e4e" d="m127.59 205h-50v-50h50v50z" />
+    </svg>
+  );
+}

--- a/src/mantine-ds/src/Icons/index.ts
+++ b/src/mantine-ds/src/Icons/index.ts
@@ -3,3 +3,4 @@ export { TwitterIcon } from './TwitterIcon';
 export { GithubIcon } from './GithubIcon';
 export { NpmIcon } from './NpmIcon';
 export { YarnIcon } from './YarnIcon';
+export { PnpmIcon } from './PnpmIcon';


### PR DESCRIPTION
This PR adds support for the [pnpm](https://pnpm.io/) package manager in the package installation instructions component in the documentation.