### PR TITLE
[@mantine/dates] CalendarBase: implement `allowedLevels` to display only certain levels

### DIFF
--- a/src/mantine-dates/src/components/CalendarBase/CalendarBase.story.tsx
+++ b/src/mantine-dates/src/components/CalendarBase/CalendarBase.story.tsx
@@ -26,6 +26,18 @@ storiesOf('CalendarBase', module)
   .add('3 months', () => <Wrapper amountOfMonths={3} />)
   .add('First day of week sunday', () => <Wrapper amountOfMonths={2} firstDayOfWeek="sunday" />)
   .add('Disallow level change', () => <Wrapper amountOfMonths={2} allowLevelChange={false} />)
+  .add('Only show specific levels', () => (
+    <>
+      <p style={{ paddingLeft: 30 }}>Only <code>year</code> and <code>month</code></p>
+      <Wrapper initialLevel="month" allowedLevels={['year', 'month']} />
+      <p style={{ paddingLeft: 30 }}>Only <code>year</code></p>
+      <Wrapper initialLevel="year" allowedLevels={['year']} />
+      <p style={{ paddingLeft: 30 }}>Only <code>month</code></p>
+      <Wrapper initialLevel="month" allowedLevels={['month']} />
+      <p style={{ paddingLeft: 30 }}>Only <code>date</code></p>
+      <Wrapper initialLevel="date" allowedLevels={['date']} />
+    </>
+  ))
   .add('Initial level: month', () => <Wrapper amountOfMonths={2} initialLevel="month" />)
   .add('Initial level: year', () => <Wrapper amountOfMonths={2} initialLevel="year" />)
   .add('Sizes: date', () => <div style={{ padding: 40 }}>{getSizes({})}</div>)

--- a/src/mantine-dates/src/components/CalendarBase/CalendarBase.tsx
+++ b/src/mantine-dates/src/components/CalendarBase/CalendarBase.tsx
@@ -41,6 +41,9 @@ export interface CalendarSharedProps extends DefaultProps<CalendarBaseStylesName
   /** Allow to change level (date – month – year) */
   allowLevelChange?: boolean;
 
+  /** Allow to change level (date – month – year) */
+  allowedLevels?: ('date' | 'month' | 'year')[];
+
   /** Initial date selection level */
   initialLevel?: 'date' | 'month' | 'year';
 
@@ -104,6 +107,7 @@ export const CalendarBase = forwardRef<HTMLDivElement, CalendarBaseProps>(
       amountOfMonths = 1,
       paginateBy = amountOfMonths,
       size = 'sm',
+      allowedLevels = ['date', 'month', 'year'],
       allowLevelChange = true,
       initialLevel = 'date',
       minDate,
@@ -256,7 +260,7 @@ export const CalendarBase = forwardRef<HTMLDivElement, CalendarBaseProps>(
 
     return (
       <Box className={cx(classes.calendarBase, className)} ref={ref} {...others}>
-        {selectionState === 'year' && (
+        {selectionState === 'year' && allowedLevels.includes('year') && (
           <YearPicker
             size={size}
             value={yearSelection}
@@ -264,7 +268,12 @@ export const CalendarBase = forwardRef<HTMLDivElement, CalendarBaseProps>(
             maxYear={maxYear}
             onChange={(year) => {
               setYearSelection(year);
-              setSelectionState('month');
+
+              if (allowedLevels.includes('month')) {
+                setSelectionState('month');
+              } else {
+                onChange?.(new Date(year, 1, 1));
+              }
             }}
             classNames={classNames}
             styles={styles}
@@ -278,19 +287,28 @@ export const CalendarBase = forwardRef<HTMLDivElement, CalendarBaseProps>(
           />
         )}
 
-        {selectionState === 'month' && (
+        {selectionState === 'month' && allowedLevels.includes('month') && (
           <MonthPicker
             size={size}
             value={{ month: _month.getMonth(), year: _month.getFullYear() }}
             year={yearSelection}
             onYearChange={setYearSelection}
-            onNextLevel={() => setSelectionState('year')}
+            onNextLevel={() => {
+              if (allowedLevels.includes('year')) {
+                setSelectionState('year');
+              }
+            }}
             locale={finalLocale}
             minDate={minDate}
             maxDate={maxDate}
             onChange={(monthValue) => {
               setMonth(new Date(yearSelection, monthValue, 1));
-              setSelectionState('date');
+
+              if (allowedLevels.includes('date')) {
+                setSelectionState('date');
+              } else {
+                onChange?.(new Date(yearSelection, monthValue, 1));
+              }
             }}
             classNames={classNames}
             styles={styles}
@@ -312,11 +330,15 @@ export const CalendarBase = forwardRef<HTMLDivElement, CalendarBaseProps>(
             locale={finalLocale}
             minDate={minDate}
             maxDate={maxDate}
-            allowLevelChange={allowLevelChange}
+            allowLevelChange={allowLevelChange && allowedLevels.some(x => x !== 'date')}
             size={size}
             daysRefs={daysRefs}
             onMonthChange={setMonth}
-            onNextLevel={() => setSelectionState('month')}
+            onNextLevel={() => {
+              if (allowedLevels.includes('month')) {
+                setSelectionState('month');
+              }
+            }}
             onDayKeyDown={handleDayKeyDown}
             classNames={classNames}
             styles={styles}


### PR DESCRIPTION
This PR makes changes to the CalendarBase component, and the associated story.

https://user-images.githubusercontent.com/1134738/209449008-9788f460-2c32-46ba-a598-7ccd95cd5ab8.mov

It introduces a new prop `allowedLevels` that defaults to all three levels (date, month, year). If a user passes down this array with just one or two of these options, it restricts input to just these levels.

I had a use-case for this, where I want the user to be able to select just the month and year, but not a specific date.

As a hack, I tried using a controlled component and closing the calendar popover as soon as onMonthChange was called, but this causes the date picker still to flash for a brief second.