### PR TITLE
[@mantine/carousel] Carousel: add options `skipSnaps` and `containScroll`

### DIFF
--- a/src/mantine-carousel/src/Carousel.tsx
+++ b/src/mantine-carousel/src/Carousel.tsx
@@ -104,6 +104,12 @@ export interface CarouselProps
 
   /** Previous control icon */
   previousControlIcon?: React.ReactNode;
+
+  /** Allow the carousel to skip scroll snaps if it's dragged vigorously. Note that this option will be ignored if the dragFree option is set to true, false by default */
+  skipSnaps?: boolean
+
+  /** Clear leading and trailing empty space that causes excessive scrolling. Use trimSnaps to only use snap points that trigger scrolling or keepSnaps to keep them. */
+  containScroll?: 'trimSnaps' | 'keepSnaps'
 }
 
 const defaultProps: Partial<CarouselProps> = {
@@ -158,6 +164,8 @@ export const _Carousel = forwardRef<HTMLDivElement, CarouselProps>((props, ref) 
     nextControlIcon,
     previousControlIcon,
     breakpoints,
+    skipSnaps,
+    containScroll,
     ...others
   } = useComponentDefaultProps('Carousel', defaultProps, props);
 
@@ -178,6 +186,8 @@ export const _Carousel = forwardRef<HTMLDivElement, CarouselProps>((props, ref) 
       dragFree,
       speed,
       inViewThreshold,
+      skipSnaps,
+      containScroll
     },
     plugins
   );

--- a/src/mantine-carousel/src/Carousel.tsx
+++ b/src/mantine-carousel/src/Carousel.tsx
@@ -109,7 +109,7 @@ export interface CarouselProps
   skipSnaps?: boolean;
 
   /** Clear leading and trailing empty space that causes excessive scrolling. Use trimSnaps to only use snap points that trigger scrolling or keepSnaps to keep them. */
-  containScroll?: 'trimSnaps' | 'keepSnaps';
+  containScroll?: 'trimSnaps' | 'keepSnaps' | '';
 }
 
 const defaultProps: Partial<CarouselProps> = {
@@ -129,6 +129,8 @@ const defaultProps: Partial<CarouselProps> = {
   inViewThreshold: 0,
   withControls: true,
   withIndicators: false,
+  skipSnaps: false,
+  containScroll: '',
 };
 
 export const _Carousel = forwardRef<HTMLDivElement, CarouselProps>((props, ref) => {

--- a/src/mantine-carousel/src/Carousel.tsx
+++ b/src/mantine-carousel/src/Carousel.tsx
@@ -106,10 +106,10 @@ export interface CarouselProps
   previousControlIcon?: React.ReactNode;
 
   /** Allow the carousel to skip scroll snaps if it's dragged vigorously. Note that this option will be ignored if the dragFree option is set to true, false by default */
-  skipSnaps?: boolean
+  skipSnaps?: boolean;
 
   /** Clear leading and trailing empty space that causes excessive scrolling. Use trimSnaps to only use snap points that trigger scrolling or keepSnaps to keep them. */
-  containScroll?: 'trimSnaps' | 'keepSnaps'
+  containScroll?: 'trimSnaps' | 'keepSnaps';
 }
 
 const defaultProps: Partial<CarouselProps> = {
@@ -187,7 +187,7 @@ export const _Carousel = forwardRef<HTMLDivElement, CarouselProps>((props, ref) 
       speed,
       inViewThreshold,
       skipSnaps,
-      containScroll
+      containScroll,
     },
     plugins
   );


### PR DESCRIPTION
Current workaround is to reinit embla instance.

```ts
const [embla, setEmbla] = useState<Embla | null>(null);
useEffect(() => {
  if (embla) {
    embla.reInit({ containScroll: "trimSnaps", skipSnaps: true });
  }
}, [embla]);
```

So to me it seems reasonable to add it directly to Mantine.