### PR TITLE
[docs] fix changlog component links

### DIFF
--- a/docs/src/docs/changelog/5-9-0.mdx
+++ b/docs/src/docs/changelog/5-9-0.mdx
@@ -27,7 +27,7 @@ the eye dropper will not be rendered if the API is not supported.
 
 ## AppShell alt layout
 
-[AppShell](https://mantine.dev/core/) component now supports placing `Navbar` and `Aside` components on top of `Header` and `Footer` with `layout="alt"` prop.
+[AppShell](https://mantine.dev/core/app-shell) component now supports placing `Navbar` and `Aside` components on top of `Header` and `Footer` with `layout="alt"` prop.
 
 <Anchor href="/app-shell-demo-alt/" target="_blank" mb="xl" style={{ display: 'block' }}>
   Open alt layout example in new tab
@@ -89,5 +89,5 @@ or do not support placeholder property natively:
 
 - [RangeSlider](https://mantine.dev/core/slider/) component now supports `maxRange` prop
 - [Stepper](https://mantine.dev/core/stepper/) component now supports any CSS color value in `color` prop
-- [use-hotkeys](https://mantine.dev/hooks/use-hot-keys/) hook now allows to configure whether default behavior should be prevented
+- [use-hotkeys](https://mantine.dev/hooks/use-hotkeys/) hook now allows to configure whether default behavior should be prevented
 - [Input](https://mantine.dev/core/input/) and other components based on it now support any valid CSS size value in `rightSectionWidth` and `iconWidth` props


### PR DESCRIPTION
fixing appshell & use hotkeys links broken in change log 

app-shell : from ```https://mantine.dev/core/```  to  ```https://mantine.dev/core/app-shell```
use hotkeys : from ```https://mantine.dev/hooks/use-hot-keys``` to ``` https://mantine.dev/hooks/use-hotkeys ```