### PR TITLE
[@mantine/form] validate-field-value: parent path validation

### DIFF
--- a/src/mantine-form/src/validate/validate-field-value.test.ts
+++ b/src/mantine-form/src/validate/validate-field-value.test.ts
@@ -29,6 +29,16 @@ describe('@mantine/form/validate-field-value', () => {
     ).toStrictEqual({ hasError: true, error: 'error-b' });
   });
 
+  it('validates parent of nested field with rules record', () => {
+    expect(
+      validateFieldValue(
+        'a',
+        { a: { b: (value) => (value === 1 ? 'error-b' : null) } },
+        { a: [{ b: 2 }, { b: 1 }] }
+      )
+    ).toStrictEqual({ hasError: true, error: 'error-b' });
+  });
+
   it('validates array field with rules record', () => {
     expect(
       validateFieldValue(

--- a/src/mantine-form/src/validate/validate-field-value.ts
+++ b/src/mantine-form/src/validate/validate-field-value.ts
@@ -11,6 +11,8 @@ export function validateFieldValue<T>(
   }
 
   const results = validateValues(rules, values);
-  const hasError = path in results.errors;
-  return { hasError, error: hasError ? results.errors[path] : null };
+  const pathInError = Object.keys(results.errors).find((errorKey) =>
+    path.split('.').every((pathPart, i) => pathPart === errorKey.split('.')[i])
+  );
+  return { hasError: !!pathInError, error: pathInError ? results.errors[pathInError] : null };
 }


### PR DESCRIPTION
## [issue addressed](https://github.com/mantinedev/mantine/issues/3064) https://github.com/mantinedev/mantine/issues/3064

### Issue summary

This is the current behavior
```
// 'parent.path.precise' is in error.
form.isValid() // false
form.isValid('parent.path') // true  
form.isValid('parent.path.precise') // false
```
This is the wanted behavior
```
// 'parent.path.precise' is in error.
form.isValid() // false
form.isValid('parent.path') // false  
form.isValid('parent.path.precise') // false
```

### Fix summary

**Current**
`validateFieldValue` receives the path used in `form.isValid('path.to.check')` and verifies if it match an exact key.

**Fixed**
`validateFieldValue` parses the path used in `form.isValid('path.to.check')` with `Array.prototype.split` and verifies each path indexes for a match with keys in error. 


