### PR TITLE
[@mantine/core] Skeleton: Omit classNames props

### DIFF
--- a/src/mantine-core/src/Skeleton/Skeleton.tsx
+++ b/src/mantine-core/src/Skeleton/Skeleton.tsx
@@ -4,7 +4,7 @@ import { Box } from '../Box';
 import useStyles, { SkeletonStylesParams } from './Skeleton.styles';
 
 export interface SkeletonProps
-  extends DefaultProps<never, SkeletonStylesParams>,
+  extends Omit<DefaultProps<never, SkeletonStylesParams>, 'classNames'>,
     React.ComponentPropsWithoutRef<'div'> {
   /** Should skeleton overlay be displayed */
   visible?: boolean;


### PR DESCRIPTION
There are no type errors with respect to arguments that do nothing when received, so `classnames="[object Object]"` is unintentionally rendered in the DOM.
https://github.com/mantinedev/mantine/issues/2467#issuecomment-1249020944

Improvements have been made to omit classNames props from `SkeletonProps` and pass classNames props to cause a type error.