### PR TITLE
[@mantine/core] TransferList: add `transferAllMatchingFilter` prop

### DIFF
--- a/docs/src/docs/core/TransferList.mdx
+++ b/docs/src/docs/core/TransferList.mdx
@@ -51,6 +51,14 @@ be a tuple of two strings, one for each list:
 
 <Demo data={TransferListDemos.controlledSearch} />
 
+## Transferring only found items
+
+By default, TransferList transfers **all** items when you click the `transferAll` button.
+
+By setting the `transferAllMatchingFilter` prop to `true`, TransferList will only transfer the items that match the current filter.
+
+<Demo data={TransferListDemos.transferAllMatchingFilter} />
+
 ## Empty search VS empty list
 
 You can specify a `placeholder` prop, which will be used in place of the `nothingFound` when a list is completely empty,

--- a/src/mantine-core/src/TransferList/RenderList/RenderList.tsx
+++ b/src/mantine-core/src/TransferList/RenderList/RenderList.tsx
@@ -36,6 +36,7 @@ export interface RenderListProps extends DefaultProps<RenderListStylesNames> {
   limit?: number;
   transferIcon?: React.FunctionComponent<{ reversed }>;
   transferAllIcon?: React.FunctionComponent<{ reversed }>;
+  transferAllMatchingFilter: boolean;
 }
 
 const icons = {
@@ -61,6 +62,7 @@ export function RenderList({
   listComponent,
   transferIcon: TransferIcon,
   transferAllIcon: TransferAllIcon,
+  transferAllMatchingFilter,
   searchPlaceholder,
   query,
   onSearch,
@@ -237,7 +239,7 @@ export function RenderList({
               size={36}
               radius={0}
               className={classes.transferListControl}
-              disabled={data.length === 0}
+              disabled={transferAllMatchingFilter ? filteredData.length === 0 : data.length === 0}
               onClick={onMoveAll}
               unstyled={unstyled}
             >

--- a/src/mantine-core/src/TransferList/TransferList.tsx
+++ b/src/mantine-core/src/TransferList/TransferList.tsx
@@ -69,6 +69,9 @@ export interface TransferListProps
 
   /** Change icon used for the transfer all control */
   transferAllIcon?: React.FunctionComponent<{ reversed: boolean }>;
+
+  /** Whether to transfer only items matching {@link filter} when clicking the transfer all control */
+  transferAllMatchingFilter?: boolean;
 }
 
 export function defaultFilter(query: string, item: TransferListItem) {
@@ -84,6 +87,7 @@ const defaultProps: Partial<TransferListProps> = {
   listComponent: SelectScrollArea,
   showTransferAll: true,
   limit: Infinity,
+  transferAllMatchingFilter: false,
 };
 
 export const TransferList = forwardRef<HTMLDivElement, TransferListProps>((props, ref) => {
@@ -110,6 +114,7 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>((props
     unstyled,
     transferIcon,
     transferAllIcon,
+    transferAllMatchingFilter,
     ...others
   } = useComponentDefaultProps('TransferList', defaultProps, props);
 
@@ -124,8 +129,19 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>((props
   const handleMoveAll = (listIndex: 0 | 1) => {
     const items: TransferListData = Array(2) as any;
     const moveToIndex = listIndex === 0 ? 1 : 0;
-    items[listIndex] = [];
-    items[moveToIndex] = [...value[moveToIndex], ...value[listIndex]];
+
+    if (transferAllMatchingFilter) {
+      const query = search[listIndex];
+      const shownItems = value[listIndex].filter((item) => filter(query, item)).slice(0, limit);
+      const hiddenItems = value[listIndex].filter((item) => !filter(query, item));
+
+      items[listIndex] = hiddenItems;
+      items[moveToIndex] = [...value[moveToIndex], ...shownItems];
+    } else {
+      items[listIndex] = [];
+      items[moveToIndex] = [...value[moveToIndex], ...value[listIndex]];
+    }
+
     onChange(items);
     handlers.deselectAll(listIndex);
   };

--- a/src/mantine-core/src/TransferList/TransferList.tsx
+++ b/src/mantine-core/src/TransferList/TransferList.tsx
@@ -206,6 +206,7 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>((props
         query={search[0]}
         onSearch={(query) => handleSearch([query, search[1]])}
         unstyled={unstyled}
+        transferAllMatchingFilter={transferAllMatchingFilter}
       />
 
       <RenderList
@@ -225,6 +226,7 @@ export const TransferList = forwardRef<HTMLDivElement, TransferListProps>((props
         onSearch={(query) => handleSearch([search[0], query])}
         reversed
         unstyled={unstyled}
+        transferAllMatchingFilter={transferAllMatchingFilter}
       />
     </SimpleGrid>
   );

--- a/src/mantine-demos/src/demos/core/TransferList/TransferList.demo.transferAllMatchingFilter.tsx
+++ b/src/mantine-demos/src/demos/core/TransferList/TransferList.demo.transferAllMatchingFilter.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { MantineDemo } from '@mantine/ds';
+import { Wrapper } from './_wrapper';
+
+const code = `
+<TransferList transferAllMatchingFilter />
+`;
+
+function Demo() {
+  return (
+    <Wrapper
+      searchPlaceholder="Search..."
+      nothingFound="Nothing here"
+      titles={['Frameworks', 'Libraries']}
+      breakpoint="sm"
+      transferAllMatchingFilter
+    />
+  );
+}
+
+export const transferAllMatchingFilter: MantineDemo = {
+  type: 'demo',
+  component: Demo,
+  code,
+};

--- a/src/mantine-demos/src/demos/core/TransferList/index.ts
+++ b/src/mantine-demos/src/demos/core/TransferList/index.ts
@@ -7,3 +7,4 @@ export { customIcons } from './TransferList.demo.customIcons';
 export { placeholder } from './TransferList.demo.placeholder';
 export { controlledSearch } from './TransferList.demo.controlledSearch';
 export { differentPlaceholders } from './TransferList.demo.differentPlaceholders';
+export { transferAllMatchingFilter } from './TransferList.demo.transferAllMatchingFilter';


### PR DESCRIPTION
Adds the `transferAllMatchingFilter` prop to `TransferList` that, when true, makes it so clicking the `transfer all` button transfers only items that match the current search.

Resolves #3430 