### PR TITLE
[@mantine/carousel] Carousel: fixed carousel indicator not changing when slidesToScroll value is changed

### DIFF
--- a/src/mantine-carousel/src/Carousel.tsx
+++ b/src/mantine-carousel/src/Carousel.tsx
@@ -255,7 +255,7 @@ export const _Carousel = forwardRef<HTMLDivElement, CarouselProps>((props, ref) 
     }
 
     return undefined;
-  }, [embla]);
+  }, [embla, slidesToScroll]);
 
   useEffect(() => {
     if (embla) {
@@ -265,7 +265,7 @@ export const _Carousel = forwardRef<HTMLDivElement, CarouselProps>((props, ref) 
         clamp(currentSelected, 0, Children.toArray(children).length - 1)
       );
     }
-  }, [Children.toArray(children).length]);
+  }, [Children.toArray(children).length, slidesToScroll]);
 
   const canScrollPrev = embla?.canScrollPrev() || false;
   const canScrollNext = embla?.canScrollNext() || false;


### PR DESCRIPTION
Included a fix to make sure the indicator count is updated based on the value of slidesToScroll

Fixes: #3057