### PR TITLE
[@mantine/spotlight] Use 'off' autocomplete value for Spotlight input

### DIFF
--- a/src/mantine-spotlight/src/Spotlight/Spotlight.tsx
+++ b/src/mantine-spotlight/src/Spotlight/Spotlight.tsx
@@ -252,7 +252,7 @@ export function Spotlight({
                   placeholder={searchPlaceholder}
                   icon={searchIcon}
                   onMouseEnter={resetHovered}
-                  autoComplete="chrome-please-just-do-not-show-it-thanks"
+                  autoComplete="off"
                 />
                 <ActionsWrapper>
                   <ActionsList


### PR DESCRIPTION
The 'off' autoComplete value is an expected attribute value: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete

Not all browsers may understand the current value of `chrome-please-just-do-not-show-it-thanks`.