### PR TITLE
[docs] remove `,` from `Menu` Demo

### DIFF
--- a/src/mantine-demos/src/demos/core/Menu/Menu.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/core/Menu/Menu.demo.usage.tsx
@@ -29,7 +29,7 @@ function Demo() {
         <Menu.Divider />
 
         <Menu.Label>Danger zone</Menu.Label>
-        <Menu.Item icon={<IconArrowsLeftRight size={14} />}>Transfer my data</Menu.Item>,
+        <Menu.Item icon={<IconArrowsLeftRight size={14} />}>Transfer my data</Menu.Item>
         <Menu.Item color="red" icon={<IconTrash size={14} />}>Delete my account</Menu.Item>
       </Menu.Dropdown>
     </Menu>


### PR DESCRIPTION
https://mantine.dev/core/menu/#usage

The code provided at above link looks like this:
![image](https://user-images.githubusercontent.com/76196237/198976780-649170b5-cbaf-4302-9dfc-e7381a988033.png)

This PR removes unwanted `,` after `Delete My Account` button.