### PR TITLE
[@mantine/spotlight] Spotlight: Pass transitionDuration to GroupedTransition

### DIFF
--- a/src/mantine-spotlight/src/Spotlight/Spotlight.tsx
+++ b/src/mantine-spotlight/src/Spotlight/Spotlight.tsx
@@ -217,6 +217,8 @@ export function Spotlight({
         onExited={() => lockScroll(false)}
         onEntered={() => lockScroll(true)}
         mounted={opened}
+        duration={transitionDuration}
+        exitDuration={transitionDuration}
         transitions={{
           spotlight: {
             duration: transitionDuration,


### PR DESCRIPTION
This prevents `setTimeout` from being called when the Spotlight transitionDuration is 0.

This is the same fix as #1089, just for the Spotlight component.