### PR TITLE
Fix useScrollIntoView ignoring parameter changes

### DIFF
--- a/src/mantine-hooks/src/use-scroll-into-view/use-scroll-into-view.ts
+++ b/src/mantine-hooks/src/use-scroll-into-view/use-scroll-into-view.ts
@@ -111,7 +111,7 @@ export function useScrollIntoView<
       }
       animateScroll();
     },
-    [scrollableRef, axis, duration, easing, isList, offset, onScrollFinish, reducedMotion]
+    [axis, duration, easing, isList, offset, onScrollFinish, reducedMotion]
   );
 
   const handleStop = () => {

--- a/src/mantine-hooks/src/use-scroll-into-view/use-scroll-into-view.ts
+++ b/src/mantine-hooks/src/use-scroll-into-view/use-scroll-into-view.ts
@@ -111,7 +111,7 @@ export function useScrollIntoView<
       }
       animateScroll();
     },
-    [scrollableRef.current]
+	[scrollableRef, axis, duration, easing, isList, offset, onScrollFinish, reducedMotion]
   );
 
   const handleStop = () => {

--- a/src/mantine-hooks/src/use-scroll-into-view/use-scroll-into-view.ts
+++ b/src/mantine-hooks/src/use-scroll-into-view/use-scroll-into-view.ts
@@ -111,7 +111,7 @@ export function useScrollIntoView<
       }
       animateScroll();
     },
-	[scrollableRef, axis, duration, easing, isList, offset, onScrollFinish, reducedMotion]
+    [scrollableRef, axis, duration, easing, isList, offset, onScrollFinish, reducedMotion]
   );
 
   const handleStop = () => {


### PR DESCRIPTION
Currently, useScrollIntoView returns a memoized callback that always refers to the params passed during the first render of the calling component, so calling with dynamically computed params, e.g. useScrollIntoView({ offset: someVariable }) will memoize the offset passed during the first render. If the component re-renders, any new offset passed is ignored.

Aditionally, 'scrollableRef.current' is an invalid dependency, see [https://epicreact.dev/why-you-shouldnt-put-refs-in-a-dependency-array/](https://epicreact.dev/why-you-shouldnt-put-refs-in-a-dependency-array/)