### PR TITLE
Rte/image uploader index error

### DIFF
--- a/src/mantine-rte/src/modules/image-uploader/ImageUploader.ts
+++ b/src/mantine-rte/src/modules/image-uploader/ImageUploader.ts
@@ -99,7 +99,7 @@ export class ImageUploader {
             setTimeout(() => {
               this.range = this.quill.getSelection();
               this.readAndUploadFile(file);
-            }, 0);
+            }, 1);
           }
         }
       }


### PR DESCRIPTION
There are at least two error reports regarding the same error when uploading images (for me, specifically pasting in images) into rte. 

`Error: Cannot read properties of null (reading 'index')`

They were marked closed but the issue persists for me, even when running mantine in storybook. 
Changing the settimeout period on the handlePaste function of ImageUploader.ts to anything other than 0 resolves the issue. I've set it to 1ms. All tests pass, all three image upload methods work as intended.

https://github.com/mantinedev/mantine/issues/1508
https://github.com/mantinedev/mantine/issues/1386
