### PR TITLE
[@mantine/core] Theme: add support other unit

### DIFF
--- a/src/mantine-demos/src/demos/theme/Theme.demo.customUnit.tsx
+++ b/src/mantine-demos/src/demos/theme/Theme.demo.customUnit.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Group, Text, MantineProvider } from '@mantine/core';
+
+const code = `
+import { Group, Text, MantineProvider } from '@mantine/core';
+
+function Demo() {
+  return (
+    <>
+      <MantineProvider
+        inherit
+        theme={{
+          fontSizes: {
+            sm: '14px',
+            lg: '1.25rem',
+            xl: '1.5em',
+          },
+          spacing: {
+            md: '1em',
+            lg: '1.25rem',
+          },
+          radius: {
+            md: '1.2em',
+            lg: '1.25rem',
+          },
+          breakpoints: {
+            md: 997,
+            lg: '1080px',
+          },
+        }}
+      >
+        <Group mt="xl">
+          <Text size="sm">SM</Text>
+          <Text size="md">MD</Text>
+          <Text size="lg">LG</Text>
+          <Text size="xl">XL</Text>
+        </Group>
+      </MantineProvider>
+    </>
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <>
+      <MantineProvider
+        inherit
+        theme={{
+          fontSizes: {
+            sm: '14px',
+            lg: '1.25rem',
+            xl: '1.5em',
+          },
+          spacing: {
+            md: '1em',
+            lg: '1.25rem',
+          },
+          radius: {
+            md: '1.2em',
+            lg: '1.25rem',
+          },
+          breakpoints: {
+            md: 997,
+            lg: '1080px',
+          },
+        }}
+      >
+        <Group mt="xl">
+          <Text size="sm">SM</Text>
+          <Text size="md">MD</Text>
+          <Text size="lg">LG</Text>
+          <Text size="xl">XL</Text>
+        </Group>
+      </MantineProvider>
+    </>
+  );
+}
+
+export const customUnit: MantineDemo = {
+  type: 'demo',
+  component: Demo,
+  code,
+};

--- a/src/mantine-demos/src/demos/theme/index.ts
+++ b/src/mantine-demos/src/demos/theme/index.ts
@@ -13,6 +13,7 @@ export { datesLocale } from './Theme.demo.datesLocale';
 export { activeStyles } from './Theme.demo.activeStyles';
 export { respectReduceMotion } from './Theme.demo.respectReduceMotion';
 export { cursorType } from './Theme.demo.cursorType';
+export { customUnit } from './Theme.demo.customUnit';
 export { defaultGradient } from './Theme.demo.defaultGradient';
 export { gradientFn } from './Theme.demo.gradientFn';
 export { colorsIndex } from './Theme.demo.colorsIndex';

--- a/src/mantine-styles/src/theme/types/MantineSize.ts
+++ b/src/mantine-styles/src/theme/types/MantineSize.ts
@@ -1,3 +1,3 @@
 export type MantineSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export type MantineNumberSize = MantineSize | number;
-export type MantineSizes = Record<MantineSize, number>;
+export type MantineSizes<T = number> = Record<MantineSize, T>;

--- a/src/mantine-styles/src/theme/types/MantineTheme.ts
+++ b/src/mantine-styles/src/theme/types/MantineTheme.ts
@@ -96,6 +96,13 @@ export interface MantineTheme {
   components: MantineThemeComponents;
 }
 
+export interface InputMantineTheme {
+  fontSizes?: Partial<MantineSizes<CSSProperties['fontSize']>>;
+  spacing?: Partial<MantineSizes<CSSProperties['padding']>>;
+  radius?: Partial<MantineSizes<CSSProperties['borderRadius']>>;
+  breakpoints?: Partial<MantineSizes<CSSProperties['width']>>;
+}
+
 interface ThemeComponent {
   defaultProps?: Record<string, any>;
   classNames?: Record<string, string>;
@@ -106,5 +113,11 @@ interface ThemeComponent {
 
 export type MantineThemeBase = Omit<MantineTheme, 'fn'>;
 
-export type MantineThemeOverride = DeepPartial<Omit<MantineThemeBase, 'other' | 'components'>> &
-  Partial<Pick<MantineThemeBase, 'other' | 'components'>>;
+export type MantineThemeOverride = DeepPartial<
+  Omit<
+    MantineThemeBase,
+    'other' | 'components' | 'fontSizes' | 'spacing' | 'radius' | 'breakpoints'
+  >
+> &
+  Partial<Pick<MantineThemeBase, 'other' | 'components'>> &
+  Partial<InputMantineTheme>;

--- a/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.test.ts
+++ b/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.test.ts
@@ -56,6 +56,35 @@ describe('@mantine/styles/merge-theme', () => {
     });
   });
 
+  it('merges fontSizes property correctly', () => {
+    const themeBase = getThemeBase();
+    expect(
+      mergeTheme(themeBase, { fontSizes: { sm: '14px', lg: '1.25rem', xl: '1.5em' } })
+    ).toStrictEqual({
+      ...themeBase,
+      fontSizes: { ...themeBase.fontSizes, sm: 14, lg: 20, xl: 24 },
+    });
+  });
+
+  it('merges spacing, radius and breakpoint property correctly', () => {
+    const themeBase = getThemeBase();
+    expect(
+      mergeTheme(themeBase, {
+        spacing: { sm: '14px', lg: '1.25rem', xl: '1.5em' },
+        radius: { sm: '1rem' },
+        breakpoints: {
+          lg: '997px',
+          xl: 1080,
+        },
+      })
+    ).toStrictEqual({
+      ...themeBase,
+      spacing: { ...themeBase.spacing, sm: 14, lg: 20, xl: 24 },
+      radius: { ...themeBase.radius, sm: 16 },
+      breakpoints: { ...themeBase.breakpoints, lg: 997, xl: 1080 },
+    });
+  });
+
   it('merges other property correctly', () => {
     const themeBase = getThemeBase();
     expect(mergeTheme(themeBase, { other: { prop: 1, test: { nested: true } } })).toStrictEqual({

--- a/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.ts
+++ b/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.ts
@@ -1,5 +1,6 @@
 import { MantineThemeOverride, MantineThemeBase, MantineTheme } from '../../types';
 import { attachFunctions } from '../../functions/attach-functions';
+import { toPx } from '../to-px/to-px';
 
 export function mergeTheme(
   currentTheme: MantineThemeBase,
@@ -29,6 +30,28 @@ export function mergeTheme(
           ...themeOverride.headings,
           sizes,
         },
+      };
+    }
+
+    if (['fontSizes', 'spacing', 'radius', 'breakpoints'].includes(key) && themeOverride[key]) {
+      const sizes = themeOverride[key]
+        ? Object.keys(currentTheme[key]).reduce((mantineSizesAcc, h) => {
+            let calculateSize = currentTheme[key][h];
+            if (h in themeOverride[key]) {
+              calculateSize =
+                typeof themeOverride[key][h] === 'number'
+                  ? themeOverride[key][h]
+                  : toPx(themeOverride[key][h]);
+            }
+            // eslint-disable-next-line no-param-reassign
+            mantineSizesAcc[h] = calculateSize;
+            return mantineSizesAcc;
+          }, {})
+        : currentTheme[key];
+
+      return {
+        ...acc,
+        [key]: sizes,
       };
     }
 

--- a/src/mantine-styles/src/theme/utils/to-px/to-px.test.ts
+++ b/src/mantine-styles/src/theme/utils/to-px/to-px.test.ts
@@ -1,0 +1,14 @@
+import { toPx } from './to-px';
+
+describe('@mantine/styles/to-px', () => {
+  it('returns the correct px values when given a px string', () => {
+    expect(toPx('10px')).toStrictEqual(10);
+    expect(toPx('14px')).toStrictEqual(14);
+  });
+
+  it('returns the correct px values when given an other unit string', () => {
+    expect(toPx('1rem')).toStrictEqual(16);
+    expect(toPx('2rem')).toStrictEqual(32);
+    expect(toPx('2em')).toStrictEqual(32);
+  });
+});

--- a/src/mantine-styles/src/theme/utils/to-px/to-px.ts
+++ b/src/mantine-styles/src/theme/utils/to-px/to-px.ts
@@ -1,0 +1,29 @@
+const PIXELS_PER_INCH = 96;
+
+const defaults = {
+  ch: 8,
+  ex: 7.15625,
+  em: 16,
+  rem: 16,
+  in: PIXELS_PER_INCH,
+  cm: PIXELS_PER_INCH / 2.54,
+  mm: PIXELS_PER_INCH / 25.4,
+  pt: PIXELS_PER_INCH / 72,
+  pc: PIXELS_PER_INCH / 6,
+  px: 1,
+};
+
+function parseUnit(str: string): [number, string] {
+  const out: [number, string] = [0, 'px'];
+  const currentString = String(str);
+  const num = parseFloat(currentString);
+  out[0] = num;
+  out[1] = currentString.match(/[\d.\-+]*\s*(.*)/)[1] || '';
+  return out;
+}
+
+export function toPx(str: string) {
+  const [numberUnit, unit] = parseUnit(str);
+  const unitFormula = unit in defaults ? defaults[unit] : 1;
+  return numberUnit * unitFormula;
+}


### PR DESCRIPTION
Add support theme with other unit on MantineSizes.  
using reference to-px library for convert string to px