### PR TITLE
ActionIcon:  Fix mismatch between demo apparent code and real code

### DIFF
--- a/src/mantine-demos/src/demos/core/ActionIcon/ActionIcon.demo.configurator.tsx
+++ b/src/mantine-demos/src/demos/core/ActionIcon/ActionIcon.demo.configurator.tsx
@@ -20,28 +20,28 @@ function Wrapper(props: ActionIconProps) {
   );
 }
 
-function computeChildIconSizeProp(props:string) {
-if (props.includes('size="xs"')) {
-return 'size={12}';
-}
-if (props.includes('size="sm"')) {
-return 'size={14}';
-}
-if (props.includes('size="md"')) {
-return 'size={18}';
-}
-if (props.includes('size="lg"')) {
-return 'size={26}';
-}
-if (props.includes('size="xl"')) {
-return 'size={34}';
-}
-return 'size={18}';
+function computeChildIconSizeProp(props: string) {
+  if (props.includes('size="xs"')) {
+    return 'size={12}';
+  }
+  if (props.includes('size="sm"')) {
+    return 'size={14}';
+  }
+  if (props.includes('size="md"')) {
+    return 'size={18}';
+  }
+  if (props.includes('size="lg"')) {
+    return 'size={26}';
+  }
+  if (props.includes('size="xl"')) {
+    return 'size={34}';
+  }
+  return 'size={18}';
 }
 
 const codeTemplate = (props: string) => {
-const childIconSizeProp = computeChildIconSizeProp(props);
-return (`
+  const childIconSizeProp = computeChildIconSizeProp(props);
+  return `
 import { ActionIcon } from '@mantine/core';
 import { IconAdjustments } from '@tabler/icons';
 
@@ -52,7 +52,7 @@ function Demo() {
     </ActionIcon>
   );
 }
-`);
+`;
 };
 
 export const configurator: MantineDemo = {

--- a/src/mantine-demos/src/demos/core/ActionIcon/ActionIcon.demo.configurator.tsx
+++ b/src/mantine-demos/src/demos/core/ActionIcon/ActionIcon.demo.configurator.tsx
@@ -2,19 +2,19 @@ import React from 'react';
 import { IconAdjustments } from '@tabler/icons';
 import { ActionIcon, ActionIconProps, Group } from '@mantine/core';
 
-const iconSizes = {
+/* const iconSizes = {
   xs: 12,
   sm: 14,
   md: 18,
   lg: 26,
   xl: 34,
-};
+}; */
 
 function Wrapper(props: ActionIconProps) {
   return (
     <Group position="center">
       <ActionIcon {...props}>
-        <IconAdjustments size={iconSizes[props.size]} />
+        <IconAdjustments />
       </ActionIcon>
     </Group>
   );

--- a/src/mantine-demos/src/demos/core/ActionIcon/ActionIcon.demo.configurator.tsx
+++ b/src/mantine-demos/src/demos/core/ActionIcon/ActionIcon.demo.configurator.tsx
@@ -2,36 +2,58 @@ import React from 'react';
 import { IconAdjustments } from '@tabler/icons';
 import { ActionIcon, ActionIconProps, Group } from '@mantine/core';
 
-/* const iconSizes = {
+const iconSizes = {
   xs: 12,
   sm: 14,
   md: 18,
   lg: 26,
   xl: 34,
-}; */
+};
 
 function Wrapper(props: ActionIconProps) {
   return (
     <Group position="center">
       <ActionIcon {...props}>
-        <IconAdjustments />
+        <IconAdjustments size={iconSizes[props.size]} />
       </ActionIcon>
     </Group>
   );
 }
 
-const codeTemplate = (props: string) => `
+function computeChildIconSizeProp(props:string) {
+if (props.includes('size="xs"')) {
+return 'size={12}';
+}
+if (props.includes('size="sm"')) {
+return 'size={14}';
+}
+if (props.includes('size="md"')) {
+return 'size={18}';
+}
+if (props.includes('size="lg"')) {
+return 'size={26}';
+}
+if (props.includes('size="xl"')) {
+return 'size={34}';
+}
+return 'size={18}';
+}
+
+const codeTemplate = (props: string) => {
+const childIconSizeProp = computeChildIconSizeProp(props);
+return (`
 import { ActionIcon } from '@mantine/core';
 import { IconAdjustments } from '@tabler/icons';
 
 function Demo() {
   return (
     <ActionIcon${props}>
-      <IconAdjustments />
+      <IconAdjustments ${childIconSizeProp} />
     </ActionIcon>
   );
 }
-`;
+`);
+};
 
 export const configurator: MantineDemo = {
   type: 'configurator',


### PR DESCRIPTION
Please see the screenshots and the videos in the discord thread: https://discord.com/channels/854810300876062770/1010668931842855064

This PR is more of a "Expose the problem to the maintainers" PR than anything, even though it does fix the mismatch

The demo real code was changing both the ActionIcon's size and the embedded Icon's size.
While this seems to be desirable, **it was not reflected in the apparent demo code**.

There are two way to "fix" this. One simple way, and one difficult way

1. (Easy way) **Make the real code match the apparent code**: do not change the embedded Icon's size when the slider moves.
2. (Hard way) **Make the apparent code match the real code**: continue to change the embedded Icon's size when the slider moves, but reflect that in the code template in real time as well.

This PR takes the first option, as it is the most straightforward, but I believe the second option might be better. **It would require extensive string manipulation though to change the template code and I want to leave that to the maintainer discretion**

Before:
![Screenshot 2022-08-21 at 11 23 18](https://user-images.githubusercontent.com/23578949/185784541-09dd0caa-5de2-44ca-bd61-baab5af8af83.jpg)


After: 
![Screenshot 2022-08-21 at 11 20 31](https://user-images.githubusercontent.com/23578949/185784693-6f026c21-5116-4bad-8293-0e3cc306649a.jpg)
 