### PR TITLE
Add hexa format to ColorPicker

### DIFF
--- a/src/mantine-core/src/ColorPicker/ColorPicker.tsx
+++ b/src/mantine-core/src/ColorPicker/ColorPicker.tsx
@@ -10,7 +10,7 @@ import { AlphaSlider } from './AlphaSlider/AlphaSlider';
 import { Saturation, SaturationStylesNames } from './Saturation/Saturation';
 import { Swatches, SwatchesStylesNames } from './Swatches/Swatches';
 import { ThumbStylesNames } from './Thumb/Thumb';
-import { HsvaColor } from './types';
+import { ColorFormat, HsvaColor } from './types';
 import useStyles from './ColorPicker.styles';
 
 export type ColorPickerStylesNames =
@@ -34,7 +34,7 @@ export interface ColorPickerBaseProps {
   onChangeEnd?(color: string): void;
 
   /** Color format */
-  format?: 'hex' | 'rgba' | 'rgb' | 'hsl' | 'hsla';
+  format?: ColorFormat;
 
   /** Set to false to display swatches only */
   withPicker?: boolean;
@@ -120,7 +120,7 @@ export const ColorPicker = forwardRef<HTMLDivElement, ColorPickerProps>(
     const formatRef = useRef(format);
     const valueRef = useRef<string>(null);
     const updateRef = useRef(true);
-    const withAlpha = format === 'rgba' || format === 'hsla';
+    const withAlpha = format === 'hexa' || format === 'rgba' || format === 'hsla';
 
     const [_value, setValue] = useUncontrolled({
       value,

--- a/src/mantine-core/src/ColorPicker/converters/converters.ts
+++ b/src/mantine-core/src/ColorPicker/converters/converters.ts
@@ -56,8 +56,15 @@ export function hsvaToHex(color: HsvaColor) {
   return `#${formatHexPart(r)}${formatHexPart(g)}${formatHexPart(b)}`;
 }
 
+export function hsvaToHexa(color: HsvaColor) {
+  const a = Math.round(color.a * 255);
+
+  return `${hsvaToHex(color)}${formatHexPart(a)}`;
+}
+
 const CONVERTERS: Record<ColorFormat, (color: HsvaColor) => string> = {
   hex: hsvaToHex,
+  hexa: (color) => hsvaToHexa(color),
   rgb: (color) => hsvaToRgba(color, false),
   rgba: (color) => hsvaToRgba(color, true),
   hsl: (color) => hsvaToHsl(color, false),

--- a/src/mantine-core/src/ColorPicker/converters/parsers.ts
+++ b/src/mantine-core/src/ColorPicker/converters/parsers.ts
@@ -83,6 +83,24 @@ export function parseHex(color: string): HsvaColor {
   });
 }
 
+export function parseHexa(color: string): HsvaColor {
+  const hex = color[0] === '#' ? color.slice(1) : color;
+
+  const roundA = (a: string) => Math.round((parseInt(a, 16) / 255) * 100) / 100;
+  if (hex.length === 4) {
+    const withoutOpacity = hex.slice(0, 3);
+    const a = roundA(hex[3] + hex[3]);
+
+    const hsvaColor: HsvaColor = { ...parseHex(withoutOpacity), a };
+    return hsvaColor;
+  }
+
+  const withoutOpacity = hex.slice(0, 6);
+  const a = roundA(hex.slice(6, 8));
+  const hsvaColor: HsvaColor = { ...parseHex(withoutOpacity), a };
+  return hsvaColor;
+}
+
 const RGB_REGEXP =
   /rgba?\(?\s*(-?\d*\.?\d+)(%)?[,\s]+(-?\d*\.?\d+)(%)?[,\s]+(-?\d*\.?\d+)(%)?,?\s*[/\s]*(-?\d*\.?\d+)?(%)?\s*\)?/i;
 
@@ -103,6 +121,7 @@ export function parseRgba(color: string): HsvaColor {
 
 const VALIDATION_REGEXP: Record<ColorFormat, RegExp> = {
   hex: /^#?([0-9A-F]{3}){1,2}$/i,
+  hexa: /^#?([0-9A-F]{4}){1,2}$/i,
   rgb: /^rgb\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/i,
   rgba: /^rgba\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/i,
   hsl: /hsl\(\s*(\d+)\s*,\s*(\d+(?:\.\d+)?%)\s*,\s*(\d+(?:\.\d+)?%)\)/i,
@@ -111,6 +130,7 @@ const VALIDATION_REGEXP: Record<ColorFormat, RegExp> = {
 
 const CONVERTERS: Record<ColorFormat, (color: string) => HsvaColor> = {
   hex: parseHex,
+  hexa: parseHexa,
   rgb: parseRgba,
   rgba: parseRgba,
   hsl: parseHsla,
@@ -142,7 +162,9 @@ export function parseColor(color: string): HsvaColor {
   // eslint-disable-next-line no-restricted-syntax
   for (const [rule, regexp] of Object.entries(VALIDATION_REGEXP)) {
     if (regexp.test(trimmed)) {
-      return CONVERTERS[rule](trimmed);
+      const result = CONVERTERS[rule](trimmed);
+
+      return result;
     }
   }
 

--- a/src/mantine-core/src/ColorPicker/converters/parsers.ts
+++ b/src/mantine-core/src/ColorPicker/converters/parsers.ts
@@ -162,9 +162,7 @@ export function parseColor(color: string): HsvaColor {
   // eslint-disable-next-line no-restricted-syntax
   for (const [rule, regexp] of Object.entries(VALIDATION_REGEXP)) {
     if (regexp.test(trimmed)) {
-      const result = CONVERTERS[rule](trimmed);
-
-      return result;
+      return CONVERTERS[rule](trimmed);
     }
   }
 

--- a/src/mantine-core/src/ColorPicker/types.ts
+++ b/src/mantine-core/src/ColorPicker/types.ts
@@ -1,4 +1,4 @@
-export type ColorFormat = 'hex' | 'rgba' | 'rgb' | 'hsl' | 'hsla';
+export type ColorFormat = 'hex' | 'hexa' | 'rgba' | 'rgb' | 'hsl' | 'hsla';
 
 export interface HsvaColor {
   h: number;

--- a/src/mantine-demos/src/demos/core/ColorInput/ColorInput.demo.formatsConfigurator.tsx
+++ b/src/mantine-demos/src/demos/core/ColorInput/ColorInput.demo.formatsConfigurator.tsx
@@ -35,6 +35,7 @@ export const formatsConfigurator: MantineDemo = {
       defaultValue: 'hex',
       data: [
         { value: 'hex', label: 'HEX' },
+        { value: 'hexa', label: 'HEXA' },
         { value: 'rgb', label: 'RGB' },
         { value: 'rgba', label: 'RGBA' },
         { value: 'hsl', label: 'HSL' },

--- a/src/mantine-demos/src/demos/core/ColorPicker/ColorPicker.demo.formatsConfigurator.tsx
+++ b/src/mantine-demos/src/demos/core/ColorPicker/ColorPicker.demo.formatsConfigurator.tsx
@@ -33,6 +33,7 @@ export const formatsConfigurator: MantineDemo = {
       defaultValue: 'hex',
       data: [
         { value: 'hex', label: 'HEX' },
+        { value: 'hexa', label: 'HEXA' },
         { value: 'rgb', label: 'RGB' },
         { value: 'rgba', label: 'RGBA' },
         { value: 'hsl', label: 'HSL' },


### PR DESCRIPTION
This PR adds a new color format to both color picker and color input. Both #rrggbbaa and #rgba are supported, as defined in https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color. 

(Didn't expect I'd have enough time to finish this today, but here we are)