### PR TITLE
[@mantine/hooks] use-disclosure

### DIFF
--- a/src/mantine-hooks/src/use-disclosure/use-disclosure.ts
+++ b/src/mantine-hooks/src/use-disclosure/use-disclosure.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 
 export function useDisclosure(
   initialState: boolean,
@@ -6,23 +6,29 @@ export function useDisclosure(
 ) {
   const [opened, setOpened] = useState(initialState);
 
-  const open = () => {
-    if (!opened) {
-      setOpened(true);
-      callbacks?.onOpen?.();
-    }
-  };
+  const open = useCallback(() => {
+    setOpened((isOpened) => {
+      if (!isOpened) {
+        callbacks?.onOpen?.();
+        return true;
+      }
+      return isOpened;
+    });
+  }, []);
 
-  const close = () => {
-    if (opened) {
-      setOpened(false);
-      callbacks?.onClose?.();
-    }
-  };
+  const close = useCallback(() => {
+    setOpened((isOpened) => {
+      if (isOpened) {
+        callbacks?.onClose?.();
+        return false;
+      }
+      return isOpened;
+    });
+  }, []);
 
-  const toggle = () => {
+  const toggle = useCallback(() => {
     opened ? close() : open();
-  };
+  }, [opened]);
 
   return [opened, { open, close, toggle }] as const;
 }

--- a/src/mantine-hooks/src/use-disclosure/use-disclosure.ts
+++ b/src/mantine-hooks/src/use-disclosure/use-disclosure.ts
@@ -1,34 +1,35 @@
 import { useState, useCallback } from 'react';
 
 export function useDisclosure(
-  initialState: boolean,
+  initialState = false,
   callbacks?: { onOpen?(): void; onClose?(): void }
 ) {
+  const { onOpen, onClose } = callbacks || {};
   const [opened, setOpened] = useState(initialState);
 
   const open = useCallback(() => {
     setOpened((isOpened) => {
       if (!isOpened) {
-        callbacks?.onOpen?.();
+        onOpen?.();
         return true;
       }
       return isOpened;
     });
-  }, []);
+  }, [onOpen]);
 
   const close = useCallback(() => {
     setOpened((isOpened) => {
       if (isOpened) {
-        callbacks?.onClose?.();
+        onClose?.();
         return false;
       }
       return isOpened;
     });
-  }, []);
+  }, [onClose]);
 
   const toggle = useCallback(() => {
     opened ? close() : open();
-  }, [opened]);
+  }, [close, open, opened]);
 
   return [opened, { open, close, toggle }] as const;
 }


### PR DESCRIPTION
Avoid re-render when using disclosure functions.
Use callbacks and the functional version of the "set" of the state to avoid re-render in effects that depend on
"open", "close" or "toggle" function of disclosure.

Something like this 

```js
const [opened, {open}] = useDisclosure(false);

useEffect(()=> {
 open();
},[open]);
```

the effect was re-run when the opened value changed, which is wrong