### PR TITLE
[@mantine/hooks] Fixing `use-hash` extra rerendering issue

### DIFF
--- a/src/mantine-hooks/src/use-hash/use-hash.ts
+++ b/src/mantine-hooks/src/use-hash/use-hash.ts
@@ -1,21 +1,23 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useWindowEvent } from '../use-window-event/use-window-event';
 
 export function useHash() {
-  const [hash, setHashValue] = useState<string>('');
+  const [hash, setHashValue] = useState<string>(() => window.location.hash);
 
   const setHash = (value: string) => {
+    if (!value.startsWith("#")) {
+      value = "#" + value;
+    }
     window.location.hash = value;
     setHashValue(value);
   };
 
-  useWindowEvent('hashchange', () => {
-    setHashValue(window.location.hash);
+  useWindowEvent("hashchange", () => {
+    const newHash = window.location.hash;
+    if (hash !== newHash) {
+      setHashValue(hash);
+    }
   });
-
-  useEffect(() => {
-    setHash(window.location.hash);
-  }, []);
 
   return [hash, setHash] as const;
 }

--- a/src/mantine-hooks/src/use-hash/use-hash.ts
+++ b/src/mantine-hooks/src/use-hash/use-hash.ts
@@ -5,11 +5,9 @@ export function useHash() {
   const [hash, setHashValue] = useState<string>('');
 
   const setHash = (value: string) => {
-    if (!value.startsWith('#')) {
-      value = '#' + value;
-    }
-    window.location.hash = value;
-    setHashValue(value);
+    const valueWithHash = value.startsWith('#') ? value : `#${value}`;
+    window.location.hash = valueWithHash;
+    setHashValue(valueWithHash);
   };
 
   useWindowEvent('hashchange', () => {

--- a/src/mantine-hooks/src/use-hash/use-hash.ts
+++ b/src/mantine-hooks/src/use-hash/use-hash.ts
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from "react";
 import { useWindowEvent } from '../use-window-event/use-window-event';
 
+
 export function useHash() {
-  const [hash, setHashValue] = useState<string>(() => window.location.hash);
+  const [hash, setHashValue] = useState<string>("");
 
   const setHash = (value: string) => {
     if (!value.startsWith("#")) {
@@ -18,6 +19,10 @@ export function useHash() {
       setHashValue(hash);
     }
   });
+
+  useEffect(() => {
+    setHashValue(window.location.hash);
+  }, []);
 
   return [hash, setHash] as const;
 }

--- a/src/mantine-hooks/src/use-hash/use-hash.ts
+++ b/src/mantine-hooks/src/use-hash/use-hash.ts
@@ -1,19 +1,18 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect } from 'react';
 import { useWindowEvent } from '../use-window-event/use-window-event';
 
-
 export function useHash() {
-  const [hash, setHashValue] = useState<string>("");
+  const [hash, setHashValue] = useState<string>('');
 
   const setHash = (value: string) => {
-    if (!value.startsWith("#")) {
-      value = "#" + value;
+    if (!value.startsWith('#')) {
+      value = '#' + value;
     }
     window.location.hash = value;
     setHashValue(value);
   };
 
-  useWindowEvent("hashchange", () => {
+  useWindowEvent('hashchange', () => {
     const newHash = window.location.hash;
     if (hash !== newHash) {
       setHashValue(hash);


### PR DESCRIPTION
Two bugs fixed:
* If you `setHash` to something that doesn't start with "#" it would be reflect that temporarily in `hash`
* `setHashValue` was being called multiple times (one in the listener and the set hash) resulting in the multiple renders

Result:
* `setHash` only rerenders the page once.
* `hash` consistently starts with '#'