### PR TITLE
[@mantine/hooks] Fix typo in use-previous test

### DIFF
--- a/src/mantine-hooks/src/use-previous/use-previous.test.ts
+++ b/src/mantine-hooks/src/use-previous/use-previous.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { usePrevious } from './use-previous';
 
 describe('@mantine/hooks/use-previous', () => {
-  it('returns undefined on intial render', () => {
+  it('returns undefined on initial render', () => {
     const hook = renderHook(() => usePrevious(1));
     expect(hook.result.current).toBeUndefined();
   });


### PR DESCRIPTION
I stumbled across a typo in the test definition of use-previous :)