### PR TITLE
[@mantine/core] Image: fix figcaption overflow with removed height from root style.

### DIFF
--- a/src/mantine-core/src/Image/Image.story.tsx
+++ b/src/mantine-core/src/Image/Image.story.tsx
@@ -32,8 +32,13 @@ storiesOf('Image', module)
     </>
   ))
   .add('src changes over time', () => <ImageChangesOverTime />)
-  .add('Placeholder with custom size', () => (
+  .add('Placeholder with custom size and container is larger than image size', () => (
     <Container size={60}>
+      <Image radius="sm" src={null} withPlaceholder width={50} height={50} />
+    </Container>
+  ))
+  .add('Placeholder with custom size and container is smaller than image size', () => (
+    <Container size={40}>
       <Image radius="sm" src={null} withPlaceholder width={50} height={50} />
     </Container>
   ));

--- a/src/mantine-core/src/Image/Image.tsx
+++ b/src/mantine-core/src/Image/Image.tsx
@@ -88,12 +88,7 @@ export const Image = forwardRef<HTMLDivElement, ImageProps>((props: ImageProps, 
   }, [src]);
 
   return (
-    <Box
-      className={cx(classes.root, className)}
-      ref={ref}
-      style={{ width, height, ...style }}
-      {...others}
-    >
+    <Box className={cx(classes.root, className)} ref={ref} style={{ width, ...style }} {...others}>
       <figure className={classes.figure}>
         <div className={classes.imageWrapper}>
           <img


### PR DESCRIPTION
Remove height from `Image` root style.

Now storybook demo can see this error directly，I also test when container is less than fixed image height, placeholder also work fine.
![image](https://user-images.githubusercontent.com/1364025/196108099-e73bca71-c9d3-40cd-9b26-581c3fa104ea.png)
