### PR TITLE
[@mantine/core] improve Stepper API

### DIFF
--- a/docs/src/docs/core/Stepper.mdx
+++ b/docs/src/docs/core/Stepper.mdx
@@ -27,6 +27,13 @@ It can be used to prevent user from reaching next steps:
 
 <Demo data={StepperDemos.allowStepSelect} />
 
+## Disable next steps selection
+
+Another way to disable selection of upcoming steps is to use the `allowNextStepsSelect` directly on the `Stepper` component.
+This is useful when you don't need to control the behavior specifically for each step.
+
+<Demo data={StepperDemos.allowNextStepsSelect} />
+
 ## Color, radius and size
 
 You can use any color from `theme.colors`, by default Stepper will use `theme.primaryColor`:

--- a/docs/src/docs/core/Stepper.mdx
+++ b/docs/src/docs/core/Stepper.mdx
@@ -63,6 +63,15 @@ You can also change completed icon for each step, for example, to indicate error
 
 <Demo data={StepperDemos.stepColor} />
 
+## Step-aware components for customization
+
+All props accepting a React Node for customizing a step (`label`, `icon`, `completedIcon`...) can also take a React _Component_
+instead, which will receive the step's index as props.
+
+This allows easily using a custom component for each steps.
+
+<Demo data={StepperDemos.stepFragmentComponents} />
+
 ## Vertical orientation
 
 <Demo data={StepperDemos.orientation} />

--- a/src/mantine-core/src/Stepper/Step/Step.tsx
+++ b/src/mantine-core/src/Stepper/Step/Step.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, FunctionComponent } from 'react';
 import {
   DefaultProps,
   MantineColor,
@@ -16,9 +16,14 @@ import useStyles from './Step.styles';
 
 export type StepStylesNames = Selectors<typeof useStyles>;
 
+export type StepFragmentComponent = FunctionComponent<{ step: number }>;
+
 export interface StepProps
   extends DefaultProps<StepStylesNames>,
     React.ComponentPropsWithoutRef<'button'> {
+  /** Step index, controlled by Steps component **/
+  step?: number;
+
   /** Step state, controlled by Steps component */
   state?: 'stepInactive' | 'stepProgress' | 'stepCompleted';
 
@@ -29,19 +34,19 @@ export interface StepProps
   withIcon?: boolean;
 
   /** Step icon, defaults to step index + 1 when rendered within Stepper */
-  icon?: React.ReactNode;
+  icon?: React.ReactNode | StepFragmentComponent;
 
   /** Step icon displayed when step is completed */
-  completedIcon?: React.ReactNode;
+  completedIcon?: React.ReactNode | StepFragmentComponent;
 
   /** Step icon displayed when step is in progress */
-  progressIcon?: React.ReactNode;
+  progressIcon?: React.ReactNode | StepFragmentComponent;
 
   /** Step label, render after icon */
-  label?: React.ReactNode;
+  label?: React.ReactNode | StepFragmentComponent;
 
   /** Step description */
-  description?: React.ReactNode;
+  description?: React.ReactNode | StepFragmentComponent;
 
   /** Icon wrapper size in px */
   iconSize?: number;
@@ -88,9 +93,18 @@ const defaultProps: Partial<StepProps> = {
   __staticSelector: 'Step',
 };
 
+const getStepFragment = (Fragment: StepFragmentComponent | React.ReactNode, step: number) => {
+  if (typeof Fragment === 'function') {
+    return <Fragment step={step} />;
+  }
+
+  return Fragment;
+};
+
 export const Step = forwardRef<HTMLButtonElement, StepProps>((props: StepProps, ref) => {
   const {
     className,
+    step,
     state,
     color,
     icon,
@@ -143,7 +157,7 @@ export const Step = forwardRef<HTMLButtonElement, StepProps>((props: StepProps, 
                   {loading ? (
                     <Loader color="#fff" size={_iconSize} className={classes.stepLoader} />
                   ) : (
-                    completedIcon || (
+                    getStepFragment(completedIcon, step) || (
                       <CheckboxIcon indeterminate={false} width={_iconSize} height={_iconSize} />
                     )
                   )}
@@ -155,7 +169,7 @@ export const Step = forwardRef<HTMLButtonElement, StepProps>((props: StepProps, 
               loading ? (
                 <Loader size={_iconSize} color={color} />
               ) : (
-                _icon || icon
+                getStepFragment(_icon || icon, step)
               )
             ) : null}
           </div>
@@ -171,10 +185,10 @@ export const Step = forwardRef<HTMLButtonElement, StepProps>((props: StepProps, 
 
       {(label || description) && (
         <div className={classes.stepBody}>
-          {label && <Text className={classes.stepLabel}>{label}</Text>}
+          {label && <Text className={classes.stepLabel}>{getStepFragment(label, step)}</Text>}
           {description && (
             <Text className={classes.stepDescription} color="dimmed">
-              {description}
+              {getStepFragment(description, step)}
             </Text>
           )}
         </div>

--- a/src/mantine-core/src/Stepper/Stepper.tsx
+++ b/src/mantine-core/src/Stepper/Stepper.tsx
@@ -56,6 +56,9 @@ export interface StepperProps
 
   /** Breakpoint at which orientation will change from horizontal to vertical */
   breakpoint?: MantineNumberSize;
+
+  /** Whether to enable click on upcoming steps by default. Defaults to true **/
+  allowNextStepsSelect?: boolean;
 }
 
 type StepperComponent = ForwardRefWithStaticComponents<
@@ -72,6 +75,7 @@ const defaultProps: Partial<StepperProps> = {
   radius: 'xl',
   orientation: 'horizontal',
   iconPosition: 'left',
+  allowNextStepsSelect: true,
 };
 
 export const Stepper: StepperComponent = forwardRef<HTMLDivElement, StepperProps>((props, ref) => {
@@ -90,6 +94,7 @@ export const Stepper: StepperComponent = forwardRef<HTMLDivElement, StepperProps
     orientation,
     breakpoint,
     iconPosition,
+    allowNextStepsSelect,
     classNames,
     styles,
     unstyled,
@@ -106,18 +111,19 @@ export const Stepper: StepperComponent = forwardRef<HTMLDivElement, StepperProps
   const completedStep = convertedChildren.find((item) => item.type === StepCompleted);
 
   const items = _children.reduce<React.ReactElement[]>((acc, item, index) => {
-    const shouldAllowSelect =
-      typeof item.props.allowStepSelect === 'boolean'
-        ? item.props.allowStepSelect
-        : typeof onStepClick === 'function';
+    const state =
+      active === index ? 'stepProgress' : active > index ? 'stepCompleted' : 'stepInactive';
+    const shouldAllowSelect = state === 'stepCompleted' || allowNextStepsSelect;
+    typeof item.props.allowStepSelect === 'boolean'
+      ? item.props.allowStepSelect
+      : typeof onStepClick === 'function';
 
     acc.push(
       cloneElement(item, {
         __staticSelector: 'Stepper',
         icon: item.props.icon || index + 1,
         key: index,
-        state:
-          active === index ? 'stepProgress' : active > index ? 'stepCompleted' : 'stepInactive',
+        state,
         onClick: () => shouldAllowSelect && typeof onStepClick === 'function' && onStepClick(index),
         allowStepClick: shouldAllowSelect && typeof onStepClick === 'function',
         completedIcon: item.props.completedIcon || completedIcon,

--- a/src/mantine-core/src/Stepper/Stepper.tsx
+++ b/src/mantine-core/src/Stepper/Stepper.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mantine/styles';
 import { ForwardRefWithStaticComponents } from '@mantine/utils';
 import { Box } from '../Box';
-import { Step, StepStylesNames } from './Step/Step';
+import { Step, StepStylesNames, StepFragmentComponent } from './Step/Step';
 import { StepCompleted } from './StepCompleted/StepCompleted';
 import useStyles from './Stepper.styles';
 
@@ -27,11 +27,14 @@ export interface StepperProps
   /** Active step index */
   active: number;
 
+  /** Step icon, defaults to step index + 1 when rendered within Stepper */
+  icon?: React.ReactNode | StepFragmentComponent;
+
   /** Step icon displayed when step is completed */
-  completedIcon?: React.ReactNode;
+  completedIcon?: React.ReactNode | StepFragmentComponent;
 
   /** Step icon displayed when step is in progress */
-  progressIcon?: React.ReactNode;
+  progressIcon?: React.ReactNode | StepFragmentComponent;
 
   /** Active and progress Step colors from theme.colors */
   color?: MantineColor;
@@ -84,6 +87,7 @@ export const Stepper: StepperComponent = forwardRef<HTMLDivElement, StepperProps
     children,
     onStepClick,
     active,
+    icon,
     completedIcon,
     progressIcon,
     color,
@@ -121,8 +125,9 @@ export const Stepper: StepperComponent = forwardRef<HTMLDivElement, StepperProps
     acc.push(
       cloneElement(item, {
         __staticSelector: 'Stepper',
-        icon: item.props.icon || index + 1,
+        icon: item.props.icon || icon || index + 1,
         key: index,
+        step: index,
         state,
         onClick: () => shouldAllowSelect && typeof onStepClick === 'function' && onStepClick(index),
         allowStepClick: shouldAllowSelect && typeof onStepClick === 'function',

--- a/src/mantine-demos/src/demos/core/Stepper/Stepper.demo.allowNextStepsSelect.tsx
+++ b/src/mantine-demos/src/demos/core/Stepper/Stepper.demo.allowNextStepsSelect.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { Stepper, Button, Group } from '@mantine/core';
+import { MantineDemo } from '@mantine/ds';
+import { Content } from './_content';
+
+const code = `
+import { useState } from 'react';
+import { Stepper, Button, Group } from '@mantine/core';
+
+function Demo() {
+  const [active, setActive] = useState(1);
+  const nextStep = () => setActive((current) => (current < 3 ? current + 1 : current));
+  const prevStep = () => setActive((current) => (current > 0 ? current - 1 : current));
+
+  return (
+    <>
+      <Stepper active={active} onStepClick={setActive} breakpoint="sm" allowNextStepsSelect={false}>
+        <Stepper.Step label="First step" description="Create an account">
+          Step 1 content: Create an account
+        </Stepper.Step>
+        <Stepper.Step label="Second step" description="Verify email">
+          Step 2 content: Verify email
+        </Stepper.Step>
+        <Stepper.Step label="Final step" description="Get full access">
+          Step 3 content: Get full access
+        </Stepper.Step>
+        <Stepper.Completed>
+          Completed, click back button to get to previous step
+        </Stepper.Completed>
+      </Stepper>
+
+      <Group position="center" mt="xl">
+        <Button variant="default" onClick={prevStep}>Back</Button>
+        <Button onClick={nextStep}>Next step</Button>
+      </Group>
+    </>
+  );
+}
+`;
+
+function Demo() {
+  const [active, setActive] = useState(1);
+  const nextStep = () => setActive((current) => (current < 3 ? current + 1 : current));
+  const prevStep = () => setActive((current) => (current > 0 ? current - 1 : current));
+
+  return (
+    <>
+      <Stepper active={active} onStepClick={setActive} breakpoint="sm" allowNextStepsSelect={false}>
+        <Stepper.Step label="First step" description="Create an account">
+          <Content>Step 1 content: Create an account</Content>
+        </Stepper.Step>
+        <Stepper.Step label="Second step" description="Verify email">
+          <Content>Step 2 content: Verify email</Content>
+        </Stepper.Step>
+        <Stepper.Step label="Final step" description="Get full access">
+          <Content>Step 3 content: Get full access</Content>
+        </Stepper.Step>
+
+        <Stepper.Completed>
+          <Content>Completed, click back button to get to previous step</Content>
+        </Stepper.Completed>
+      </Stepper>
+
+      <Group position="center" mt="xl">
+        <Button variant="default" onClick={prevStep}>
+          Back
+        </Button>
+        <Button onClick={nextStep}>Next step</Button>
+      </Group>
+    </>
+  );
+}
+
+export const allowNextStepsSelect: MantineDemo = {
+  type: 'demo',
+  component: Demo,
+  code,
+};

--- a/src/mantine-demos/src/demos/core/Stepper/Stepper.demo.stepFragmentComponents.tsx
+++ b/src/mantine-demos/src/demos/core/Stepper/Stepper.demo.stepFragmentComponents.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { IconCheck } from '@tabler/icons';
+import { MantineDemo } from '@mantine/ds';
+import { Group, Stepper, Text } from '@mantine/core';
+
+const code = `
+import { Stepper, Group, Text } from '@mantine/core';
+import { IconCheck } from '@tabler/icons';
+
+function Label(props: { step: number }) {
+  return (
+    <>Step {props.step + 1}</>
+  );
+}
+
+function ProgressIcon(props: { step: number }) {
+  return (
+    <Text color="blue">{props.step + 1}</Text>
+  );
+}
+
+function CompletedIcon(props: { step: number }) {
+  return (
+    <Group spacing={0} noWrap>
+      <Text>{props.step + 1}</Text>
+      <IconCheck size={16} />
+    </Group>
+  );
+}
+
+function Demo() {
+  return (
+    <Stepper active={1} breakpoint="sm" progressIcon={ProgressIcon} completedIcon={CompletedIcon}>
+      <Stepper.Step label={Label} description="Create an account" />
+      <Stepper.Step label={Label} description="Verify email" />
+      <Stepper.Step label={Label} description="Get full access" />
+    </Stepper>
+  );
+}
+`;
+
+function Label(props: { step: number }) {
+  return <>Step {props.step + 1}</>;
+}
+
+function ProgressIcon(props: { step: number }) {
+  return <Text color="blue">{props.step + 1}</Text>;
+}
+
+function CompletedIcon(props: { step: number }) {
+  return (
+    <Group spacing={0} noWrap>
+      <Text>{props.step + 1}</Text>
+      <IconCheck size={16} />
+    </Group>
+  );
+}
+
+function Demo() {
+  return (
+    <Stepper active={1} breakpoint="sm" progressIcon={ProgressIcon} completedIcon={CompletedIcon}>
+      <Stepper.Step label={Label} description="Create an account" />
+      <Stepper.Step label={Label} description="Verify email" />
+      <Stepper.Step label={Label} description="Get full access" />
+    </Stepper>
+  );
+}
+
+export const stepFragmentComponents: MantineDemo = {
+  type: 'demo',
+  component: Demo,
+  code,
+};

--- a/src/mantine-demos/src/demos/core/Stepper/index.ts
+++ b/src/mantine-demos/src/demos/core/Stepper/index.ts
@@ -10,3 +10,4 @@ export { stepColor } from './Stepper.demo.stepColor';
 export { stylesApi } from './Stepper.demo.stylesApi';
 export { stylesApi2 } from './Stepper.demo.stylesApi2';
 export { allowStepSelect } from './Stepper.demo.allowStepSelect';
+export { allowNextStepsSelect } from './Stepper.demo.allowNextStepsSelect';

--- a/src/mantine-demos/src/demos/core/Stepper/index.ts
+++ b/src/mantine-demos/src/demos/core/Stepper/index.ts
@@ -7,6 +7,7 @@ export { orientation } from './Stepper.demo.orientation';
 export { iconPosition } from './Stepper.demo.iconPosition';
 export { loading } from './Stepper.demo.loading';
 export { stepColor } from './Stepper.demo.stepColor';
+export { stepFragmentComponents } from './Stepper.demo.stepFragmentComponents';
 export { stylesApi } from './Stepper.demo.stylesApi';
 export { stylesApi2 } from './Stepper.demo.stylesApi2';
 export { allowStepSelect } from './Stepper.demo.allowStepSelect';


### PR DESCRIPTION
As discussed on Discord, this PR adds some flexibility to Stepper's API:

- Adds a `allowSelectNextSteps` props on Stepper, defaults to `true` to match current behavior. When false, clicking is disabled by default on upcoming steps.
- Adds a `StepFragmentComponent` type for all props currently accepting a React.Node. This is a component that receives the current step index as props, allowing the use of reusable templates easily.

I added some demos, don't hesitate to ask for changes in them if they are not useful enough!