### PR TITLE
[@mantine/core] Popover: fixed issue with popover/menu not staying in place

### DIFF
--- a/src/mantine-core/src/Popover/use-popover.ts
+++ b/src/mantine-core/src/Popover/use-popover.ts
@@ -8,6 +8,7 @@ import {
   size,
   Middleware,
   inline,
+  limitShift,
 } from '@floating-ui/react-dom-interactions';
 import { FloatingPosition, useFloatingAutoUpdate } from '../Floating';
 import { PopoverWidth, PopoverMiddlewares } from './Popover.types';
@@ -31,7 +32,7 @@ function getPopoverMiddlewares(options: UsePopoverOptions) {
   const middlewares: Middleware[] = [offset(options.offset)];
 
   if (options.middlewares.shift) {
-    middlewares.push(shift());
+    middlewares.push(shift({ limiter: limitShift() }));
   }
 
   if (options.middlewares.flip) {


### PR DESCRIPTION
Add [limiter](https://floating-ui.com/docs/shift#limiter) to shift middleware which prevents detachment from its target element

Reference to #2688