### PR TITLE
[@mantine/core] Slider: added scale prop

### DIFF
--- a/docs/src/docs/core/Slider.mdx
+++ b/docs/src/docs/core/Slider.mdx
@@ -87,6 +87,14 @@ Note that mark value is relative to slider value, not width:
 
 <Demo data={SliderDemos.thumbChildren} />
 
+## Scale
+
+You can use the `scale` prop to represent the value on a different scale.
+
+In the following demo, the value _x_ represents the value 2^x. Increasing _x_ by one increases the represented value by 2 to the power of _x_.
+
+<Demo data={SliderDemos.scale} />
+
 ## Styles API
 
 You can change styles of any element in slider component with [Styles API](/styles/styles-api/) to match your design requirements:

--- a/src/mantine-core/src/Slider/RangeSlider/RangeSlider.tsx
+++ b/src/mantine-core/src/Slider/RangeSlider/RangeSlider.tsx
@@ -101,6 +101,12 @@ export interface RangeSliderProps
 
   /** Thumb width and height in px */
   thumbSize?: number;
+
+  /**
+   * A transformation function, to change the scale of the slider
+   * @default (value) => value
+   */
+  scale?: (value: number) => number;
 }
 
 const defaultProps: Partial<RangeSliderProps> = {
@@ -119,6 +125,7 @@ const defaultProps: Partial<RangeSliderProps> = {
   thumbToLabel: '',
   showLabelOnHover: true,
   disabled: false,
+  scale: (v) => v,
 };
 
 export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, ref) => {
@@ -151,6 +158,7 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
     disabled,
     unstyled,
     thumbSize,
+    scale,
     ...others
   } = useComponentDefaultProps('RangeSlider', defaultProps, props);
 
@@ -400,10 +408,10 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
       >
         <Thumb
           {...sharedThumbProps}
-          value={_value[0]}
+          value={scale(_value[0])}
           position={positions[0]}
           dragging={active}
-          label={typeof label === 'function' ? label(_value[0]) : label}
+          label={typeof label === 'function' ? label(scale(_value[0])) : label}
           ref={(node) => {
             thumbs.current[0] = node;
           }}
@@ -421,10 +429,10 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
         <Thumb
           {...sharedThumbProps}
           thumbLabel={thumbToLabel}
-          value={_value[1]}
+          value={scale(_value[1])}
           position={positions[1]}
           dragging={active}
-          label={typeof label === 'function' ? label(_value[1]) : label}
+          label={typeof label === 'function' ? label(scale(_value[1])) : label}
           ref={(node) => {
             thumbs.current[1] = node;
           }}

--- a/src/mantine-core/src/Slider/Slider/Slider.test.tsx
+++ b/src/mantine-core/src/Slider/Slider/Slider.test.tsx
@@ -42,6 +42,12 @@ describe('@mantine/core/Slider', () => {
     expect(spy).toHaveBeenLastCalledWith(40);
   });
 
+  it('should scale the value', async () => {
+    const { container } = render(<Slider value={50} scale={(v) => v * 2} />);
+    await pressArrow('right');
+    expectInputValue('100', container);
+  });
+
   it('supports uncontrolled state', async () => {
     const { container } = render(<Slider defaultValue={50} step={10} />);
     expectInputValue('50', container);

--- a/src/mantine-core/src/Slider/Slider/Slider.tsx
+++ b/src/mantine-core/src/Slider/Slider/Slider.tsx
@@ -92,6 +92,12 @@ export interface SliderProps
 
   /** Thumb width and height in px */
   thumbSize?: number;
+
+  /**
+   * A transformation function, to change the scale of the slider
+   * @default (value) => value
+   */
+  scale?: (value: number) => number;
 }
 
 const defaultProps: Partial<SliderProps> = {
@@ -108,6 +114,7 @@ const defaultProps: Partial<SliderProps> = {
   thumbLabel: '',
   showLabelOnHover: true,
   disabled: false,
+  scale: (v) => v,
 };
 
 export const Slider = forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
@@ -138,6 +145,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
     disabled,
     unstyled,
     thumbSize,
+    scale,
     ...others
   } = useComponentDefaultProps('Slider', defaultProps, props);
 
@@ -153,7 +161,8 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
   const valueRef = useRef(_value);
   const thumb = useRef<HTMLDivElement>();
   const position = getPosition({ value: _value, min, max });
-  const _label = typeof label === 'function' ? label(_value) : label;
+  const scaledValue = scale(_value);
+  const _label = typeof label === 'function' ? label(scaledValue) : label;
 
   const handleChange = useCallback(
     ({ x }: { x: number }) => {
@@ -267,7 +276,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
         color={color}
         min={min}
         max={max}
-        value={_value}
+        value={scaledValue}
         onChange={setValue}
         onMouseEnter={showLabelOnHover ? () => setHovered(true) : undefined}
         onMouseLeave={showLabelOnHover ? () => setHovered(false) : undefined}
@@ -279,7 +288,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
         <Thumb
           max={max}
           min={min}
-          value={_value}
+          value={scaledValue}
           position={position}
           dragging={active}
           color={color}
@@ -303,7 +312,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
         </Thumb>
       </Track>
 
-      <input type="hidden" name={name} value={_value} />
+      <input type="hidden" name={name} value={scaledValue} />
     </SliderRoot>
   );
 });

--- a/src/mantine-demos/src/demos/core/Slider/Slider.demo.scale.tsx
+++ b/src/mantine-demos/src/demos/core/Slider/Slider.demo.scale.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { RangeSlider, Slider, Stack } from '@mantine/core';
+
+const code = `
+import { RangeSlider, Slider, Stack } from '@mantine/core';
+
+function Demo() {
+  function valueLabelFormat(value: number) {
+    const units = ['KB', 'MB', 'GB', 'TB'];
+
+    let unitIndex = 0;
+    let scaledValue = value;
+
+    while (scaledValue >= 1024 && unitIndex < units.length - 1) {
+      unitIndex += 1;
+      scaledValue /= 1024;
+    }
+
+    return \`\${scaledValue} \${units[unitIndex]}\`;
+  }
+
+  return (
+    <Stack spacing="xl" p="xl">
+      <Slider
+        py="xl"
+        scale={(v) => 2 ** v}
+        step={1}
+        min={2}
+        max={30}
+        labelAlwaysOn
+        defaultValue={10}
+        label={valueLabelFormat}
+      />
+      <RangeSlider
+        py="xl"
+        scale={(v) => 2 ** v}
+        step={1}
+        min={2}
+        max={30}
+        labelAlwaysOn
+        defaultValue={[10, 20]}
+        label={valueLabelFormat}
+      />
+    </Stack>
+  );
+}
+`;
+
+function Demo() {
+  function valueLabelFormat(value: number) {
+    const units = ['KB', 'MB', 'GB', 'TB'];
+
+    let unitIndex = 0;
+    let scaledValue = value;
+
+    while (scaledValue >= 1024 && unitIndex < units.length - 1) {
+      unitIndex += 1;
+      scaledValue /= 1024;
+    }
+
+    return `${scaledValue} ${units[unitIndex]}`;
+  }
+  return (
+    <Stack spacing="xl" p="xl">
+      <Slider
+        py="xl"
+        scale={(v) => 2 ** v}
+        step={1}
+        min={2}
+        max={30}
+        labelAlwaysOn
+        defaultValue={10}
+        label={valueLabelFormat}
+      />
+      <RangeSlider
+        py="xl"
+        scale={(v) => 2 ** v}
+        step={1}
+        min={2}
+        max={30}
+        labelAlwaysOn
+        defaultValue={[10, 20]}
+        label={valueLabelFormat}
+      />
+    </Stack>
+  );
+}
+
+export const scale: MantineDemo = {
+  type: 'demo',
+  component: Demo,
+  code,
+};

--- a/src/mantine-demos/src/demos/core/Slider/index.ts
+++ b/src/mantine-demos/src/demos/core/Slider/index.ts
@@ -7,3 +7,4 @@ export { changeEnd } from './Slider.demo.changeEnd';
 export { disabled } from './Slider.demo.disabled';
 export { thumbSize } from './Slider.demo.thumbSize';
 export { thumbChildren } from './Slider.demo.thumbChildren';
+export { scale } from './Slider.demo.scale';


### PR DESCRIPTION
Added a `scale` prop to mimic the functionality of the Slider for [Material UI](https://mui.com/material-ui/react-slider/#non-linear-scale) as requested by @rtivital in Discord [here](https://discord.com/channels/854810300876062770/887408088800448553/1016792289542148227).