### PR TITLE
[docs] Fix props typo

### DIFF
--- a/docs/src/docs/changelog/6-0-0.mdx
+++ b/docs/src/docs/changelog/6-0-0.mdx
@@ -240,7 +240,7 @@ props were renamed:
 - `overlayOpacity` → `overlayProps.opacity`
 - `exitTransitionDuration` → `transitionProps.exitDuration`
 - `transition` → `transitionProps.transition`
-- `transitionDuration` → `transitionProps.transition`
+- `transitionDuration` → `transitionProps.duration`
 - `transitionTimingFunction` → `transitionProps.timingFunction`
 
 `Modal` styles API changes:


### PR DESCRIPTION
Fix props typo from `transitionDuration` → `transitionProps.transition` to `transitionDuration` → `transitionProps.duration`