### PR TITLE
[@mantine/core] Refactor: rename isValidSizeValue, getSizeValue parameter

### DIFF
--- a/src/mantine-core/src/Box/use-sx/get-system-styles/get-system-styles.ts
+++ b/src/mantine-core/src/Box/use-sx/get-system-styles/get-system-styles.ts
@@ -13,16 +13,16 @@ const SYSTEM_PROPS = {
 
 const NEGATIVE_VALUES = ['-xs', '-sm', '-md', '-lg', '-xl'];
 
-function isValidSizeValue(margin: any) {
-  return typeof margin === 'string' || typeof margin === 'number';
+function isValidSizeValue(size: any) {
+  return typeof size === 'string' || typeof size === 'number';
 }
 
-function getSizeValue(margin: any, theme: MantineTheme) {
-  if (NEGATIVE_VALUES.includes(margin)) {
-    return theme.fn.size({ size: margin.replace('-', ''), sizes: theme.spacing }) * -1;
+function getSizeValue(size: any, theme: MantineTheme) {
+  if (NEGATIVE_VALUES.includes(size)) {
+    return theme.fn.size({ size: size.replace('-', ''), sizes: theme.spacing }) * -1;
   }
 
-  return theme.fn.size({ size: margin, sizes: theme.spacing });
+  return theme.fn.size({ size, sizes: theme.spacing });
 }
 
 export function getSystemStyles(systemStyles: MantineStyleSystemProps, theme: MantineTheme) {


### PR DESCRIPTION
## Suggest

In addition to `margin`, also receive `padding` values, so I think need to change the name!

