### PR TITLE
[@mantine/core] (Image) fix: `Image` hides corners in `Card`

### DIFF
--- a/src/mantine-core/src/Image/Image.styles.ts
+++ b/src/mantine-core/src/Image/Image.styles.ts
@@ -8,7 +8,7 @@ export default createStyles((theme, { radius }: ImageStylesParams) => ({
   root: {},
 
   imageWrapper: {
-    position: 'relative',
+    position: 'static',
   },
 
   figure: {


### PR DESCRIPTION
This fix for #3216 should not cause breaking changes, please let me know if any potential issues after setting `imageWrapper` to be static in position.