### PR TITLE
[@mantine/core] Dependency: migrate `@floating-ui/react-dom-interactions` to `@floating-ui/react`

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@emotion/react": "11.9.3",
     "@emotion/server": "11.4.0",
     "@emotion/styled": "^11.10.0",
-    "@floating-ui/react-dom-interactions": "^0.10.1",
+    "@floating-ui/react": "^0.19.1",
     "@radix-ui/react-scroll-area": "1.0.2",
     "@tabler/icons": "^1.119.0",
     "@tiptap/extension-code-block-lowlight": "^2.0.0-beta.202",

--- a/src/mantine-core/package.json
+++ b/src/mantine-core/package.json
@@ -36,7 +36,7 @@
     "@mantine/styles": "5.10.2",
     "@radix-ui/react-scroll-area": "1.0.2",
     "react-textarea-autosize": "8.3.4",
-    "@floating-ui/react-dom-interactions": "^0.10.1"
+    "@floating-ui/react": "^0.19.1"
   },
   "devDependencies": {}
 }

--- a/src/mantine-core/src/Floating/use-floating-auto-update.ts
+++ b/src/mantine-core/src/Floating/use-floating-auto-update.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { autoUpdate } from '@floating-ui/react-dom-interactions';
+import { autoUpdate } from '@floating-ui/react';
 import { useDidUpdate } from '@mantine/hooks';
 
 interface Payload {

--- a/src/mantine-core/src/Popover/Popover.context.ts
+++ b/src/mantine-core/src/Popover/Popover.context.ts
@@ -1,4 +1,4 @@
-import { ReferenceType } from '@floating-ui/react-dom-interactions';
+import { ReferenceType } from '@floating-ui/react';
 import { createSafeContext } from '@mantine/utils';
 import { MantineNumberSize, MantineShadow, ClassNames, Styles } from '@mantine/styles';
 import { FloatingPosition, ArrowPosition } from '../Floating';

--- a/src/mantine-core/src/Popover/use-popover.ts
+++ b/src/mantine-core/src/Popover/use-popover.ts
@@ -9,7 +9,7 @@ import {
   Middleware,
   inline,
   limitShift,
-} from '@floating-ui/react-dom-interactions';
+} from '@floating-ui/react';
 import { FloatingPosition, useFloatingAutoUpdate } from '../Floating';
 import { PopoverWidth, PopoverMiddlewares } from './Popover.types';
 

--- a/src/mantine-core/src/Tooltip/TooltipFloating/use-floating-tooltip.ts
+++ b/src/mantine-core/src/Tooltip/TooltipFloating/use-floating-tooltip.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useFloating, shift, getOverflowAncestors } from '@floating-ui/react-dom-interactions';
+import { useFloating, shift, getOverflowAncestors } from '@floating-ui/react';
 import { FloatingPosition } from '../../Floating';
 
 interface UseFloatingTooltip {

--- a/src/mantine-core/src/Tooltip/TooltipGroup/TooltipGroup.tsx
+++ b/src/mantine-core/src/Tooltip/TooltipGroup/TooltipGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FloatingDelayGroup } from '@floating-ui/react-dom-interactions';
+import { FloatingDelayGroup } from '@floating-ui/react';
 import { TooltipGroupProvider } from './TooltipGroup.context';
 
 export interface TooltipGroupProps {

--- a/src/mantine-core/src/Tooltip/use-tooltip.ts
+++ b/src/mantine-core/src/Tooltip/use-tooltip.ts
@@ -13,7 +13,7 @@ import {
   useDelayGroupContext,
   useDelayGroup,
   inline,
-} from '@floating-ui/react-dom-interactions';
+} from '@floating-ui/react';
 import { useId, useDidUpdate } from '@mantine/hooks';
 import { useTooltipGroupContext } from './TooltipGroup/TooltipGroup.context';
 import { FloatingPosition, useFloatingAutoUpdate } from '../Floating';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1866,32 +1866,33 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@floating-ui/core@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.1.tgz#00e64d74e911602c8533957af0cce5af6b2e93c8"
-  integrity sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==
+"@floating-ui/core@^1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.1.1.tgz#cf8b4cdd8987c687329a6099561764d8a16f2f22"
+  integrity sha512-PL7g3dhA4dHgZfujkuD8Q+tfJJynEtnNQSPzmucCnxMvkxf4cLBJw/ZYqZUn4HCh33U3WHrAfv2R2tbi9UCSmw==
 
-"@floating-ui/dom@^1.0.0":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.2.tgz#c5184c52c6f50abd11052d71204f4be2d9245237"
-  integrity sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==
+"@floating-ui/dom@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.1.1.tgz#66aa747e15894910869bf9144fc54fc7d6e9f975"
+  integrity sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==
   dependencies:
-    "@floating-ui/core" "^1.0.1"
+    "@floating-ui/core" "^1.1.0"
 
-"@floating-ui/react-dom-interactions@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom-interactions/-/react-dom-interactions-0.10.1.tgz#45fc7c3d9a2ae58f0ef39078660e97594f484af8"
-  integrity sha512-mb9Sn/cnPjVlEucSZTSt4Iu7NAvqnXTvmzeE5EtfdRhVQO6L94dqqT+DPTmJmbiw4XqzoyGP+Q6J+I5iK2p6bw==
+"@floating-ui/react-dom@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-1.2.2.tgz#ed256992fd44fcfcddc96da68b4b92f123d61871"
+  integrity sha512-DbmFBLwFrZhtXgCI2ra7wXYT8L2BN4/4AMQKyu05qzsVji51tXOfF36VE2gpMB6nhJGHa85PdEg75FB4+vnLFQ==
   dependencies:
-    "@floating-ui/react-dom" "^1.0.0"
+    "@floating-ui/dom" "^1.1.1"
+
+"@floating-ui/react@^0.19.1":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.19.1.tgz#bcaeaf3856dfeea388816f7e66750cab26208376"
+  integrity sha512-h7hr53rLp+VVvWvbu0dOBvGsLeeZwn1DTLIllIaLYjGWw20YhAgEqegHU+nc7BJ30ttxq4Sq6hqARm0ne6chXQ==
+  dependencies:
+    "@floating-ui/react-dom" "^1.2.2"
     aria-hidden "^1.1.3"
-
-"@floating-ui/react-dom@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-1.0.0.tgz#e0975966694433f1f0abffeee5d8e6bb69b7d16e"
-  integrity sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==
-  dependencies:
-    "@floating-ui/dom" "^1.0.0"
+    tabbable "^6.0.1"
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
@@ -14243,6 +14244,11 @@ syncpack@^5.7.11:
     glob "7.1.6"
     read-yaml-file "2.0.0"
     semver "7.3.4"
+
+tabbable@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.0.1.tgz#427a09b13c83ae41eed3e88abb76a4af28bde1a6"
+  integrity sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA==
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
issue: https://github.com/mantinedev/mantine/issues/3376