### PR TITLE
[@mantine/dropzone] Add the getFilesFromEvent and validator props

### DIFF
--- a/src/mantine-dropzone/src/Dropzone.tsx
+++ b/src/mantine-dropzone/src/Dropzone.tsx
@@ -1,27 +1,27 @@
+import React from 'react';
 import {
-  Box,
+  useDropzone,
+  FileRejection,
+  Accept,
+  FileWithPath,
+  DropEvent,
+  FileError,
+} from 'react-dropzone';
+import { fromEvent } from 'file-selector';
+import {
   DefaultProps,
-  LoadingOverlay,
-  MantineNumberSize,
   Selectors,
-  useComponentDefaultProps
+  MantineNumberSize,
+  LoadingOverlay,
+  Box,
+  useComponentDefaultProps,
 } from '@mantine/core';
 import { assignRef } from '@mantine/hooks';
 import { ForwardRefWithStaticComponents } from '@mantine/utils';
-import { fromEvent } from 'file-selector';
-import React from 'react';
-import {
-  Accept,
-  DropEvent,
-  FileError,
-  FileRejection,
-  FileWithPath,
-  useDropzone
-} from 'react-dropzone';
 import { DropzoneProvider } from './Dropzone.context';
-import useStyles from './Dropzone.styles';
-import type { DropzoneFullScreenType } from './DropzoneFullScreen';
 import { DropzoneAccept, DropzoneIdle, DropzoneReject } from './DropzoneStatus';
+import type { DropzoneFullScreenType } from './DropzoneFullScreen';
+import useStyles from './Dropzone.styles';
 
 export type DropzoneStylesNames = Selectors<typeof useStyles>;
 
@@ -124,8 +124,6 @@ export const defaultProps: Partial<DropzoneProps> = {
   dragEventsBubbling: true,
   activateOnKeyboard: true,
   useFsAccessApi: true,
-  getFilesFromEvent: fromEvent,
-  validator: null,
 };
 
 export function _Dropzone(props: DropzoneProps) {
@@ -191,9 +189,9 @@ export function _Dropzone(props: DropzoneProps) {
     onFileDialogOpen,
     preventDropOnDocument,
     useFsAccessApi,
-    getFilesFromEvent,
-    validator,
-``  });
+    getFilesFromEvent: getFilesFromEvent || fromEvent,
+    validator: validator || null,
+  });
 
   assignRef(openRef, open);
 

--- a/src/mantine-dropzone/src/Dropzone.tsx
+++ b/src/mantine-dropzone/src/Dropzone.tsx
@@ -7,7 +7,6 @@ import {
   DropEvent,
   FileError,
 } from 'react-dropzone';
-import { fromEvent } from 'file-selector';
 import {
   DefaultProps,
   Selectors,
@@ -189,8 +188,8 @@ export function _Dropzone(props: DropzoneProps) {
     onFileDialogOpen,
     preventDropOnDocument,
     useFsAccessApi,
-    getFilesFromEvent: getFilesFromEvent || fromEvent,
-    validator: validator || null,
+    getFilesFromEvent,
+    validator,
   });
 
   assignRef(openRef, open);

--- a/src/mantine-dropzone/src/Dropzone.tsx
+++ b/src/mantine-dropzone/src/Dropzone.tsx
@@ -1,19 +1,27 @@
-import React from 'react';
-import { useDropzone, FileRejection, Accept, FileWithPath } from 'react-dropzone';
 import {
-  DefaultProps,
-  Selectors,
-  MantineNumberSize,
-  LoadingOverlay,
   Box,
-  useComponentDefaultProps,
+  DefaultProps,
+  LoadingOverlay,
+  MantineNumberSize,
+  Selectors,
+  useComponentDefaultProps
 } from '@mantine/core';
 import { assignRef } from '@mantine/hooks';
 import { ForwardRefWithStaticComponents } from '@mantine/utils';
+import { fromEvent } from 'file-selector';
+import React from 'react';
+import {
+  Accept,
+  DropEvent,
+  FileError,
+  FileRejection,
+  FileWithPath,
+  useDropzone
+} from 'react-dropzone';
 import { DropzoneProvider } from './Dropzone.context';
-import { DropzoneAccept, DropzoneIdle, DropzoneReject } from './DropzoneStatus';
-import type { DropzoneFullScreenType } from './DropzoneFullScreen';
 import useStyles from './Dropzone.styles';
+import type { DropzoneFullScreenType } from './DropzoneFullScreen';
+import { DropzoneAccept, DropzoneIdle, DropzoneReject } from './DropzoneStatus';
 
 export type DropzoneStylesNames = Selectors<typeof useStyles>;
 
@@ -97,6 +105,12 @@ export interface DropzoneProps
 
   /** Set to true to use the File System Access API to open the file picker instead of using an <input type="file"> click event, defaults to true */
   useFsAccessApi?: boolean;
+
+  /** Use this to provide a custom file aggregator */
+  getFilesFromEvent?: (event: DropEvent) => Promise<Array<File | DataTransferItem>>;
+
+  /** Custom validation function. It must return null if there's no errors. */
+  validator?: <T extends File>(file: T) => FileError | FileError[] | null;
 }
 
 export const defaultProps: Partial<DropzoneProps> = {
@@ -110,6 +124,8 @@ export const defaultProps: Partial<DropzoneProps> = {
   dragEventsBubbling: true,
   activateOnKeyboard: true,
   useFsAccessApi: true,
+  getFilesFromEvent: fromEvent,
+  validator: null,
 };
 
 export function _Dropzone(props: DropzoneProps) {
@@ -144,6 +160,8 @@ export function _Dropzone(props: DropzoneProps) {
     onFileDialogOpen,
     preventDropOnDocument,
     useFsAccessApi,
+    getFilesFromEvent,
+    validator,
     ...others
   } = useComponentDefaultProps('Dropzone', defaultProps, props);
 
@@ -173,7 +191,9 @@ export function _Dropzone(props: DropzoneProps) {
     onFileDialogOpen,
     preventDropOnDocument,
     useFsAccessApi,
-  });
+    getFilesFromEvent,
+    validator,
+``  });
 
   assignRef(openRef, open);
 


### PR DESCRIPTION
## Description

Add getFilesFromEvent and validator props to the Dropzone component, both are methods that React Dropzone supports

## getFilesFromEvent prop

The Dropzone component a getFilesFromEvent prop that enhances the handling of dropped file system objects and allows more flexible use of them e.g. passing a function that accepts drop event of a folder and resolves it to an array of files adds plug-in functionality of folders drag-and-drop.

Though, note that the provided getFilesFromEvent fn must return a Promise with a list of File objects (or DataTransferItem of {kind: 'file'} when data cannot be accessed). Otherwise, the results will be discarded and none of the drag events callbacks will be invoked.

In case you need to extend the File with some additional properties, you should use [Object.defineProperty()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) so that the result will still pass through our filter:

## validator prop

By providing validator prop you can specify custom validation for files.

The value must be a function that accepts File object and returns null if file should be accepted or error object/array of error objects if file should be rejected.