### PR TITLE
[@mantine/core] Pagination: Added zero spacing support

### DIFF
--- a/src/mantine-core/src/Pagination/Pagination.tsx
+++ b/src/mantine-core/src/Pagination/Pagination.tsx
@@ -136,7 +136,7 @@ export const Pagination = forwardRef<HTMLDivElement, PaginationProps>((props, re
   return (
     <Group
       role="navigation"
-      spacing={spacing || theme.fn.size({ size, sizes: theme.spacing }) / 2}
+      spacing={spacing ?? theme.fn.size({ size, sizes: theme.spacing }) / 2}
       ref={ref}
       sx={sx}
       unstyled={unstyled}


### PR DESCRIPTION
This fixes issue #3441 where passing `spacing={0}` defaults to the fallback