### PR TITLE
[@mantine/form] useForm: fix isDirty for list fields

### DIFF
--- a/src/mantine-form/src/tests/dirty.test.ts
+++ b/src/mantine-form/src/tests/dirty.test.ts
@@ -40,4 +40,23 @@ describe('@mantine/form/dirty', () => {
     act(() => hook.result.current.resetDirty());
     expect(hook.result.current.isDirty()).toBe(false);
   });
+
+  it('sets list field as dirty if list item changes', () => {
+    const hook = renderHook(() => useForm({ initialValues: { a: [{ b: 1 }, { b: 2 }] } }));
+    act(() => hook.result.current.setFieldValue('a.0', 3));
+    expect(hook.result.current.isDirty('a.0')).toBe(true);
+    expect(hook.result.current.isDirty('a')).toBe(true);
+
+    act(() => hook.result.current.setFieldValue('a', [{ b: 1 }, { b: 2 }]));
+    expect(hook.result.current.isDirty('a.0')).toBe(false);
+    expect(hook.result.current.isDirty('a')).toBe(false);
+
+    act(() => hook.result.current.insertListItem('a', [{ b: 3 }]));
+    expect(hook.result.current.isDirty('a.2')).toBe(true);
+    expect(hook.result.current.isDirty('a')).toBe(true);
+
+    act(() => hook.result.current.removeListItem('a', 2));
+    expect(hook.result.current.isDirty('a.2')).toBe(false);
+    expect(hook.result.current.isDirty('a')).toBe(false);
+  });
 });

--- a/src/mantine-form/src/types.ts
+++ b/src/mantine-form/src/types.ts
@@ -70,6 +70,7 @@ export type SetFieldValue<Values> = <Field extends LooseKeys<Values>>(
 ) => void;
 
 export type ClearFieldError = (path: unknown) => void;
+export type ClearFieldDirty = (path: unknown) => void;
 export type ClearErrors = () => void;
 export type Reset = () => void;
 export type Validate = () => FormValidationResult;

--- a/src/mantine-form/src/use-form.ts
+++ b/src/mantine-form/src/use-form.ts
@@ -46,7 +46,7 @@ export function useForm<
   validate: rules,
 }: UseFormInput<Values, TransformValues> = {}): UseFormReturnType<Values, TransformValues> {
   const [touched, setTouched] = useState(initialTouched);
-  const [manualDirtyOverride, setDirtyManualOverride] = useState(initialDirty);
+  const [dirty, setDirty] = useState(initialDirty);
   const [values, _setValues] = useState(initialValues);
   const [errors, _setErrors] = useState(filterErrors(initialErrors));
   const _dirtyValues = useRef<Values>(initialValues);
@@ -57,7 +57,7 @@ export function useForm<
   const resetTouched = useCallback(() => setTouched({}), []);
   const resetDirty: ResetDirty<Values> = (_values) => {
     _setDirtyValues(_values || values);
-    setDirtyManualOverride({});
+    setDirty({});
   };
 
   const setErrors: SetErrors = useCallback(
@@ -93,9 +93,9 @@ export function useForm<
     []
   );
 
-  const clearDirtyOverride: ClearFieldDirty = useCallback(
+  const clearFieldDirty: ClearFieldDirty = useCallback(
     (path) =>
-      setDirtyManualOverride((current) => {
+      setDirty((current) => {
         if (typeof path !== 'string') {
           return current;
         }
@@ -109,7 +109,7 @@ export function useForm<
 
   const setFieldValue: SetFieldValue<Values> = useCallback((path, value) => {
     const shouldValidate = shouldValidateOnChange(path, validateInputOnChange);
-    clearDirtyOverride(path);
+    clearFieldDirty(path);
     setTouched((currentTouched) => ({ ...currentTouched, [path]: true }));
     _setValues((current) => {
       const result = setPath(path, value, current);
@@ -136,18 +136,18 @@ export function useForm<
   }, []);
 
   const reorderListItem: ReorderListItem<Values> = useCallback((path, payload) => {
-    clearDirtyOverride(path);
+    clearFieldDirty(path);
     _setValues((current) => reorderPath(path, payload, current));
   }, []);
 
   const removeListItem: RemoveListItem<Values> = useCallback((path, index) => {
-    clearDirtyOverride(path);
+    clearFieldDirty(path);
     _setValues((current) => removePath(path, index, current));
     _setErrors((errs) => clearListState(path, errs));
   }, []);
 
   const insertListItem: InsertListItem<Values> = useCallback((path, item, index) => {
-    clearDirtyOverride(path);
+    clearFieldDirty(path);
     _setValues((current) => insertPath(path, item, index, current));
   }, []);
 
@@ -217,10 +217,10 @@ export function useForm<
   }, []);
 
   const isDirty: GetFieldStatus<Values> = (path) => {
-    const isOverridden = Object.keys(manualDirtyOverride).length > 0;
+    const isOverridden = Object.keys(dirty).length > 0;
 
     if (isOverridden) {
-      return getStatus(manualDirtyOverride, path);
+      return getStatus(dirty, path);
     }
 
     if (path) {
@@ -266,7 +266,7 @@ export function useForm<
     isDirty,
     isTouched,
     setTouched,
-    setDirty: setDirtyManualOverride,
+    setDirty,
     resetTouched,
     resetDirty,
     isValid,


### PR DESCRIPTION
By computing the isDirty only on demand using deep comparison of the `values` state, it removes many bugs related to `isDirty` and nested fields. Manually managing a dirty state parallel to the values state was very much bug prone, considering all the possible updates to form values that can occur.

~Disclaimer: by doing this we loose 2 functionalities `initialDirty` and `setDirty`. IMHO the pros outweighs the cons, but I am curious to see what the community thinks.~ Fixed ✅ 

Fixes:  https://github.com/mantinedev/mantine/issues/3001 and https://github.com/mantinedev/mantine/issues/2937