### PR TITLE
[@mantine/core] Notification: spread closeButtonProps after iconSize, color

### DIFF
--- a/docs/src/docs/core/Notification.mdx
+++ b/docs/src/docs/core/Notification.mdx
@@ -32,6 +32,15 @@ Notification component has 3 variants:
 
 <Demo data={NotificationDemos.configurator} />
 
+## CloseButtonProps
+
+To customize CloseButton inside Notification, you can pass `CloseButtonProps`.
+
+```tsx
+<Notification closeButtonProps={{ color: 'red' }} />
+<Notification closeButtonProps={{ iconSize: 20 }} />
+```
+
 ## Accessibility
 
 To support screen readers set close button aria-label or title with `closeButtonProps`:

--- a/src/mantine-core/src/Notification/Notification.tsx
+++ b/src/mantine-core/src/Notification/Notification.tsx
@@ -93,9 +93,9 @@ export const Notification = forwardRef<HTMLDivElement, NotificationProps>((props
 
       {!disallowClose && (
         <CloseButton
-          {...closeButtonProps}
           iconSize={16}
           color="gray"
+          {...closeButtonProps}
           onClick={onClose}
           className={classes.closeButton}
         />


### PR DESCRIPTION
[original discord thread](https://discord.com/channels/854810300876062770/887408088800448553/1011259560012566609)

Spread Notification's `closeButtonProps` after CloseButton's `iconSize` and `color` would be better experience to customize Notification's CloseButton. (override default prop `iconSize=16, color=gray`)

Like below code, for customizing, using  CloseButton's props will better than using `classNames` because it is more simple and It can use CloseButton's predefined props.
```tsx
// If using classNames to customize Notification's closeButton
const useStyles = createStyles(
  (theme) => ({
    closeButton: {
      color: theme.colors.gray[2],
      width: '44px',
      height: '44px',
    },
  })
);
const { classes } = useStyles();
<Notification classNames={{ ...classes }} />

// If using closeButtonProps to customize Notification's closeButton
<Notification closeButtonProps={{ color: 'gray.2', size: 'xl' }}  />
```