### PR TITLE
[@mantine/core] TypographyStylesProvider: Add borderLeft to blockquote.

### DIFF
--- a/src/mantine-core/src/TypographyStylesProvider/TypographyStylesProvider.styles.ts
+++ b/src/mantine-core/src/TypographyStylesProvider/TypographyStylesProvider.styles.ts
@@ -177,6 +177,9 @@ export default createStyles((theme) => {
         borderBottomRightRadius: theme.radius.sm,
         padding: `${theme.spacing.md}px ${theme.spacing.lg}px`,
         color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
+        borderLeft: `6px solid ${
+          theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
+        }`,
 
         '& cite': {
           display: 'block',


### PR DESCRIPTION
Add a vertical line to blockquote in the TipTap editor by updating TypographyStylesProvider to have border-left property on blockquote.