### PR TITLE
[@mantine/docs] Update Container documentation to remove outdated component prop

### DIFF
--- a/docs/src/docs/core/Container.mdx
+++ b/docs/src/docs/core/Container.mdx
@@ -20,7 +20,7 @@ Container is the most basic layout element, it centers content horizontally and 
 Component accepts these props:
 
 - **size** – controls default max width
-- **padding** – controls horizontal padding of container, use xs, sm, md, lg, xl for value defined in theme.spacing or number to set horizontal padding in px
+- **sizes** - configures container sizes 
 - **fluid** – overwrites size prop and sets max width to 100%
 
 <Demo data={ContainerDemos.usage} />


### PR DESCRIPTION
`padding` is not an accepted component prop for Container.