### PR TITLE
[@mantine/utils] fix: closeModal not working with openModal

### DIFF
--- a/src/mantine-utils/src/create-use-external-events/create-use-external-events.ts
+++ b/src/mantine-utils/src/create-use-external-events/create-use-external-events.ts
@@ -25,7 +25,7 @@ export function createUseExternalEvents<Handlers extends Record<string, (detail:
         Object.keys(handlers).forEach((eventKey) => {
           window.removeEventListener(eventKey, handlers[eventKey]);
         });
-    }, []);
+    }, [handlers]);
   }
 
   function createEvent<EventKey extends keyof Handlers>(event: EventKey) {


### PR DESCRIPTION
#2436, when creating the closeModal function, the state is empty. But openModal will change the state modals, so I think we should update the handlers. Maybe there are other problems with this, I think we can update the handlers to get the latest state in all cases. Not sure of the best practice for this. Please give feedback or give improvement advice.