### PR TITLE
[docs] fix: Change the style of code controls in the demo

### DIFF
--- a/src/mantine-demos/src/components/Demo/CodeDemo/CodeDemo.styles.ts
+++ b/src/mantine-demos/src/components/Demo/CodeDemo/CodeDemo.styles.ts
@@ -38,9 +38,8 @@ export default createStyles((theme: MantineTheme, { radius }: CodeDemoStylesPara
   },
 
   controls: {
-    position: 'absolute',
-    bottom: theme.spacing.xs - 1,
-    right: theme.spacing.xs - 1,
+    marginTop: theme.spacing.xs - 1,
+    alignItems: 'flex-end',
   },
 
   withToggle: {


### PR DESCRIPTION
## Description

- https://mantine.dev/core/tabs/#icon-and-right-section
- https://mantine.dev/core/stepper/#customize-with-styles-api
- https://mantine.dev/core/accordion/#custom-control-label

### Before

![image](https://user-images.githubusercontent.com/27342882/183277817-a5b761d7-861b-41e4-9536-755943646a49.png)
![image](https://user-images.githubusercontent.com/27342882/183277844-80d91309-7150-4bb4-a59e-a370f7162815.png)
![image](https://user-images.githubusercontent.com/27342882/183277914-4ad5fbb1-475d-4711-85a7-c3375b471861.png)

### After

![image](https://user-images.githubusercontent.com/27342882/183277807-35edb42f-405f-409a-9295-a206f34c7a24.png)
![image](https://user-images.githubusercontent.com/27342882/183277855-9613aefc-a89a-4177-89b6-85db91a57808.png)
![image](https://user-images.githubusercontent.com/27342882/183277906-daec8492-66a8-4b98-bcd3-b3c60d659ab9.png)
