### PR TITLE
Update MultiSelect.mdx

### DIFF
--- a/docs/src/docs/core/MultiSelect.mdx
+++ b/docs/src/docs/core/MultiSelect.mdx
@@ -37,7 +37,7 @@ function Demo() {
 }
 ```
 
-Note that MultiSelect value should always be an array of either **string** or **null**:
+Note that MultiSelect value should always be an array of either **string** or **undefined**:
 
 ```tsx
 // Incorrect, will have bugs


### PR DESCRIPTION
According to:

https://github.com/mantinedev/mantine/blob/4784c078b8b611e3c8b240a4f28c324394577984/src/mantine-core/src/Select/Select.tsx#L21

Looks like the type of `value` is actually `string[] | undefined` rather than `string[] | null`