### PR TITLE
[@mantine/core] fixed hook issue in segmented-control

### DIFF
--- a/src/mantine-core/src/SegmentedControl/SegmentedControl.story.tsx
+++ b/src/mantine-core/src/SegmentedControl/SegmentedControl.story.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Button } from '../Button';
 import { SegmentedControl } from './SegmentedControl';
 
 export default { title: 'SegmentedControl' };
@@ -16,6 +17,18 @@ export function Usage() {
 
 export function EmptyData() {
   return <SegmentedControl data={[]} />;
+}
+
+export function ToggleEmptyData() {
+  const [emptyData, setEmptyData] = useState(true);
+
+  return (
+    <>
+      <Button onClick={() => setEmptyData((e) => !e)}>Toggle Data</Button>
+      <br />
+      <SegmentedControl data={emptyData ? [] : data} />
+    </>
+  );
 }
 
 export function EmptyStringValue() {

--- a/src/mantine-core/src/SegmentedControl/SegmentedControl.tsx
+++ b/src/mantine-core/src/SegmentedControl/SegmentedControl.tsx
@@ -206,12 +206,14 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
     </div>
   ));
 
+  const mergedRef = useMergedRef(observerRef, ref);
+
   if (data.length === 0) {
     return null;
   }
 
   return (
-    <Box className={cx(classes.root, className)} ref={useMergedRef(observerRef, ref)} {...others}>
+    <Box className={cx(classes.root, className)} ref={mergedRef} {...others}>
       {typeof _value === 'string' && shouldAnimate && (
         <Box
           component="span"


### PR DESCRIPTION
Fix an edge-case in SegmentedControl with dynamic data, where going from 0 option to >0 option or the other way around would crash because of broken rule of hooks