### PR TITLE
[docs] Fix an overflow issue in iOS

### DIFF
--- a/docs/src/components/Layout/Layout.styles.ts
+++ b/docs/src/components/Layout/Layout.styles.ts
@@ -1,6 +1,6 @@
 import { createStyles } from '@mantine/core';
 import { HEADER_HEIGHT } from './Header/HeaderDesktop.styles';
-import { NAVBAR_WIDTH, NAVBAR_BREAKPOINT } from './Navbar/Navbar.styles';
+import { NAVBAR_BREAKPOINT, NAVBAR_WIDTH } from './Navbar/Navbar.styles';
 
 interface LayoutStyles {
   shouldRenderHeader: boolean;
@@ -36,6 +36,7 @@ export default createStyles((theme, { shouldRenderHeader }: LayoutStyles) => ({
     [`@media (max-width: ${NAVBAR_BREAKPOINT}px)`]: {
       paddingLeft: 0,
       paddingRight: 0,
+      overflowX: 'hidden',
     },
   },
 


### PR DESCRIPTION
I found that some pages have overflow issues when I access Mantine docs on my iPhone.

<img width="256" alt="image" src="https://user-images.githubusercontent.com/66169832/216605350-aa7f46c8-e6f7-4e0b-93d7-bce909a02d5d.png">
<img width="261" alt="image" src="https://user-images.githubusercontent.com/66169832/216605515-809d3bc1-09d3-418d-9d8c-72e070583d94.png">
