### PR TITLE
[@mantine/core] add all properties to polymorphic component types

### DIFF
--- a/src/mantine-utils/src/create-polymorphic-component/create-polymorphic-component.ts
+++ b/src/mantine-utils/src/create-polymorphic-component/create-polymorphic-component.ts
@@ -35,7 +35,9 @@ export function createPolymorphicComponent<
     props: ComponentProps<C>
   ) => React.ReactElement;
 
-  type PolymorphicComponent = _PolymorphicComponent & StaticComponents;
+  type ComponentProperties = Omit<React.FunctionComponent<ComponentProps<any>>, never>;
+
+  type PolymorphicComponent = _PolymorphicComponent & ComponentProperties & StaticComponents;
 
   return component as PolymorphicComponent;
 }


### PR DESCRIPTION
This PR adds missing Typescript properties on polymorphic components: `displayName`, `defaultProps`, `propTypes` and `contextTypes`.

It uses a future-proof select on `FunctionComponent` to include any property that could be added by the React team in the future