### PR TITLE
[@mantine/core] ListItem:  Span limits the full width capability

### DIFF
--- a/src/mantine-core/src/List/ListItem/ListItem.tsx
+++ b/src/mantine-core/src/List/ListItem/ListItem.tsx
@@ -33,7 +33,7 @@ export function ListItem({ className, children, icon, ...others }: ListItemProps
     >
       <div className={classes.itemWrapper}>
         {_icon && <span className={classes.itemIcon}>{_icon}</span>}
-        <span>{children}</span>
+        {children}
       </div>
     </Box>
   );


### PR DESCRIPTION
By Removing the span we can now pass a div or any other JSX Element which can take the full width of the container the list is in.
Eg. I can put Text on the left side and have a button floated / flexed to the right side.