### PR TITLE
[@mantine/date] TimeInput: fix the width of the am/pm input

### DIFF
--- a/src/mantine-dates/src/components/TimeInputBase/TimeInputBase.styles.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/TimeInputBase.styles.ts
@@ -1,4 +1,4 @@
-import { createStyles, MantineSize } from '@mantine/core';
+import { createStyles, MantineSize } from "@mantine/core";
 
 export const inputSizes = {
   xs: 20,
@@ -43,7 +43,6 @@ export default createStyles((theme, { size, hasValue }: TimeInputBaseStyles) => 
   },
 
   amPmInput: {
-    width: 'auto',
     textAlign: 'left',
   },
 }));

--- a/src/mantine-dates/src/components/TimeInputBase/TimeInputBase.styles.ts
+++ b/src/mantine-dates/src/components/TimeInputBase/TimeInputBase.styles.ts
@@ -1,4 +1,4 @@
-import { createStyles, MantineSize } from "@mantine/core";
+import { createStyles, MantineSize } from '@mantine/core';
 
 export const inputSizes = {
   xs: 20,


### PR DESCRIPTION
The AM/PM label for `TimeInput` is getting reset to `auto` which causes it to be around 200px wide. If the TimeInput's width is shrunk to make it take up less extraneous space, that interior input bleeds outside of the container width. It seems that if this `width: auto` is removed then the input has a more reasonable size.

Motivation (copied over from Discord):

> I have a horizontal form with a TimeInput on the end. For some reason, the TimeInput uses up a lot of extra space:
> 
> https://codesandbox.io/s/long-pine-68z7s3?file=/src/App.tsx
>
> As a workaround, I've set its width property manually, and while that does make it take up less space in the <Group/>, it still bleeds outside of its container which is causing a horizontal scroll bar to show up:
> 
> https://codesandbox.io/s/recursing-antonelli-j5d9hq?file=/src/App.tsx
>
> Is there a way to make TimeInput not take up that extra space? Is the extra horizontal space a bug?

I've been unable to use the styles API to affect the width of that amPmInput.