### PR TITLE
[docs] Fix typo in use-intersection docs

### DIFF
--- a/docs/src/docs/hooks/use-intersection.mdx
+++ b/docs/src/docs/hooks/use-intersection.mdx
@@ -38,7 +38,7 @@ See [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API
 On the first render (as well as during SSR), or when no element is being observed, the entry is `null`.
 
 ```tsx
-const [ref, ioEntry] = useIntersection();
+const { ref, entry } = useIntersection();
 
 // With regular element:
 <div ref={ref}>Observed</div>


### PR DESCRIPTION
By the way, should I be branching off of `dev` instead of `master` for more complex changes? I've been branching from master since it seems to be more up-to-date.