### PR TITLE
Pr/media query initialvalue

### DIFF
--- a/src/mantine-hooks/src/use-color-scheme/use-color-scheme.story.tsx
+++ b/src/mantine-hooks/src/use-color-scheme/use-color-scheme.story.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { useColorScheme } from './use-color-scheme';
+
+const Demo = () => {
+  const colorScheme = useColorScheme(undefined, {
+    getInitialValueInEffect: false,
+  });
+  const [history, setHistory] = useState([]);
+
+  useEffect(() => {
+    setHistory((current) => [...current, colorScheme]);
+  }, [colorScheme, setHistory]);
+
+  return (
+    <div>
+      {history.map((mode, i) => (
+        <div key={i}>Color Scheme: {mode}</div>
+      ))}
+    </div>
+  );
+};
+
+storiesOf('Hooks/use-color-scheme', module).add('General usage', () => (
+  <div style={{ padding: 40 }}>
+    <Demo />
+  </div>
+));

--- a/src/mantine-hooks/src/use-color-scheme/use-color-scheme.test.tsx
+++ b/src/mantine-hooks/src/use-color-scheme/use-color-scheme.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+// import { renderHook } from '@testing-library/react-hooks';
+import { render } from '@testing-library/react';
+import { useColorScheme } from './use-color-scheme';
+
+describe('@maintine/hooks/use-color-scheme', () => {
+  let trace = jest.fn<(colorScheme: string) => void, string[]>();
+  beforeEach(() => {
+    trace = jest.fn();
+  });
+  function WrapperComponent() {
+    const colorScheme = useColorScheme();
+    trace(colorScheme);
+    return <>{colorScheme}</>;
+  }
+
+  it('correctly returns initial state without useEffect', async () => {
+    render(<WrapperComponent />);
+    expect(trace).toHaveBeenCalledTimes(1);
+    expect(trace.mock.calls[0][0]).toBe('light');
+  });
+});

--- a/src/mantine-hooks/src/use-color-scheme/use-color-scheme.test.tsx
+++ b/src/mantine-hooks/src/use-color-scheme/use-color-scheme.test.tsx
@@ -5,18 +5,67 @@ import { useColorScheme } from './use-color-scheme';
 
 describe('@maintine/hooks/use-color-scheme', () => {
   let trace = jest.fn<(colorScheme: string) => void, string[]>();
+  const mockmatchMedia = jest.fn().mockImplementation(() => ({
+    matches: true,
+    media: '',
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+  }));
+  const retainMatchMedia = window.matchMedia;
   beforeEach(() => {
     trace = jest.fn();
+    window.matchMedia = retainMatchMedia;
   });
-  function WrapperComponent() {
-    const colorScheme = useColorScheme();
+  function WrapperComponent({
+    initialValue,
+    getInitialValueInEffect = true,
+  }: {
+    initialValue?: 'light' | 'dark';
+    getInitialValueInEffect?: boolean;
+  }) {
+    const colorScheme = useColorScheme(initialValue, {
+      getInitialValueInEffect,
+    });
     trace(colorScheme);
     return <>{colorScheme}</>;
   }
 
-  it('correctly returns initial state without useEffect', async () => {
+  it('correctly returns initial dark state without useEffect', async () => {
+    render(<WrapperComponent initialValue="dark" getInitialValueInEffect={false} />);
+    expect(trace).toHaveBeenCalledTimes(2);
+    expect(trace.mock.calls[0][0]).toBe('dark');
+    expect(trace.mock.calls[1][0]).toBe('light');
+  });
+  it('correctly returns initial dark state state without useEffect', async () => {
+    window.matchMedia = mockmatchMedia;
+    render(<WrapperComponent initialValue="dark" getInitialValueInEffect={false} />);
+    expect(trace).toHaveBeenCalledTimes(1);
+    expect(trace.mock.calls[0][0]).toBe('dark');
+  });
+
+  it('correctly returns initial light state with useEffect', async () => {
+    render(<WrapperComponent initialValue="dark" getInitialValueInEffect />);
+    expect(trace).toHaveBeenCalledTimes(2);
+    expect(trace.mock.calls[0][0]).toBe('dark');
+    expect(trace.mock.calls[1][0]).toBe('light');
+  });
+  it('correctly returns initial dark state with useEffect', async () => {
+    window.matchMedia = mockmatchMedia;
+    render(<WrapperComponent initialValue="dark" getInitialValueInEffect />);
+    expect(trace).toHaveBeenCalledTimes(1);
+    expect(trace.mock.calls[0][0]).toBe('dark');
+  });
+  it('correctly returns initial light state with deafult props', async () => {
     render(<WrapperComponent />);
     expect(trace).toHaveBeenCalledTimes(1);
     expect(trace.mock.calls[0][0]).toBe('light');
+  });
+  it('correctly returns initial dark state with deafult props', async () => {
+    window.matchMedia = mockmatchMedia;
+    render(<WrapperComponent />);
+    expect(trace).toHaveBeenCalledTimes(2);
+    expect(trace.mock.calls[0][0]).toBe('light');
+    expect(trace.mock.calls[1][0]).toBe('dark');
   });
 });

--- a/src/mantine-hooks/src/use-color-scheme/use-color-scheme.ts
+++ b/src/mantine-hooks/src/use-color-scheme/use-color-scheme.ts
@@ -1,7 +1,7 @@
-import { useMediaQuery } from '../use-media-query/use-media-query';
+import { useMediaQuery, UseMediaQueryOptions } from '../use-media-query/use-media-query';
 
-export function useColorScheme() {
-  return useMediaQuery('(prefers-color-scheme: dark)')
+export function useColorScheme(initialValue?: 'dark' | 'light', options?: UseMediaQueryOptions) {
+  return useMediaQuery('(prefers-color-scheme: dark)', initialValue === 'dark', options)
     ? 'dark'
     : 'light';
 }

--- a/src/mantine-hooks/src/use-color-scheme/use-color-scheme.ts
+++ b/src/mantine-hooks/src/use-color-scheme/use-color-scheme.ts
@@ -1,7 +1,7 @@
-import { useMediaQuery, UseMediaQueryOptions } from '../use-media-query/use-media-query';
+import { useMediaQuery } from '../use-media-query/use-media-query';
 
-export function useColorScheme(initialValue?: 'dark' | 'light', options?: UseMediaQueryOptions) {
-  return useMediaQuery('(prefers-color-scheme: dark)', initialValue === undefined ? undefined : initialValue === 'dark', options)
+export function useColorScheme() {
+  return useMediaQuery('(prefers-color-scheme: dark)')
     ? 'dark'
     : 'light';
 }

--- a/src/mantine-hooks/src/use-color-scheme/use-color-scheme.ts
+++ b/src/mantine-hooks/src/use-color-scheme/use-color-scheme.ts
@@ -1,7 +1,7 @@
 import { useMediaQuery, UseMediaQueryOptions } from '../use-media-query/use-media-query';
 
 export function useColorScheme(initialValue?: 'dark' | 'light', options?: UseMediaQueryOptions) {
-  return useMediaQuery('(prefers-color-scheme: dark)', initialValue === 'dark', options)
+  return useMediaQuery('(prefers-color-scheme: dark)', initialValue === undefined ? undefined : initialValue === 'dark', options)
     ? 'dark'
     : 'light';
 }

--- a/src/mantine-hooks/src/use-media-query/use-media-query.ts
+++ b/src/mantine-hooks/src/use-media-query/use-media-query.ts
@@ -35,9 +35,12 @@ function getInitialValue(query: string, initialValue?: boolean) {
 export function useMediaQuery(
   query: string,
   initialValue?: boolean,
+  { getInitialValueInEffect }: UseMediaQueryOptions = {
+    getInitialValueInEffect: true,
+  }
 ) {
   const [matches, setMatches] = useState(
-    getInitialValue(query, initialValue)
+    getInitialValueInEffect ? initialValue : getInitialValue(query, initialValue)
   );
   const queryRef = useRef<MediaQueryList>();
 

--- a/src/mantine-hooks/src/use-media-query/use-media-query.ts
+++ b/src/mantine-hooks/src/use-media-query/use-media-query.ts
@@ -35,12 +35,9 @@ function getInitialValue(query: string, initialValue?: boolean) {
 export function useMediaQuery(
   query: string,
   initialValue?: boolean,
-  { getInitialValueInEffect }: UseMediaQueryOptions = {
-    getInitialValueInEffect: true,
-  }
 ) {
   const [matches, setMatches] = useState(
-    getInitialValueInEffect ? false : getInitialValue(query, initialValue)
+    getInitialValue(query, initialValue)
   );
   const queryRef = useRef<MediaQueryList>();
 


### PR DESCRIPTION
There is a a rendering conflict flicker on client side rendered websites with `useColorScheme` due to the default value not being set on initial render.

You'll get a light -> dark render when browser is set to dark mode

Added storybook and unit test to prove situation