### PR TITLE
[@mantine/hooks] use-click-outside: Use capture phase

### DIFF
--- a/src/mantine-hooks/src/use-click-outside/use-click-outside.ts
+++ b/src/mantine-hooks/src/use-click-outside/use-click-outside.ts
@@ -23,7 +23,9 @@ export function useClickOutside<T extends HTMLElement = any>(
       }
     };
 
-    (events || DEFAULT_EVENTS).forEach((fn) => document.addEventListener(fn, listener));
+    (events || DEFAULT_EVENTS).forEach((fn) =>
+      document.addEventListener(fn, listener, { capture: true })
+    );
 
     return () => {
       (events || DEFAULT_EVENTS).forEach((fn) => document.removeEventListener(fn, listener));


### PR DESCRIPTION
This fixes https://github.com/mantinedev/mantine/issues/2867

I believe this fixes the general issue of recently rendered elements not being considered to be within the target ref in the use-click-outside hook.

Context:
https://github.com/facebook/react/issues/20325#issuecomment-852080269
https://reactjs.org/blog/2020/08/10/react-v17-rc.html#fixing-potential-issues

However this does fail a test (Popover.test.tsx:77:17):
```
  FAIL  src/mantine-core/src/Popover/Popover.test.tsx (5.324 s)

 RUNS  src/mantine-core/src/Select/Select.test.tsx
 RUNS  src/mantine-core/src/Autocomplete/Autocomplete.test.tsx
 RUNS  src/mantine-dates/src/components/DatePickerBase/DatePickerBase.test.tsx
 RUNS  src/mantine-core/src/Popover/Popover.test.tsx
  ● @mantine/core/component › supports controlled mode

    expect(jest.fn()).toHaveBeenCalledTimes(expected)

    Expected number of calls: 2
    Received number of calls: 3

      75 |
      76 |     await userEvent.click(document.body);
    > 77 |     expect(spy).toHaveBeenCalledTimes(2);
         |                 ^
      78 |     expect(spy).toHaveBeenLastCalledWith(false);
      79 |   });
      80 |

      at Object.<anonymous> (src/mantine-core/src/Popover/Popover.test.tsx:77:17)
```

But I'm not sure what the failure means so I would like feedback on that.