### PR TITLE
[@mantine/core] NumberInput: Preserve cursor selection on format/parse

### DIFF
--- a/src/mantine-core/src/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, forwardRef } from 'react';
+import React, { useState, useEffect, useRef, forwardRef, useMemo } from 'react';
 import { useMergedRef, assignRef, useOs, clamp } from '@mantine/hooks';
 import { DefaultProps, Selectors, useComponentDefaultProps } from '@mantine/styles';
 import { TextInput } from '../TextInput';
@@ -169,15 +169,23 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
     }
   };
 
-  const formatNum = (val: string | number = '') => {
-    let parsedStr = typeof val === 'number' ? String(val) : val;
+  const formatNum = useMemo(() => {
+    let parsedStr = typeof tempValue === 'number' ? String(tempValue) : tempValue;
+
+    // save the current selection position
+    const selectionStart = inputRef.current?.selectionStart;
 
     if (decimalSeparator) {
       parsedStr = parsedStr.replace(/\./g, decimalSeparator);
     }
 
+    // restore the current selection position
+    setTimeout(() => {
+      inputRef.current?.setSelectionRange(selectionStart, selectionStart);
+    });
+
     return formatter(parsedStr);
-  };
+  }, [tempValue, decimalSeparator, inputMode, formatter]);
 
   const parseNum = (val: string): string | undefined => {
     let num = val;
@@ -386,7 +394,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
     <TextInput
       {...others}
       variant={variant}
-      value={formatNum(tempValue)}
+      value={formatNum}
       disabled={disabled}
       ref={useMergedRef(inputRef, ref)}
       type="text"


### PR DESCRIPTION
Related issue: https://github.com/mantinedev/mantine/issues/1905 and https://github.com/mantinedev/mantine/issues/1968

Before:
https://user-images.githubusercontent.com/22859283/181459033-21669098-e90c-4173-9e60-677fbdc75a23.mov

After:
https://user-images.githubusercontent.com/22859283/181459057-3de74e75-c259-4f90-9f2c-69990f35af0d.mov


<img width="1438" alt="Schermata 2022-08-03 alle 10 28 08" src="https://user-images.githubusercontent.com/22859283/182561686-7c95f5bc-469f-4639-8482-ba325b2adab2.png">


https://github.com/mantinedev/mantine/pull/1908#issuecomment-1203107099
I solved the performance problem on Safari by using a useMemo for the input value so that it doesn't change with each render. If anyone can give me a hand to verify that it is really fixed, you would help me out :)