### PR TITLE
[@mantine/modals] Fix various issues regarding usage assumptions

### DIFF
--- a/src/mantine-modals/src/ModalsProvider.tsx
+++ b/src/mantine-modals/src/ModalsProvider.tsx
@@ -122,16 +122,15 @@ export function ModalsProvider({ children, modalProps, labels, modals }: ModalsP
   };
 
   const closeModal = (id: string, canceled?: boolean) => {
-    if (state.modals.length <= 1) {
-      closeAll(canceled);
+    const modal = state.modals.find((item) => item.id === id);
+    if (!modal) {
       return;
     }
 
-    const modal = state.modals.find((item) => item.id === id);
-    if (modal?.type === 'confirm' && canceled) {
-      modal.props?.onCancel?.();
+    if (modal.type === 'confirm' && canceled) {
+      modal.props.onCancel?.();
     }
-    modal?.props?.onClose?.();
+    modal.props.onClose?.();
     dispatch({ type: 'CLOSE', payload: modal.id });
   };
 

--- a/src/mantine-modals/src/reducer.ts
+++ b/src/mantine-modals/src/reducer.ts
@@ -31,14 +31,15 @@ export function modalsReducer(
       };
     }
     case 'CLOSE': {
+      const modals = state.modals.filter((m) => m.id !== action.payload);
       return {
-        current: state.modals[state.modals.length - 2] || null,
-        modals: state.modals.filter((m) => m.id !== action.payload),
+        current: modals[modals.length - 1] || null,
+        modals,
       };
     }
     case 'CLOSE_ALL': {
       return {
-        current: state.current,
+        current: null,
         modals: [],
       };
     }


### PR DESCRIPTION
This PR fixes some issues regarding multi modal handling.
- `closeModal()` crashed when providing an invalid id
- If only one modal was left calling `closeModal()` would close this modal regardless whether the given id is correct
- `closeModal()` assumed that the given modal is the topmost one and therefore modified the state accordingly. This might lead to a not topmost modal suddenly popping up

The fixes now introduce a more defensive approach by checking for validity and not making these assumptions.