### PR TITLE
[@mantine/hooks] use-color-scheme-value: Return value according to the system theme

### DIFF
--- a/docs/src/docs/hooks/use-color-scheme-value.mdx
+++ b/docs/src/docs/hooks/use-color-scheme-value.mdx
@@ -1,0 +1,28 @@
+---
+group: 'mantine-hooks'
+package: '@mantine/hooks'
+category: 'dom'
+title: 'use-color-scheme-value'
+order: 1
+slug: /hooks/use-color-scheme-value/
+description: 'Returns the corresponding results according to the user system color scheme'
+import: "import { useColorSchemeValue } from '@mantine/hooks';"
+docs: 'hooks/use-color-scheme-value.mdx'
+source: 'mantine-hooks/src/use-color-scheme-value/use-color-scheme-value.ts'
+---
+
+import { HooksDemos } from '@mantine/demos';
+
+## Usage
+
+use-color-scheme-color returns the corresponding results according to the user's system color scheme:
+
+<Demo data={HooksDemos.useColorSchemeValueDemo} />
+
+Hook uses [use-color-scheme](/hooks/use-color-scheme/) hook under the hood.
+
+## Definition
+
+```tsx
+function useColorSchemeValue(light: any, dark: any): light | dark;
+```

--- a/src/mantine-demos/src/demos/hooks/index.ts
+++ b/src/mantine-demos/src/demos/hooks/index.ts
@@ -2,6 +2,7 @@ export { useClickOutsideEvents } from './use-click-outside.demo.events';
 export { useClickOutsideUsage } from './use-click-outside.demo.usage';
 export { useClipboardDemo } from './use-clipboard.usage.demo';
 export { useColorSchemeDemo } from './use-color-scheme.demo.usage';
+export { useColorSchemeValueDemo } from './use-color-scheme-value.demo.usage';
 export { useCounterDemo } from './use-counter.demo.usage';
 export { useDebouncedStateUsage } from './use-debounced-state.demo.usage';
 export { useDebouncedStateLeading } from './use-debounced-state.demo.leading';

--- a/src/mantine-demos/src/demos/hooks/use-color-scheme-value.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/hooks/use-color-scheme-value.demo.usage.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Group, Badge } from '@mantine/core';
+import { useColorSchemeValue, useColorScheme } from '@mantine/hooks';
+
+const code = `
+import { Badge } from '@mantine/core';
+import { useColorSchemeValue, useColorScheme } from '@mantine/hooks';
+
+function Demo() {
+
+  const colorScheme = useColorScheme();
+
+  return (
+    Your System  color scheme is {colorScheme}
+    <Badge color={useColorSchemeValue('teal', 'blue')} variant="filled">
+      Your Badge color scheme is {useColorSchemeValue('teal', 'blue')}
+    </Badge>
+  );
+}
+`;
+
+function Demo() {
+  const colorScheme = useColorScheme();
+  return (
+    <Group position="center">
+      Your System color scheme is {colorScheme}
+      <Badge color={useColorSchemeValue('teal', 'blue')} variant="filled">
+        Your Badge color scheme is{useColorSchemeValue('teal', 'blue')}
+      </Badge>
+    </Group>
+  );
+}
+
+export const useColorSchemeValueDemo: MantineDemo = {
+  type: 'demo',
+  code,
+  component: Demo,
+};

--- a/src/mantine-demos/src/demos/hooks/use-color-scheme-value.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/hooks/use-color-scheme-value.demo.usage.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import { Group, Badge } from '@mantine/core';
-import { useColorSchemeValue, useColorScheme } from '@mantine/hooks';
+import { useColorSchemeValue } from '@mantine/hooks';
 
 const code = `
 import { Badge } from '@mantine/core';
-import { useColorSchemeValue, useColorScheme } from '@mantine/hooks';
+import { Group, Badge } from '@mantine/core';
 
 function Demo() {
-
-  const colorScheme = useColorScheme();
-
   return (
-    Your System  color scheme is {colorScheme}
+    <p>If System color scheme is Light it will be teal</p>
+    <p>If System color scheme is Light it will be blu</p>
     <Badge color={useColorSchemeValue('teal', 'blue')} variant="filled">
       Your Badge color scheme is {useColorSchemeValue('teal', 'blue')}
     </Badge>
@@ -20,14 +18,18 @@ function Demo() {
 `;
 
 function Demo() {
-  const colorScheme = useColorScheme();
   return (
-    <Group position="center">
-      Your System color scheme is {colorScheme}
-      <Badge color={useColorSchemeValue('teal', 'blue')} variant="filled">
-        Your Badge color scheme is{useColorSchemeValue('teal', 'blue')}
-      </Badge>
-    </Group>
+    <>
+      <div style={{ textAlign: 'center' }}>
+        <p>If System color scheme is Light it color will be teal</p>
+        <p>If System color scheme is Dark it color will be blue</p>
+      </div>
+      <Group position="center">
+        <Badge color={useColorSchemeValue('teal', 'blue')} variant="filled">
+          Your Badge color scheme is {useColorSchemeValue('teal', 'blue')}
+        </Badge>
+      </Group>
+    </>
   );
 }
 

--- a/src/mantine-hooks/src/index.ts
+++ b/src/mantine-hooks/src/index.ts
@@ -3,6 +3,7 @@ export * from './utils';
 export { useClickOutside } from './use-click-outside/use-click-outside';
 export { useClipboard } from './use-clipboard/use-clipboard';
 export { useColorScheme } from './use-color-scheme/use-color-scheme';
+export { useColorSchemeValue } from './use-color-scheme-value/use-color-scheme-value';
 export { useCounter } from './use-counter/use-counter';
 export { useDebouncedState } from './use-debounced-state/use-debounced-state';
 export { useDebouncedValue } from './use-debounced-value/use-debounced-value';

--- a/src/mantine-hooks/src/use-color-scheme-value/use-color-scheme-value.ts
+++ b/src/mantine-hooks/src/use-color-scheme-value/use-color-scheme-value.ts
@@ -1,0 +1,7 @@
+import { useColorScheme } from '../use-color-scheme/use-color-scheme';
+
+export function useColorSchemeValue(light: any, dark: any) {
+  const colorScheme = useColorScheme();
+
+  return colorScheme === 'dark' ? dark : light;
+}


### PR DESCRIPTION
I would like to add a more convenient Hook function for `useColorScheme`. It is `useColorSchemeValue` allows the user to enter two parameters `useColorSchemeValue('dark', ' light');` the first parameter will be returned when the current theme is light, and the second parameter will be returned when the current theme is dark, so that the user does not have to make frequent determinations `if theme === 'dark'`