### PR TITLE
[@mantine/core] Adjust Inline input label while passing component as label

### DIFF
--- a/src/mantine-core/src/InlineInput/InlineInput.styles.ts
+++ b/src/mantine-core/src/InlineInput/InlineInput.styles.ts
@@ -22,6 +22,8 @@ export default createStyles((theme, { labelPosition, size }: InlineInputStylesPa
 
   labelWrapper: {
     ...theme.fn.fontStyles(),
+    display: 'inline-flex',
+    flexDirection: 'column',
     WebkitTapHighlightColor: 'transparent',
     fontSize: theme.fn.size({ size, sizes: theme.fontSizes }),
     lineHeight: `${theme.fn.size({ size, sizes })}px`,


### PR DESCRIPTION
When a component is passed as label then it appears on the bottom right of the component like  Checkbox, Switch or Radio component, added inline flex on InlineInput labelWrapper class to fix this issue