### PR TITLE
[core] Update yarn cache in github action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,22 +13,14 @@ jobs:
   test_pull_request:
     runs-on: ubuntu-latest
     steps:
-      - name: Get Yarn cache path
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.8.0'
-      - name: Load Yarn cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
+          cache-dependency-path: '**/yarn.lock'
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --prefer-offline
       - name: Build public packages
         run: npm run build:all
       - name: Run syncpack, eslint, tsc and jest


### PR DESCRIPTION
- Currently, the `yarn` cache in the `pull_request` always misses. The total time to install dependencies take ~2 minutes.

  <img width="738" alt="Screen Shot 2022-12-15 at 01 42 44" src="https://user-images.githubusercontent.com/1933157/207826175-2897d5da-0c4a-4ae5-b78f-350434a7966b.png">

- This PR fixes this issue by using the latest `setup-node@v3`.
- With the new cache, it takes ~30 seconds to download the cache, and ~1 minute 10 seconds to install the dependencies. So in total it saves 20 seconds. It's not a huge improvement because the cache size is very large and it takes a while to download.
- Also there are no more deprecated `set-output` / `save-state` command warnings.
- Please note that the cache will only start to work on the second run. So on this PR, the installation time will remain the same. But here is a screenshot of subsequent runs:

  <img width="602" alt="Screen Shot 2022-12-15 at 01 40 46" src="https://user-images.githubusercontent.com/1933157/207825833-a00c47ad-dd91-44fe-993d-cc072917c83a.png">
