### PR TITLE
[docs] Include usage of Radio.Group name prop and fix Calendar example

### DIFF
--- a/docs/src/docs/core/Radio.mdx
+++ b/docs/src/docs/core/Radio.mdx
@@ -49,6 +49,7 @@ function Demo() {
     <Radio.Group
       value={value}
       onChange={setValue}
+      name="favoriteFramework"
       label="Select your favorite framework/library"
       description="This is anonymous"
       withAsterisk

--- a/src/mantine-demos/src/demos/core/Radio/Radio.demo.groupConfigurator.tsx
+++ b/src/mantine-demos/src/demos/core/Radio/Radio.demo.groupConfigurator.tsx
@@ -7,6 +7,7 @@ import { Radio } from '@mantine/core';
 function Demo() {
   return (
     <Radio.Group
+      name="favoriteFramework"
      ${props}
     >
       <Radio value="react" label="React" />
@@ -20,7 +21,7 @@ function Demo() {
 
 function Wrapper(props: RadioGroupProps) {
   return (
-    <Radio.Group defaultValue="react" {...props}>
+    <Radio.Group defaultValue="react" name="favoriteFramework" {...props}>
       <Radio value="react" label="React" />
       <Radio value="svelte" label="Svelte" />
       <Radio value="ng" label="Angular" />

--- a/src/mantine-demos/src/demos/dates/Calendar/Calendar.demo.stylesApi.tsx
+++ b/src/mantine-demos/src/demos/dates/Calendar/Calendar.demo.stylesApi.tsx
@@ -13,7 +13,6 @@ function Demo() {
     <Calendar
       value={value}
       onChange={setValue}
-      month={value}
       fullWidth
       size="xl"
       styles={(theme) => ({


### PR DESCRIPTION
Previously, if you copied the [example from the Calendar Styles API demo](http://localhost:7521/dates/calendar/#customize-with-styles-api), you were unable to switch the current month.

I noticed you updated to `useState<Date | null>`. Sneaky sneaky :grin: 