### PR TITLE
[@mantine/tiptap]: Add icon prop to link control base

### DIFF
--- a/src/mantine-tiptap/src/controls/LinkControl/LinkControl.tsx
+++ b/src/mantine-tiptap/src/controls/LinkControl/LinkControl.tsx
@@ -33,11 +33,12 @@ const defaultProps: Partial<RichTextEditorLinkControlProps> = {};
 
 export const LinkControl = forwardRef<HTMLButtonElement, RichTextEditorLinkControlProps>(
   (props, ref) => {
-    const { icon, popoverProps, disableTooltips, ...others } = useComponentDefaultProps(
-      'RichTextEditorLinkControl',
-      defaultProps,
-      props
-    );
+    const {
+      icon = LinkIcon,
+      popoverProps,
+      disableTooltips,
+      ...others
+    } = useComponentDefaultProps('RichTextEditorLinkControl', defaultProps, props);
 
     const { editor, labels, classNames, styles, unstyled } = useRichTextEditorContext();
     const { classes } = useStyles(null, { name: 'RichTextEditor', classNames, styles, unstyled });
@@ -93,7 +94,7 @@ export const LinkControl = forwardRef<HTMLButtonElement, RichTextEditorLinkContr
       >
         <Popover.Target>
           <ControlBase
-            icon={LinkIcon}
+            icon={icon}
             aria-label={labels.linkControlLabel}
             title={labels.linkControlLabel}
             onClick={handleOpen}


### PR DESCRIPTION
As mentioned in the issue https://github.com/mantinedev/mantine/issues/3196, I have added the icon prop to the Link Control Base and set the default icon of Link Control Base to Link Icon