### PR TITLE
[@mantine/core] Stack: Fix default justify property

### DIFF
--- a/src/mantine-core/src/Stack/Stack.tsx
+++ b/src/mantine-core/src/Stack/Stack.tsx
@@ -20,7 +20,7 @@ export interface StackProps
 const defaultProps: Partial<StackProps> = {
   spacing: 'md',
   align: 'stretch',
-  justify: 'top',
+  justify: 'flex-start',
 };
 
 export const Stack = forwardRef<HTMLDivElement, StackProps>((props, ref) => {


### PR DESCRIPTION
There is no `top` property for `justify-content`. I search elsewhere and didn't found other occurrence.