### PR TITLE
[@mantine/core] Container: Change desc of fluid prop

### DIFF
--- a/src/mantine-core/src/Container/Container.tsx
+++ b/src/mantine-core/src/Container/Container.tsx
@@ -12,7 +12,7 @@ export interface ContainerProps extends DefaultProps, React.ComponentPropsWithou
   /** Predefined container max-width or number for max-width in px */
   size?: MantineNumberSize;
 
-  /** If fluid is set to true, size prop is ignored and Container always take 100% of width */
+  /** If fluid is set to true, size prop is ignored and Container can expand to 100% of width */
   fluid?: boolean;
 
   /** Container sizes */


### PR DESCRIPTION
Description of fluid prop was misleading because it implied that the prop would apply `width: 100%`, but it actually applies `max-width: 100%`

closes #2175 