### PR TITLE
[docs] Fix erroneous drawer size prop documentation

### DIFF
--- a/docs/src/docs/core/Drawer.mdx
+++ b/docs/src/docs/core/Drawer.mdx
@@ -44,7 +44,7 @@ Size cannot exceed 100% of width and 100vh of height.
 
 ```tsx
 <Drawer position="right" size="xl" /> // predefined xl width
-<Drawer position="top" size={200} /> // 200px width
+<Drawer position="top" size={200} /> // 200px height
 <Drawer position="left" size="75%" /> // 75% width
 ```
 


### PR DESCRIPTION
The size prop controls the width of the drawer for left/right positionned drawers and height for top/bottom drawers. I've corrected a tiny issue where the documentation contradicted itself by saying the size controlled the width for a top drawer