### PR TITLE
[@mantine/core] Group: extend props with BoxProps

### DIFF
--- a/src/mantine-core/src/Group/Group.tsx
+++ b/src/mantine-core/src/Group/Group.tsx
@@ -1,10 +1,10 @@
 import React, { forwardRef } from 'react';
 import { DefaultProps, MantineNumberSize, useComponentDefaultProps } from '@mantine/styles';
-import { Box } from '../Box';
+import { Box, BoxProps } from '../Box';
 import { filterFalsyChildren } from './filter-falsy-children/filter-falsy-children';
 import useStyles, { GroupPosition } from './Group.styles';
 
-export interface GroupProps extends DefaultProps, React.ComponentPropsWithoutRef<'div'> {
+export interface GroupProps extends DefaultProps, React.ComponentPropsWithoutRef<'div'>, BoxProps {
   /** Defines justify-content property */
   position?: GroupPosition;
 


### PR DESCRIPTION
I was looking to create a (HTML) `<header>` whit the styling of a `Group`.  
Since the (`others`) props are spread and the `Box` component has a `component` prop that would accept a `header` value.

Not sure if some omitting should be done (`Omit<BoxProps, '...'>`) tho.