### PR TITLE
[@mantine/hooks] use-id: replace with `useIsomorphicEffect` hooks

### DIFF
--- a/src/mantine-hooks/src/use-id/use-id.ts
+++ b/src/mantine-hooks/src/use-id/use-id.ts
@@ -1,8 +1,7 @@
-import React, { useState, useEffect, useLayoutEffect } from 'react';
+import React, { useState } from 'react';
+import { useIsomorphicEffect } from '../use-isomorphic-effect/use-isomorphic-effect';
 
 const randomId = () => `mantine-${Math.random().toString(36).slice(2, 11)}`;
-
-const useIsomorphicEffect = typeof document !== 'undefined' ? useLayoutEffect : useEffect;
 
 const useReactId: () => string | undefined =
   (React as any)['useId'.toString()] || (() => undefined);


### PR DESCRIPTION
## Suggest

I thought I could replace that syntax with the already existing Hooks.

## Question

1. If you look at the use-isomorphic-effect hook, you are checking the document, not the window. Is it intentional?

```ts
// hooks/use-isomorphic-effect.ts
export const useIsomorphicEffect = typeof document !== 'undefined' ? useLayoutEffect : useEffect;
```