### PR TITLE
[@mantine/nprogress] Fix Next.js usage example

### DIFF
--- a/docs/src/docs/others/nprogress.mdx
+++ b/docs/src/docs/others/nprogress.mdx
@@ -63,7 +63,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import {
   startNavigationProgress,
-  finishNavigationProgress,
+  completeNavigationProgress,
   NavigationProgress,
 } from '@mantine/nprogress';
 
@@ -72,7 +72,7 @@ export function RouterTransition() {
 
   useEffect(() => {
     const handleStart = (url: string) => url !== router.asPath && startNavigationProgress();
-    const handleComplete = () => finishNavigationProgress();
+    const handleComplete = () => completeNavigationProgress();
 
     router.events.on('routeChangeStart', handleStart);
     router.events.on('routeChangeComplete', handleComplete);


### PR DESCRIPTION
@mantine/nprogress doesn't have an exported member `finishNavigationProgress`, and from looking at previous examples, I believe it's supposed to be `completeNavigationProgress`