### PR TITLE
[@mantine/core] InlineInput: Replace display inline-flex by flex

### DIFF
--- a/src/mantine-core/src/InlineInput/InlineInput.styles.ts
+++ b/src/mantine-core/src/InlineInput/InlineInput.styles.ts
@@ -17,7 +17,7 @@ export default createStyles((theme, { labelPosition, size }: InlineInputStylesPa
   root: {},
 
   body: {
-    display: 'inline-flex',
+    display: 'flex',
   },
 
   labelWrapper: {


### PR DESCRIPTION
The problem with `inline-flex` was only visible on `Switch`. Nothing changes on `Checkbox` and `Radio`. 

Let me know if I missed something.

closes #3295 