### PR TITLE
[@mantine/core] - Add @emotion/react to package.json

### DIFF
--- a/src/mantine-core/package.json
+++ b/src/mantine-core/package.json
@@ -32,6 +32,7 @@
     "react-dom": ">=16.8.0"
   },
   "dependencies": {
+    "@emotion/react": ">=11.9.0",
     "@mantine/utils": "5.2.0",
     "@mantine/styles": "5.2.0",
     "@radix-ui/react-scroll-area": "1.0.0",


### PR DESCRIPTION
`@emotion/react` is currently a peer dependency for @mantine/styles, but when installing (tested with yarn), it will not be installed, causing mantine to crash on startup.