### PR TITLE
Custom avatar image component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .idea/
 .vscode/
 .nova/
+.gitpod.yml
 
 # node
 node_modules/

--- a/src/mantine-core/src/Avatar/Avatar.tsx
+++ b/src/mantine-core/src/Avatar/Avatar.tsx
@@ -13,6 +13,7 @@ import { AvatarPlaceholderIcon } from './AvatarPlaceholderIcon';
 import { AvatarGroup } from './AvatarGroup/AvatarGroup';
 import { useAvatarGroupContext } from './AvatarGroup/AvatarGroup.context';
 import useStyles, { AvatarStylesParams, AvatarVariant } from './Avatar.styles';
+import { AvatarCustomComponentProps } from './AvatarCustomComponentProps';
 
 export type AvatarStylesNames = Selectors<typeof useStyles>;
 
@@ -41,6 +42,9 @@ export interface AvatarProps extends DefaultProps<AvatarStylesNames, AvatarStyle
   /** img element attributes */
   imageProps?: Record<string, any>;
 
+  /** Custom image component */
+  imageComponent?: React.FunctionComponent<AvatarCustomComponentProps>;
+
   /** Custom placeholder */
   children?: React.ReactNode;
 }
@@ -65,10 +69,12 @@ export const _Avatar = forwardRef<HTMLDivElement, AvatarProps>((props, ref) => {
     classNames,
     styles,
     imageProps,
+    imageComponent,
     unstyled,
     ...others
   } = useComponentDefaultProps('Avatar', defaultProps, props);
 
+  const ImageComponent = imageComponent;
   const ctx = useAvatarGroupContext();
   const [error, setError] = useState(!src);
 
@@ -87,6 +93,14 @@ export const _Avatar = forwardRef<HTMLDivElement, AvatarProps>((props, ref) => {
         <div className={classes.placeholder} title={alt}>
           {children || <AvatarPlaceholderIcon className={classes.placeholderIcon} />}
         </div>
+      ) : imageComponent ? (
+        <ImageComponent
+          {...imageProps}
+          className={classes.image}
+          src={src}
+          alt={alt}
+          onError={() => setError(true)}
+        />
       ) : (
         <img
           {...imageProps}

--- a/src/mantine-core/src/Avatar/AvatarCustomComponentProps.ts
+++ b/src/mantine-core/src/Avatar/AvatarCustomComponentProps.ts
@@ -1,0 +1,8 @@
+interface AvatarCustomComponentProps {
+  className: string;
+  src: string;
+  alt: string;
+  onError: any;
+}
+
+export type { AvatarCustomComponentProps };

--- a/src/mantine-core/src/Slider/RangeSlider/RangeSlider.tsx
+++ b/src/mantine-core/src/Slider/RangeSlider/RangeSlider.tsx
@@ -45,6 +45,9 @@ export interface RangeSliderProps
   /** Minimal range interval */
   minRange?: number;
 
+  /** Maximum range interval */
+  maxRange?: number;
+
   /** Number by which value will be incremented/decremented with thumb drag and arrows */
   step?: number;
 
@@ -141,6 +144,7 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
     min,
     max,
     minRange,
+    maxRange,
     step,
     precision,
     defaultValue,
@@ -206,6 +210,10 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
       if (val > (max - (minRange - 0.000000001) || min)) {
         clone[index] = valueRef.current[index];
       }
+
+      if (clone[1] - val > maxRange) {
+        clone[1] = val + maxRange;
+      }
     }
 
     if (index === 1) {
@@ -215,6 +223,10 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
 
       if (val < clone[0] + minRange) {
         clone[index] = valueRef.current[index];
+      }
+
+      if (val - clone[0] > maxRange) {
+        clone[0] = val - maxRange;
       }
     }
 

--- a/src/mantine-core/src/Slider/Slider.story.tsx
+++ b/src/mantine-core/src/Slider/Slider.story.tsx
@@ -73,3 +73,18 @@ export function MinRangeWithNegativeValues() {
     </div>
   );
 }
+
+export function MinMaxSliderDistance() {
+  return (
+    <div style={{ maxWidth: 400, padding: 40 }}>
+      <RangeSlider
+        min={0}
+        max={100}
+        minRange={5}
+        maxRange={20}
+        step={0.5}
+        defaultValue={[0, 100]}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
This was first mentioned in #719.

This is an excellent feature, even if not a high priority. It would also allow interoperability with other image components if the library user would so wish to use those.

This is accomplished by adding an additional property to the `Avatar` component:
```
  /** Custom image component */
  imageComponent?: React.FunctionComponent<AvatarCustomComponentProps>;
```

I added a new file `AvatarCustomComponentProps.tsx` in the `Avatar` directory to contain the TypeScript `interface` responsible for making sure the passed React Component has the required props:
```
interface AvatarCustomComponentProps {
  className: string;
  src: string;
  alt: string;
  onError: any;
}

export type { AvatarCustomComponentProps };
```
Finally, the actual custom component is consumed by a simple inline if statement:
```
imageComponent ? (
        <ImageComponent
          {...imageProps}
          className={classes.image}
          src={src}
          alt={alt}
          onError={() => setError(true)}
        />
      ) : (
        <img
          {...imageProps}
          className={classes.image}
          src={src}
          alt={alt}
          onError={() => setError(true)}
        />
      )
```
It is worth noting that the prop is renamed inline to an uppercase letter for React:
```
const ImageComponent = imageComponent;
```
I'd like to see if the same type of thing could be done for the Mantine `Image` component so that the styles could be applied to a `next/image` `Image` if it were passed as a parameter.

Thanks for your time!