### PR TITLE
[@mantine/hooks] use-focus-trap: Fix aria-hidden

### DIFF
--- a/src/mantine-core/src/FocusTrap/FocusTrap.test.tsx
+++ b/src/mantine-core/src/FocusTrap/FocusTrap.test.tsx
@@ -51,6 +51,29 @@ describe('@mantine/core/FocusTrap', () => {
     expect(document.body).toHaveFocus();
   });
 
+  it('manages aria-hidden attributes', () => {
+    const adjacentDiv = document.createElement('div');
+    adjacentDiv.setAttribute('data-testid', 'adjacent');
+    document.body.appendChild(adjacentDiv);
+
+    const { rerender } = render(
+      <FocusTrap active>
+        <div />
+      </FocusTrap>
+    );
+
+    const adjacent = screen.getByTestId('adjacent');
+    expect(adjacent).toHaveAttribute('aria-hidden', 'true');
+
+    rerender(
+      <FocusTrap active={false}>
+        <div />
+      </FocusTrap>
+    );
+
+    expect(adjacent).not.toHaveAttribute('aria-hidden');
+  });
+
   it('has correct displayName', () => {
     expect(FocusTrap.displayName).toEqual('@mantine/core/FocusTrap');
   });

--- a/src/mantine-hooks/src/use-focus-trap/use-focus-trap.ts
+++ b/src/mantine-hooks/src/use-focus-trap/use-focus-trap.ts
@@ -9,22 +9,21 @@ export function useFocusTrap(active = true): (instance: HTMLElement | null) => v
 
   const setRef = useCallback(
     (node: HTMLElement | null) => {
-      if (restoreAria.current) {
-        restoreAria.current();
-      }
-
       if (!active) {
         return;
       }
 
-      if (node === ref.current || node === null) {
+      if (node === null) {
+        return;
+      }
+
+      restoreAria.current = createAriaHider(node);
+      if (ref.current === node) {
         return;
       }
 
       if (node) {
-        const processNode = (_node: HTMLElement) => {
-          restoreAria.current = createAriaHider(_node);
-
+        const processNode = () => {
           let focusElement: HTMLElement = node.querySelector('[data-autofocus]');
 
           if (!focusElement) {
@@ -47,7 +46,7 @@ export function useFocusTrap(active = true): (instance: HTMLElement | null) => v
         // Delay processing the HTML node by a frame. This ensures focus is assigned correctly.
         setTimeout(() => {
           if (node.ownerDocument) {
-            processNode(node);
+            processNode();
           } else if (process.env.NODE_ENV === 'development') {
             // eslint-disable-next-line no-console
             console.warn('[@mantine/hooks/use-focus-trap] Ref node is not part of the dom', node);
@@ -76,6 +75,10 @@ export function useFocusTrap(active = true): (instance: HTMLElement | null) => v
     document.addEventListener('keydown', handleKeyDown);
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
+
+      if (restoreAria.current) {
+        restoreAria.current();
+      }
     };
   }, [active]);
 

--- a/src/mantine-hooks/src/use-focus-trap/use-focus-trap.ts
+++ b/src/mantine-hooks/src/use-focus-trap/use-focus-trap.ts
@@ -9,16 +9,16 @@ export function useFocusTrap(active = true): (instance: HTMLElement | null) => v
 
   const setRef = useCallback(
     (node: HTMLElement | null) => {
+      if (restoreAria.current) {
+        restoreAria.current();
+      }
+
       if (!active) {
         return;
       }
 
       if (node === ref.current || node === null) {
         return;
-      }
-
-      if (restoreAria.current) {
-        restoreAria.current();
       }
 
       if (node) {


### PR DESCRIPTION
This PR resolves #2726.

Turns out that `restoreAria.current();` was simply not called on unmount; this has now been changed.
Furthermore, I fixed an additional issue where aria-hidden attributes would only be applied on the first render, but would not update after that. This was caused by https://github.com/mantinedev/mantine/blob/f7da1459fba6284e23ff57f3e839e691bbb8e980/src/mantine-hooks/src/use-focus-trap/use-focus-trap.ts#L16 After the first render, `ref.current` would already hold the node and aria attributes would not be reapplied again.

Finally, I added a test to `FocusTrap.test.tsx` which makes sure aria-hidden is added and removed. I'll be the first to admit it is kinda ugly but I could not find a better version. Also tested it manually with storybook - components like `Modal` or `Drawer` now remove the attribute correctly.