### PR TITLE
[@mantine/core] [docs] change dependency `@tabler/icons` to `@tabler/icons-react`

### DIFF
--- a/docs/src/components/HomePage/Components/Components.tsx
+++ b/docs/src/components/HomePage/Components/Components.tsx
@@ -6,7 +6,7 @@ import {
   IconBold,
   IconNotebook,
   IconSlideshow,
-} from '@tabler/icons';
+} from '@tabler/icons-react';
 import { Inputs } from './demos/Inputs';
 import { Dates } from './demos/Dates';
 import { Overlays } from './demos/Overlays';

--- a/docs/src/components/HomePage/Components/demos/Overlays.tsx
+++ b/docs/src/components/HomePage/Components/demos/Overlays.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { IconPhoto, IconMessageCircle, IconSettings } from '@tabler/icons';
+import { IconPhoto, IconMessageCircle, IconSettings } from '@tabler/icons-react';
 import {
   Text,
   Group,

--- a/docs/src/components/HomePage/Customize/Customize.tsx
+++ b/docs/src/components/HomePage/Customize/Customize.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'gatsby';
-import { IconArrowRight } from '@tabler/icons';
+import { IconArrowRight } from '@tabler/icons-react';
 import { Text, SimpleGrid, Slider, Button } from '@mantine/core';
 import { Prism } from '@mantine/prism';
 import { Slider as SliderStylesApi } from '@mantine/styles-api';

--- a/docs/src/components/HomePage/DarkTheme/DarkTheme.tsx
+++ b/docs/src/components/HomePage/DarkTheme/DarkTheme.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, Image, SimpleGrid, Text, useMantineColorScheme, Group } from '@mantine/core';
 import { Prism } from '@mantine/prism';
-import { IconMoonStars, IconSun } from '@tabler/icons';
+import { IconMoonStars, IconSun } from '@tabler/icons-react';
 import { PageSection } from '../PageSection/PageSection';
 import image from './dark-theme-image.png';
 import useStyles from './DarkTheme.styles';

--- a/docs/src/components/HomePage/DemoTabs/DemoTabs.tsx
+++ b/docs/src/components/HomePage/DemoTabs/DemoTabs.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from 'react';
 import { Container, Grid, UnstyledButton, Text } from '@mantine/core';
-import { IconForms } from '@tabler/icons';
+import { IconForms } from '@tabler/icons-react';
 import { useMediaQuery } from '@mantine/hooks';
 import { SectionTitle } from '../SectionTitle/SectionTitle';
 import useStyles from './DemoTabs.styles';

--- a/docs/src/components/HomePage/Hooks/Hooks.tsx
+++ b/docs/src/components/HomePage/Hooks/Hooks.tsx
@@ -8,7 +8,7 @@ import {
   IconLock,
   IconMaximize,
   IconResize,
-} from '@tabler/icons';
+} from '@tabler/icons-react';
 import { Demo } from '@mantine/ds';
 import { FormDemos, HooksDemos } from '@mantine/demos';
 import { DemoTabs } from '../DemoTabs/DemoTabs';

--- a/docs/src/components/HomePage/Jumbotron/features.ts
+++ b/docs/src/components/HomePage/Jumbotron/features.ts
@@ -1,4 +1,4 @@
-import { IconScale, IconRocket, IconLifebuoy } from '@tabler/icons';
+import { IconScale, IconRocket, IconLifebuoy } from '@tabler/icons-react';
 
 export const FEATURES_DATA = [
   {

--- a/docs/src/components/Layout/Header/HeaderDesktop.tsx
+++ b/docs/src/components/Layout/Header/HeaderDesktop.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-relative-packages */
 import React from 'react';
-import { IconChevronDown, IconExternalLink } from '@tabler/icons';
+import { IconChevronDown, IconExternalLink } from '@tabler/icons-react';
 import { Code, Menu, UnstyledButton, Text } from '@mantine/core';
 import { useSpotlight } from '@mantine/spotlight';
 import { HeaderControls } from '@mantine/ds';

--- a/docs/src/components/Layout/LayoutInner.tsx
+++ b/docs/src/components/Layout/LayoutInner.tsx
@@ -5,7 +5,7 @@ import { NotificationsProvider } from '@mantine/notifications';
 import { ModalsProvider, ContextModalProps } from '@mantine/modals';
 import { SpotlightProvider, SpotlightAction } from '@mantine/spotlight';
 import { Text, Button } from '@mantine/core';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 import MdxProvider from '../MdxPage/MdxProvider/MdxProvider';
 import Navbar from './Navbar/Navbar';
 import Header from './Header/Header';

--- a/docs/src/components/Layout/Navbar/NavbarDocsCategory/NavbarDocsCategory.tsx
+++ b/docs/src/components/Layout/Navbar/NavbarDocsCategory/NavbarDocsCategory.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Link } from 'gatsby';
-import { IconChevronDown } from '@tabler/icons';
+import { IconChevronDown } from '@tabler/icons-react';
 import { Text } from '@mantine/core';
 import { useLocation } from '@reach/router';
 import { getDocsData } from '../../get-docs-data';

--- a/docs/src/components/Layout/Navbar/main-links.tsx
+++ b/docs/src/components/Layout/Navbar/main-links.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DEFAULT_THEME } from '@mantine/core';
-import { IconCode, IconStar, IconRocket } from '@tabler/icons';
+import { IconCode, IconStar, IconRocket } from '@tabler/icons-react';
 import { MantineLogo } from '@mantine/ds';
 
 export default [

--- a/docs/src/components/MdxPage/MdxPageHeader/MdxPageHeader.tsx
+++ b/docs/src/components/MdxPage/MdxPageHeader/MdxPageHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Title, Text, Badge } from '@mantine/core';
 import { GithubIcon, NpmIcon } from '@mantine/ds';
-import { IconPencil, IconLicense, IconCalendar } from '@tabler/icons';
+import { IconPencil, IconLicense, IconCalendar } from '@tabler/icons-react';
 import { Link } from 'gatsby';
 import { ImportStatement } from './ImportStatement/ImportStatement';
 import { LinkItem } from './LinkItem/LinkItem';

--- a/docs/src/components/MdxPage/MdxPageTabs/MdxPageTabs.tsx
+++ b/docs/src/components/MdxPage/MdxPageTabs/MdxPageTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useLocation } from '@reach/router';
 import { navigate } from 'gatsby';
 import { Tabs, Title, TextInput } from '@mantine/core';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 import { useMediaQuery } from '@mantine/hooks';
 import { MDXRenderer } from 'gatsby-plugin-mdx';
 import { MdxSiblings } from '../MdxSiblings/MdxSiblings';

--- a/docs/src/components/MdxPage/MdxPageTabs/StylesApi/StylesApi.tsx
+++ b/docs/src/components/MdxPage/MdxPageTabs/StylesApi/StylesApi.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Group } from '@mantine/core';
-import { IconArrowRight } from '@tabler/icons';
+import { IconArrowRight } from '@tabler/icons-react';
 import GatsbyLink from '../../MdxProvider/GatsbyLink/GatsbyLink';
 import { StylesApiItem } from './StylesApiItem/StylesApiItem';
 

--- a/docs/src/components/MdxPage/MdxSiblings/MdxSibling/MdxSibling.tsx
+++ b/docs/src/components/MdxPage/MdxSiblings/MdxSibling/MdxSibling.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'gatsby';
 import { Text } from '@mantine/core';
 import { upperFirst } from '@mantine/hooks';
-import { IconArrowLeft, IconArrowRight } from '@tabler/icons';
+import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react';
 import { Frontmatter } from '../../../../types';
 import useStyles from './MdxSibling.styles';
 

--- a/docs/src/components/MdxPage/TableOfContents/TableOfContents.tsx
+++ b/docs/src/components/MdxPage/TableOfContents/TableOfContents.tsx
@@ -3,7 +3,7 @@ import Slugger from 'github-slugger';
 import { navigate } from 'gatsby';
 import { useLocation } from '@reach/router';
 import { Text, ScrollArea, useMantineTheme } from '@mantine/core';
-import { IconList } from '@tabler/icons';
+import { IconList } from '@tabler/icons-react';
 import useStyles from './TableOfContents.styles';
 
 interface Heading {

--- a/docs/src/components/NextSteps/data.ts
+++ b/docs/src/components/NextSteps/data.ts
@@ -1,4 +1,4 @@
-import { IconStar, IconPalette, IconCode } from '@tabler/icons';
+import { IconStar, IconPalette, IconCode } from '@tabler/icons-react';
 
 export const NEXT_STEPS_DATA = [
   {

--- a/docs/src/components/PackagesInstallation/data.ts
+++ b/docs/src/components/PackagesInstallation/data.ts
@@ -36,7 +36,7 @@ export const PACKAGES_DATA = [
       '@mantine/hooks',
       '@mantine/core',
       '@mantine/tiptap',
-      '@tabler/icons',
+      '@tabler/icons-react',
       '@tiptap/react',
       '@tiptap/extension-link',
       '@tiptap/starter-kit',

--- a/docs/src/docs/hooks/use-local-storage.mdx
+++ b/docs/src/docs/hooks/use-local-storage.mdx
@@ -38,7 +38,7 @@ Mantine docs website uses this hook to store color scheme information:
 ```tsx
 import { useLocalStorage } from '@mantine/hooks';
 import { ActionIcon, ColorScheme } from '@mantine/core';
-import { IconSun, IconMoonStars } from '@tabler/icons';
+import { IconSun, IconMoonStars } from '@tabler/icons-react';
 
 function ColorSchemeToggle() {
   const [colorScheme, setColorScheme] = useLocalStorage<ColorScheme>({

--- a/docs/src/docs/others/notifications.mdx
+++ b/docs/src/docs/others/notifications.mdx
@@ -90,7 +90,7 @@ Notification state item can have these properties:
 All properties except **message** are optional.
 
 ```tsx
-import { IconX } from '@tabler/icons';
+import { IconX } from '@tabler/icons-react';
 import { showNotification } from '@mantine/notifications';
 
 // Bare minimum – message is required for all notifications

--- a/docs/src/docs/others/tiptap.mdx
+++ b/docs/src/docs/others/tiptap.mdx
@@ -21,13 +21,13 @@ import { TipTapDemos } from '@mantine/demos';
 Install with yarn:
 
 ```bash
-yarn add @mantine/tiptap @mantine/core @mantine/hooks @tabler/icons @tiptap/react @tiptap/extension-link @tiptap/starter-kit
+yarn add @mantine/tiptap @mantine/core @mantine/hooks @tabler/icons-react @tiptap/react @tiptap/extension-link @tiptap/starter-kit
 ```
 
 Install with npm:
 
 ```bash
-npm install @mantine/tiptap @mantine/core @mantine/hooks @tabler/icons @tiptap/react @tiptap/extension-link @tiptap/starter-kit
+npm install @mantine/tiptap @mantine/core @mantine/hooks @tabler/icons-react @tiptap/react @tiptap/extension-link @tiptap/starter-kit
 ```
 
 ## TipTap editor

--- a/docs/src/settings/mantine-core.ts
+++ b/docs/src/settings/mantine-core.ts
@@ -8,7 +8,7 @@ import {
   IconLetterCase,
   IconSpeakerphone,
   IconComponents,
-} from '@tabler/icons';
+} from '@tabler/icons-react';
 import { Category } from './types';
 
 export const MANTINE_CORE_ORDER = [

--- a/docs/src/settings/mantine-hooks.ts
+++ b/docs/src/settings/mantine-hooks.ts
@@ -1,4 +1,4 @@
-import { IconRefresh, IconBulb, IconForms, IconBox } from '@tabler/icons';
+import { IconRefresh, IconBulb, IconForms, IconBox } from '@tabler/icons-react';
 import { Category } from './types';
 
 export const MANTINE_HOOKS_ORDER = ['state', 'dom', 'utils', 'lifecycle'] as const;

--- a/docs/src/settings/types.ts
+++ b/docs/src/settings/types.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Icon2fa } from '@tabler/icons';
+import { Icon2fa } from '@tabler/icons-react';
 
 export interface Category {
   title: string;

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "@emotion/styled": "^11.10.0",
     "@floating-ui/react-dom-interactions": "^0.10.1",
     "@radix-ui/react-scroll-area": "1.0.2",
-    "@tabler/icons": "^1.68.0",
+    "@tabler/icons-react": "^2.0.0",
     "@tiptap/extension-code-block-lowlight": "^2.0.0-beta.202",
     "@tiptap/extension-color": "^2.0.0-beta.202",
     "@tiptap/extension-highlight": "^2.0.0-beta.202",

--- a/src/mantine-core/src/Accordion/Accordion.story.tsx
+++ b/src/mantine-core/src/Accordion/Accordion.story.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { IconPictureInPicture } from '@tabler/icons';
+import { IconPictureInPicture } from '@tabler/icons-react';
 import { Accordion } from './Accordion';
 
 export default { title: 'Accordion' };

--- a/src/mantine-core/src/Button/Button.story.tsx
+++ b/src/mantine-core/src/Button/Button.story.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties } from 'react';
 import { MANTINE_COLORS, useMantineTheme } from '@mantine/styles';
-import { IconExternalLink } from '@tabler/icons';
+import { IconExternalLink } from '@tabler/icons-react';
 import { Button } from './Button';
 import { Group } from '../Group';
 import { Center } from '../Center';

--- a/src/mantine-core/src/Input/Input.story.tsx
+++ b/src/mantine-core/src/Input/Input.story.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDisclosure } from '@mantine/hooks';
 import { storiesOf } from '@storybook/react';
 import { MANTINE_SIZES } from '@mantine/styles';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 import Textarea from 'react-textarea-autosize';
 import { ActionIcon } from '../ActionIcon/ActionIcon';
 import { Input } from './Input';

--- a/src/mantine-core/src/Menu/Menu.story.tsx
+++ b/src/mantine-core/src/Menu/Menu.story.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { IconTable, IconSearch } from '@tabler/icons';
+import { IconTable, IconSearch } from '@tabler/icons-react';
 import { WithinOverlays } from '@mantine/storybook';
 import { Menu } from './Menu';
 import { Button } from '../Button';

--- a/src/mantine-core/src/NavLink/NavLink.story.tsx
+++ b/src/mantine-core/src/NavLink/NavLink.story.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconHome2, IconChevronRight } from '@tabler/icons';
+import { IconHome2, IconChevronRight } from '@tabler/icons-react';
 import { useCounter } from '@mantine/hooks';
 import { Button } from '../Button';
 import { NavLink } from './NavLink';

--- a/src/mantine-core/src/Notification/Notification.story.tsx
+++ b/src/mantine-core/src/Notification/Notification.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { IconMoodSmile, IconCheck, IconX, IconExclamationMark, IconBookmark } from '@tabler/icons';
+import { IconMoodSmile, IconCheck, IconX, IconExclamationMark, IconBookmark } from '@tabler/icons-react';
 import { Notification } from './Notification';
 
 const demo = (

--- a/src/mantine-core/src/Rating/Rating.story.tsx
+++ b/src/mantine-core/src/Rating/Rating.story.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { IconMoon } from '@tabler/icons';
+import { IconMoon } from '@tabler/icons-react';
 import { Stack } from '../Stack';
 import { Rating } from './Rating';
 import { Box } from '../Box';

--- a/src/mantine-core/src/Switch/Switch.story.tsx
+++ b/src/mantine-core/src/Switch/Switch.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MantineProvider } from '@mantine/styles';
-import { IconBadge } from '@tabler/icons';
+import { IconBadge } from '@tabler/icons-react';
 import { Group } from '../Group';
 import { Switch } from './Switch';
 import { Stack } from '../Stack';

--- a/src/mantine-core/src/Switch/Switch.test.tsx
+++ b/src/mantine-core/src/Switch/Switch.test.tsx
@@ -8,7 +8,7 @@ import {
   itSupportsWrapperProps,
   itSupportsFocusEvents,
 } from '@mantine/tests';
-import { IconCrown } from '@tabler/icons';
+import { IconCrown } from '@tabler/icons-react';
 import { Switch, SwitchProps } from './Switch';
 
 const defaultProps: SwitchProps = {

--- a/src/mantine-core/src/Tabs/Tabs.story.tsx
+++ b/src/mantine-core/src/Tabs/Tabs.story.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { IconPackage } from '@tabler/icons';
+import { IconPackage } from '@tabler/icons-react';
 import { MantineProvider } from '@mantine/styles';
 import { Tabs, TabsProps } from './Tabs';
 import { Badge } from '../Badge';

--- a/src/mantine-demos/package.json
+++ b/src/mantine-demos/package.json
@@ -49,7 +49,7 @@
     "@mantine/spotlight": "5.10.1",
     "@mantine/carousel": "5.10.1",
     "@mantine/ds": "5.10.1",
-    "@tabler/icons": "*",
+    "@tabler/icons-react": "^2.0.0",
     "react-beautiful-dnd": "*",
     "embla-carousel-autoplay": "*",
     "react-input-mask": "*",

--- a/src/mantine-demos/src/demos/carousel/Carousel.demo.icons.tsx
+++ b/src/mantine-demos/src/demos/carousel/Carousel.demo.icons.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Carousel } from '@mantine/carousel';
-import { IconArrowRight, IconArrowLeft } from '@tabler/icons';
+import { IconArrowRight, IconArrowLeft } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Slides } from './_slides';
 
 const code = `
 import { Carousel } from '@mantine/carousel';
-import { IconArrowRight, IconArrowLeft } from '@tabler/icons';
+import { IconArrowRight, IconArrowLeft } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Accordion/Accordion.demo.chevron.tsx
+++ b/src/mantine-demos/src/demos/core/Accordion/Accordion.demo.chevron.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconPlus } from '@tabler/icons';
+import { IconPlus } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { BaseDemo } from './_base';
 
 const code = `
 import { Accordion } from '@mantine/core';
-import { IconPlus } from '@tabler/icons';
+import { IconPlus } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Accordion/Accordion.demo.icons.tsx
+++ b/src/mantine-demos/src/demos/core/Accordion/Accordion.demo.icons.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { IconPhoto, IconPrinter, IconCameraSelfie } from '@tabler/icons';
+import { IconPhoto, IconPrinter, IconCameraSelfie } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Accordion, AccordionProps, useMantineTheme } from '@mantine/core';
 
 const code = `
-import { IconPhoto, IconPrinter, IconCameraSelfie } from '@tabler/icons';
+import { IconPhoto, IconPrinter, IconCameraSelfie } from '@tabler/icons-react';
 import { Accordion, useMantineTheme } from '@mantine/core';
 
 function Demo() {

--- a/src/mantine-demos/src/demos/core/Accordion/Accordion.demo.sideControls.tsx
+++ b/src/mantine-demos/src/demos/core/Accordion/Accordion.demo.sideControls.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Accordion, ActionIcon, AccordionControlProps, Box } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
-import { IconDots } from '@tabler/icons';
+import { IconDots } from '@tabler/icons-react';
 
 const code = `
 import { Accordion, ActionIcon, AccordionControlProps, Box } from '@mantine/core';
-import { IconDots } from '@tabler/icons';
+import { IconDots } from '@tabler/icons-react';
 
 function AccordionControl(props: AccordionControlProps) {
   return (

--- a/src/mantine-demos/src/demos/core/ActionIcon/ActionIcon.demo.colors.tsx
+++ b/src/mantine-demos/src/demos/core/ActionIcon/ActionIcon.demo.colors.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconSun } from '@tabler/icons';
+import { IconSun } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Group, MANTINE_COLORS, ActionIcon, ActionIconProps } from '@mantine/core';
 

--- a/src/mantine-demos/src/demos/core/ActionIcon/ActionIcon.demo.configurator.tsx
+++ b/src/mantine-demos/src/demos/core/ActionIcon/ActionIcon.demo.configurator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconAdjustments } from '@tabler/icons';
+import { IconAdjustments } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { ActionIcon, ActionIconProps, Group } from '@mantine/core';
 
@@ -44,7 +44,7 @@ const codeTemplate = (props: string) => {
   const childIconSizeProp = computeChildIconSizeProp(props);
   return `
 import { ActionIcon } from '@mantine/core';
-import { IconAdjustments } from '@tabler/icons';
+import { IconAdjustments } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/ActionIcon/ActionIcon.demo.gradient.tsx
+++ b/src/mantine-demos/src/demos/core/ActionIcon/ActionIcon.demo.gradient.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ActionIcon, Group } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
-import { IconSun } from '@tabler/icons';
+import { IconSun } from '@tabler/icons-react';
 
 const code = `
 import { ActionIcon, Group } from '@mantine/core';

--- a/src/mantine-demos/src/demos/core/ActionIcon/ActionIcon.demo.variants.tsx
+++ b/src/mantine-demos/src/demos/core/ActionIcon/ActionIcon.demo.variants.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconSettings } from '@tabler/icons';
+import { IconSettings } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { ActionIcon, Group } from '@mantine/core';
 
 const code = `
 import { ActionIcon } from '@mantine/core';
-import { IconSettings } from '@tabler/icons';
+import { IconSettings } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Affix/Affix.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/core/Affix/Affix.demo.usage.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconArrowUp } from '@tabler/icons';
+import { IconArrowUp } from '@tabler/icons-react';
 import { useWindowScroll } from '@mantine/hooks';
 import { MantineDemo } from '@mantine/ds';
 import { Button, Text, Transition, Affix } from '@mantine/core';
 
 const code = `
-import { IconArrowUp } from '@tabler/icons';
+import { IconArrowUp } from '@tabler/icons-react';
 import { useWindowScroll } from '@mantine/hooks';
 import { Affix, Button, Text, Transition } from '@mantine/core';
 

--- a/src/mantine-demos/src/demos/core/Alert/Alert.demo.configurator.tsx
+++ b/src/mantine-demos/src/demos/core/Alert/Alert.demo.configurator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconAlertCircle } from '@tabler/icons';
+import { IconAlertCircle } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Alert } from '@mantine/core';
 
@@ -13,7 +13,7 @@ function Wrapper(props: React.ComponentPropsWithoutRef<typeof Alert>) {
 
 const codeTemplate = (props: string, children: string) => `
 import { Alert } from '@mantine/core';
-import { IconAlertCircle } from '@tabler/icons';
+import { IconAlertCircle } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/AppShell/AppShell.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/core/AppShell/AppShell.demo.usage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconSun, IconMoonStars } from '@tabler/icons';
+import { IconSun, IconMoonStars } from '@tabler/icons-react';
 import { AppShell, Navbar, Header, Group, ActionIcon, useMantineColorScheme } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
 import { MainLinks } from './_mainLinks';

--- a/src/mantine-demos/src/demos/core/AppShell/_brand.tsx
+++ b/src/mantine-demos/src/demos/core/AppShell/_brand.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Group, ActionIcon, useMantineColorScheme, Box } from '@mantine/core';
-import { IconSun, IconMoonStars } from '@tabler/icons';
+import { IconSun, IconMoonStars } from '@tabler/icons-react';
 import { Logo } from './_logo';
 
 export function Brand() {

--- a/src/mantine-demos/src/demos/core/AppShell/_mainLinks.tsx
+++ b/src/mantine-demos/src/demos/core/AppShell/_mainLinks.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconGitPullRequest, IconAlertCircle, IconMessages, IconDatabase } from '@tabler/icons';
+import { IconGitPullRequest, IconAlertCircle, IconMessages, IconDatabase } from '@tabler/icons-react';
 import { ThemeIcon, UnstyledButton, Group, Text } from '@mantine/core';
 
 interface MainLinkProps {

--- a/src/mantine-demos/src/demos/core/AppShell/_user.tsx
+++ b/src/mantine-demos/src/demos/core/AppShell/_user.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconChevronRight, IconChevronLeft } from '@tabler/icons';
+import { IconChevronRight, IconChevronLeft } from '@tabler/icons-react';
 import { UnstyledButton, Group, Avatar, Text, Box, useMantineTheme } from '@mantine/core';
 
 export function User() {

--- a/src/mantine-demos/src/demos/core/Autocomplete/Autocomplete.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/core/Autocomplete/Autocomplete.demo.icon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconHash } from '@tabler/icons';
+import { IconHash } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Autocomplete } from '@mantine/core';
 
 const code = `
 import { Autocomplete } from '@mantine/core';
-import { IconHash } from '@tabler/icons';
+import { IconHash } from '@tabler/icons-react';
 
 function Demo() {
   return <Autocomplete icon={<IconHash />} data={['React', 'Angular', 'Svelte', 'Vue']} />;

--- a/src/mantine-demos/src/demos/core/Avatar/Avatar.demo.gradient.tsx
+++ b/src/mantine-demos/src/demos/core/Avatar/Avatar.demo.gradient.tsx
@@ -3,7 +3,7 @@ import { MantineDemo } from '@mantine/ds';
 import { Avatar, Group } from '@mantine/core';
 
 const code = `
-import { IconPhoto } from '@tabler/icons';
+import { IconPhoto } from '@tabler/icons-react';
 import { Avatar, Group } from '@mantine/core';
 
 function Demo() {

--- a/src/mantine-demos/src/demos/core/Avatar/Avatar.demo.placeholders.tsx
+++ b/src/mantine-demos/src/demos/core/Avatar/Avatar.demo.placeholders.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconStar } from '@tabler/icons';
+import { IconStar } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Avatar, Group } from '@mantine/core';
 
 const code = `
 import { Avatar } from '@mantine/core';
-import { IconStar } from '@tabler/icons';
+import { IconStar } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Avatar/Avatar.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/core/Avatar/Avatar.demo.usage.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { IconStar } from '@tabler/icons';
+import { IconStar } from '@tabler/icons-react';
 import { Avatar, Group } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
 import { avatars } from './_mockdata';
 
 const code = `
 import { Avatar } from '@mantine/core';
-import { IconStar } from '@tabler/icons';
+import { IconStar } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Badge/Badge.demo.sections.tsx
+++ b/src/mantine-demos/src/demos/core/Badge/Badge.demo.sections.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconX } from '@tabler/icons';
+import { IconX } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Group, Badge, ActionIcon, Avatar } from '@mantine/core';
 
 const code = `
 import { ActionIcon, Avatar, Badge, Group } from '@mantine/core';
-import { IconX } from '@tabler/icons';
+import { IconX } from '@tabler/icons-react';
 
 function Demo() {
   const avatar = (

--- a/src/mantine-demos/src/demos/core/Blockquote/Blockquote.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/core/Blockquote/Blockquote.demo.icon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconFlame } from '@tabler/icons';
+import { IconFlame } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Blockquote } from '@mantine/core';
 
 const code = `
 import { Blockquote } from '@mantine/core';
-import { IconFlame } from '@tabler/icons';
+import { IconFlame } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Button/Button.demo.component.tsx
+++ b/src/mantine-demos/src/demos/core/Button/Button.demo.component.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconExternalLink } from '@tabler/icons';
+import { IconExternalLink } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Button, Group } from '@mantine/core';
 
 const code = `
 import { Button } from '@mantine/core';
-import { IconExternalLink } from '@tabler/icons';
+import { IconExternalLink } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Button/Button.demo.customize.tsx
+++ b/src/mantine-demos/src/demos/core/Button/Button.demo.customize.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconBrandTwitter } from '@tabler/icons';
+import { IconBrandTwitter } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Button, Group } from '@mantine/core';
 
 const code = `
 import { Button } from '@mantine/core';
-import { IconBrandTwitter } from '@tabler/icons';
+import { IconBrandTwitter } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Button/Button.demo.loadingConfigurator.tsx
+++ b/src/mantine-demos/src/demos/core/Button/Button.demo.loadingConfigurator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconDatabase } from '@tabler/icons';
+import { IconDatabase } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Button, Group, ButtonProps } from '@mantine/core';
 
@@ -14,7 +14,7 @@ function Wrapper(props: ButtonProps) {
 }
 
 const codeTemplate = (props: string) => `
-import { IconDatabase } from '@tabler/icons';
+import { IconDatabase } from '@tabler/icons-react';
 import { Button } from '@mantine/core';
 
 function Demo() {

--- a/src/mantine-demos/src/demos/core/Button/Button.demo.whiteConfigurator.tsx
+++ b/src/mantine-demos/src/demos/core/Button/Button.demo.whiteConfigurator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconDatabase } from '@tabler/icons';
+import { IconDatabase } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { DEFAULT_THEME, Button, Group, ButtonProps } from '@mantine/core';
 
@@ -15,7 +15,7 @@ function Wrapper(props: ButtonProps) {
 
 const codeTemplate = (props: string) => `
 import { Button } from '@mantine/core';
-import { IconDatabase } from '@tabler/icons';
+import { IconDatabase } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Card/Card.demo.section.tsx
+++ b/src/mantine-demos/src/demos/core/Card/Card.demo.section.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Card, Group, Text, Menu, ActionIcon, Image, SimpleGrid } from '@mantine/core';
-import { IconDots, IconEye, IconFileZip, IconTrash } from '@tabler/icons';
+import { IconDots, IconEye, IconFileZip, IconTrash } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { demoBase } from './_demo-base';
 
 const code = `
 import { Card, Group, Text, Menu, ActionIcon, Image, SimpleGrid } from '@mantine/core';
-import { IconDots, IconEye, IconFileZip, IconTrash } from '@tabler/icons';
+import { IconDots, IconEye, IconFileZip, IconTrash } from '@tabler/icons-react';
 
 const images = [
   'https://images.unsplash.com/photo-1449824913935-59a10b8d2000?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=250&q=80',

--- a/src/mantine-demos/src/demos/core/Center/Center.demo.inline.tsx
+++ b/src/mantine-demos/src/demos/core/Center/Center.demo.inline.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconArrowLeft, IconArrowRight } from '@tabler/icons';
+import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Center, useMantineTheme, Anchor, Box } from '@mantine/core';
 
 const code = `
 import { Center, Anchor, Box } from '@mantine/core';
-import { IconArrowLeft } from '@tabler/icons';
+import { IconArrowLeft } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Checkbox/Checkbox.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/core/Checkbox/Checkbox.demo.icon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconBiohazard, IconRadioactive } from '@tabler/icons';
+import { IconBiohazard, IconRadioactive } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Checkbox, CheckboxProps } from '@mantine/core';
 
 const code = `
 import { Checkbox, CheckboxProps } from '@mantine/core';
-import { IconBiohazard, IconRadioactive } from '@tabler/icons';
+import { IconBiohazard, IconRadioactive } from '@tabler/icons-react';
 
 const CheckboxIcon: CheckboxProps['icon'] = ({ indeterminate, className }) =>
   indeterminate ? <IconRadioactive className={className} /> : <IconBiohazard className={className} />;

--- a/src/mantine-demos/src/demos/core/ColorInput/ColorInput.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/core/ColorInput/ColorInput.demo.icon.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { IconPaint } from '@tabler/icons';
+import { IconPaint } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { ColorInput } from '@mantine/core';
 
 const code = `
-import { IconPaint } from '@tabler/icons';
+import { IconPaint } from '@tabler/icons-react';
 import { ColorInput } from '@mantine/core';
 
 function Demo() {

--- a/src/mantine-demos/src/demos/core/ColorInput/ColorInput.demo.rightSection.tsx
+++ b/src/mantine-demos/src/demos/core/ColorInput/ColorInput.demo.rightSection.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { IconRefresh } from '@tabler/icons';
+import { IconRefresh } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { ActionIcon, ColorInput } from '@mantine/core';
 
 const code = `
 import { useState } from 'react';
-import { IconRefresh } from '@tabler/icons';
+import { IconRefresh } from '@tabler/icons-react';
 import { ActionIcon, ColorInput } from '@mantine/core';
 
 const randomColor = () => \`#\${Math.floor(Math.random() * 16777215).toString(16)}\`;

--- a/src/mantine-demos/src/demos/core/CopyButton/CopyButton.demo.tooltip.tsx
+++ b/src/mantine-demos/src/demos/core/CopyButton/CopyButton.demo.tooltip.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Group, CopyButton, ActionIcon, Tooltip } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
-import { IconCopy, IconCheck } from '@tabler/icons';
+import { IconCopy, IconCheck } from '@tabler/icons-react';
 
 const code = `
 import { CopyButton, ActionIcon, Tooltip } from '@mantine/core';
-import { IconCopy, IconCheck } from '@tabler/icons';
+import { IconCopy, IconCheck } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Divider/Divider.demo.labels.tsx
+++ b/src/mantine-demos/src/demos/core/Divider/Divider.demo.labels.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Divider, Box } from '@mantine/core';
 
 const code = `
 import { Divider, Box } from '@mantine/core';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/FileInput/FileInput.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/core/FileInput/FileInput.demo.icon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconUpload } from '@tabler/icons';
+import { IconUpload } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { FileInput } from '@mantine/core';
 
 const code = `
 import { FileInput } from '@mantine/core';
-import { IconUpload } from '@tabler/icons';
+import { IconUpload } from '@tabler/icons-react';
 
 function Demo() {
   return <FileInput label="Your resume" placeholder="Your resume" icon={<IconUpload size={14} />} />;

--- a/src/mantine-demos/src/demos/core/FileInput/FileInput.demo.valueComponent.tsx
+++ b/src/mantine-demos/src/demos/core/FileInput/FileInput.demo.valueComponent.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { FileInput, FileInputProps, Group, Center } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
-import { IconPhoto } from '@tabler/icons';
+import { IconPhoto } from '@tabler/icons-react';
 
 const code = `
 import { FileInput, FileInputProps, Group, Center } from '@mantine/core';
-import { IconPhoto } from '@tabler/icons';
+import { IconPhoto } from '@tabler/icons-react';
 
 function Value({ file }: { file: File }) {
   return (

--- a/src/mantine-demos/src/demos/core/Input/Input.demo.component.tsx
+++ b/src/mantine-demos/src/demos/core/Input/Input.demo.component.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconChevronDown } from '@tabler/icons';
+import { IconChevronDown } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Input } from '@mantine/core';
 
 const code = `
 import { Input } from '@mantine/core';
-import { IconChevronDown } from '@tabler/icons';
+import { IconChevronDown } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Input/Input.demo.configurator.tsx
+++ b/src/mantine-demos/src/demos/core/Input/Input.demo.configurator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconAt } from '@tabler/icons';
+import { IconAt } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Input, InputProps } from '@mantine/core';
 
@@ -17,7 +17,7 @@ function Wrapper(props: InputProps) {
 
 const codeTemplate = (props: string) => `
 import { Input } from '@mantine/core';
-import { IconAt } from '@tabler/icons';
+import { IconAt } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Input/Input.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/core/Input/Input.demo.icon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconBrandTwitter, IconAlertCircle } from '@tabler/icons';
+import { IconBrandTwitter, IconAlertCircle } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Input, Tooltip } from '@mantine/core';
 
 const code = `
 import { Input, Tooltip } from '@mantine/core';
-import { IconBrandTwitter, IconAlertCircle } from '@tabler/icons';
+import { IconBrandTwitter, IconAlertCircle } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Kbd/Kbd.demo.input.tsx
+++ b/src/mantine-demos/src/demos/core/Kbd/Kbd.demo.input.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Kbd, TextInput } from '@mantine/core';
 
 const code = `
 import { Kbd, TextInput } from '@mantine/core';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 
 function Demo() {
   const rightSection = (

--- a/src/mantine-demos/src/demos/core/List/List.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/core/List/List.demo.icon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconCircleCheck, IconCircleDashed } from '@tabler/icons';
+import { IconCircleCheck, IconCircleDashed } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { ThemeIcon, List } from '@mantine/core';
 
 const code = `
 import { List, ThemeIcon } from '@mantine/core';
-import { IconCircleCheck, IconCircleDashed } from '@tabler/icons';
+import { IconCircleCheck, IconCircleDashed } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Menu/Menu.demo.component.tsx
+++ b/src/mantine-demos/src/demos/core/Menu/Menu.demo.component.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconExternalLink } from '@tabler/icons';
+import { IconExternalLink } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Menu, Group, Button } from '@mantine/core';
 
 const code = `
 import { Menu, Button } from '@mantine/core';
-import { IconExternalLink } from '@tabler/icons';
+import { IconExternalLink } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Menu/Menu.demo.customControl.tsx
+++ b/src/mantine-demos/src/demos/core/Menu/Menu.demo.customControl.tsx
@@ -1,12 +1,12 @@
 import React, { forwardRef } from 'react';
-import { IconChevronRight } from '@tabler/icons';
+import { IconChevronRight } from '@tabler/icons-react';
 import { Group, Avatar, Text, UnstyledButton, Menu } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
 import { DemoMenuItems } from './_menu-items';
 
 const code = `
 import { forwardRef } from 'react';
-import { IconChevronRight } from '@tabler/icons';
+import { IconChevronRight } from '@tabler/icons-react';
 import { Group, Avatar, Text, Menu, UnstyledButton } from '@mantine/core';
 
 interface UserButtonProps extends React.ComponentPropsWithoutRef<'button'> {

--- a/src/mantine-demos/src/demos/core/Menu/Menu.demo.disabled.tsx
+++ b/src/mantine-demos/src/demos/core/Menu/Menu.demo.disabled.tsx
@@ -8,11 +8,11 @@ import {
   IconMessageCircle,
   IconTrash,
   IconArrowsLeftRight,
-} from '@tabler/icons';
+} from '@tabler/icons-react';
 
 const code = `
 import { Menu, Button } from '@mantine/core';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Menu/Menu.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/core/Menu/Menu.demo.usage.tsx
@@ -5,7 +5,7 @@ import { DemoMenuItems } from './_menu-items';
 
 const code = `
 import { Menu, Button, Text } from '@mantine/core';
-import { IconSettings, IconSearch, IconPhoto, IconMessageCircle, IconTrash, IconArrowsLeftRight } from '@tabler/icons';
+import { IconSettings, IconSearch, IconPhoto, IconMessageCircle, IconTrash, IconArrowsLeftRight } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Menu/_menu-items.tsx
+++ b/src/mantine-demos/src/demos/core/Menu/_menu-items.tsx
@@ -6,7 +6,7 @@ import {
   IconMessageCircle,
   IconTrash,
   IconArrowsLeftRight,
-} from '@tabler/icons';
+} from '@tabler/icons-react';
 import { Menu, Text, Button } from '@mantine/core';
 
 export function DemoMenuItems({ widthRightSection = true, withTarget = true }) {

--- a/src/mantine-demos/src/demos/core/MultiSelect/MultiSelect.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/core/MultiSelect/MultiSelect.demo.icon.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { IconHash } from '@tabler/icons';
+import { IconHash } from '@tabler/icons-react';
 import { MultiSelect } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
 import { data } from './_data';
 
 const code = `
 import { MultiSelect } from '@mantine/core';
-import { IconHash } from '@tabler/icons';
+import { IconHash } from '@tabler/icons-react';
 
 function Demo() {
   return <MultiSelect icon={<IconHash />} />;

--- a/src/mantine-demos/src/demos/core/MultiSelect/MultiSelect.demo.rightSection.tsx
+++ b/src/mantine-demos/src/demos/core/MultiSelect/MultiSelect.demo.rightSection.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { IconChevronDown } from '@tabler/icons';
+import { IconChevronDown } from '@tabler/icons-react';
 import { MultiSelect } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
 import { data } from './_data';
 
 const code = `
 import { MultiSelect } from '@mantine/core';
-import { IconChevronDown } from '@tabler/icons';
+import { IconChevronDown } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/NativeSelect/NativeSelect.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/core/NativeSelect/NativeSelect.demo.icon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconHash } from '@tabler/icons';
+import { IconHash } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { NativeSelect } from '@mantine/core';
 
 const code = `
 import { NativeSelect } from '@mantine/core';
-import { IconHash } from '@tabler/icons';
+import { IconHash } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/NativeSelect/NativeSelect.demo.rightSection.tsx
+++ b/src/mantine-demos/src/demos/core/NativeSelect/NativeSelect.demo.rightSection.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconChevronDown } from '@tabler/icons';
+import { IconChevronDown } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { NativeSelect } from '@mantine/core';
 
 const code = `
 import { NativeSelect } from '@mantine/core';
-import { IconChevronDown } from '@tabler/icons';
+import { IconChevronDown } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/NavLink/NavLink.demo.active.tsx
+++ b/src/mantine-demos/src/demos/core/NavLink/NavLink.demo.active.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { IconGauge, IconFingerprint, IconActivity, IconChevronRight } from '@tabler/icons';
+import { IconGauge, IconFingerprint, IconActivity, IconChevronRight } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Box, NavLink, Group } from '@mantine/core';
 
 const codeTemplate = (props: string) => `
 import { useState } from 'react';
-import { IconGauge, IconFingerprint, IconActivity, IconChevronRight } from '@tabler/icons';
+import { IconGauge, IconFingerprint, IconActivity, IconChevronRight } from '@tabler/icons-react';
 import { Box, NavLink } from '@mantine/core';
 
 const data = [

--- a/src/mantine-demos/src/demos/core/NavLink/NavLink.demo.nested.tsx
+++ b/src/mantine-demos/src/demos/core/NavLink/NavLink.demo.nested.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Box, NavLink, Group } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
-import { IconGauge, IconFingerprint } from '@tabler/icons';
+import { IconGauge, IconFingerprint } from '@tabler/icons-react';
 
 const code = `
 import { Box, NavLink } from '@mantine/core';
-import { IconGauge, IconFingerprint } from '@tabler/icons';
+import { IconGauge, IconFingerprint } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/NavLink/NavLink.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/core/NavLink/NavLink.demo.usage.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Badge, Box, NavLink, Group } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
-import { IconHome2, IconGauge, IconChevronRight, IconActivity, IconCircleOff } from '@tabler/icons';
+import { IconHome2, IconGauge, IconChevronRight, IconActivity, IconCircleOff } from '@tabler/icons-react';
 
 const code = `
 import { Badge, Box, NavLink } from '@mantine/core';
-import { IconHome2, IconGauge, IconChevronRight, IconActivity, IconCircleOff } from '@tabler/icons';
+import { IconHome2, IconGauge, IconChevronRight, IconActivity, IconCircleOff } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Notification/Notification.demo.configurator.tsx
+++ b/src/mantine-demos/src/demos/core/Notification/Notification.demo.configurator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconCheck } from '@tabler/icons';
+import { IconCheck } from '@tabler/icons-react';
 import { Notification, NotificationProps } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
 import { demoBase } from './_demo-base';
@@ -15,7 +15,7 @@ function Wrapper(props: NotificationProps) {
 
 const codeTemplate = (props: string, children: string) => `
 import { Notification } from '@mantine/core';
-import { IconCheck } from '@tabler/icons';
+import { IconCheck } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Notification/Notification.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/core/Notification/Notification.demo.usage.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { IconCheck, IconX } from '@tabler/icons';
+import { IconCheck, IconX } from '@tabler/icons-react';
 import { Notification } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
 import { demoBase } from './_demo-base';
 
 const code = `
 import { Notification } from '@mantine/core';
-import { IconCheck, IconX } from '@tabler/icons';
+import { IconCheck, IconX } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/NumberInput/NumberInput.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/core/NumberInput/NumberInput.demo.icon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconMedal } from '@tabler/icons';
+import { IconMedal } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { NumberInput } from '@mantine/core';
 
 const code = `
 import { NumberInput } from '@mantine/core';
-import { IconMedal } from '@tabler/icons';
+import { IconMedal } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/PasswordInput/PasswordInput.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/core/PasswordInput/PasswordInput.demo.icon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconLock } from '@tabler/icons';
+import { IconLock } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { PasswordInput } from '@mantine/core';
 
 const code = `
 import { PasswordInput } from '@mantine/core';
-import { IconLock } from '@tabler/icons';
+import { IconLock } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/PasswordInput/PasswordInput.demo.strengthMeter.tsx
+++ b/src/mantine-demos/src/demos/core/PasswordInput/PasswordInput.demo.strengthMeter.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { IconX, IconCheck } from '@tabler/icons';
+import { IconX, IconCheck } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { PasswordInput, Progress, Text, Popover, Box } from '@mantine/core';
 
 const code = `
 import { useState } from 'react';
-import { IconX, IconCheck } from '@tabler/icons';
+import { IconX, IconCheck } from '@tabler/icons-react';
 import { PasswordInput, Progress, Text, Popover, Box } from '@mantine/core';
 
 function PasswordRequirement({ meets, label }: { meets: boolean; label: string }) {

--- a/src/mantine-demos/src/demos/core/PasswordInput/PasswordInput.demo.visibilityIcon.tsx
+++ b/src/mantine-demos/src/demos/core/PasswordInput/PasswordInput.demo.visibilityIcon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconEyeCheck, IconEyeOff } from '@tabler/icons';
+import { IconEyeCheck, IconEyeOff } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { PasswordInput } from '@mantine/core';
 
 const code = `
 import { PasswordInput } from '@mantine/core';
-import { IconEyeCheck, IconEyeOff } from '@tabler/icons';
+import { IconEyeCheck, IconEyeOff } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Rating/Rating.demo.customSymbol.tsx
+++ b/src/mantine-demos/src/demos/core/Rating/Rating.demo.customSymbol.tsx
@@ -8,7 +8,7 @@ import {
   IconMoodHappy,
   IconMoodCrazyHappy,
   IconMoodEmpty,
-} from '@tabler/icons';
+} from '@tabler/icons-react';
 
 const code = `
 import { Rating, useMantineTheme } from '@mantine/core';
@@ -19,7 +19,7 @@ import {
   IconMoodSmile,
   IconMoodHappy,
   IconMoodCrazyHappy,
-} from '@tabler/icons';
+} from '@tabler/icons-react';
 
 function Demo() {
 

--- a/src/mantine-demos/src/demos/core/Rating/Rating.demo.symbol.tsx
+++ b/src/mantine-demos/src/demos/core/Rating/Rating.demo.symbol.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { MantineDemo } from '@mantine/ds';
 import { Group, Rating } from '@mantine/core';
-import { IconSun, IconMoon } from '@tabler/icons';
+import { IconSun, IconMoon } from '@tabler/icons-react';
 
 const code = `
 import { Group, Rating } from '@mantine/core';
-import { IconSun, IconMoon } from '@tabler/icons';
+import { IconSun, IconMoon } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/RingProgress/RingProgress.demo.label.tsx
+++ b/src/mantine-demos/src/demos/core/RingProgress/RingProgress.demo.label.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconCheck } from '@tabler/icons';
+import { IconCheck } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { ThemeIcon, RingProgress, Group, Text, Center } from '@mantine/core';
 
 const code = `
 import { ThemeIcon, RingProgress, Text, Center } from '@mantine/core';
-import { IconCheck } from '@tabler/icons';
+import { IconCheck } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/SegmentedControl/SegmentedControl.demo.labels.tsx
+++ b/src/mantine-demos/src/demos/core/SegmentedControl/SegmentedControl.demo.labels.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconEye, IconCode, IconExternalLink } from '@tabler/icons';
+import { IconEye, IconCode, IconExternalLink } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Center, SegmentedControl, Box, Group } from '@mantine/core';
 
 const code = `
 import { Center, SegmentedControl, Box } from '@mantine/core';
-import { IconEye, IconCode, IconExternalLink } from '@tabler/icons';
+import { IconEye, IconCode, IconExternalLink } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Select/Select.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/core/Select/Select.demo.icon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconHash } from '@tabler/icons';
+import { IconHash } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Select } from '@mantine/core';
 
 const code = `
 import { Select } from '@mantine/core';
-import { IconHash } from '@tabler/icons';
+import { IconHash } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Select/Select.demo.rightSection.tsx
+++ b/src/mantine-demos/src/demos/core/Select/Select.demo.rightSection.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconChevronDown } from '@tabler/icons';
+import { IconChevronDown } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Select } from '@mantine/core';
 
 const code = `
 import { Select } from '@mantine/core';
-import { IconChevronDown } from '@tabler/icons';
+import { IconChevronDown } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Slider/Slider.demo.thumbChildren.tsx
+++ b/src/mantine-demos/src/demos/core/Slider/Slider.demo.thumbChildren.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Slider, RangeSlider } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
-import { IconHeart, IconHeartBroken } from '@tabler/icons';
+import { IconHeart, IconHeartBroken } from '@tabler/icons-react';
 
 const code = `
 import { Slider, RangeSlider } from '@mantine/core';
-import { IconHeart, IconHeartBroken } from '@tabler/icons';
+import { IconHeart, IconHeartBroken } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Stepper/Stepper.demo.icons.tsx
+++ b/src/mantine-demos/src/demos/core/Stepper/Stepper.demo.icons.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { IconUserCheck, IconMailOpened, IconShieldCheck, IconCircleCheck } from '@tabler/icons';
+import { IconUserCheck, IconMailOpened, IconShieldCheck, IconCircleCheck } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Stepper } from '@mantine/core';
 
 const code = `
 import { useState } from 'react';
-import { IconUserCheck, IconMailOpened, IconShieldCheck, IconCircleCheck } from '@tabler/icons';
+import { IconUserCheck, IconMailOpened, IconShieldCheck, IconCircleCheck } from '@tabler/icons-react';
 import { Stepper } from '@mantine/core';
 
 function Demo() {

--- a/src/mantine-demos/src/demos/core/Stepper/Stepper.demo.iconsOnly.tsx
+++ b/src/mantine-demos/src/demos/core/Stepper/Stepper.demo.iconsOnly.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
-import { IconUserCheck, IconMailOpened, IconShieldCheck } from '@tabler/icons';
+import { IconUserCheck, IconMailOpened, IconShieldCheck } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Stepper } from '@mantine/core';
 
 const code = `
 import { useState } from 'react';
 import { Stepper } from '@mantine/core';
-import { IconUserCheck, IconMailOpened, IconShieldCheck } from '@tabler/icons';
+import { IconUserCheck, IconMailOpened, IconShieldCheck } from '@tabler/icons-react';
 
 function Demo() {
   const [active, setActive] = useState(0);

--- a/src/mantine-demos/src/demos/core/Stepper/Stepper.demo.stepColor.tsx
+++ b/src/mantine-demos/src/demos/core/Stepper/Stepper.demo.stepColor.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconCircleX } from '@tabler/icons';
+import { IconCircleX } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Stepper } from '@mantine/core';
 
 const code = `
 import { Stepper } from '@mantine/core';
-import { IconCircleX } from '@tabler/icons';
+import { IconCircleX } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Stepper/Stepper.demo.stepFragmentComponents.tsx
+++ b/src/mantine-demos/src/demos/core/Stepper/Stepper.demo.stepFragmentComponents.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconCheck } from '@tabler/icons';
+import { IconCheck } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Group, Stepper, Text } from '@mantine/core';
 
 const code = `
 import { Stepper, Group, Text } from '@mantine/core';
-import { IconCheck } from '@tabler/icons';
+import { IconCheck } from '@tabler/icons-react';
 
 function Label(props: { step: number }) {
   return (

--- a/src/mantine-demos/src/demos/core/Switch/Switch.demo.iconLabels.tsx
+++ b/src/mantine-demos/src/demos/core/Switch/Switch.demo.iconLabels.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Switch, Group, useMantineTheme } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
-import { IconSun, IconMoonStars } from '@tabler/icons';
+import { IconSun, IconMoonStars } from '@tabler/icons-react';
 
 const code = `
 import { Switch, Group, useMantineTheme } from '@mantine/core';
-import { IconSun, IconMoonStars } from '@tabler/icons';
+import { IconSun, IconMoonStars } from '@tabler/icons-react';
 
 function Demo() {
   const theme = useMantineTheme();

--- a/src/mantine-demos/src/demos/core/Switch/Switch.demo.thumbIcon.tsx
+++ b/src/mantine-demos/src/demos/core/Switch/Switch.demo.thumbIcon.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import { Switch, Group, useMantineTheme } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
-import { IconCheck, IconX } from '@tabler/icons';
+import { IconCheck, IconX } from '@tabler/icons-react';
 
 const code = `
 import { useState } from 'react';
 import { Switch, Group, useMantineTheme } from '@mantine/core';
-import { IconCheck, IconX } from '@tabler/icons';
+import { IconCheck, IconX } from '@tabler/icons-react';
 
 function Demo() {
   const theme = useMantineTheme();

--- a/src/mantine-demos/src/demos/core/Tabs/Tabs.demo.configurator.tsx
+++ b/src/mantine-demos/src/demos/core/Tabs/Tabs.demo.configurator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconPhoto, IconMessageCircle, IconSettings } from '@tabler/icons';
+import { IconPhoto, IconMessageCircle, IconSettings } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Tabs, TabsProps } from '@mantine/core';
 
@@ -38,7 +38,7 @@ const codeTemplate = (props: string) => {
   const panelProps = props.includes('vertical') ? 'pl="xs"' : 'pt="xs"';
   return `
 import { Tabs } from '@mantine/core';
-import { IconPhoto, IconMessageCircle, IconSettings } from '@tabler/icons';
+import { IconPhoto, IconMessageCircle, IconSettings } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Tabs/Tabs.demo.icons.tsx
+++ b/src/mantine-demos/src/demos/core/Tabs/Tabs.demo.icons.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconSettings, IconMessageCircle, IconCoin } from '@tabler/icons';
+import { IconSettings, IconMessageCircle, IconCoin } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Tabs } from '@mantine/core';
 
 const code = `
 import { Tabs } from '@mantine/core';
-import { IconSettings, IconMessageCircle, IconCoin } from '@tabler/icons';
+import { IconSettings, IconMessageCircle, IconCoin } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Tabs/Tabs.demo.stylesApi.tsx
+++ b/src/mantine-demos/src/demos/core/Tabs/Tabs.demo.stylesApi.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconPhoto, IconMessageCircle, IconSettings } from '@tabler/icons';
+import { IconPhoto, IconMessageCircle, IconSettings } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Tabs, TabsProps } from '@mantine/core';
 
 const code = `
 import { Tabs, TabsProps } from '@mantine/core';
-import { IconPhoto, IconMessageCircle, IconSettings } from '@tabler/icons';
+import { IconPhoto, IconMessageCircle, IconSettings } from '@tabler/icons-react';
 
 function StyledTabs(props: TabsProps) {
   return (

--- a/src/mantine-demos/src/demos/core/TextInput/TextInput.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/core/TextInput/TextInput.demo.icon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconAt } from '@tabler/icons';
+import { IconAt } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { TextInput } from '@mantine/core';
 
 const code = `
 import { TextInput } from '@mantine/core';
-import { IconAt } from '@tabler/icons';
+import { IconAt } from '@tabler/icons-react';
 
 function Demo() {
   return <TextInput label="Your email" placeholder="Your email" icon={<IconAt size={14} />} />;

--- a/src/mantine-demos/src/demos/core/ThemeIcon/ThemeIcon.demo.colors.tsx
+++ b/src/mantine-demos/src/demos/core/ThemeIcon/ThemeIcon.demo.colors.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconPhoto } from '@tabler/icons';
+import { IconPhoto } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { MANTINE_COLORS, Group, ThemeIcon, ThemeIconProps } from '@mantine/core';
 

--- a/src/mantine-demos/src/demos/core/ThemeIcon/ThemeIcon.demo.configurator.tsx
+++ b/src/mantine-demos/src/demos/core/ThemeIcon/ThemeIcon.demo.configurator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconPhoto } from '@tabler/icons';
+import { IconPhoto } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { ThemeIcon, ThemeIconProps } from '@mantine/core';
 
@@ -23,7 +23,7 @@ function Wrapper(props: ThemeIconProps) {
 
 const codeTemplate = (props: string) => `
 import { ThemeIcon } from '@mantine/core';
-import { IconPhoto } from '@tabler/icons';
+import { IconPhoto } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/ThemeIcon/ThemeIcon.demo.gradient.tsx
+++ b/src/mantine-demos/src/demos/core/ThemeIcon/ThemeIcon.demo.gradient.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { IconPhoto } from '@tabler/icons';
+import { IconPhoto } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Group, ThemeIcon } from '@mantine/core';
 
 const code = `
-import { IconPhoto } from '@tabler/icons';
+import { IconPhoto } from '@tabler/icons-react';
 import { ThemeIcon } from '@mantine/core';
 
 function Demo() {

--- a/src/mantine-demos/src/demos/core/Timeline/Timeline.demo.bullet.tsx
+++ b/src/mantine-demos/src/demos/core/Timeline/Timeline.demo.bullet.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { ThemeIcon, Text, Avatar, Timeline } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
-import { IconSun, IconVideo } from '@tabler/icons';
+import { IconSun, IconVideo } from '@tabler/icons-react';
 
 const code = `
 import { ThemeIcon, Text, Avatar, Timeline } from '@mantine/core';
-import { IconSun, IconVideo } from '@tabler/icons';
+import { IconSun, IconVideo } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Timeline/Timeline.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/core/Timeline/Timeline.demo.usage.tsx
@@ -4,7 +4,7 @@ import { TimelineBase } from './_base';
 
 const code = `
 import { Timeline, Text } from '@mantine/core';
-import { IconGitBranch, IconGitPullRequest, IconGitCommit, IconMessageDots } from '@tabler/icons';
+import { IconGitBranch, IconGitPullRequest, IconGitCommit, IconMessageDots } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/core/Timeline/_base.tsx
+++ b/src/mantine-demos/src/demos/core/Timeline/_base.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconGitBranch, IconGitPullRequest, IconGitCommit, IconMessageDots } from '@tabler/icons';
+import { IconGitBranch, IconGitPullRequest, IconGitCommit, IconMessageDots } from '@tabler/icons-react';
 import { Text, Timeline, TimelineProps } from '@mantine/core';
 
 export function TimelineBase(props: Partial<TimelineProps> & { noIcon?: boolean }) {

--- a/src/mantine-demos/src/demos/core/TransferList/TransferList.demo.customIcons.tsx
+++ b/src/mantine-demos/src/demos/core/TransferList/TransferList.demo.customIcons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconFilePlus, IconFolderPlus, IconFileMinus, IconFolderMinus } from '@tabler/icons';
+import { IconFilePlus, IconFolderPlus, IconFileMinus, IconFolderMinus } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Wrapper } from './_wrapper';
 
@@ -9,7 +9,7 @@ import {
   IconFolderPlus,
   IconFileMinus,
   IconFolderMinus,
-} from '@tabler/icons';
+} from '@tabler/icons-react';
 import { TransferList } from '@mantine/core';
 
 function Demo() {

--- a/src/mantine-demos/src/demos/dates/DatePicker/DatePicker.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/dates/DatePicker/DatePicker.demo.icon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconCalendar } from '@tabler/icons';
+import { IconCalendar } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { DatePicker } from '@mantine/dates';
 
 const code = `
 import { DatePicker } from '@mantine/dates';
-import { IconCalendar } from '@tabler/icons';
+import { IconCalendar } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/dates/TimeInput/TimeInput.demo.icon.tsx
+++ b/src/mantine-demos/src/demos/dates/TimeInput/TimeInput.demo.icon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { IconClock } from '@tabler/icons';
+import { IconClock } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { TimeInput } from '@mantine/dates';
 
 const code = `
 import { TimeInput } from '@mantine/dates';
-import { IconClock } from '@tabler/icons';
+import { IconClock } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/dropzone/Dropzone.demo.fullScreen.tsx
+++ b/src/mantine-demos/src/demos/dropzone/Dropzone.demo.fullScreen.tsx
@@ -8,7 +8,7 @@ import { DropzoneDemoChildren } from './_base';
 const code = `
 import { useState } from 'react';
 import { Group, Text, useMantineTheme, Button } from '@mantine/core';
-import { IconUpload, IconPhoto, IconX } from '@tabler/icons';
+import { IconUpload, IconPhoto, IconX } from '@tabler/icons-react';
 import { Dropzone, DropzoneProps, IMAGE_MIME_TYPE } from '@mantine/dropzone';
 
 function Demo() {

--- a/src/mantine-demos/src/demos/dropzone/Dropzone.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/dropzone/Dropzone.demo.usage.tsx
@@ -3,7 +3,7 @@ import { BaseDemo } from './_base';
 
 const code = `
 import { Group, Text, useMantineTheme } from '@mantine/core';
-import { IconUpload, IconPhoto, IconX } from '@tabler/icons';
+import { IconUpload, IconPhoto, IconX } from '@tabler/icons-react';
 import { Dropzone, DropzoneProps, IMAGE_MIME_TYPE } from '@mantine/dropzone';
 
 export function BaseDemo(props: Partial<DropzoneProps>) {

--- a/src/mantine-demos/src/demos/dropzone/_base.tsx
+++ b/src/mantine-demos/src/demos/dropzone/_base.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import React from 'react';
 import { Group, Text, useMantineTheme } from '@mantine/core';
-import { IconUpload, IconPhoto, IconX } from '@tabler/icons';
+import { IconUpload, IconPhoto, IconX } from '@tabler/icons-react';
 import { Dropzone, DropzoneProps, IMAGE_MIME_TYPE } from '@mantine/dropzone';
 
 export function DropzoneDemoChildren() {

--- a/src/mantine-demos/src/demos/form/Form.demo.dnd.tsx
+++ b/src/mantine-demos/src/demos/form/Form.demo.dnd.tsx
@@ -3,13 +3,13 @@ import { Group, TextInput, Box, Text, Code, Button, Center } from '@mantine/core
 import { useForm } from '@mantine/form';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 import { MantineDemo } from '@mantine/ds';
-import { IconGripVertical } from '@tabler/icons';
+import { IconGripVertical } from '@tabler/icons-react';
 
 const code = `
 import { Group, TextInput, Box, Text, Code, Button, Center } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
-import { IconGripVertical } from '@tabler/icons';
+import { IconGripVertical } from '@tabler/icons-react';
 
 function Demo() {
   const form = useForm({

--- a/src/mantine-demos/src/demos/form/Form.demo.lists.tsx
+++ b/src/mantine-demos/src/demos/form/Form.demo.lists.tsx
@@ -3,13 +3,13 @@ import { useForm } from '@mantine/form';
 import { TextInput, Switch, Group, ActionIcon, Box, Text, Button, Code } from '@mantine/core';
 import { randomId } from '@mantine/hooks';
 import { MantineDemo } from '@mantine/ds';
-import { IconTrash } from '@tabler/icons';
+import { IconTrash } from '@tabler/icons-react';
 
 const code = `
 import { useForm } from '@mantine/form';
 import { TextInput, Switch, Group, ActionIcon, Box, Text, Button, Code } from '@mantine/core';
 import { randomId } from '@mantine/hooks';
-import { IconTrash } from '@tabler/icons';
+import { IconTrash } from '@tabler/icons-react';
 
 function Demo() {
   const form = useForm({

--- a/src/mantine-demos/src/demos/hooks/use-eye-dropper.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/hooks/use-eye-dropper.demo.usage.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import { MantineDemo } from '@mantine/ds';
 import { ActionIcon, Group, ColorSwatch, Text } from '@mantine/core';
-import { IconColorPicker } from '@tabler/icons';
+import { IconColorPicker } from '@tabler/icons-react';
 import { useEyeDropper } from '@mantine/hooks';
 
 const code = `
 import { useState } from 'react';
 import { ActionIcon, Group, ColorSwatch, Text } from '@mantine/core';
-import { IconColorPicker } from '@tabler/icons';
+import { IconColorPicker } from '@tabler/icons-react';
 import { useEyeDropper } from '@mantine/hooks';
 
 function Demo() {

--- a/src/mantine-demos/src/demos/hooks/use-scroll-lock.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/hooks/use-scroll-lock.demo.usage.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { useScrollLock } from '@mantine/hooks';
-import { IconLock, IconLockOpen } from '@tabler/icons';
+import { IconLock, IconLockOpen } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Group, Button } from '@mantine/core';
 
 const code = `
 import { useScrollLock } from '@mantine/hooks';
 import { Button, Group } from '@mantine/core';
-import { IconLock, IconLockOpen } from '@tabler/icons';
+import { IconLock, IconLockOpen } from '@tabler/icons-react';
 
 function Demo() {
   const [scrollLocked, setScrollLocked] = useScrollLock();

--- a/src/mantine-demos/src/demos/notifications/Notifications.demo.root.tsx
+++ b/src/mantine-demos/src/demos/notifications/Notifications.demo.root.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconCheck } from '@tabler/icons';
+import { IconCheck } from '@tabler/icons-react';
 import { Group, Button } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
 import { showNotification, updateNotification } from '@mantine/notifications';

--- a/src/mantine-demos/src/demos/notifications/Notifications.demo.update.tsx
+++ b/src/mantine-demos/src/demos/notifications/Notifications.demo.update.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconCheck } from '@tabler/icons';
+import { IconCheck } from '@tabler/icons-react';
 import { Group, Button } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
 import { showNotification, updateNotification } from '@mantine/notifications';
@@ -7,7 +7,7 @@ import { showNotification, updateNotification } from '@mantine/notifications';
 const code = `
 import { Group, Button } from '@mantine/core';
 import { showNotification, updateNotification } from '@mantine/notifications';
-import { IconCheck } from '@tabler/icons';
+import { IconCheck } from '@tabler/icons-react';
 
 function Demo() {
   return (

--- a/src/mantine-demos/src/demos/spotlight/Spotlight.demo.actionsWrapperComponent.tsx
+++ b/src/mantine-demos/src/demos/spotlight/Spotlight.demo.actionsWrapperComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 import { Group, Text, Anchor } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
 import { Wrapper } from './_wrapper';

--- a/src/mantine-demos/src/demos/spotlight/Spotlight.demo.customTransition.tsx
+++ b/src/mantine-demos/src/demos/spotlight/Spotlight.demo.customTransition.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Wrapper } from './_wrapper';
 

--- a/src/mantine-demos/src/demos/spotlight/Spotlight.demo.filter.tsx
+++ b/src/mantine-demos/src/demos/spotlight/Spotlight.demo.filter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Wrapper } from './_wrapper';
 

--- a/src/mantine-demos/src/demos/spotlight/Spotlight.demo.highlightQuery.tsx
+++ b/src/mantine-demos/src/demos/spotlight/Spotlight.demo.highlightQuery.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Wrapper } from './_wrapper';
 

--- a/src/mantine-demos/src/demos/spotlight/Spotlight.demo.register.tsx
+++ b/src/mantine-demos/src/demos/spotlight/Spotlight.demo.register.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { Group, Button } from '@mantine/core';
 import { SpotlightProvider, useSpotlight } from '@mantine/spotlight';
-import { IconAlien, IconSearch } from '@tabler/icons';
+import { IconAlien, IconSearch } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { actions } from './_actions';
 
@@ -10,7 +10,7 @@ const code = `
 import { useState } from 'react';
 import { Group, Button } from '@mantine/core';
 import { SpotlightProvider, registerSpotlightActions, openSpotlight, removeSpotlightActions } from '@mantine/spotlight';
-import { IconAlien, IconSearch } from '@tabler/icons';
+import { IconAlien, IconSearch } from '@tabler/icons-react';
 
 function SpotlightControls() {
   const [registered, setRegistered] = useState(false);

--- a/src/mantine-demos/src/demos/spotlight/Spotlight.demo.transitionNone.tsx
+++ b/src/mantine-demos/src/demos/spotlight/Spotlight.demo.transitionNone.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Wrapper } from './_wrapper';
 

--- a/src/mantine-demos/src/demos/spotlight/Spotlight.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/spotlight/Spotlight.demo.usage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 import { MantineDemo } from '@mantine/ds';
 import { Wrapper } from './_wrapper';
 
@@ -7,7 +7,7 @@ const code = `
 import { Button, Group } from '@mantine/core';
 import { SpotlightProvider, openSpotlight } from '@mantine/spotlight';
 import type { SpotlightAction } from '@mantine/spotlight';
-import { IconHome, IconDashboard, IconFileText, IconSearch } from '@tabler/icons';
+import { IconHome, IconDashboard, IconFileText, IconSearch } from '@tabler/icons-react';
 
 function SpotlightControl() {
   return (

--- a/src/mantine-demos/src/demos/spotlight/_actions.tsx
+++ b/src/mantine-demos/src/demos/spotlight/_actions.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import React from 'react';
 import type { SpotlightAction } from '@mantine/spotlight';
-import { IconHome, IconDashboard, IconFileText } from '@tabler/icons';
+import { IconHome, IconDashboard, IconFileText } from '@tabler/icons-react';
 
 export const actions: SpotlightAction[] = [
   {

--- a/src/mantine-demos/src/demos/theme/Theme.demo.darkThemeToggle.tsx
+++ b/src/mantine-demos/src/demos/theme/Theme.demo.darkThemeToggle.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Group, ActionIcon, useMantineColorScheme } from '@mantine/core';
 import { MantineDemo } from '@mantine/ds';
-import { IconSun, IconMoonStars } from '@tabler/icons';
+import { IconSun, IconMoonStars } from '@tabler/icons-react';
 
 const code = `
 import { ActionIcon, useMantineColorScheme } from '@mantine/core';
-import { IconSun, IconMoonStars } from '@tabler/icons';
+import { IconSun, IconMoonStars } from '@tabler/icons-react';
 
 function Demo() {
   const { colorScheme, toggleColorScheme } = useMantineColorScheme();

--- a/src/mantine-demos/src/demos/tiptap/TipTap.demo.colors.tsx
+++ b/src/mantine-demos/src/demos/tiptap/TipTap.demo.colors.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MantineDemo } from '@mantine/ds';
 import { useEditor } from '@tiptap/react';
-import { IconColorPicker } from '@tabler/icons';
+import { IconColorPicker } from '@tabler/icons-react';
 import { Color } from '@tiptap/extension-color';
 import TextStyle from '@tiptap/extension-text-style';
 import StarterKit from '@tiptap/starter-kit';
@@ -9,7 +9,7 @@ import { RichTextEditor } from '@mantine/tiptap';
 
 const code = `
 import { useEditor } from '@tiptap/react';
-import { IconColorPicker } from '@tabler/icons';
+import { IconColorPicker } from '@tabler/icons-react';
 import { Color } from '@tiptap/extension-color';
 import TextStyle from '@tiptap/extension-text-style';
 import StarterKit from '@tiptap/starter-kit';

--- a/src/mantine-demos/src/demos/tiptap/TipTap.demo.customControl.tsx
+++ b/src/mantine-demos/src/demos/tiptap/TipTap.demo.customControl.tsx
@@ -3,13 +3,13 @@ import { MantineDemo } from '@mantine/ds';
 import { useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { RichTextEditor, useRichTextEditorContext } from '@mantine/tiptap';
-import { IconStar } from '@tabler/icons';
+import { IconStar } from '@tabler/icons-react';
 
 const code = `
 import { useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { RichTextEditor, useRichTextEditorContext } from '@mantine/tiptap';
-import { IconStar } from '@tabler/icons';
+import { IconStar } from '@tabler/icons-react';
 
 function InsertStarControl() {
   const { editor } = useRichTextEditorContext();

--- a/src/mantine-demos/src/demos/tiptap/TipTap.demo.icons.tsx
+++ b/src/mantine-demos/src/demos/tiptap/TipTap.demo.icons.tsx
@@ -3,13 +3,13 @@ import { MantineDemo } from '@mantine/ds';
 import { useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { RichTextEditor } from '@mantine/tiptap';
-import { IconBold, IconItalic } from '@tabler/icons';
+import { IconBold, IconItalic } from '@tabler/icons-react';
 
 const code = `
 import { useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { RichTextEditor } from '@mantine/tiptap';
-import { IconBold, IconItalic } from '@tabler/icons';
+import { IconBold, IconItalic } from '@tabler/icons-react';
 
 const BoldIcon = () => <IconBold size={18} stroke={3.5} />;
 const ItalicIcon = () => <IconItalic size={18} stroke={3.5} />;

--- a/src/mantine-demos/src/shared/AuthenticationForm/AuthenticationForm.tsx
+++ b/src/mantine-demos/src/shared/AuthenticationForm/AuthenticationForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useForm } from '@mantine/form';
-import { IconLock, IconAt } from '@tabler/icons';
+import { IconLock, IconAt } from '@tabler/icons-react';
 import {
   TextInput,
   PasswordInput,

--- a/src/mantine-ds/package.json
+++ b/src/mantine-ds/package.json
@@ -21,7 +21,7 @@
     "@mantine/core": "5.10.1",
     "@mantine/hooks": "5.10.1",
     "@mantine/prism": "5.10.1",
-    "@tabler/icons": "*",
+    "@tabler/icons-react": "^2.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },

--- a/src/mantine-ds/src/Demo/CodeDemo/CodeDemo.tsx
+++ b/src/mantine-ds/src/Demo/CodeDemo/CodeDemo.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Language } from 'prism-react-renderer';
-import { IconCode } from '@tabler/icons';
+import { IconCode } from '@tabler/icons-react';
 import { Paper, Stack, ActionIcon, Tooltip, Box, MantineNumberSize } from '@mantine/core';
 import { Prism } from '@mantine/prism';
 import useStyles from './CodeDemo.styles';

--- a/src/mantine-ds/src/HeaderControl/ColorSchemeControl.tsx
+++ b/src/mantine-ds/src/HeaderControl/ColorSchemeControl.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useMantineColorScheme } from '@mantine/core';
-import { IconSun, IconMoon } from '@tabler/icons';
+import { IconSun, IconMoon } from '@tabler/icons-react';
 import { HeaderControl } from './HeaderControl';
 
 export function ColorSchemeControl() {

--- a/src/mantine-ds/src/HeaderControl/DirectionControl.tsx
+++ b/src/mantine-ds/src/HeaderControl/DirectionControl.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconTextDirectionLtr, IconTextDirectionRtl } from '@tabler/icons';
+import { IconTextDirectionLtr, IconTextDirectionRtl } from '@tabler/icons-react';
 import { HeaderControl } from './HeaderControl';
 
 interface DirectionControlProps {

--- a/src/mantine-ds/src/SearchControl/SearchControl.tsx
+++ b/src/mantine-ds/src/SearchControl/SearchControl.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 import { UnstyledButton, Text, Group, DefaultProps } from '@mantine/core';
 import { useOs } from '@mantine/hooks';
 import useStyles from './SearchControl.styles';

--- a/src/mantine-form/src/stories/Form.dirty.story.tsx
+++ b/src/mantine-form/src/stories/Form.dirty.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ActionIcon, Code, Group, MantineProvider, TextInput, Text, Button } from '@mantine/core';
-import { IconTrash } from '@tabler/icons';
+import { IconTrash } from '@tabler/icons-react';
 import { useForm } from '../use-form';
 
 export default { title: 'Form' };

--- a/src/mantine-notifications/src/Notifications.story.tsx
+++ b/src/mantine-notifications/src/Notifications.story.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconCheck } from '@tabler/icons';
+import { IconCheck } from '@tabler/icons-react';
 import { storiesOf } from '@storybook/react';
 import { Button, Group, MantineProvider } from '@mantine/core';
 import { showNotification, updateNotification } from './events';

--- a/src/mantine-rte/package.json
+++ b/src/mantine-rte/package.json
@@ -36,7 +36,7 @@
     "react-dom": ">=16.8.0"
   },
   "dependencies": {
-    "@tabler/icons": "^1.68.0",
+    "@tabler/icons-react": "^2.0.0",
     "react-quill": "2.0.0",
     "quill-mention": "^3.0.8"
   },

--- a/src/mantine-rte/src/components/Toolbar/controls.ts
+++ b/src/mantine-rte/src/components/Toolbar/controls.ts
@@ -22,7 +22,7 @@ import {
   IconSuperscript,
   IconSubscript,
   IconPhoto,
-} from '@tabler/icons';
+} from '@tabler/icons-react';
 
 export const CONTROLS = {
   code: {

--- a/src/mantine-spotlight/src/Spotlight.story.tsx
+++ b/src/mantine-spotlight/src/Spotlight.story.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect } from 'react';
 import { storiesOf } from '@storybook/react';
 import { Button, Box } from '@mantine/core';
-import { IconSearch } from '@tabler/icons';
+import { IconSearch } from '@tabler/icons-react';
 import {
   SpotlightProvider,
   useSpotlight,

--- a/src/mantine-tiptap/package.json
+++ b/src/mantine-tiptap/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@mantine/core": "5.10.1",
     "@mantine/hooks": "5.10.1",
-    "@tabler/icons": "*",
+    "@tabler/icons-react": "^2.0.0",
     "@tiptap/extension-link": "^2.0.0-beta.202",
     "@tiptap/react": "^2.0.0-beta.202",
     "react": ">=16.8.0"

--- a/src/mantine-tiptap/src/RichTextEditor.story.tsx
+++ b/src/mantine-tiptap/src/RichTextEditor.story.tsx
@@ -16,7 +16,7 @@ import css from 'highlight.js/lib/languages/css';
 import js from 'highlight.js/lib/languages/javascript';
 import ts from 'highlight.js/lib/languages/typescript';
 import html from 'highlight.js/lib/languages/xml';
-import { IconColorPicker } from '@tabler/icons';
+import { IconColorPicker } from '@tabler/icons-react';
 import { Link } from './extensions/Link';
 import { RichTextEditor, RichTextEditorProps } from './RichTextEditor';
 import { RichTextEditorToolbarProps } from './Toolbar/Toolbar';

--- a/src/mantine-tiptap/src/controls/ColorPickerControl/ColorPickerControl.tsx
+++ b/src/mantine-tiptap/src/controls/ColorPickerControl/ColorPickerControl.tsx
@@ -13,7 +13,7 @@ import {
   useComponentDefaultProps,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconCircleOff, IconColorPicker, IconX, IconPalette, IconCheck } from '@tabler/icons';
+import { IconCircleOff, IconColorPicker, IconX, IconPalette, IconCheck } from '@tabler/icons-react';
 import { Control } from '../Control/Control';
 import { useRichTextEditorContext } from '../../RichTextEditor.context';
 

--- a/src/mantine-tiptap/src/controls/LinkControl/LinkControl.tsx
+++ b/src/mantine-tiptap/src/controls/LinkControl/LinkControl.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useState } from 'react';
-import { IconLink, IconExternalLink } from '@tabler/icons';
+import { IconLink, IconExternalLink } from '@tabler/icons-react';
 import {
   Popover,
   TextInput,

--- a/src/mantine-tiptap/src/controls/controls.tsx
+++ b/src/mantine-tiptap/src/controls/controls.tsx
@@ -25,7 +25,7 @@ import {
   IconHighlight,
   IconLineDashed,
   IconCircleOff,
-} from '@tabler/icons';
+} from '@tabler/icons-react';
 import { createControl } from './ControlBase/create-control';
 
 export const BoldControl = createControl({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3679,10 +3679,17 @@
   dependencies:
     tslib "^2.4.0"
 
-"@tabler/icons-react@^1.68.0":
-  version "1.68.0"
-  resolved "https://registry.yarnpkg.com/@tabler/icons-react/-/icons-1.68.0.tgz#047bd88966cc24ef957b3c429a13bb82cca95561"
-  integrity sha512-UseBEEhv7r+Drl3iZih7rkwqkfJJZscjd5ZvK1WdIIulQsBa+qE8WBDGdAO0RtjkCclEK88z9kC0s5wiVPIvkw==
+"@tabler/icons-react@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tabler/icons-react/-/icons-react-2.0.0.tgz#7500c3ad1821bde11e742fc3e6d010b2fc0c16a6"
+  integrity sha512-KUgJtVS+HDLQuFfqIdgYMDAbUlfG6LqfPwomc26cS6BEL9v01YptZtBU+KVaP6QZ+kleKrHMzFJajOtK9xIXDw==
+  dependencies:
+    "@tabler/icons" "2.0.0"
+
+"@tabler/icons@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tabler/icons/-/icons-2.0.0.tgz#051d769b23560af3d04389041072c0a299bd0742"
+  integrity sha512-ye93cVD8baCwJJ7J3GKlUM3FN+qW6lsEz4uaH8bHCwC8un2R4p+ZzyRNc/ksqVgMQJ4PKQ8xbYpv4dnbbRffsA==
 
 "@testing-library/dom@8.13.0", "@testing-library/dom@^8.5.0":
   version "8.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3679,9 +3679,9 @@
   dependencies:
     tslib "^2.4.0"
 
-"@tabler/icons@^1.68.0":
+"@tabler/icons-react@^1.68.0":
   version "1.68.0"
-  resolved "https://registry.yarnpkg.com/@tabler/icons/-/icons-1.68.0.tgz#047bd88966cc24ef957b3c429a13bb82cca95561"
+  resolved "https://registry.yarnpkg.com/@tabler/icons-react/-/icons-1.68.0.tgz#047bd88966cc24ef957b3c429a13bb82cca95561"
   integrity sha512-UseBEEhv7r+Drl3iZih7rkwqkfJJZscjd5ZvK1WdIIulQsBa+qE8WBDGdAO0RtjkCclEK88z9kC0s5wiVPIvkw==
 
 "@testing-library/dom@8.13.0", "@testing-library/dom@^8.5.0":


### PR DESCRIPTION
Hi! I've released Tabler Icons v2.0 package. In newest version we separate React version of package to `@tabler/icons-react`. New package supports tree-shaking and include new "filled" version of icons.

More info about this release is here: https://github.com/tabler/tabler-icons/releases/tag/v2.0.0

I've create PR with changes to new package, API is the same as in `@tabler/icons` v1