### PR TITLE
[@mantine/core] add custom icons capability to transfer-list

### DIFF
--- a/docs/src/docs/core/TransferList.mdx
+++ b/docs/src/docs/core/TransferList.mdx
@@ -48,6 +48,10 @@ Value should be a tuple of two arrays which contain values from data:
 
 <Demo data={TransferListDemos.group} />
 
+## Custom control icons
+
+<Demo data={TransferListDemos.customIcons} />
+
 ## Responsive styles
 
 Set `breakpoint` prop to specify at which breakpoint TransferList will collapse to 1 column:

--- a/src/mantine-core/src/TransferList/RenderList/RenderList.tsx
+++ b/src/mantine-core/src/TransferList/RenderList/RenderList.tsx
@@ -7,7 +7,7 @@ import { UnstyledButton } from '../../UnstyledButton';
 import { ActionIcon } from '../../ActionIcon';
 import { TextInput } from '../../TextInput';
 import { Text } from '../../Text';
-import { Divider } from '../../Divider/Divider';
+import { Divider } from '../../Divider';
 import { LastIcon, NextIcon, FirstIcon, PrevIcon } from '../../Pagination/icons';
 import { TransferListItem, TransferListItemComponent } from '../types';
 import useStyles from './RenderList.styles';
@@ -31,6 +31,8 @@ export interface RenderListProps extends DefaultProps<RenderListStylesNames> {
   radius: MantineNumberSize;
   listComponent?: React.FC<any>;
   limit?: number;
+  transferIcon?: React.FunctionComponent<{ reversed }>;
+  transferAllIcon?: React.FunctionComponent<{ reversed }>;
 }
 
 const icons = {
@@ -54,6 +56,8 @@ export function RenderList({
   selection,
   itemComponent: ItemComponent,
   listComponent,
+  transferIcon: TransferIcon,
+  transferAllIcon: TransferAllIcon,
   searchPlaceholder,
   filter,
   nothingFound,
@@ -181,6 +185,9 @@ export function RenderList({
     }
   };
 
+  const transferIcon = reversed ? <Icons.Prev /> : <Icons.Next />;
+  const transferAllIcon = reversed ? <Icons.First /> : <Icons.Last />;
+
   return (
     <div className={cx(classes.transferList, className)}>
       {title && (
@@ -216,7 +223,7 @@ export function RenderList({
             onClick={onMove}
             unstyled={unstyled}
           >
-            {reversed ? <Icons.Prev /> : <Icons.Next />}
+            {TransferIcon ? <TransferIcon reversed={reversed} /> : transferIcon}
           </ActionIcon>
 
           {showTransferAll && (
@@ -229,7 +236,7 @@ export function RenderList({
               onClick={onMoveAll}
               unstyled={unstyled}
             >
-              {reversed ? <Icons.First /> : <Icons.Last />}
+              {TransferAllIcon ? <TransferAllIcon reversed={reversed} /> : transferAllIcon}
             </ActionIcon>
           )}
         </div>

--- a/src/mantine-core/src/TransferList/TransferList.tsx
+++ b/src/mantine-core/src/TransferList/TransferList.tsx
@@ -53,6 +53,12 @@ export interface TransferListProps
 
   /** Limit amount of items showed at a time */
   limit?: number;
+
+  /** Change icon used for the transfer selected control */
+  transferIcon?: React.FunctionComponent<{ reversed: boolean }>;
+
+  /** Change icon used for the transfer all control */
+  transferAllIcon?: React.FunctionComponent<{ reversed: boolean }>;
 }
 
 export function defaultFilter(query: string, item: TransferListItem) {
@@ -88,6 +94,8 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>((props
     styles,
     limit,
     unstyled,
+    transferIcon,
+    transferAllIcon,
     ...others
   } = useComponentDefaultProps('TransferList', defaultProps, props);
 
@@ -126,6 +134,8 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>((props
   const sharedListProps = {
     itemComponent,
     listComponent,
+    transferIcon,
+    transferAllIcon,
     searchPlaceholder,
     filter,
     nothingFound,

--- a/src/mantine-demos/src/demos/core/TransferList/TransferList.demo.customIcons.tsx
+++ b/src/mantine-demos/src/demos/core/TransferList/TransferList.demo.customIcons.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { IconFilePlus, IconFolderPlus, IconFileMinus, IconFolderMinus } from '@tabler/icons';
+import { MantineDemo } from '@mantine/ds';
+import { Wrapper } from './_wrapper';
+
+const code = `
+import {
+  IconFilePlus,
+  IconFolderPlus,
+  IconFileMinus,
+  IconFolderMinus,
+} from '@tabler/icons';
+import { TransferList } from '@mantine/core';
+
+function Demo() {
+  return (
+    <TransferList
+      transferIcon={({ reversed }) => (reversed ? <IconFileMinus /> : <IconFilePlus />)}
+      transferAllIcon={({ reversed }) => (reversed ? <IconFolderMinus /> : <IconFolderPlus />)}
+      {/* ...other props */}
+    />
+  )
+}
+`;
+
+function Demo() {
+  return (
+    <Wrapper
+      searchPlaceholder="Search..."
+      nothingFound="Nothing here"
+      titles={['Frameworks', 'Libraries']}
+      breakpoint="sm"
+      transferIcon={({ reversed }) => (reversed ? <IconFileMinus /> : <IconFilePlus />)}
+      transferAllIcon={({ reversed }) => (reversed ? <IconFolderMinus /> : <IconFolderPlus />)}
+    />
+  );
+}
+
+export const customIcons: MantineDemo = {
+  type: 'demo',
+  component: Demo,
+  code,
+};

--- a/src/mantine-demos/src/demos/core/TransferList/index.ts
+++ b/src/mantine-demos/src/demos/core/TransferList/index.ts
@@ -3,3 +3,4 @@ export { scrollbars } from './TransferList.demo.scrollbars';
 export { itemComponent } from './TransferList.demo.itemComponent';
 export { initialSelection } from './TransferList.demo.initialSelection';
 export { group } from './TransferList.demo.group';
+export { customIcons } from './TransferList.demo.customIcons';


### PR DESCRIPTION
Adds custom icon support for TransferList controls, to allow people to use their own design system icons.

The props take a component with a `reversed` props to allow handling both lists correctly.