### PR TITLE
[@mantine/dates] Fix openDropdownOnClear on DateRangePicker

### DIFF
--- a/src/mantine-dates/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/src/mantine-dates/src/components/DateRangePicker/DateRangePicker.tsx
@@ -176,9 +176,11 @@ export const DateRangePicker = forwardRef<HTMLInputElement, DateRangePickerProps
 
     const handleClear = () => {
       setValue([null, null]);
-      setDropdownOpened(true);
-      openDropdownOnClear && onDropdownOpen?.();
-      inputRef.current?.focus();
+      if (openDropdownOnClear) {
+        setDropdownOpened(true);
+        onDropdownOpen?.();
+        inputRef.current?.focus();
+      }
     };
 
     const handleDropdownToggle = (isOpened: boolean) => {


### PR DESCRIPTION
openDropdownOnClear would still open dropdown on DateRangePicker when set to false