### PR TITLE
Fix bug when dragging mouse outside

### DIFF
--- a/src/mantine-core/src/Modal/Modal.story.tsx
+++ b/src/mantine-core/src/Modal/Modal.story.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Modal } from './Modal';
 import { Button } from '../Button';
+import { ColorInput } from '../ColorInput';
 
 export default { title: 'Modal' };
 
@@ -49,6 +50,17 @@ export function WithPageScrollbars() {
     <div style={{ padding: 40 }}>
       <WrappedModal>Wrapped modal</WrappedModal>
       {content}
+    </div>
+  );
+}
+
+export function WithPortalChildren() {
+  return (
+    <div style={{ padding: 40 }}>
+      <WrappedModal>
+        <ColorInput label="No Portal" mb="md" />
+        <ColorInput label="Within Portal" mb="md" withinPortal />
+      </WrappedModal>
     </div>
   );
 }

--- a/src/mantine-core/src/Modal/Modal.tsx
+++ b/src/mantine-core/src/Modal/Modal.tsx
@@ -1,5 +1,12 @@
-import React, { useEffect } from 'react';
-import { useScrollLock, useFocusTrap, useFocusReturn, useId } from '@mantine/hooks';
+import React, { useEffect, useRef } from 'react';
+import {
+  useScrollLock,
+  useFocusTrap,
+  useFocusReturn,
+  useId,
+  useWindowEvent,
+  useMergedRef,
+} from '@mantine/hooks';
 import {
   DefaultProps,
   MantineNumberSize,
@@ -171,6 +178,9 @@ export function Modal(props: ModalProps) {
     { unstyled, classNames, styles, name: 'Modal' }
   );
   const focusTrapRef = useFocusTrap(trapFocus && opened);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const mergedRef = useMergedRef(focusTrapRef, overlayRef);
+
   const _overlayOpacity =
     typeof overlayOpacity === 'number'
       ? overlayOpacity
@@ -196,6 +206,17 @@ export function Modal(props: ModalProps) {
   }, [trapFocus]);
 
   useFocusReturn({ opened, shouldReturnFocus: trapFocus && withFocusReturn });
+
+  const clickTarget = useRef<EventTarget>(null);
+  useWindowEvent('mousedown', (e) => {
+    clickTarget.current = e.target;
+  });
+
+  const handleOutsideClick = () => {
+    if (clickTarget.current !== overlayRef.current) return;
+
+    closeOnClickOutside && onClose();
+  };
 
   return (
     <OptionalPortal withinPortal={withinPortal} target={target}>
@@ -236,13 +257,13 @@ export function Modal(props: ModalProps) {
               <div
                 role="presentation"
                 className={classes.inner}
-                onClick={() => closeOnClickOutside && onClose()}
+                onClick={handleOutsideClick}
                 onKeyDown={(event) => {
                   const shouldTrigger =
                     (event.target as any)?.getAttribute('data-mantine-stop-propagation') !== 'true';
                   shouldTrigger && event.key === 'Escape' && closeOnEscape && onClose();
                 }}
-                ref={focusTrapRef}
+                ref={mergedRef}
               >
                 <Paper<'div'>
                   className={classes.modal}


### PR DESCRIPTION
As discussed in #2890 and in the Discord, this PR fixes a bug where the modal would close when you mouse down in the modal but drag the mouse outside before releasing it. I've added a story which shows this working, even when the modal content uses portals.

The fix also doesn't cause a regression in #2669.