### PR TITLE
[docs] import FileWithPath type in Dropzone for image previews example

### DIFF
--- a/src/mantine-demos/src/demos/dropzone/Dropzone.demo.preview.tsx
+++ b/src/mantine-demos/src/demos/dropzone/Dropzone.demo.preview.tsx
@@ -6,7 +6,7 @@ import { Dropzone, IMAGE_MIME_TYPE, FileWithPath } from '@mantine/dropzone';
 const code = `
 import { useState } from 'react';
 import { Text, Image, SimpleGrid } from '@mantine/core';
-import { Dropzone, IMAGE_MIME_TYPE } from '@mantine/dropzone';
+import { Dropzone, IMAGE_MIME_TYPE, FileWithPath } from '@mantine/dropzone';
 
 function Demo() {
   const [files, setFiles] = useState<FileWithPath[]>([]);


### PR DESCRIPTION
- fix[docs] : add FileWithPath type imports for  image previews example in Dropzone