### PR TITLE
[@mantine/core] add data-position attribute to popover dropdown

### DIFF
--- a/src/mantine-core/src/Popover/PopoverDropdown/PopoverDropdown.tsx
+++ b/src/mantine-core/src/Popover/PopoverDropdown/PopoverDropdown.tsx
@@ -67,6 +67,7 @@ export function PopoverDropdown({ style, className, children, ...others }: Popov
                 active: ctx.closeOnEscape,
                 onTrigger: returnFocus,
               })}
+              data-position={ctx.placement}
               {...others}
             >
               {children}


### PR DESCRIPTION
As discussed on Discord, simply expose the `ctx.placement` from Floating UI as a `data-position` attribute on `Popover.Dropdown`