### PR TITLE
[@mantine/core] Fixed the position of `errorProps` in the `Input` component

### DIFF
--- a/src/mantine-core/src/Input/InputWrapper/InputWrapper.tsx
+++ b/src/mantine-core/src/Input/InputWrapper/InputWrapper.tsx
@@ -140,7 +140,7 @@ export const InputWrapper = forwardRef<HTMLDivElement, InputWrapperProps>((props
   const _input = <Fragment key="input">{inputContainer(children)}</Fragment>;
 
   const _error = typeof error !== 'boolean' && error && (
-    <InputError {...errorProps} key="error" {...sharedProps}>
+    <InputError key="error" {...sharedProps} {...errorProps}>
       {error}
     </InputError>
   );

--- a/src/mantine-core/src/PasswordInput/PasswordInput.tsx
+++ b/src/mantine-core/src/PasswordInput/PasswordInput.tsx
@@ -39,8 +39,8 @@ export interface PasswordInputProps
 
 const buttonSizes = {
   xs: 22,
-  sm: 28,
-  md: 26,
+  sm: 26,
+  md: 28,
   lg: 32,
   xl: 40,
 };
@@ -55,7 +55,7 @@ const iconSizes = {
 
 const rightSectionSizes = {
   xs: 28,
-  sm: 34,
+  sm: 32,
   md: 34,
   lg: 44,
   xl: 54,


### PR DESCRIPTION
While using the inputs in the library I noticed that the `error props` were overridden by the `shared props` so I tried to fix that. Hopefully, this would help.