### PR TITLE
[@mantine/dropzone] Add onDropAny prop

### DIFF
--- a/src/mantine-dropzone/src/Dropzone.tsx
+++ b/src/mantine-dropzone/src/Dropzone.tsx
@@ -32,7 +32,10 @@ export interface DropzoneProps
   /** Disable files capturing */
   disabled?: boolean;
 
-  /** Called when files are dropped into dropzone */
+  /** Called when any files are dropped into dropzone */
+  onDropAny?(files: FileWithPath[], fileRejections: FileRejection[]): void;
+
+  /** Called when valid files are dropped into dropzone */
   onDrop(files: FileWithPath[]): void;
 
   /** Called when selected files don't meet file restrictions */
@@ -122,6 +125,7 @@ export function _Dropzone(props: DropzoneProps) {
     maxSize,
     accept,
     children,
+    onDropAny,
     onDrop,
     onReject,
     openRef,
@@ -149,6 +153,7 @@ export function _Dropzone(props: DropzoneProps) {
   );
 
   const { getRootProps, getInputProps, isDragAccept, isDragReject, open } = useDropzone({
+    onDrop: onDropAny,
     onDropAccepted: onDrop,
     onDropRejected: onReject,
     disabled: disabled || loading,


### PR DESCRIPTION
Add a new prop to the `<Dropzone />` component that receives a function that is called on any file drop. 
This callback function will receive two arguments, the accepted files, and the rejected ones.

This solves the following issue: https://github.com/mantinedev/mantine/issues/3003