### PR TITLE
[@mantine/hooks] use-local-storage: return undefined instead of empty string

### DIFF
--- a/src/mantine-hooks/src/use-local-storage/create-storage.ts
+++ b/src/mantine-hooks/src/use-local-storage/create-storage.ts
@@ -54,12 +54,12 @@ export function createStorage<T>(type: StorageType, hookName: string) {
           window[type] === null ||
           skipStorage
         ) {
-          return (defaultValue ?? '') as T;
+          return defaultValue as T;
         }
 
         const storageValue = window[type].getItem(key);
 
-        return storageValue !== null ? deserialize(storageValue) : ((defaultValue ?? '') as T);
+        return storageValue !== null ? deserialize(storageValue) : (defaultValue as T);
       },
       [key, defaultValue]
     );


### PR DESCRIPTION
Fixes #2642