### PR TITLE
Fix #2093: [@mantine/hooks] Interval hook ensure only 1 running timer

### DIFF
--- a/src/mantine-hooks/src/use-interval/use-interval.ts
+++ b/src/mantine-hooks/src/use-interval/use-interval.ts
@@ -11,7 +11,7 @@ export function useInterval(fn: () => void, interval: number) {
 
   const start = () => {
     setActive((old) => {
-      if (!old) {
+      if (!old && !intervalRef.current) {
         intervalRef.current = window.setInterval(fnRef.current, interval);
       }
       return true;
@@ -21,6 +21,7 @@ export function useInterval(fn: () => void, interval: number) {
   const stop = () => {
     setActive(false);
     window.clearInterval(intervalRef.current);
+    intervalRef.current = undefined;
   };
 
   const toggle = () => {


### PR DESCRIPTION
Fix #2093: Interval hook ensure only 1 running timer

This ensures even when creating and destroying components in React 18 it ensures that only 1 timer can be running at a time.