### PR TITLE
[@mantine/core] MultiSelect: Add missing default for dropdownPosition

### DIFF
--- a/src/mantine-core/src/MultiSelect/MultiSelect.tsx
+++ b/src/mantine-core/src/MultiSelect/MultiSelect.tsx
@@ -147,6 +147,7 @@ const defaultProps: Partial<MultiSelectProps> = {
   selectOnBlur: false,
   clearButtonTabIndex: 0,
   positionDependencies: [],
+  dropdownPosition: "flip"
 };
 
 export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>((props, ref) => {

--- a/src/mantine-core/src/MultiSelect/MultiSelect.tsx
+++ b/src/mantine-core/src/MultiSelect/MultiSelect.tsx
@@ -147,7 +147,7 @@ const defaultProps: Partial<MultiSelectProps> = {
   selectOnBlur: false,
   clearButtonTabIndex: 0,
   positionDependencies: [],
-  dropdownPosition: "flip"
+  dropdownPosition: 'flip',
 };
 
 export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>((props, ref) => {


### PR DESCRIPTION
The [documentation](https://mantine.dev/core/multi-select/#dropdown-position) claims `MultiSelect` uses `"flip"` as the default for `dropdownPosition`, but is instead `undefined`.