### PR TITLE
PasswordInput: Fix validations Example doc typo

### DIFF
--- a/src/mantine-demos/src/demos/core/PasswordInput/PasswordInput.demo.validation.tsx
+++ b/src/mantine-demos/src/demos/core/PasswordInput/PasswordInput.demo.validation.tsx
@@ -7,7 +7,7 @@ const code = `
 <PasswordInput error />
 
 // Error as React node – red border color and message below input
-<PasswordInput error="Invalid email" />
+<PasswordInput error="Invalid password" />
 `;
 
 function Demo() {


### PR DESCRIPTION
Updated the docs for [PasswordInput Validations example](https://mantine.dev/core/password-input/#invalid-state-and-error) from "Incorrect email" to "Incorrect password" to match the code example