### PR TITLE
Revaluate initialValues

### DIFF
--- a/src/mantine-form/src/stories/Form.initialValuesReset.story.tsx
+++ b/src/mantine-form/src/stories/Form.initialValuesReset.story.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { TextInput, Code, Button, Group } from '@mantine/core';
+import { useForm } from '../use-form';
+
+export default { title: 'Form' };
+
+export function RevaluateInitialValues() {
+  const [initialValues, setInitialValues] = useState({
+    name: 'Mantine',
+  });
+  const form = useForm({
+    initialValues,
+    revaluateInitialValues: true,
+    validate: {
+      name: (value) => (value.length === 0 ? 'Required' : null),
+    },
+  });
+
+  const save = () => {};
+  const update = () => {
+    setInitialValues({
+      name: 'Form',
+    });
+    /* Previously done with setValues & resetDirty. Reset would still revert back to initial values */
+    // form.setValues({ name: 'Form' });
+    // form.resetDirty({ name: 'Form' });
+  };
+
+  return (
+    <form
+      style={{ padding: 40, maxWidth: 400, marginLeft: 'auto', marginRight: 'auto' }}
+      onSubmit={form.onSubmit(save)}
+      onReset={form.onReset}
+    >
+      <TextInput label="Name" {...form.getInputProps('name')} />
+
+      <Group mt="xl" mb="xl" position="right">
+        <Button type="reset" variant="default">
+          Reset
+        </Button>
+        <Button onClick={() => update()} variant="default">
+          Update
+        </Button>
+        <Button type="submit">Submit</Button>
+      </Group>
+
+      <div>Submitted values:</div>
+      <Code block mt={5}>
+        {`Is Dirty: ${JSON.stringify(form.isDirty(), null, 2)}`}
+      </Code>
+    </form>
+  );
+}

--- a/src/mantine-form/src/types.ts
+++ b/src/mantine-form/src/types.ts
@@ -120,6 +120,7 @@ export interface UseFormInput<
   clearInputErrorOnChange?: boolean;
   validateInputOnChange?: boolean | LooseKeys<Values>[];
   validateInputOnBlur?: boolean | LooseKeys<Values>[];
+  revaluateInitialValues?: boolean;
 }
 
 export interface UseFormReturnType<


### PR DESCRIPTION
Acts like enabled flag with `initialData` in react-query

This is useful when the `useForm` hook is used in react context in a shared parent component where initialValues are pulled from another hook. Revaluating the `initialValues` allows the form to reset gracefully to a new initial state.

This prevents race conditions triggered by attempting to use the below from outside of the form

```
useEffect(() => {
	form.setValues(myValues);
	form.resetDirty(myValues);
}, [myValues])
```

- [ ] Discuss `revaluateInitialValues` public API property with @rtivital
- [x] Storybook
- [ ] Unit test