### PR TITLE
[@mantine/core] Button: Button is disabled when inside fieldset disabled

### DIFF
--- a/src/mantine-core/src/ActionIcon/ActionIcon.story.tsx
+++ b/src/mantine-core/src/ActionIcon/ActionIcon.story.tsx
@@ -111,6 +111,14 @@ export function States() {
   );
 }
 
+export function StatesInsideFieldsetDisabled() {
+  return (
+    <fieldset disabled>
+      <States />
+    </fieldset>
+  );
+}
+
 export function ColorsIndex() {
   return (
     <div style={{ padding: 40 }}>

--- a/src/mantine-core/src/ActionIcon/ActionIcon.styles.ts
+++ b/src/mantine-core/src/ActionIcon/ActionIcon.styles.ts
@@ -84,7 +84,7 @@ export default createStyles(
 
       '&:active': theme.activeStyles,
 
-      '&[data-disabled]': {
+      '&:disabled, &[data-disabled]': {
         color: theme.colors.gray[theme.colorScheme === 'dark' ? 6 : 4],
         cursor: 'not-allowed',
         backgroundColor:
@@ -96,6 +96,7 @@ export default createStyles(
             ? undefined
             : theme.fn.themeColor('gray', theme.colorScheme === 'dark' ? 8 : 1),
         backgroundImage: 'none',
+        pointerEvents: 'none',
 
         '&:active': {
           transform: 'none',

--- a/src/mantine-core/src/ActionIcon/ActionIcon.test.tsx
+++ b/src/mantine-core/src/ActionIcon/ActionIcon.test.tsx
@@ -64,4 +64,13 @@ describe('@mantine/core/ActionIcon', () => {
     expect(loading.querySelectorAll('.test-icon')).toHaveLength(0);
     expect(loading.querySelectorAll('svg')).toHaveLength(1);
   });
+
+  it('is disabled when inside fieldset disabled', () => {
+    render(
+      <fieldset disabled>
+        <ActionIcon>$</ActionIcon>
+      </fieldset>
+    );
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
 });

--- a/src/mantine-core/src/Button/Button.story.tsx
+++ b/src/mantine-core/src/Button/Button.story.tsx
@@ -128,6 +128,105 @@ export function States() {
   );
 }
 
+/**
+ * All buttons should be disabled
+ */
+export function StatesInFieldsetDisabled() {
+  const theme = useMantineTheme();
+
+  const sharedStyles: CSSProperties = {
+    padding: '10px 20px',
+    border: `1px solid ${
+      theme.colorScheme === 'light' ? theme.colors.gray[1] : theme.colors.dark[6]
+    }`,
+  };
+
+  const states = [
+    {
+      name: 'enabled',
+      props: undefined,
+    },
+    {
+      name: 'disabled',
+      props: {
+        disabled: true,
+      },
+    },
+    {
+      name: 'loading',
+      props: {
+        loading: true,
+      },
+    },
+  ];
+
+  return (
+    <fieldset disabled>
+      <div
+        style={{
+          padding: '40px',
+        }}
+      >
+        <table
+          style={{
+            borderCollapse: 'collapse',
+          }}
+        >
+          <thead>
+            <tr>
+              <th
+                style={{
+                  ...sharedStyles,
+                }}
+              >
+                &nbsp;
+              </th>
+
+              {BUTTON_VARIANTS.map((variant) => (
+                <th
+                  key={variant}
+                  style={{
+                    ...sharedStyles,
+                  }}
+                >
+                  {variant}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {states.map((state) => (
+              <tr key={state.name}>
+                <td
+                  style={{
+                    ...sharedStyles,
+                  }}
+                >
+                  {state.name}
+                </td>
+
+                {BUTTON_VARIANTS.map((variant) => (
+                  <td
+                    key={variant}
+                    style={{
+                      ...sharedStyles,
+                    }}
+                  >
+                    <Center>
+                      <Button variant={variant} {...state.props}>
+                        {state.name}
+                      </Button>
+                    </Center>
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </fieldset>
+  );
+}
 export function CustomComponent() {
   return (
     <div style={{ padding: 40 }}>

--- a/src/mantine-core/src/Button/Button.story.tsx
+++ b/src/mantine-core/src/Button/Button.story.tsx
@@ -132,98 +132,9 @@ export function States() {
  * All buttons should be disabled
  */
 export function StatesInFieldsetDisabled() {
-  const theme = useMantineTheme();
-
-  const sharedStyles: CSSProperties = {
-    padding: '10px 20px',
-    border: `1px solid ${
-      theme.colorScheme === 'light' ? theme.colors.gray[1] : theme.colors.dark[6]
-    }`,
-  };
-
-  const states = [
-    {
-      name: 'enabled',
-      props: undefined,
-    },
-    {
-      name: 'disabled',
-      props: {
-        disabled: true,
-      },
-    },
-    {
-      name: 'loading',
-      props: {
-        loading: true,
-      },
-    },
-  ];
-
   return (
     <fieldset disabled>
-      <div
-        style={{
-          padding: '40px',
-        }}
-      >
-        <table
-          style={{
-            borderCollapse: 'collapse',
-          }}
-        >
-          <thead>
-            <tr>
-              <th
-                style={{
-                  ...sharedStyles,
-                }}
-              >
-                &nbsp;
-              </th>
-
-              {BUTTON_VARIANTS.map((variant) => (
-                <th
-                  key={variant}
-                  style={{
-                    ...sharedStyles,
-                  }}
-                >
-                  {variant}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {states.map((state) => (
-              <tr key={state.name}>
-                <td
-                  style={{
-                    ...sharedStyles,
-                  }}
-                >
-                  {state.name}
-                </td>
-
-                {BUTTON_VARIANTS.map((variant) => (
-                  <td
-                    key={variant}
-                    style={{
-                      ...sharedStyles,
-                    }}
-                  >
-                    <Center>
-                      <Button variant={variant} {...state.props}>
-                        {state.name}
-                      </Button>
-                    </Center>
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <States />
     </fieldset>
   );
 }

--- a/src/mantine-core/src/Button/Button.styles.ts
+++ b/src/mantine-core/src/Button/Button.styles.ts
@@ -135,6 +135,15 @@ export default createStyles(
 
       '&:active': theme.activeStyles,
 
+      '&:disabled': {
+        borderColor: 'transparent',
+        backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[2],
+        color: theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[5],
+        cursor: 'not-allowed',
+        backgroundImage: 'none',
+        pointerEvents: 'none',
+      },
+
       '&[data-disabled]': {
         borderColor: 'transparent',
         backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[2],

--- a/src/mantine-core/src/Button/Button.styles.ts
+++ b/src/mantine-core/src/Button/Button.styles.ts
@@ -135,21 +135,13 @@ export default createStyles(
 
       '&:active': theme.activeStyles,
 
-      '&:disabled': {
+      '&:disabled, &[data-disabled]': {
         borderColor: 'transparent',
         backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[2],
         color: theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[5],
         cursor: 'not-allowed',
         backgroundImage: 'none',
         pointerEvents: 'none',
-      },
-
-      '&[data-disabled]': {
-        borderColor: 'transparent',
-        backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[2],
-        color: theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[5],
-        cursor: 'not-allowed',
-        backgroundImage: 'none',
 
         '&:active': {
           transform: 'none',

--- a/src/mantine-core/src/Button/Button.test.tsx
+++ b/src/mantine-core/src/Button/Button.test.tsx
@@ -52,4 +52,13 @@ describe('@mantine/core/Button', () => {
   it('exposes ButtonGroup as static component', () => {
     expect(Button.Group).toBe(ButtonGroup);
   });
+
+  it('is disabled when inside fieldset disabled', () => {
+    render(
+      <fieldset disabled>
+        <Button type="submit" />
+      </fieldset>
+    );
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
 });


### PR DESCRIPTION
Fixes #2428 using adding a disabled style to button, as suggested by @UgurKacak.

I added simple storybook story, wrapping the states example in a fieldset disabled, all buttons should be disabled.

I have added a basic test as well, please provide feedback if you'd like to see more details on top. 

