### PR TITLE
[@mantine/nprogress] add finishNavigationProgress

### DIFF
--- a/docs/src/docs/others/nprogress.mdx
+++ b/docs/src/docs/others/nprogress.mdx
@@ -63,7 +63,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import {
   startNavigationProgress,
-  resetNavigationProgress,
+  finishNavigationProgress,
   NavigationProgress,
 } from '@mantine/nprogress';
 
@@ -72,7 +72,7 @@ export function RouterTransition() {
 
   useEffect(() => {
     const handleStart = (url: string) => url !== router.asPath && startNavigationProgress();
-    const handleComplete = () => resetNavigationProgress();
+    const handleComplete = () => finishNavigationProgress();
 
     router.events.on('routeChangeStart', handleStart);
     router.events.on('routeChangeComplete', handleComplete);
@@ -85,7 +85,7 @@ export function RouterTransition() {
     };
   }, [router.asPath]);
 
-  return <NavigationProgress />;
+  return <NavigationProgress autoReset={true} />;
 }
 ```
 

--- a/src/mantine-demos/src/demos/nprogress/NProgress.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/nprogress/NProgress.demo.usage.tsx
@@ -7,6 +7,7 @@ import {
   startNavigationProgress,
   stopNavigationProgress,
   resetNavigationProgress,
+  finishNavigationProgress,
 } from '@mantine/nprogress';
 import React from 'react';
 
@@ -35,6 +36,7 @@ function Demo() {
         <Button onClick={() => startNavigationProgress()}>Start</Button>
         <Button onClick={() => stopNavigationProgress()}>Stop</Button>
         <Button onClick={() => resetNavigationProgress()}>Reset</Button>
+        <Button onClick={() => finishNavigationProgress()}>Finish</Button>
       </Group>
     </>
   );
@@ -63,6 +65,9 @@ function Demo() {
         </Button>
         <Button onClick={() => resetNavigationProgress()} variant="outline">
           Reset
+        </Button>
+        <Button onClick={() => finishNavigationProgress()} variant="outline">
+          Finish
         </Button>
       </Group>
     </>

--- a/src/mantine-nprogress/src/NavigationProgress.tsx
+++ b/src/mantine-nprogress/src/NavigationProgress.tsx
@@ -101,6 +101,9 @@ export function NavigationProgress({
     setProgress(0);
     window.setTimeout(() => setUnmountProgress(false), 0);
   };
+  const finish = () => {
+    setProgress(100);
+  };
 
   const cancelUnmount = () => {
     if (unmountRef.current) {
@@ -139,7 +142,7 @@ export function NavigationProgress({
     }
   }, [_progress]);
 
-  useNavigationProgressEvents({ start, stop, set, increment, decrement, reset });
+  useNavigationProgressEvents({ start, stop, set, increment, decrement, reset, finish });
 
   return (
     <OptionalPortal withinPortal={withinPortal}>

--- a/src/mantine-nprogress/src/events.ts
+++ b/src/mantine-nprogress/src/events.ts
@@ -7,6 +7,7 @@ export type NavigationProgressEvents = {
   increment(progress: number): void;
   decrement(progress: number): void;
   reset(): void;
+  finish(): void;
 };
 
 export const [useNavigationProgressEvents, createEvent] =
@@ -18,3 +19,4 @@ export const resetNavigationProgress = createEvent('reset');
 export const setNavigationProgress = createEvent('set');
 export const incrementNavigationProgress = createEvent('increment');
 export const decrementNavigationProgress = createEvent('decrement');
+export const finishNavigationProgress = createEvent('finish');

--- a/src/mantine-nprogress/src/index.ts
+++ b/src/mantine-nprogress/src/index.ts
@@ -6,6 +6,7 @@ export {
   setNavigationProgress,
   incrementNavigationProgress,
   decrementNavigationProgress,
+  finishNavigationProgress,
 } from './events';
 
 export type { NavigationProgressProps } from './NavigationProgress';


### PR DESCRIPTION
tried to resolve this issue https://github.com/mantinedev/mantine/issues/2359
the idea is instead of calling `resetNavigationProgress` when the page load is done which will set the progress to 0 and reset the progress, now can use `finishNavigationProgress` to set the progress to 100, so progress will fill the entire width and then set the `autoReset` to `true` to automatically reset the progress bar.