### PR TITLE
[docs] Fix typo in Tabs documentation

### DIFF
--- a/docs/src/docs/core/Tabs.mdx
+++ b/docs/src/docs/core/Tabs.mdx
@@ -47,7 +47,7 @@ function Demo() {
 
 ## Uncontrolled Tabs
 
-If you do need to subscribe to Tabs state changes use `defaultValue`:
+If you do not need to subscribe to Tabs state changes use `defaultValue`:
 
 ```tsx
 import { Tabs } from '@mantine/core';


### PR DESCRIPTION
Fixing a typo in the `Uncontrolled Tabs` section of the docs.