### PR TITLE
[@mantine/form] fix type inference of validation for union types

### DIFF
--- a/src/mantine-form/src/types.ts
+++ b/src/mantine-form/src/types.ts
@@ -21,7 +21,7 @@ export interface ReorderPayload {
 
 type Rule<Value, Values> = (value: Value, values: Values, path: string) => React.ReactNode;
 
-type FormRule<Value, Values> = Value extends Array<infer ListValue>
+type FormRule<Value, Values> = NonNullable<Value> extends Array<infer ListValue>
   ?
       | Partial<{
           [Key in keyof ListValue]: ListValue[Key] extends Array<infer NestedListItem>
@@ -29,7 +29,7 @@ type FormRule<Value, Values> = Value extends Array<infer ListValue>
             : FormRulesRecord<ListValue[Key]> | Rule<ListValue[Key], Values>;
         }>
       | Rule<Value, Values>
-  : Value extends Record<string, unknown>
+  : NonNullable<Value> extends Record<string, unknown>
   ? FormRulesRecord<Value> | Rule<Value, Values>
   : Rule<Value, Values>;
 


### PR DESCRIPTION
Union types were incorrectly distributed when computing validation functions. This was not visible for the most classic unions, those including `undefined` and `null`, because Mantine's codebase is not in strict mode.

In strict mode, if the type of a value includes `null` or `undefined` in a union, it will get incorrectly distributed, as `undefined` and `null` will be inferred independently.

To avoid that, I wrap the `Value` inferred type into `NonNullable` before checking it against Array and Record cases. This prevents early distribution of the `Value` inferred type since the check is not directly against it. 

It is safe since `NonNullable` will get rid of `undefined` and `null`, which would be "false" in those checks anyway (not an Array, not a Record), so the comparison is still correct.