### PR TITLE
[@mantine-form] add values ref to access the changed values immediately when executing `setFieldValue`

### DIFF
--- a/src/mantine-form/src/types.ts
+++ b/src/mantine-form/src/types.ts
@@ -127,6 +127,7 @@ export interface UseFormReturnType<
   TransformValues extends _TransformValues<Values> = (values: Values) => Values
 > {
   values: Values;
+  valuesRef: MutableRefObject<Values>;
   errors: FormErrors;
   setValues: SetValues<Values>;
   setErrors: SetErrors;

--- a/src/mantine-form/src/use-form.ts
+++ b/src/mantine-form/src/use-form.ts
@@ -48,6 +48,7 @@ export function useForm<
   const [touched, setTouched] = useState(initialTouched);
   const [dirty, setDirty] = useState(initialDirty);
   const [values, _setValues] = useState(initialValues);
+  const valuesRef = useRef<Values>(values);
   const [errors, _setErrors] = useState(filterErrors(initialErrors));
   const _dirtyValues = useRef<Values>(initialValues);
   const _setDirtyValues = (_values: Values) => {
@@ -120,6 +121,8 @@ export function useForm<
           ? setFieldError(path, validationResults.error)
           : clearFieldError(path);
       }
+
+      valuesRef.current = result;
 
       return result;
     });
@@ -251,6 +254,7 @@ export function useForm<
 
   return {
     values,
+    valuesRef,
     errors,
     setValues,
     setErrors,


### PR DESCRIPTION
### Discussion
https://github.com/mantinedev/mantine/discussions/3445

### Proposal

`useForm` hook should return a ref of the changed `form.values`.
 
### What's the use?

We can use the changed `form.values` via the ref immediately, without waiting for React to execute the `setState` function that requires a re-render.

### Any Example/Design Spec ?

```
import { useForm } from '@mantine/form';

const Test = () => {
  const form = useForm({
    initialValues: {
      fruit: ''
    }
  });

  return (
    <select
      value={form.values.fruit}
      onChange={event => {
        form.setFieldValue('fruit', event.target.value);
        // I want to access the updated `form.values` here.
        // But current `form.values` couldn't adapt the requirement.
        console.log(form.values);
      }}
    >
      <option value="grapefruit">Grapefruit</option>
      <option value="lime">Lime</option>
      <option value="coconut">Coconut</option>
      <option value="mango">Mango</option>
    </select>
  );
};

export default Test;
```

If having a ref of values
```
<select
  value={form.values.fruit}
  onChange={event => {
    form.setFieldValue('fruit', event.target.value);

    // Works now
    console.log(form.valuesRef.current);
  }}
>
  ...
</select>
```
