### PR TITLE
[@mantine/core] Image: Edit error setting when src updates

### DIFF
--- a/src/mantine-core/src/Image/Image.tsx
+++ b/src/mantine-core/src/Image/Image.tsx
@@ -82,7 +82,7 @@ export const Image = forwardRef<HTMLDivElement, ImageProps>((props: ImageProps, 
   const isPlaceholder = withPlaceholder && error;
 
   useDidUpdate(() => {
-    setError(false);
+    setError(!src);
   }, [src]);
 
   return (


### PR DESCRIPTION
Currently the Image component's placeholder is only visible in the first time when the src is `null`. If a src is set and then changed to `null` the placeholder wouldn't show because anytime the src changes the error state becomes `false`.

So, I changed it to only set the error state to `false` whenever there's a src. Otherwise it will be set to `true`.