### PR TITLE
[@mantine/core] ScrollAreaProps missing children prop

### DIFF
--- a/src/mantine-core/src/ScrollArea/ScrollArea.tsx
+++ b/src/mantine-core/src/ScrollArea/ScrollArea.tsx
@@ -15,6 +15,9 @@ export type ScrollAreaStylesNames = Selectors<typeof useStyles>;
 export interface ScrollAreaProps
   extends DefaultProps<ScrollAreaStylesNames, ScrollAreaStylesParams>,
     React.ComponentPropsWithRef<'div'> {
+      
+  children?: React.ReactNode;
+
   /** Scrollbar size in px */
   scrollbarSize?: number;
 


### PR DESCRIPTION
Ran into an issue using `ScrollArea` complaining that `children` is an unknown prop (as shown on the screenshot). 
Hopefully I patched it in the right place :)

Manually editing it in my own local `ScrollArea.d.ts` made typescript happy.

![image](https://user-images.githubusercontent.com/12704199/199762602-83382700-a77d-4090-aa36-167cf5099c47.png)
