### PR TITLE
[@mantine/hooks]use-text-selection: Fixed typo on useTextSelection document

### DIFF
--- a/docs/src/docs/hooks/use-text-selection.mdx
+++ b/docs/src/docs/hooks/use-text-selection.mdx
@@ -6,7 +6,7 @@ title: 'use-text-selection'
 order: 1
 slug: /hooks/use-text-selection/
 description: 'Get current selected text on the page'
-import: "import { useClipboard } from '@mantine/hooks';"
+import: "import { useTextSelection } from '@mantine/hooks';"
 docs: 'hooks/use-text-selection.mdx'
 source: 'mantine-hooks/src/use-text-selection/use-text-selection.ts'
 ---


### PR DESCRIPTION
from ...  `import { useClipboard } from '@mantine/hooks';`
to ...  `import { useTextSelection } from '@mantine/hooks';`