### PR TITLE
[@mantine/core] Add `right` system prop to extracted system styles and remove from docs.

### DIFF
--- a/scripts/docgen/docgen-parser.ts
+++ b/scripts/docgen/docgen-parser.ts
@@ -47,6 +47,7 @@ const EXCLUDE_PROPS = [
   'miw',
   'opacity',
   'pos',
+  'right',
   'ta',
   'td',
   'top',

--- a/src/mantine-core/src/Box/style-system-props/extract-system-styles/extract-system-styles.ts
+++ b/src/mantine-core/src/Box/style-system-props/extract-system-styles/extract-system-styles.ts
@@ -44,6 +44,7 @@ export function extractSystemStyles<T extends Record<string, any>>(
     top,
     left,
     bottom,
+    right,
     inset,
     ...rest
   } = others;
@@ -88,6 +89,7 @@ export function extractSystemStyles<T extends Record<string, any>>(
     top,
     left,
     bottom,
+    right,
     inset,
   });
 


### PR DESCRIPTION
Fix for #2887.