### PR TITLE
[@mantine/modals] Fixed closeModal async logic

### DIFF
--- a/src/mantine-modals/src/ModalsProvider.tsx
+++ b/src/mantine-modals/src/ModalsProvider.tsx
@@ -122,11 +122,6 @@ export function ModalsProvider({ children, modalProps, labels, modals }: ModalsP
   };
 
   const closeModal = (id: string, canceled?: boolean) => {
-    if (state.modals.length <= 1) {
-      closeAll(canceled);
-      return;
-    }
-
     const modal = state.modals.find((item) => item.id === id);
     if (modal?.type === 'confirm' && canceled) {
       modal.props?.onCancel?.();

--- a/src/mantine-modals/src/reducer.ts
+++ b/src/mantine-modals/src/reducer.ts
@@ -31,9 +31,10 @@ export function modalsReducer(
       };
     }
     case 'CLOSE': {
+      const modals = state.modals.filter((m) => m.id !== action.payload);
       return {
-        current: state.modals[state.modals.length - 2] || null,
-        modals: state.modals.filter((m) => m.id !== action.payload),
+        current: modals[modals.length - 1],
+        modals,
       };
     }
     case 'CLOSE_ALL': {


### PR DESCRIPTION
Closes #3289

Made the logic simpler and not assume that the closed modal is the last in the stack.