### PR TITLE
Fixed performance in NavLink

### DIFF
--- a/src/mantine-core/src/NavLink/NavLink.tsx
+++ b/src/mantine-core/src/NavLink/NavLink.tsx
@@ -160,9 +160,9 @@ export const _NavLink = forwardRef<HTMLButtonElement, NavLinkProps>((props, ref)
           </span>
         )}
       </UnstyledButton>
-      <Collapse in={_opened}>
+      {withChildren && <Collapse in={_opened}>
         <div className={classes.children}>{children}</div>
-      </Collapse>
+      </Collapse> }
     </>
   );
 });


### PR DESCRIPTION
We have noticed that NavLink can cause some performance issues since its always rendering a Collapse. Using the already defined "withChildren", this is avoided.
What do you think?