### PR TITLE
[core]: Add volta support

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,5 +146,8 @@
     "react-transition-group": "4.4.2",
     "stylis-plugin-rtl": "^2.1.1",
     "zod": "^3.13.4"
+  },
+  "volta": {
+    "node": "14.17.0"
   }
 }


### PR DESCRIPTION
@rtivital

Volta is a node version manager just like **nvm** 
https://volta.sh/

By pinning the `node version` to `package.json`, volta can automatically pick up the node version to use when running `yarn install` making the process more user friendly.