### PR TITLE
[@mantine/core] Add name attribute to Radio.Group

### DIFF
--- a/src/mantine-core/src/Radio/Radio.story.tsx
+++ b/src/mantine-core/src/Radio/Radio.story.tsx
@@ -82,3 +82,20 @@ export function Asterisk() {
     </div>
   );
 }
+
+export function WithNameAttribute() {
+  return (
+    <div style={{ width: 300, padding: 20 }}>
+      <Radio.Group label="group1" name="group1">
+        <Radio value="1" label="1" />
+        <Radio value="2" label="2" />
+        <Radio value="3" label="3" />
+      </Radio.Group>
+      <Radio.Group label="group2" name="group2">
+        <Radio value="a" label="a" />
+        <Radio value="b" label="b" />
+        <Radio value="c" label="c" />
+      </Radio.Group>
+    </div>
+  );
+}

--- a/src/mantine-core/src/Radio/Radio.tsx
+++ b/src/mantine-core/src/Radio/Radio.tsx
@@ -82,6 +82,7 @@ export const Radio: RadioComponent = forwardRef<HTMLInputElement, RadioProps>((p
   const contextProps = ctx
     ? {
         checked: ctx.value === rest.value,
+        name: rest.name ?? ctx.name,
         onChange: ctx.onChange,
       }
     : {};

--- a/src/mantine-core/src/Radio/RadioGroup.context.ts
+++ b/src/mantine-core/src/Radio/RadioGroup.context.ts
@@ -5,6 +5,7 @@ interface RadioGroupContextValue {
   size: MantineSize;
   value: string;
   onChange(event: React.ChangeEvent<HTMLInputElement>): void;
+  name: string;
 }
 
 const RadioGroupContext = createContext<RadioGroupContextValue>(null);

--- a/src/mantine-core/src/Radio/RadioGroup/RadioGroup.tsx
+++ b/src/mantine-core/src/Radio/RadioGroup/RadioGroup.tsx
@@ -42,6 +42,9 @@ export interface RadioGroupProps
 
   /** Props spread to root element */
   wrapperProps?: Record<string, any>;
+
+  /* Name attribute of radio inputs */
+  name?: string;
 }
 
 const defaultProps: Partial<RadioGroupProps> = {
@@ -64,6 +67,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
       wrapperProps,
       unstyled,
       offset,
+      name,
       ...others
     } = useComponentDefaultProps('RadioGroup', defaultProps, props);
 
@@ -78,7 +82,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
       setValue(event.currentTarget.value);
 
     return (
-      <RadioGroupProvider value={{ value: _value, onChange: handleChange, size }}>
+      <RadioGroupProvider value={{ value: _value, onChange: handleChange, size, name }}>
         <Input.Wrapper
           labelElement="div"
           size={size}


### PR DESCRIPTION
The name prop should probably be required in a future major release because otherwise you get [odd behaviour](https://codesandbox.io/s/jolly-worker-yfclb5).