### PR TITLE
[@mantine/styles] Add support for `color-scheme` attribute

### DIFF
--- a/src/mantine-styles/src/theme/GlobalStyles.tsx
+++ b/src/mantine-styles/src/theme/GlobalStyles.tsx
@@ -10,6 +10,10 @@ export function GlobalStyles({ theme }: { theme: MantineTheme }) {
           boxSizing: 'border-box',
         },
 
+        html: {
+          colorScheme: theme.colorScheme === 'dark' ? 'dark' : 'light',
+        },
+
         body: {
           ...theme.fn.fontStyles(),
           backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,


### PR DESCRIPTION
Using `color-scheme` attribute instructs the browser which color scheme is used on the current web page to help it in rendering interface (e.g. scroll bars) in appropriate mode. It's really missing piece right now, just feel the difference:

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/198038267-73c28ec8-01d9-430f-a047-013d4a688138.png) | ![image](https://user-images.githubusercontent.com/4408379/198038166-0dbb78b4-cff2-4a16-8534-4e74846e3a28.png) |