### PR TITLE
Add peer dependencies to @mantine/core and @mantine/next

### DIFF
--- a/src/mantine-core/package.json
+++ b/src/mantine-core/package.json
@@ -28,6 +28,7 @@
   ],
   "peerDependencies": {
     "@mantine/hooks": "5.6.3",
+    "@emotion/react": ">=11.9.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },

--- a/src/mantine-next/package.json
+++ b/src/mantine-next/package.json
@@ -26,7 +26,9 @@
   },
   "dependencies": {
     "@mantine/ssr": "5.6.3",
-    "@mantine/styles": "5.6.3"
+    "@mantine/styles": "5.6.3",
+    "@emotion/react": ">=11.9.0",
+    "@emotion/server": ">=11.4.0"
   },
   "devDependencies": {}
 }

--- a/src/mantine-next/package.json
+++ b/src/mantine-next/package.json
@@ -22,13 +22,13 @@
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "next": "*"
+    "next": "*",
+    "@emotion/react": ">=11.9.0",
+    "@emotion/server": ">=11.4.0"
   },
   "dependencies": {
     "@mantine/ssr": "5.6.3",
-    "@mantine/styles": "5.6.3",
-    "@emotion/react": ">=11.9.0",
-    "@emotion/server": ">=11.4.0"
+    "@mantine/styles": "5.6.3"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
This PR adds a couple of peer dependencies:
- Both `@mantine/core` and `@mantine/next` depend on `@mantine/styles`, which has a peer dependency on `@emotion/react`.
- `@mantine/next` depends on `@mantine/ssr`, which has a peer dependency on `@emotion/server`.