### PR TITLE
Allow `auto` value for prop `slidesToScroll`

### DIFF
--- a/src/mantine-carousel/src/Carousel.tsx
+++ b/src/mantine-carousel/src/Carousel.tsx
@@ -67,7 +67,7 @@ export interface CarouselProps
   align?: 'start' | 'center' | 'end' | number;
 
   /** Number of slides that should be scrolled with next/previous buttons */
-  slidesToScroll?: number;
+  slidesToScroll?: number | 'auto';
 
   /** Determines whether gap should be treated as part of the slide size, true by default */
   includeGapInSize?: boolean;


### PR DESCRIPTION
Allow `auto` value for prop `slidesToScroll` 
Docs:  https://www.embla-carousel.com/api/options/#slidestoscroll