### PR TITLE
types: make createStyle go to original definition

### DIFF
--- a/src/mantine-styles/src/tss/create-styles.ts
+++ b/src/mantine-styles/src/tss/create-styles.ts
@@ -49,14 +49,14 @@ function getStyles<Key extends string>(
   return extractStyles(styles);
 }
 
-export function createStyles<Key extends string = string, Params = void>(
+export function createStyles<
+  Key extends string = string,
+  Params = void,
+  Input extends Record<string, CSSObject> = Record<Key, CSSObject>
+>(
   input:
-    | ((
-        theme: MantineTheme,
-        params: Params,
-        createRef: (refName: string) => string
-      ) => Record<Key, CSSObject>)
-    | Record<Key, CSSObject>
+    | ((theme: MantineTheme, params: Params, createRef: (refName: string) => string) => Input)
+    | Input
 ) {
   const getCssObject = typeof input === 'function' ? input : () => input;
 
@@ -80,7 +80,9 @@ export function createStyles<Key extends string = string, Params = void>(
         );
         return [key, mergedStyles];
       })
-    ) as Record<Key, string>;
+    ) as {
+      [key in keyof Input]: string;
+    };
 
     return {
       classes: mergeClassNames({

--- a/src/mantine-styles/src/tss/create-styles.ts
+++ b/src/mantine-styles/src/tss/create-styles.ts
@@ -52,7 +52,7 @@ function getStyles<Key extends string>(
 export function createStyles<
   Key extends string = string,
   Params = void,
-  Input extends Record<string, CSSObject> = Record<Key, CSSObject>
+  Input extends Record<Key, CSSObject> = Record<Key, CSSObject>
 >(
   input:
     | ((theme: MantineTheme, params: Params, createRef: (refName: string) => string) => Input)
@@ -85,11 +85,13 @@ export function createStyles<
     };
 
     return {
-      classes: mergeClassNames({
+      classes: mergeClassNames<{ [key in keyof Input]: string }>({
         cx,
         classes,
         context,
-        classNames: options?.classNames,
+        classNames: options?.classNames as {
+          [key in keyof Input]: string;
+        },
         name: options?.name,
         cache,
       }),


### PR DESCRIPTION
By making this change, a user can click on the className to go to the original definition. Like clicking on `classes.wrapper`, it'll go to the object where `wrapper` was defined. Also renaming `wrapper` will rename it from all the places