### PR TITLE
[@mantine/spotlight] Allow overriding search input size

### DIFF
--- a/src/mantine-spotlight/src/Spotlight/Spotlight.tsx
+++ b/src/mantine-spotlight/src/Spotlight/Spotlight.tsx
@@ -242,6 +242,7 @@ export function Spotlight({
               >
                 <TextInput
                   autoComplete="chrome-please-just-do-not-show-it-thanks"
+                  size="lg"
                   {...searchInputProps}
                   value={query}
                   onChange={handleInputChange}
@@ -249,7 +250,6 @@ export function Spotlight({
                   onCompositionStart={() => setIMEOpen(true)}
                   onCompositionEnd={() => setIMEOpen(false)}
                   classNames={{ input: classes.searchInput }}
-                  size="lg"
                   placeholder={searchPlaceholder}
                   icon={searchIcon}
                   onMouseEnter={resetHovered}


### PR DESCRIPTION
Hey, it would be awesome to have the ability to override search input size via searchInputProps on Spotlight/SpotlightProvider 🙏

![image](https://user-images.githubusercontent.com/697301/207386576-416533ac-bbce-42ef-8ee3-786109beaa1f.png)

Checked locally, also verified in Storybook, test/types passing ☑️

(Mantine is great btw!)


