### PR TITLE
[@mantine/core] RingProgress: Add rootColor property

### DIFF
--- a/docs/src/docs/core/RingProgress.mdx
+++ b/docs/src/docs/core/RingProgress.mdx
@@ -42,6 +42,12 @@ Add `tooltip` property to section to display floating [Tooltip](/core/tooltip/) 
 
 <Demo data={RingProgressDemos.tooltip} />
 
+## Rootcolor
+
+Use `rootColor` property to change the root color:
+
+<Demo data={RingProgressDemos.rootColor} />
+
 ## Sections props
 
 You can add any additional props to sections:

--- a/src/mantine-core/src/RingProgress/RingProgress.story.tsx
+++ b/src/mantine-core/src/RingProgress/RingProgress.story.tsx
@@ -54,3 +54,18 @@ export function WithSectionProps() {
     </div>
   );
 }
+
+export function WithRootColor() {
+  return (
+    <div style={{ padding: 40 }}>
+      <RingProgress
+        sections={[
+          { value: 40, color: 'cyan' },
+          { value: 20, color: 'blue' },
+          { value: 15, color: 'indigo' },
+        ]}
+        rootColor="red"
+      />
+    </div>
+  );
+}

--- a/src/mantine-core/src/RingProgress/RingProgress.test.tsx
+++ b/src/mantine-core/src/RingProgress/RingProgress.test.tsx
@@ -55,4 +55,20 @@ describe('@mantine/core/RingProgress', () => {
     await userEvent.click(container.querySelectorAll('.mantine-Progress-bar')[2]);
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('displays the root in specified color', () => {
+    const { container } = render(
+      <RingProgress
+        sections={[
+          { value: 10, color: 'blue' },
+          { value: 15, color: 'red' },
+          { value: 10, color: 'green' },
+        ]}
+        rootColor="transparent"
+      />
+    );
+
+    // 3 sections + 1 root element
+    expect(container.querySelectorAll('circle[stroke="transparent"]')).toHaveLength(1);
+  });
 });

--- a/src/mantine-core/src/RingProgress/RingProgress.tsx
+++ b/src/mantine-core/src/RingProgress/RingProgress.tsx
@@ -31,7 +31,7 @@ export interface RingProgressProps
   /** Ring sections */
   sections: RingProgressSection[];
 
-  /** Root color */
+  /** Color of the root section, key of theme.colors or CSS color value */
   rootColor?: MantineColor;
 }
 

--- a/src/mantine-core/src/RingProgress/RingProgress.tsx
+++ b/src/mantine-core/src/RingProgress/RingProgress.tsx
@@ -30,6 +30,9 @@ export interface RingProgressProps
 
   /** Ring sections */
   sections: RingProgressSection[];
+
+  /** Root color */
+  rootColor?: MantineColor;
 }
 
 const defaultProps: Partial<RingProgressProps> = {
@@ -48,6 +51,7 @@ export const RingProgress = forwardRef<HTMLDivElement, RingProgressProps>((props
     classNames,
     styles,
     roundCaps,
+    rootColor,
     unstyled,
     ...others
   } = useComponentDefaultProps('RingProgress', defaultProps, props);
@@ -59,11 +63,11 @@ export const RingProgress = forwardRef<HTMLDivElement, RingProgressProps>((props
     thickness,
     sections,
     renderRoundedLineCaps: roundCaps,
+    rootColor,
   }).map(({ data, sum, root, lineRoundCaps, offset }, index) => (
     <Curve
       {...data}
       key={index}
-      value={data?.value}
       size={size}
       thickness={thickness}
       sum={sum}
@@ -71,7 +75,6 @@ export const RingProgress = forwardRef<HTMLDivElement, RingProgressProps>((props
       color={data?.color}
       root={root}
       lineRoundCaps={lineRoundCaps}
-      tooltip={data?.tooltip}
     />
   ));
 

--- a/src/mantine-core/src/RingProgress/get-curves/get-curves.test.ts
+++ b/src/mantine-core/src/RingProgress/get-curves/get-curves.test.ts
@@ -11,6 +11,7 @@ describe('@mantine/core/RingProgress/get-curves', () => {
         { value: 9, color: 'blue' },
       ],
       renderRoundedLineCaps: false,
+      rootColor: 'blue',
     });
     const expectedCurves = [
       {
@@ -34,7 +35,13 @@ describe('@mantine/core/RingProgress/get-curves', () => {
         sum: 71.345,
         lineRoundCaps: false,
       },
-      { data: null, offset: 261.9650020918711, root: true, sum: 71.345, lineRoundCaps: false },
+      {
+        data: { color: 'blue' },
+        offset: 261.9650020918711,
+        root: true,
+        sum: 71.345,
+        lineRoundCaps: false,
+      },
     ];
     expect(curves.length).toStrictEqual(expectedCurves.length);
     expect(curves).toStrictEqual(expect.arrayContaining(expectedCurves));

--- a/src/mantine-core/src/RingProgress/get-curves/get-curves.ts
+++ b/src/mantine-core/src/RingProgress/get-curves/get-curves.ts
@@ -6,22 +6,33 @@ interface CurveData extends React.ComponentPropsWithRef<'circle'> {
   tooltip?: React.ReactNode;
 }
 
+interface RootCurveData extends React.ComponentPropsWithRef<'circle'> {
+  color?: MantineColor;
+}
+
 interface GetCurves {
   sections: CurveData[];
   size: number;
   thickness: number;
   renderRoundedLineCaps: boolean;
+  rootColor?: MantineColor;
 }
 
 interface Curve {
   sum: number;
   offset: number;
   root: boolean;
-  data: CurveData;
+  data: CurveData | RootCurveData;
   lineRoundCaps?: boolean;
 }
 
-export function getCurves({ size, thickness, sections, renderRoundedLineCaps }: GetCurves) {
+export function getCurves({
+  size,
+  thickness,
+  sections,
+  renderRoundedLineCaps,
+  rootColor,
+}: GetCurves) {
   const sum = sections.reduce((acc, current) => acc + current.value, 0);
   const accumulated = Math.PI * ((size * 0.9 - thickness * 2) / 2) * 2;
   let offset = accumulated;
@@ -33,7 +44,7 @@ export function getCurves({ size, thickness, sections, renderRoundedLineCaps }: 
     offset -= (sections[i].value / 100) * accumulated;
   }
 
-  curves.push({ sum, offset, data: null, root: true });
+  curves.push({ sum, offset, data: { color: rootColor }, root: true });
 
   // Reorder curves to layer appropriately and selectively set caps to round
 

--- a/src/mantine-demos/src/demos/core/RingProgress/RingProgress.demo.rootColor.tsx
+++ b/src/mantine-demos/src/demos/core/RingProgress/RingProgress.demo.rootColor.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { MantineDemo } from '@mantine/ds';
+import { RingProgress, Group } from '@mantine/core';
+
+const code = `
+import { RingProgress } from '@mantine/core';
+
+function Demo() {
+  return (
+    <RingProgress sections={[{ value: 40, color: 'yellow' }]} rootColor="red" />
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <Group position="center">
+      <RingProgress sections={[{ value: 40, color: 'yellow' }]} rootColor="red" />
+    </Group>
+  );
+}
+
+export const rootColor: MantineDemo = {
+  type: 'demo',
+  code,
+  component: Demo,
+};

--- a/src/mantine-demos/src/demos/core/RingProgress/index.ts
+++ b/src/mantine-demos/src/demos/core/RingProgress/index.ts
@@ -4,3 +4,4 @@ export { label } from './RingProgress.demo.label';
 export { colors } from './RingProgress.demo.colors';
 export { tooltip } from './RingProgress.demo.tooltip';
 export { sectionsProps } from './RingProgress.demo.sectionsProps';
+export { rootColor } from './RingProgress.demo.rootColor';


### PR DESCRIPTION
Pr for discussion #3147
Adds the `rootColor` property to the RingProgress which can be used to define the color of the root curve. 