### PR TITLE
[@mantine/form] add getSubmitButtonProps

### DIFF
--- a/docs/src/docs/form/use-form.mdx
+++ b/docs/src/docs/form/use-form.mdx
@@ -222,6 +222,13 @@ As second parameter options can be passed.
 <Checkbox {...form.getInputProps('accepted', { type: 'checkbox' })} />
 ```
 
+### getSubmitButtonProps
+
+`form.getSubmitButtonProps` returns an object with `loading` that should be spread on the submit button of your form.
+
+This will make you button enter in a loading state while your `form.onSubmit` handler is executing. If it returns a promise,
+  the loading state will be kept until the promise resolve or reject.
+
 ## UseFormReturnType
 
 `UseFormReturnType` can be used when you want to pass `form` as a prop to another component:

--- a/src/mantine-demos/src/demos/form/Form.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/form/Form.demo.usage.tsx
@@ -20,9 +20,17 @@ function Demo() {
     },
   });
 
+  const submit = async (values) => {
+    await new Promise(resolve => {
+      setTimeout(resolve, 1000);
+    });
+
+    console.log(values);
+  };
+
   return (
     <Box sx={{ maxWidth: 300 }} mx="auto">
-      <form onSubmit={form.onSubmit((values) => console.log(values))}>
+      <form onSubmit={form.onSubmit(submit)}>
         <TextInput
           withAsterisk
           label="Email"
@@ -37,7 +45,9 @@ function Demo() {
         />
 
         <Group position="right" mt="md">
-          <Button type="submit">Submit</Button>
+          <Button type="submit" {...form.getSubmitButtonProps()}>
+            Submit
+          </Button>
         </Group>
       </form>
     </Box>
@@ -59,9 +69,17 @@ function Demo() {
     },
   });
 
+  const submit = async (values) => {
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 1000);
+    });
+
+    console.log(values);
+  };
+
   return (
     <Box sx={{ maxWidth: 300 }} mx="auto">
-      <form onSubmit={form.onSubmit((values) => console.log(values))}>
+      <form onSubmit={form.onSubmit(submit)}>
         <TextInput
           withAsterisk
           label="Email"
@@ -76,7 +94,9 @@ function Demo() {
         />
 
         <Group position="right" mt="md">
-          <Button type="submit">Submit</Button>
+          <Button type="submit" {...form.getSubmitButtonProps()}>
+            Submit
+          </Button>
         </Group>
       </form>
     </Box>

--- a/src/mantine-form/src/tests/get-submit-button-props.test.ts
+++ b/src/mantine-form/src/tests/get-submit-button-props.test.ts
@@ -1,0 +1,68 @@
+import { act, renderHook } from '@testing-library/react';
+import { useForm } from '../use-form';
+
+const getFormEvent = () => ({ preventDefault: jest.fn() } as any);
+
+describe('@mantine/form/get-submit-button-props', () => {
+  it('returns correct submit button props (root property)', () => {
+    const hook = renderHook(() => useForm());
+
+    const props = hook.result.current.getSubmitButtonProps();
+    expect(props.loading).toBe(false);
+  });
+
+  it('returns correct submit button props (with non-promise return from handler)', () => {
+    const hook = renderHook(() => useForm());
+
+    const handleSubmit = () => {};
+
+    const event = getFormEvent();
+    act(() => hook.result.current.onSubmit(handleSubmit)(event));
+
+    const props = hook.result.current.getSubmitButtonProps();
+    expect(props.loading).toBe(false);
+  });
+
+  it('returns correct submit button props (with promise resolving from handler)', () => {
+    const hook = renderHook(() => useForm());
+
+    const handleSubmit = () => Promise.resolve();
+
+    const event = getFormEvent();
+    act(() => hook.result.current.onSubmit(handleSubmit)(event));
+
+    const props = hook.result.current.getSubmitButtonProps();
+    expect(props.loading).toBe(false);
+  });
+
+  it('returns correct submit button props (with promise rejecting from handler)', () => {
+    const hook = renderHook(() => useForm());
+
+    const handleSubmit = () => Promise.reject();
+
+    const event = getFormEvent();
+    act(() => hook.result.current.onSubmit(handleSubmit)(event));
+
+    const props = hook.result.current.getSubmitButtonProps();
+    expect(props.loading).toBe(false);
+  });
+
+  it('returns correct submit button props (while Promise still pending)', async () => {
+    const hook = renderHook(() => useForm());
+
+    const handleSubmit = () =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, 1000);
+      });
+
+    const event = getFormEvent();
+    const promise = act(() => hook.result.current.onSubmit(handleSubmit)(event));
+
+    const props = hook.result.current.getSubmitButtonProps();
+    expect(props.loading).toBe(true);
+
+    await promise;
+
+    expect(props.loading).toBe(false);
+  });
+});

--- a/src/mantine-form/src/types.ts
+++ b/src/mantine-form/src/types.ts
@@ -46,7 +46,7 @@ export type SetErrors = React.Dispatch<React.SetStateAction<FormErrors>>;
 export type SetFormStatus = React.Dispatch<React.SetStateAction<FormStatus>>;
 
 export type OnSubmit<Values> = (
-  handleSubmit: (values: Values, event: React.FormEvent<HTMLFormElement>) => void,
+  handleSubmit: (values: Values, event: React.FormEvent<HTMLFormElement>) => void | Promise<void>,
   handleValidationFailure?: (
     errors: FormErrors,
     values: Values,
@@ -60,6 +60,10 @@ export type GetInputProps<Values> = <Field extends LooseKeys<Values>>(
   path: Field,
   options?: { type?: GetInputPropsType; withError?: boolean; withFocus?: boolean }
 ) => any;
+
+export type GetSubmitButtonProps = () => {
+  loading: boolean;
+};
 
 export type SetFieldValue<Values> = <Field extends LooseKeys<Values>>(
   path: Field,
@@ -112,6 +116,8 @@ export interface UseFormInput<Values> {
   validateInputOnBlur?: boolean | LooseKeys<Values>[];
 }
 
+export type SubmitButtonState = 'loading' | 'done';
+
 export interface UseFormReturnType<Values> {
   values: Values;
   errors: FormErrors;
@@ -128,6 +134,7 @@ export interface UseFormReturnType<Values> {
   removeListItem: RemoveListItem<Values>;
   insertListItem: InsertListItem<Values>;
   getInputProps: GetInputProps<Values>;
+  getSubmitButtonProps: GetSubmitButtonProps;
   onSubmit: OnSubmit<Values>;
   onReset: OnReset;
   isDirty: GetFieldStatus<Values>;


### PR DESCRIPTION
I think this may be useful to help preventing double submitting the same form twice while also providing a way to add the "loading" state to the UI automatically.

Been using this on a personal project and would love to see it in the main lib as well so others can use too
