### PR TITLE
[@mantine/core] Modal: Prevent overlay from sitting on top of scrollbar

### DIFF
--- a/src/mantine-core/src/Modal/Modal.tsx
+++ b/src/mantine-core/src/Modal/Modal.tsx
@@ -262,7 +262,7 @@ export function Modal(props: ModalProps) {
                 <Overlay
                   className={classes.overlay}
                   sx={{ position: 'fixed' }}
-                  zIndex={0}
+                  zIndex={-1}
                   onMouseDown={() => closeOnClickOutside && onClose()}
                   blur={overlayBlur}
                   color={


### PR DESCRIPTION
Fixes #2371 by setting the Modal Overlay z-index to -1 instead of 0.