### PR TITLE
[@mantine/core] Select: do not rely on searchable in readonly prop

### DIFF
--- a/src/mantine-core/src/Select/Select.tsx
+++ b/src/mantine-core/src/Select/Select.tsx
@@ -586,7 +586,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>((props, ref) => 
               onMouseDown={handleInputClick}
               onBlur={handleInputBlur}
               onFocus={handleInputFocus}
-              readOnly={!searchable || readOnly}
+              readOnly={readOnly}
               disabled={disabled}
               data-mantine-stop-propagation={shouldShowDropdown}
               name={null}


### PR DESCRIPTION
All non searchable `Select` component are marked as `readonly`. It causes issues especially for CSS selection.

Example when we want to apply special style to readonly Select like this :
```css
input[readonly] {
  cursor: "not-allowed"
}
```
=> this style applies to all non searchable `Select` that are still editable. I think it makes no sense. What do you think?

### Solution

Get rid of `!searchable` in `readOnly={!searchable || readOnly}`