### PR TITLE
[@mantine/core] NumberInput: make 'removeTrailingZeros' false by default

### DIFF
--- a/src/mantine-core/src/NumberInput/NumberInput.test.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.test.tsx
@@ -137,7 +137,7 @@ describe('@mantine/core/NumberInput', () => {
     await enterText('6.12300000');
     expect(spy).toHaveBeenLastCalledWith(6.123);
     blurInput();
-    expectValue('6.123');
+    expectValue('6.12300000');
     expect(spy).toHaveBeenLastCalledWith(6.123);
   });
 

--- a/src/mantine-core/src/NumberInput/NumberInput.test.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.test.tsx
@@ -141,6 +141,16 @@ describe('@mantine/core/NumberInput', () => {
     expect(spy).toHaveBeenLastCalledWith(6.123);
   });
 
+  it('supports removing trailing zeros and decimal separator with precision', async () => {
+    const spy = jest.fn();
+    render(<NumberInput precision={8} removeTrailingZeros onChange={spy} />);
+    await enterText('6.00000000');
+    expect(spy).toHaveBeenLastCalledWith(6);
+    blurInput();
+    expectValue('6.00000000');
+    expect(spy).toHaveBeenLastCalledWith(6);
+  });
+
   it('sets state to min if input is empty and is incremented/decremented', async () => {
     const spy = jest.fn();
     const { container } = render(<NumberInput max={10} min={0} step={6} onChange={spy} />);

--- a/src/mantine-core/src/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.tsx
@@ -117,7 +117,7 @@ const defaultProps: Partial<NumberInputProps> = {
   size: 'sm',
   precision: 0,
   noClampOnBlur: false,
-  removeTrailingZeros: true,
+  removeTrailingZeros: false,
   formatter: defaultFormatter,
   parser: defaultParser,
   type: 'text',
@@ -359,7 +359,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
 
       if (!Number.isNaN(val)) {
         if (!noClampOnBlur) {
-          if (removeTrailingZeros) {
+          if (!removeTrailingZeros) {
             const valNoZeros = val
               .toFixed(precision)
               .replace(new RegExp(`[0]{0,${precision}}$`), '');

--- a/src/mantine-core/src/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.tsx
@@ -359,7 +359,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
 
       if (!Number.isNaN(val)) {
         if (!noClampOnBlur) {
-          if (!removeTrailingZeros) {
+          if (removeTrailingZeros) {
             const valNoZeros = val
               .toFixed(precision)
               .replace(new RegExp(`[0]{0,${precision}}$`), '');


### PR DESCRIPTION
The default was set to true this fixes it and adds an additional test.