### PR TITLE
[@mantine/hooks] use-timout: Add parameters for callback function

### DIFF
--- a/docs/src/docs/hooks/use-timeout.mdx
+++ b/docs/src/docs/hooks/use-timeout.mdx
@@ -38,13 +38,13 @@ Return object:
 
 ```tsx
 function useTimeout(
-  callback: (callbackParams?: any) => void,
+  callback: (...callbackParams: any[]) => void,
   delay: number,
   options?: {
     autoInvoke: boolean;
   }
 ): {
-  start: (callbackParams?: any) => void;
+  start: (...callbackParams: any[]) => void;
   clear: () => void;
 };
 ```

--- a/docs/src/docs/hooks/use-timeout.mdx
+++ b/docs/src/docs/hooks/use-timeout.mdx
@@ -38,13 +38,13 @@ Return object:
 
 ```tsx
 function useTimeout(
-  callback: () => void,
+  callback: (callbackParams?: any) => void,
   delay: number,
   options?: {
     autoInvoke: boolean;
   }
 ): {
-  start: () => void;
+  start: (callbackParams?: any) => void;
   clear: () => void;
 };
 ```

--- a/src/mantine-hooks/src/use-timeout/use-timeout.test.ts
+++ b/src/mantine-hooks/src/use-timeout/use-timeout.test.ts
@@ -88,4 +88,19 @@ describe('@mantine/hooks/use-timeout', () => {
     expect(setTimeout).toHaveBeenCalled();
     expect(clearTimeout).toHaveBeenCalled();
   });
+
+  it('start function passes parameters to callback', () => {
+    const { timeout, advanceTimerToNextTick } = setupTimer(10);
+    const hook = renderHook(() => useTimeout(callback, timeout));
+
+    const MOCK_CALLBACK_VALUE = 'MOCK_CALLBACK_VALUE';
+    act(() => {
+      hook.result.current.start(MOCK_CALLBACK_VALUE);
+    });
+
+    advanceTimerToNextTick();
+
+    expect(setTimeout).toHaveBeenCalled();
+    expect(callback).toBeCalledWith(MOCK_CALLBACK_VALUE);
+  });
 });

--- a/src/mantine-hooks/src/use-timeout/use-timeout.test.ts
+++ b/src/mantine-hooks/src/use-timeout/use-timeout.test.ts
@@ -101,6 +101,6 @@ describe('@mantine/hooks/use-timeout', () => {
     advanceTimerToNextTick();
 
     expect(setTimeout).toHaveBeenCalled();
-    expect(callback).toBeCalledWith(MOCK_CALLBACK_VALUE);
+    expect(callback).toBeCalledWith([MOCK_CALLBACK_VALUE]);
   });
 });

--- a/src/mantine-hooks/src/use-timeout/use-timeout.ts
+++ b/src/mantine-hooks/src/use-timeout/use-timeout.ts
@@ -1,16 +1,16 @@
 import { useRef, useEffect } from 'react';
 
 export function useTimeout(
-  fn: () => void,
+  callback: (callbackParams?: any) => void,
   delay: number,
   options: { autoInvoke: boolean } = { autoInvoke: false }
 ) {
   const timeoutRef = useRef<number>(null);
 
-  const start = () => {
+  const start = (callbackParams?: any) => {
     if (!timeoutRef.current) {
       timeoutRef.current = window.setTimeout(() => {
-        fn();
+        callback(callbackParams);
         timeoutRef.current = null;
       }, delay);
     }

--- a/src/mantine-hooks/src/use-timeout/use-timeout.ts
+++ b/src/mantine-hooks/src/use-timeout/use-timeout.ts
@@ -1,13 +1,13 @@
 import { useRef, useEffect } from 'react';
 
 export function useTimeout(
-  callback: (callbackParams?: any) => void,
+  callback: (...callbackParams: any[]) => void,
   delay: number,
   options: { autoInvoke: boolean } = { autoInvoke: false }
 ) {
   const timeoutRef = useRef<number>(null);
 
-  const start = (callbackParams?: any) => {
+  const start = (...callbackParams: any[]) => {
     if (!timeoutRef.current) {
       timeoutRef.current = window.setTimeout(() => {
         callback(callbackParams);


### PR DESCRIPTION
Issue discussed here - https://discord.com/channels/854810300876062770/1029643292431892491/1029643292431892491

As of now, setTimeout callback function is called without any parameters. I found it to be useful when these parameters can be pased from start() function.