### PR TITLE
Update url to Tabler Icons website

### DIFF
--- a/docs/src/docs/changelog/5-0-0.mdx
+++ b/docs/src/docs/changelog/5-0-0.mdx
@@ -511,7 +511,7 @@ to configure thumbs width and height from prop:
 - [NumberInput](https://mantine.dev/core/number-input/) has new increment/decrement controls
 - [ThemeIcon](https://mantine.dev/core/theme-icon/) now support any CSS color value in `color` prop
 - [Text](https://mantine.dev/core/) now supports numbers in `size` prop to set size in px
-- [RichTextEditor](https://mantine.dev/others/rte/) now uses [tabler icons](https://tablericons.com/) instead of Radix icons
+- [RichTextEditor](https://mantine.dev/others/rte/) now uses [tabler icons](https://tabler-icons.io/) instead of Radix icons
 - [LoadingOverlay](https://mantine.dev/core/loading-overlay/) now supports `overlayBlur` prop
 - [Slider](https://mantine.dev/core/slider/) now supports `Home` and `End` keys
 - [Modals manager](https://mantine.dev/others/modals/) now supports event based functions, it is now the primary way to work with the package


### PR DESCRIPTION
Hi! Website of Tabler Icons is https://tabler-icons.io, not tablericons.com - this site is not connected with my project :) 

You can verify it here: https://github.com/tabler/tabler-icons

Paweł, author of Tabler Icons 

btw, great project! If you need any extra icon to your framework give me a ping :) 