### PR TITLE
[@mantine/hooks] use-local-storage: Fix event not called when remove …

### DIFF
--- a/src/mantine-hooks/src/use-local-storage/create-storage.ts
+++ b/src/mantine-hooks/src/use-local-storage/create-storage.ts
@@ -88,6 +88,7 @@ export function createStorage<T>(type: StorageType, hookName: string) {
 
     const removeStorageValue = useCallback(() => {
       window[type].removeItem(key);
+      window.dispatchEvent(new CustomEvent(eventName, { detail: { key, value: undefined } }));
     }, []);
 
     useWindowEvent('storage', (event) => {

--- a/src/mantine-hooks/src/use-local-storage/create-storage.ts
+++ b/src/mantine-hooks/src/use-local-storage/create-storage.ts
@@ -88,7 +88,7 @@ export function createStorage<T>(type: StorageType, hookName: string) {
 
     const removeStorageValue = useCallback(() => {
       window[type].removeItem(key);
-      window.dispatchEvent(new CustomEvent(eventName, { detail: { key, value: undefined } }));
+      window.dispatchEvent(new CustomEvent(eventName, { detail: { key, value: null } }));
     }, []);
 
     useWindowEvent('storage', (event) => {


### PR DESCRIPTION
fixes https://github.com/mantinedev/mantine/discussions/3279

it's related remove item will trigger no event on window caused localstorage just save string value. 
so we just need add custom event like setStorageValue does.

checked use-session-storage works normally.