### PR TITLE
[@mantine/core] Pagination: Respect `font-family` from theme.

### DIFF
--- a/src/mantine-core/src/Pagination/Pagination.styles.ts
+++ b/src/mantine-core/src/Pagination/Pagination.styles.ts
@@ -19,13 +19,13 @@ export default createStyles((theme, { size, radius, color }: PaginationStylesPar
 
   return {
     item: {
+      ...theme.fn.fontStyles(),
       ...theme.fn.focusStyles(),
       cursor: 'pointer',
       userSelect: 'none',
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-      fontWeight: 500,
       border: `1px solid ${
         theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[4]
       }`,


### PR DESCRIPTION
`font-weight` is removed as it didn't affect the boldness before but it does now.