### PR TITLE
[@mantine/hooks] use-idle: improves typing of events options

### DIFF
--- a/src/mantine-hooks/src/use-idle/use-idle.ts
+++ b/src/mantine-hooks/src/use-idle/use-idle.ts
@@ -1,6 +1,12 @@
 import { useState, useEffect, useRef } from 'react';
 
-const DEFAULT_EVENTS = ['keypress', 'mousemove', 'touchmove', 'click', 'scroll'];
+const DEFAULT_EVENTS: (keyof DocumentEventMap)[] = [
+  'keypress',
+  'mousemove',
+  'touchmove',
+  'click',
+  'scroll',
+];
 const DEFAULT_OPTIONS = {
   events: DEFAULT_EVENTS,
   initialState: true,
@@ -8,7 +14,7 @@ const DEFAULT_OPTIONS = {
 
 export function useIdle(
   timeout: number,
-  options?: Partial<{ events: string[]; initialState: boolean }>
+  options?: Partial<{ events: (keyof DocumentEventMap)[]; initialState: boolean }>
 ) {
   const { events, initialState } = { ...DEFAULT_OPTIONS, ...options };
   const [idle, setIdle] = useState<boolean>(initialState);


### PR DESCRIPTION
Improve typing of events option to useIdle hook. This change allows for a better development experience, verifying code-time typing and making it easier to find correct events.