### PR TITLE
[@mantine/core] Table: Fix wrong styling with borders and rowspan

### DIFF
--- a/src/mantine-core/src/Table/Table.styles.ts
+++ b/src/mantine-core/src/Table/Table.styles.ts
@@ -79,9 +79,8 @@ export default createStyles(
           '&:last-of-type': {
             borderRight: 'none',
             borderLeft: withColumnBorders ? border : 'none',
-          }
+          },
         },
-
 
         '&[data-striped] tbody tr:nth-of-type(odd)': {
           backgroundColor:

--- a/src/mantine-core/src/Table/Table.styles.ts
+++ b/src/mantine-core/src/Table/Table.styles.ts
@@ -65,17 +65,23 @@ export default createStyles(
             size: verticalSpacing,
             sizes: theme.spacing,
           })}px ${theme.fn.size({ size: horizontalSpacing, sizes: theme.spacing })}px`,
-          borderBottom: border,
+          borderTop: border,
           fontSize: theme.fn.size({ size: fontSize, sizes: theme.fontSizes }),
         },
 
-        '& tbody tr:last-of-type td': {
-          borderBottom: 'none',
+        '& tbody tr:first-of-type td': {
+          borderTop: 'none',
         },
 
-        '& th + th, & td + td': {
-          borderLeft: withColumnBorders ? border : '',
+        '& thead th, & tbody td': {
+          borderRight: withColumnBorders ? border : 'none',
+
+          '&:last-of-type': {
+            borderRight: 'none',
+            borderLeft: withColumnBorders ? border : 'none',
+          }
         },
+
 
         '&[data-striped] tbody tr:nth-of-type(odd)': {
           backgroundColor:


### PR DESCRIPTION
# Issue: #3049

## Description
Fixed the style issues with table component. There are multiple issues with borders when we use the table component with different props such as striped, withBorder or withColumnBorders.

## What package has changed?
@mantine/core

### Fixes # (issues)

[x] When we use withColumnBorders and rowSpan, the border left is not visible of the cells which are now in front of the rowSpan cell. (This is fixed by using borderRight instead of borderLeft for the cells)

[x] When we use rowSpan and rowspaned cell reaches the last row, the unexpected border bottom is added to the last row. (This is fixed by using borderTop for the rows instead of borderBottom)

[ ] When we use striped, striping works well but when the rowspan is used along, the user might expect the striping to be applied to the cells in front of the rowspan cell regarded as one row. (This is not fixed)

## Screenshots
normal without any props
![image](https://user-images.githubusercontent.com/26021449/205448841-ec3e9517-d112-4fa4-a200-f1e70d9d5fed.png)

props: withBorder, withColumnBorders and striped
![image](https://user-images.githubusercontent.com/26021449/205448760-384dfc09-df16-439c-8209-60396764c41e.png)

props: withColumnBorders and striped
![image](https://user-images.githubusercontent.com/26021449/205448801-9eb090a6-6789-4ea9-a44d-463cd8411d6b.png)


