### PR TITLE
Add repository field

### DIFF
--- a/src/mantine-dates/package.json
+++ b/src/mantine-dates/package.json
@@ -8,6 +8,11 @@
   "license": "MIT",
   "author": "Vitaly Rtishchev <rtivital@gmail.com>",
   "homepage": "https://mantine.dev/dates/getting-started/",
+  "repository": {
+    "url": "https://github.com/mantinedev/mantine.git",
+    "type": "git",
+    "directory": "src/mantine-dates"
+  },
   "keywords": [
     "react",
     "next",


### PR DESCRIPTION
My renovate configuration cannot group `@mantine/*` dependencies by source URL, since `@mantine/dates` missed the repository field

```json
{
  "matchSourceUrls": ["https://github.com/mantinedev/mantine"],
  "groupName": "mantine"
}
```