### PR TITLE
[core] RangeSlider maxRange Property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .idea/
 .vscode/
 .nova/
+.gitpod.yml
 
 # node
 node_modules/

--- a/src/mantine-core/src/Slider/RangeSlider/RangeSlider.tsx
+++ b/src/mantine-core/src/Slider/RangeSlider/RangeSlider.tsx
@@ -45,6 +45,9 @@ export interface RangeSliderProps
   /** Minimal range interval */
   minRange?: number;
 
+  /** Maximum range interval */
+  maxRange?: number;
+
   /** Number by which value will be incremented/decremented with thumb drag and arrows */
   step?: number;
 
@@ -141,6 +144,7 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
     min,
     max,
     minRange,
+    maxRange,
     step,
     precision,
     defaultValue,
@@ -206,6 +210,10 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
       if (val > (max - (minRange - 0.000000001) || min)) {
         clone[index] = valueRef.current[index];
       }
+
+      if (clone[1] - val > maxRange) {
+        clone[1] = val + maxRange;
+      }
     }
 
     if (index === 1) {
@@ -215,6 +223,10 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
 
       if (val < clone[0] + minRange) {
         clone[index] = valueRef.current[index];
+      }
+
+      if (val - clone[0] > maxRange) {
+        clone[0] = val - maxRange;
       }
     }
 

--- a/src/mantine-core/src/Slider/Slider.story.tsx
+++ b/src/mantine-core/src/Slider/Slider.story.tsx
@@ -73,3 +73,18 @@ export function MinRangeWithNegativeValues() {
     </div>
   );
 }
+
+export function MinMaxSliderDistance() {
+  return (
+    <div style={{ maxWidth: 400, padding: 40 }}>
+      <RangeSlider
+        min={0}
+        max={100}
+        minRange={5}
+        maxRange={20}
+        step={0.5}
+        defaultValue={[0, 100]}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds a feature that I think is very useful, particularly in a use case such as a video-length cropping application. This PR introduces the sibling feature to `minRange`, which allows you to not only customize the minimum distance between the two thumbs of the RangeSlider but also allows you to limit the distance possible between the thumbs of RangeSlider via the `maxRange` property.