### PR TITLE
SegmentedControl value: null

### DIFF
--- a/src/mantine-core/src/SegmentedControl/SegmentedControl.tsx
+++ b/src/mantine-core/src/SegmentedControl/SegmentedControl.tsx
@@ -37,7 +37,7 @@ export interface SegmentedControlProps
   data: string[] | SegmentedControlItem[];
 
   /** Current selected value */
-  value?: string;
+  value?: string | null;
 
   /** Disabled input state */
   disabled?: boolean;


### PR DESCRIPTION
Hello, friends.

<img width="209" alt="image" src="https://user-images.githubusercontent.com/98721968/190549549-e76a82d6-0b35-4491-adbf-cfaaf9a0fd95.png">

Ability to set null so that none of the options is selected.

`value: "Hello"`

<img width="196" alt="image" src="https://user-images.githubusercontent.com/98721968/190549758-e1155750-41b8-431f-b945-8c1266b32686.png">

`value: undefined`

<img width="190" alt="image" src="https://user-images.githubusercontent.com/98721968/190549940-22d84f21-4b09-42bb-8daf-c608f8c1d04a.png">

`value: "none"`

<img width="189" alt="image" src="https://user-images.githubusercontent.com/98721968/190549853-2a34cc6a-717f-4c32-981e-5593381247dc.png">

`value: null`

<img width="190" alt="image" src="https://user-images.githubusercontent.com/98721968/190550011-72d59768-d692-4f72-9138-087a20e9b91f.png">

