### PR TITLE
[@mantine/core] Indicator: Fix Indicator dot showing

### DIFF
--- a/src/mantine-core/src/Indicator/Indicator.tsx
+++ b/src/mantine-core/src/Indicator/Indicator.tsx
@@ -116,7 +116,7 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>((props, ref)
 
   const isShowIndicator = useMemo(
     () => !disabled && (dot || (label != null && !(label <= 0 && !showZero))),
-    [disabled, label, showZero]
+    [disabled, label, showZero, dot]
   );
 
   return (


### PR DESCRIPTION
Resolving [#2697](https://github.com/mantinedev/mantine/issues/2697)
Add `dot` in isShowIndicator useMemo dependency array