### PR TITLE
Added <span> tag around {children} in ListItem.tsx

### DIFF
--- a/src/mantine-core/src/List/ListItem/ListItem.tsx
+++ b/src/mantine-core/src/List/ListItem/ListItem.tsx
@@ -33,7 +33,7 @@ export function ListItem({ className, children, icon, ...others }: ListItemProps
     >
       <div className={classes.itemWrapper}>
         {_icon && <span className={classes.itemIcon}>{_icon}</span>}
-        {children}
+        <span>{children}</span>
       </div>
     </Box>
   );


### PR DESCRIPTION
#2146 makes a pull request that removes the `<span>` tag around the `{children}` in `ListItem.tsx` This causes an overflow to happen in the `ListItem`, as represented in the image below. In this pull request, I re-added the `<span>` tags.

Before (from MantineUI, it overflows in to 2 lines):

<img width="1279" alt="Screenshot 2022-11-01 at 7 58 35 PM" src="https://user-images.githubusercontent.com/84251015/199365822-80057355-0cba-4101-83ba-34b0542b12ba.png">

After (my own personal project, it stays on one line):

<img width="1093" alt="Screenshot 2022-11-01 at 8 20 40 PM" src="https://user-images.githubusercontent.com/84251015/199366087-c76d69dd-0591-494e-b1e1-291cec38fc49.png">
