### PR TITLE
[docs] Fix link to go to global styles guide in theme object page

### DIFF
--- a/docs/src/docs/theming/theme-object.mdx
+++ b/docs/src/docs/theming/theme-object.mdx
@@ -259,7 +259,7 @@ Note that you should also import `dayjs/locale/[locale]` to load localization fi
 
 ### globalStyles
 
-`theme.globalStyles` adds global styles, see [global styles guide](/styles/global/) to learn more.
+`theme.globalStyles` adds global styles, see [global styles guide](/styles/global-styles/) to learn more.
 
 ### other
 


### PR DESCRIPTION
- fix[docs]: corrected link for global styles guide in theme object page