### PR TITLE
[docs] Fix useform list validation example

### DIFF
--- a/docs/src/docs/form/nested.mdx
+++ b/docs/src/docs/form/nested.mdx
@@ -140,7 +140,7 @@ form.validate('users.1.name');
 form.validate();
 console.log(form.errors);
 // {
-//  'users.0.name': 'Name should have at least 2 letters',
-//  'users.1.age': 'User must be 18 or older'
+//  'users.0.age': 'User must be 18 or older',
+//  'users.1.name': 'Name should have at least 2 letters'
 // }
 ```


### PR DESCRIPTION
Fixes [#1994](https://github.com/mantinedev/mantine/issues/1994) - validation example for lists in useform has error messages swapped