### PR TITLE
[@mantine/dropzone]: Dependencies: upgrade react-dropzone version

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "prism-react-renderer": "^1.2.1",
     "quill-mention": "^3.0.8",
     "react": "18.1.0",
-    "react-dropzone": "14.2.1",
+    "react-dropzone": "14.2.2",
     "react-input-mask": "^2.0.4",
     "react-quill": "2.0.0",
     "react-textarea-autosize": "8.3.4",

--- a/src/mantine-dropzone/package.json
+++ b/src/mantine-dropzone/package.json
@@ -34,7 +34,7 @@
     "react-dom": ">=16.8.0"
   },
   "dependencies": {
-    "react-dropzone": "14.2.1",
+    "react-dropzone": "14.2.2",
     "@mantine/utils": "5.3.2"
   },
   "devDependencies": {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11735,10 +11735,10 @@ react-dom@18.1.0:
     loose-envify "^1.1.0"
     scheduler "^0.22.0"
 
-react-dropzone@14.2.1:
-  version "14.2.1"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-14.2.1.tgz#aad17e06290723358398a7be76fb38ecf6d77c1a"
-  integrity sha512-jzX6wDtAjlfwZ+Fbg+G17EszWUkQVxhMTWMfAC9qSUq7II2pKglHA8aarbFKl0mLpRPDaNUcy+HD/Sf4gkf76Q==
+react-dropzone@14.2.2:
+  version "14.2.2"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-14.2.2.tgz#a75a0676055fe9e2cb78578df4dedb4c42b54f98"
+  integrity sha512-5oyGN/B5rNhop2ggUnxztXBQ6q6zii+OMEftPzsxAR2hhpVWz0nAV+3Ktxo2h5bZzdcCKrpd8bfWAVsveIBM+w==
   dependencies:
     attr-accept "^2.2.2"
     file-selector "^0.6.0"


### PR DESCRIPTION
The react-dropzone 14.2.2 version is fixing an issue on multiple MIME types accepted (https://github.com/react-dropzone/react-dropzone/pull/1207

