### PR TITLE
[docs] Add guide on custom notifications component

### DIFF
--- a/docs/src/docs/others/notifications.mdx
+++ b/docs/src/docs/others/notifications.mdx
@@ -118,11 +118,15 @@ Notifications preview (`message` prop used as `children`):
 
 <Demo data={NotificationDemos.configurator} configuratorProps={{ includeCode: false }} />
 
-## Customize notification styles
+## Customize notification via function call
 
 You can use `sx`, `style`, `className` or [Styles API](/styles/styles-api/) `classNames`, `styles` props to customize notification styles:
 
 <Demo data={NotificationsDemos.customize} />
+
+## Customize notification via theme
+To override the default styles of the notification component, you can use [Mantine Provider](/theming/default-props/#overriding-default-props).
+Just override the props of the `Notification` component in the `theme.components` section.
 
 ## Notifications container position
 


### PR DESCRIPTION
# Help user understand how to customise notification per component

Currently, the docs only mentioned how to customise the notification via showNotification function call. However, most users are most likely looking for how to customise the notification per component. This is my first experience, having stumbled upon the @mantine/notifications package, without reading through the theming section of the docs. Thus, add a section on how to customise the notification component via the theme.