### PR TITLE
Update getLineClamp in Text.styles.ts to support 1 liner

### DIFF
--- a/docs/src/docs/theming/mantine-provider.mdx
+++ b/docs/src/docs/theming/mantine-provider.mdx
@@ -41,7 +41,7 @@ and global styles (`withGlobalStyles`). It is recommended to enable these option
 - background-color to `theme.colors.dark[7]` in dark color scheme and `theme.white` in light
 - color to `theme.colors.dark[0]` in dark color scheme and `theme.black` in light
 - font-family and font-smoothing based on theme
-- font-size to `theme.fontSize.md`
+- font-size to `theme.fontSizes.md`
 
 ```tsx
 import { MantineProvider } from '@mantine/core';

--- a/src/mantine-core/src/Text/Text.styles.ts
+++ b/src/mantine-core/src/Text/Text.styles.ts
@@ -62,6 +62,14 @@ function getTextColor({ theme, color, variant }: GetTextColor) {
 
 function getLineClamp(lineClamp: number): CSSObject {
   if (typeof lineClamp === 'number') {
+    if (lineClamp === 1) {
+      return {
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap'
+      };
+    }
+
     return {
       overflow: 'hidden',
       textOverflow: 'ellipsis',

--- a/src/mantine-core/src/Text/Text.styles.ts
+++ b/src/mantine-core/src/Text/Text.styles.ts
@@ -12,6 +12,7 @@ export interface TextStylesParams {
   variant: 'text' | 'link' | 'gradient';
   size: MantineNumberSize;
   lineClamp: number;
+  truncate: boolean;
   inline: boolean;
   inherit: boolean;
   underline: boolean;
@@ -62,14 +63,6 @@ function getTextColor({ theme, color, variant }: GetTextColor) {
 
 function getLineClamp(lineClamp: number): CSSObject {
   if (typeof lineClamp === 'number') {
-    if (lineClamp === 1) {
-      return {
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap'
-      };
-    }
-
     return {
       overflow: 'hidden',
       textOverflow: 'ellipsis',
@@ -82,6 +75,18 @@ function getLineClamp(lineClamp: number): CSSObject {
   return null;
 }
 
+function getTruncate(truncate: boolean): CSSObject {
+  if (truncate) {
+    return {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap'
+    };
+  }
+
+  return null
+}
+
 export default createStyles(
   (
     theme,
@@ -90,6 +95,7 @@ export default createStyles(
       variant,
       size,
       lineClamp,
+      truncate,
       inline,
       inherit,
       underline,
@@ -108,6 +114,7 @@ export default createStyles(
         ...theme.fn.fontStyles(),
         ...theme.fn.focusStyles(),
         ...getLineClamp(lineClamp),
+        ...getTruncate(truncate),
         color: getTextColor({ color, theme, variant }),
         fontFamily: inherit ? 'inherit' : theme.fontFamily,
         fontSize:

--- a/src/mantine-core/src/Text/Text.styles.ts
+++ b/src/mantine-core/src/Text/Text.styles.ts
@@ -80,11 +80,11 @@ function getTruncate(truncate: boolean): CSSObject {
     return {
       overflow: 'hidden',
       textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap'
+      whiteSpace: 'nowrap',
     };
   }
 
-  return null
+  return null;
 }
 
 export default createStyles(

--- a/src/mantine-core/src/Text/Text.tsx
+++ b/src/mantine-core/src/Text/Text.tsx
@@ -35,6 +35,9 @@ export interface TextProps extends DefaultProps {
   /** CSS -webkit-line-clamp property */
   lineClamp?: number;
 
+  /** CSS truncate overflowing text with an ellipsis */
+  truncate?: boolean;
+
   /** Sets line-height to 1 for centering */
   inline?: boolean;
 
@@ -71,6 +74,7 @@ export const _Text = forwardRef<HTMLDivElement, TextProps>((props, ref) => {
     align,
     variant,
     lineClamp,
+    truncate,
     gradient,
     inline,
     inherit,
@@ -90,6 +94,7 @@ export const _Text = forwardRef<HTMLDivElement, TextProps>((props, ref) => {
       color,
       size,
       lineClamp,
+      truncate,
       inline,
       inherit,
       underline,


### PR DESCRIPTION
This PR updates the getLineClamp function to behave like how Tailwind or Bootstrap works.

### Something to consider?
There is also a case for changing the getLineClamp function to truncate as it's more descriptive.  Also perhaps something like:

```
<Text truncate>Foo foo foo foo</Text> 
```

> Foo foo foo foo...

As a default (1 line) option, but then 

```
<Text truncate={3}>
Foo foo foo foo
Foo foo foo foo
Foo foo foo foo
</Text>
``` 

>Foo foo foo foo
>Foo foo foo foo
>Foo foo foo foo...

To support the 3 line truncate.

It's a breaking change but something to think about for Mantine 6?  🤔 