### PR TITLE
fix(hooks) : update `use-fullscreen`;

### DIFF
--- a/src/mantine-hooks/src/use-fullscreen/use-fullscreen.ts
+++ b/src/mantine-hooks/src/use-fullscreen/use-fullscreen.ts
@@ -29,6 +29,7 @@ async function enterFullScreen(element: HTMLElement) {
   return (
     _element.requestFullscreen?.() ||
     _element.msRequestFullscreen?.() ||
+     _element.webkitEnterFullscreen?.() ||
     _element.webkitRequestFullscreen?.() ||
     _element.mozRequestFullscreen?.()
   );


### PR DESCRIPTION
add `webkitEnterFullscreen` method on `enterFullScreen` function to support `ios devices`;