### PR TITLE
[@mantine/hooks] use-click-outside: ignore clicks on elements removed from DOM

### DIFF
--- a/src/mantine-hooks/src/use-click-outside/use-click-outside.ts
+++ b/src/mantine-hooks/src/use-click-outside/use-click-outside.ts
@@ -11,11 +11,13 @@ export function useClickOutside<T extends HTMLElement = any>(
 
   useEffect(() => {
     const listener = (event: any) => {
+      const { target } = event ?? {};
       if (Array.isArray(nodes)) {
-        const shouldIgnore = event?.target?.hasAttribute('data-ignore-outside-clicks');
-        const shouldTrigger = nodes.every((node) => !!node && !node.contains(event.target));
+        const shouldIgnore =
+          target?.hasAttribute('data-ignore-outside-clicks') || !document.body.contains(target);
+        const shouldTrigger = nodes.every((node) => !!node && !node.contains(target));
         shouldTrigger && !shouldIgnore && handler();
-      } else if (ref.current && !ref.current.contains(event.target)) {
+      } else if (ref.current && !ref.current.contains(target)) {
         handler();
       }
     };


### PR DESCRIPTION
This PR makes `useClickOutside` less permissive. If an element is not inside the DOM (it was removed), assume that the deleted element could have been inside the relevant `nodes` and do NOT fire the click outside event.

This is a proposed solution to #1986.