### PR TITLE
Change from "below" to "behind"

### DIFF
--- a/docs/src/docs/core/BackgroundImage.mdx
+++ b/docs/src/docs/core/BackgroundImage.mdx
@@ -17,7 +17,7 @@ import { BackgroundImageDemos } from '@mantine/demos';
 
 ## Usage
 
-Use `BackgroundImage` component when you need to display the image below any content.
+Use `BackgroundImage` component when you need to display the image behind any content.
 Component sets background-image to given `src`, background-size to `cover` and background-position to `center`.
 It can be used for cards, hero headers and similar components:
 


### PR DESCRIPTION
It tripped me up so I thought worth fixing for others.  "below" indicates content displayed after content, while "behind" indicates content displayed under content.