### PR TITLE
Update NumberInput.demo.formatter.tsx

### DIFF
--- a/src/mantine-demos/src/demos/core/NumberInput/NumberInput.demo.formatter.tsx
+++ b/src/mantine-demos/src/demos/core/NumberInput/NumberInput.demo.formatter.tsx
@@ -13,7 +13,7 @@ function Demo() {
       parser={(value) => value.replace(/\\$\\s?|(,*)/g, '')}
       formatter={(value) =>
         !Number.isNaN(parseFloat(value))
-          ? \`$ \${value}\`.replace(/\\B(?=(\\d{3})+(?!\\d))/g, ',')
+          ? \`$ \${value}\`.replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",")
           : '$ '
       }
     />

--- a/src/mantine-demos/src/demos/core/NumberInput/NumberInput.demo.formatter.tsx
+++ b/src/mantine-demos/src/demos/core/NumberInput/NumberInput.demo.formatter.tsx
@@ -13,7 +13,7 @@ function Demo() {
       parser={(value) => value.replace(/\\$\\s?|(,*)/g, '')}
       formatter={(value) =>
         !Number.isNaN(parseFloat(value))
-          ? \`$ \${value}\`.replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",")
+          ? \`$ \${value}\`.replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',')
           : '$ '
       }
     />


### PR DESCRIPTION
This PR uses a Regexp that supports more than 3 decimals digits. The current Regexp adds ',' after the '.' (invalid math!), see this example of mine:

With the current Regexp example
![image](https://user-images.githubusercontent.com/28177550/212229644-933089ed-a12b-45f4-93c0-2f43171d5129.png)

With the StackOverflow Regexp
![image](https://user-images.githubusercontent.com/28177550/212229658-1cb7b994-4d01-484e-bbb4-0a0e4c19969b.png)

Source: https://stackoverflow.com/a/2901298 (last item)

I know it's just an example and it isn't required to be followed, but took me some time to understand the issue I was having and to find this improved regexp. Seems a good change to help other users in similar situations.