### PR TITLE
[@mantine/rte] fix prop types

### DIFF
--- a/src/mantine-rte/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/mantine-rte/src/components/RichTextEditor/RichTextEditor.tsx
@@ -43,7 +43,7 @@ function defaultImageUpload(file: File): Promise<string> {
 
 export interface RichTextEditorProps
   extends DefaultProps<RichTextEditorStylesNames>,
-    Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange' | 'defaultValue'> {
   /** HTML content, value not forced as quill works in uncontrolled mode */
   value?: string | Delta;
 
@@ -97,6 +97,7 @@ export const RichTextEditor = forwardRef<Editor, RichTextEditorProps>(
   (props: RichTextEditorProps, ref) => {
     const {
       value,
+      defaultValue,
       onChange,
       onImageUpload,
       sticky,
@@ -166,6 +167,7 @@ export const RichTextEditor = forwardRef<Editor, RichTextEditorProps>(
           theme="snow"
           modules={modules}
           value={value}
+          defaultValue={defaultValue}
           onChange={onChange}
           ref={mergeRefs(editorRef, ref)}
           placeholder={placeholder}

--- a/src/mantine-rte/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/mantine-rte/src/components/RichTextEditor/RichTextEditor.tsx
@@ -45,10 +45,13 @@ export interface RichTextEditorProps
   extends DefaultProps<RichTextEditorStylesNames>,
     Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange'> {
   /** HTML content, value not forced as quill works in uncontrolled mode */
-  value: string | Delta;
+  value?: string | Delta;
+
+  /** Initial value of input */
+  defaultValue?: string | Delta;
 
   /** Called each time value changes */
-  onChange(value: string, delta: Delta, sources: Sources, editor: Editor.UnprivilegedEditor): void;
+  onChange?(value: string, delta: Delta, sources: Sources, editor: Editor.UnprivilegedEditor): void;
 
   /** Called when image image is inserted in editor */
   onImageUpload?(image: File): Promise<string>;


### PR DESCRIPTION
- Quill can proceed undefined values
- defaultValue is related to defaultValue of HTML input, this is not right
- Also, onChange can be undefined because field can be readOnly