### PR TITLE
[@mantine-form] zodResolver: Make schema parameter typesafe

### DIFF
--- a/src/mantine-form/src/resolvers/zod-resolver/zod-resolver.ts
+++ b/src/mantine-form/src/resolvers/zod-resolver/zod-resolver.ts
@@ -5,22 +5,24 @@ interface ZodError {
   message: string;
 }
 
-interface ZodResults {
-  success: boolean;
+interface ZodParseSuccess {
+  success: true;
+}
+
+interface ZodParseError {
+  success: false;
   error: {
     errors: ZodError[];
   };
 }
 
-interface ZodSchema {
-  safeParse(values: Record<string, any>): ZodResults;
+interface ZodSchema<T extends Record<string, any>> {
+  safeParse(values: T): ZodParseSuccess | ZodParseError;
 }
 
-export function zodResolver<T extends Record<string, any>>(schema: any) {
-  const _schema: ZodSchema = schema;
-
+export function zodResolver<T extends Record<string, any>>(schema: ZodSchema<T>) {
   return (values: T): FormErrors => {
-    const parsed = _schema.safeParse(values);
+    const parsed = schema.safeParse(values);
 
     if (parsed.success) {
       return {};
@@ -28,7 +30,7 @@ export function zodResolver<T extends Record<string, any>>(schema: any) {
 
     const results = {};
 
-    parsed.error.errors.forEach((error) => {
+    (parsed as ZodParseError).error.errors.forEach((error) => {
       results[error.path.join('.')] = error.message;
     });
 


### PR DESCRIPTION
I had a situation where a wrong & invalid data was being passed to the zodResolver as the schema argument.

This makes the zodResolver schema parameter to require the safeParse property.

I don't see a way to type test this in Mantine repo. In my codebase it didn't throw false negatives and it did complain properly.