### PR TITLE
[@mantine/dates] Clear invalid range value on dropdown close and add labelSeprator to range value

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.8.0'
+          node-version: '16.10.0'
           cache: 'yarn'
           cache-dependency-path: '**/yarn.lock'
       - name: Install dependencies

--- a/docs/src/docs/changelog/6-0-0.mdx
+++ b/docs/src/docs/changelog/6-0-0.mdx
@@ -240,7 +240,7 @@ props were renamed:
 - `overlayOpacity` → `overlayProps.opacity`
 - `exitTransitionDuration` → `transitionProps.exitDuration`
 - `transition` → `transitionProps.transition`
-- `transitionDuration` → `transitionProps.transition`
+- `transitionDuration` → `transitionProps.duration`
 - `transitionTimingFunction` → `transitionProps.timingFunction`
 
 `Modal` styles API changes:

--- a/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.story.tsx
+++ b/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.story.tsx
@@ -151,6 +151,7 @@ export function Range() {
   return (
     <div style={{ padding: 40 }}>
       <DatePickerInput type="range" label="Date picker input" />
+      <DatePickerInput type="range" label="Custom labelSeparator" labelSeparator="~" />
     </div>
   );
 }

--- a/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.tsx
+++ b/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.tsx
@@ -27,7 +27,6 @@ type DatePickerInputComponent = (<Type extends DatePickerType = 'default'>(
 const defaultProps: Partial<DatePickerInputProps> = {
   type: 'default',
   valueFormat: 'MMMM D, YYYY',
-  labelSeparator: '-',
   closeOnChange: true,
   sortDates: true,
   dropdownType: 'popover',

--- a/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.tsx
+++ b/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.tsx
@@ -27,6 +27,7 @@ type DatePickerInputComponent = (<Type extends DatePickerType = 'default'>(
 const defaultProps: Partial<DatePickerInputProps> = {
   type: 'default',
   valueFormat: 'MMMM D, YYYY',
+  labelSeparator: '-',
   closeOnChange: true,
   sortDates: true,
   dropdownType: 'popover',
@@ -39,6 +40,7 @@ export const DatePickerInput: DatePickerInputComponent = forwardRef((props, ref)
     defaultValue,
     onChange,
     valueFormat,
+    labelSeparator,
     locale,
     classNames,
     styles,
@@ -70,6 +72,7 @@ export const DatePickerInput: DatePickerInputComponent = forwardRef((props, ref)
     onChange,
     locale,
     format: valueFormat,
+    labelSeparator,
     closeOnChange,
     sortDates,
   });

--- a/src/mantine-dates/src/components/DatesProvider/DatesProvider.tsx
+++ b/src/mantine-dates/src/components/DatesProvider/DatesProvider.tsx
@@ -3,6 +3,7 @@ import { DayOfWeek } from '../../types';
 
 export interface DatesProviderValue {
   locale: string;
+  labelSeparator: string;
   firstDayOfWeek: DayOfWeek;
   weekendDays: DayOfWeek[];
 }
@@ -11,6 +12,7 @@ export type DatesProviderSettings = Partial<DatesProviderValue>;
 
 export const DATES_PROVIDER_DEFAULT_SETTINGS: DatesProviderValue = {
   locale: 'en',
+  labelSeparator: '-',
   firstDayOfWeek: 1,
   weekendDays: [0, 6],
 };

--- a/src/mantine-dates/src/components/DatesProvider/use-dates-context.ts
+++ b/src/mantine-dates/src/components/DatesProvider/use-dates-context.ts
@@ -15,10 +15,16 @@ export function useDatesContext() {
     [ctx.weekendDays]
   );
 
+  const getLabelSeparator = useCallback(
+    (input?: string) => input || ctx.labelSeparator,
+    [ctx.labelSeparator]
+  );
+
   return {
     ...ctx,
     getLocale,
     getFirstDayOfWeek,
     getWeekendDays,
+    getLabelSeparator,
   };
 }

--- a/src/mantine-dates/src/components/MonthPickerInput/MonthPickerInput.story.tsx
+++ b/src/mantine-dates/src/components/MonthPickerInput/MonthPickerInput.story.tsx
@@ -39,6 +39,7 @@ export function Range() {
   return (
     <div style={{ padding: 40 }}>
       <MonthPickerInput type="range" label="Month picker input" />
+      <MonthPickerInput type="range" label="Custom labelSeparator" labelSeparator="~" />
     </div>
   );
 }

--- a/src/mantine-dates/src/components/MonthPickerInput/MonthPickerInput.tsx
+++ b/src/mantine-dates/src/components/MonthPickerInput/MonthPickerInput.tsx
@@ -27,6 +27,7 @@ type MonthPickerInputComponent = (<Type extends DatePickerType = 'default'>(
 const defaultProps: Partial<MonthPickerInputProps> = {
   type: 'default',
   valueFormat: 'MMMM YYYY',
+  labelSeparator: '-',
   closeOnChange: true,
   sortDates: true,
   dropdownType: 'popover',
@@ -39,6 +40,7 @@ export const MonthPickerInput: MonthPickerInputComponent = forwardRef((props, re
     defaultValue,
     onChange,
     valueFormat,
+    labelSeparator,
     locale,
     classNames,
     styles,
@@ -70,6 +72,7 @@ export const MonthPickerInput: MonthPickerInputComponent = forwardRef((props, re
     onChange,
     locale,
     format: valueFormat,
+    labelSeparator,
     closeOnChange,
     sortDates,
   });

--- a/src/mantine-dates/src/components/MonthPickerInput/MonthPickerInput.tsx
+++ b/src/mantine-dates/src/components/MonthPickerInput/MonthPickerInput.tsx
@@ -27,7 +27,6 @@ type MonthPickerInputComponent = (<Type extends DatePickerType = 'default'>(
 const defaultProps: Partial<MonthPickerInputProps> = {
   type: 'default',
   valueFormat: 'MMMM YYYY',
-  labelSeparator: '-',
   closeOnChange: true,
   sortDates: true,
   dropdownType: 'popover',

--- a/src/mantine-dates/src/components/PickerInputBase/PickerInputBase.tsx
+++ b/src/mantine-dates/src/components/PickerInputBase/PickerInputBase.tsx
@@ -54,6 +54,9 @@ export interface DateInputSharedProps
 
   /** Determines whether dates value should be sorted before onChange call, only applicable when type="multiple", true by default */
   sortDates?: boolean;
+
+  /** Separator between range value */
+  labelSeparator?: string;
 }
 
 export interface PickerInputBaseProps extends DateInputSharedProps {
@@ -96,6 +99,7 @@ export const PickerInputBase = forwardRef<HTMLButtonElement, PickerInputBaseProp
     name,
     form,
     type,
+    disabled,
     ...others
   } = useInputProps(props.__staticSelector, defaultProps, props);
 
@@ -110,7 +114,7 @@ export const PickerInputBase = forwardRef<HTMLButtonElement, PickerInputBaseProp
 
   const _rightSection =
     rightSection ||
-    (clearable && shouldClear && !readOnly ? (
+    (clearable && shouldClear && !readOnly && !disabled ? (
       <CloseButton
         variant="transparent"
         onClick={onClear}
@@ -120,12 +124,21 @@ export const PickerInputBase = forwardRef<HTMLButtonElement, PickerInputBaseProp
       />
     ) : null);
 
+  const handleClose = () => {
+    const isInvalidRangeValue = type === 'range' && value[0] && !value[1];
+    if (isInvalidRangeValue) {
+      onClear();
+    }
+
+    dropdownHandlers.close();
+  };
+
   return (
     <>
       {dropdownType === 'modal' && !readOnly && (
         <Modal
           opened={dropdownOpened}
-          onClose={dropdownHandlers.close}
+          onClose={handleClose}
           withCloseButton={false}
           size="auto"
           data-dates-modal
@@ -140,7 +153,7 @@ export const PickerInputBase = forwardRef<HTMLButtonElement, PickerInputBaseProp
         <Popover
           position="bottom-start"
           opened={dropdownOpened}
-          onClose={dropdownHandlers.close}
+          onClose={handleClose}
           disabled={dropdownType === 'modal' || readOnly}
           trapFocus
           returnFocus
@@ -151,6 +164,7 @@ export const PickerInputBase = forwardRef<HTMLButtonElement, PickerInputBaseProp
             <Input
               data-dates-input
               data-read-only={readOnly || undefined}
+              disabled={disabled}
               component="button"
               type="button"
               multiline

--- a/src/mantine-dates/src/components/YearPickerInput/YearPickerInput.story.tsx
+++ b/src/mantine-dates/src/components/YearPickerInput/YearPickerInput.story.tsx
@@ -56,6 +56,7 @@ export function Range() {
   return (
     <div style={{ padding: 40 }}>
       <YearPickerInput type="range" label="Year picker input" />
+      <YearPickerInput type="range" label="Custom labelSeparator" labelSeparator="~" />
     </div>
   );
 }
@@ -94,6 +95,8 @@ export function Clearable() {
       <YearPickerInput label="Default" clearable />
       <YearPickerInput label="Multiple" type="multiple" clearable />
       <YearPickerInput label="Range" type="range" clearable />
+      <YearPickerInput label="Readonly" value={[new Date(), new Date()]} type="range" clearable readOnly />
+      <YearPickerInput label="Disabled" value={[new Date(), new Date()]} type="range" clearable disabled />
     </div>
   );
 }

--- a/src/mantine-dates/src/components/YearPickerInput/YearPickerInput.story.tsx
+++ b/src/mantine-dates/src/components/YearPickerInput/YearPickerInput.story.tsx
@@ -95,8 +95,20 @@ export function Clearable() {
       <YearPickerInput label="Default" clearable />
       <YearPickerInput label="Multiple" type="multiple" clearable />
       <YearPickerInput label="Range" type="range" clearable />
-      <YearPickerInput label="Readonly" value={[new Date(), new Date()]} type="range" clearable readOnly />
-      <YearPickerInput label="Disabled" value={[new Date(), new Date()]} type="range" clearable disabled />
+      <YearPickerInput
+        label="Readonly"
+        value={[new Date(), new Date()]}
+        type="range"
+        clearable
+        readOnly
+      />
+      <YearPickerInput
+        label="Disabled"
+        value={[new Date(), new Date()]}
+        type="range"
+        clearable
+        disabled
+      />
     </div>
   );
 }

--- a/src/mantine-dates/src/components/YearPickerInput/YearPickerInput.tsx
+++ b/src/mantine-dates/src/components/YearPickerInput/YearPickerInput.tsx
@@ -27,6 +27,7 @@ type YearPickerInputComponent = (<Type extends DatePickerType = 'default'>(
 const defaultProps: Partial<YearPickerInputProps> = {
   type: 'default',
   valueFormat: 'YYYY',
+  labelSeparator: '-',
   closeOnChange: true,
   sortDates: true,
   dropdownType: 'popover',
@@ -39,6 +40,7 @@ export const YearPickerInput: YearPickerInputComponent = forwardRef((props, ref)
     defaultValue,
     onChange,
     valueFormat,
+    labelSeparator,
     locale,
     classNames,
     styles,
@@ -70,6 +72,7 @@ export const YearPickerInput: YearPickerInputComponent = forwardRef((props, ref)
     onChange,
     locale,
     format: valueFormat,
+    labelSeparator,
     closeOnChange,
     sortDates,
   });

--- a/src/mantine-dates/src/components/YearPickerInput/YearPickerInput.tsx
+++ b/src/mantine-dates/src/components/YearPickerInput/YearPickerInput.tsx
@@ -27,7 +27,6 @@ type YearPickerInputComponent = (<Type extends DatePickerType = 'default'>(
 const defaultProps: Partial<YearPickerInputProps> = {
   type: 'default',
   valueFormat: 'YYYY',
-  labelSeparator: '-',
   closeOnChange: true,
   sortDates: true,
   dropdownType: 'popover',

--- a/src/mantine-dates/src/hooks/use-dates-input/use-dates-input.ts
+++ b/src/mantine-dates/src/hooks/use-dates-input/use-dates-input.ts
@@ -11,6 +11,7 @@ interface UseDatesInput<Type extends DatePickerType = 'default'> {
   onChange(value: DatePickerValue<Type>): void;
   locale: string;
   format: string;
+  labelSeparator: string;
   closeOnChange: boolean;
   sortDates: boolean;
 }
@@ -22,6 +23,7 @@ export function useDatesInput<Type extends DatePickerType = 'default'>({
   onChange,
   locale,
   format,
+  labelSeparator,
   closeOnChange,
   sortDates,
 }: UseDatesInput<Type>) {
@@ -41,6 +43,7 @@ export function useDatesInput<Type extends DatePickerType = 'default'>({
     date: _value,
     locale: ctx.getLocale(locale),
     format,
+    labelSeparator,
   });
 
   const setValue = (val: any) => {

--- a/src/mantine-dates/src/hooks/use-dates-input/use-dates-input.ts
+++ b/src/mantine-dates/src/hooks/use-dates-input/use-dates-input.ts
@@ -43,7 +43,7 @@ export function useDatesInput<Type extends DatePickerType = 'default'>({
     date: _value,
     locale: ctx.getLocale(locale),
     format,
-    labelSeparator,
+    labelSeparator: ctx.getLabelSeparator(labelSeparator),
   });
 
   const setValue = (val: any) => {

--- a/src/mantine-dates/src/utils/get-formatted-date.ts
+++ b/src/mantine-dates/src/utils/get-formatted-date.ts
@@ -6,6 +6,7 @@ interface GetFormattedDate<Type extends DatePickerType = 'default'> {
   date: DatePickerValue<Type>;
   locale: string;
   format: string;
+  labelSeparator: string;
 }
 
 export function getFormattedDate<Type extends DatePickerType>({
@@ -13,6 +14,7 @@ export function getFormattedDate<Type extends DatePickerType>({
   date,
   locale,
   format,
+  labelSeparator,
 }: GetFormattedDate<Type>) {
   const formatDate = (value: Date) => dayjs(value).locale(locale).format(format);
 
@@ -26,11 +28,11 @@ export function getFormattedDate<Type extends DatePickerType>({
 
   if (type === 'range') {
     if (date[0] && date[1]) {
-      return `${formatDate(date[0])} – ${formatDate(date[1])}`;
+      return `${formatDate(date[0])} ${labelSeparator} ${formatDate(date[1])}`;
     }
 
     if (date[0]) {
-      return `${formatDate(date[0])} – `;
+      return `${formatDate(date[0])} ${labelSeparator} `;
     }
 
     return '';

--- a/src/mantine-demos/src/demos/core/Input/Input.demo.configurator.tsx
+++ b/src/mantine-demos/src/demos/core/Input/Input.demo.configurator.tsx
@@ -50,6 +50,6 @@ export const configurator: MantineDemo = {
     { name: 'radius', type: 'size', initialValue: 'sm', defaultValue: 'sm' },
     { name: 'size', type: 'size', initialValue: 'sm', defaultValue: 'sm' },
     { name: 'disabled', type: 'boolean', initialValue: false, defaultValue: false },
-    { name: 'invalid', type: 'boolean', initialValue: false, defaultValue: false },
+    { name: 'error', type: 'boolean', initialValue: false, defaultValue: false },
   ],
 };

--- a/src/mantine-spotlight/src/DefaultAction/DefaultAction.styles.ts
+++ b/src/mantine-spotlight/src/DefaultAction/DefaultAction.styles.ts
@@ -43,4 +43,10 @@ export default createStyles((theme, { radius }: DefaultActionStylesParams) => ({
   },
 
   actionBody: {},
+
+  actionHighlight: {
+    '& [data-highlight]': {
+      color: theme.colorScheme === 'dark' ? theme.colors.dark[9] : theme.black,
+    },
+  },
 }));

--- a/src/mantine-spotlight/src/DefaultAction/DefaultAction.tsx
+++ b/src/mantine-spotlight/src/DefaultAction/DefaultAction.tsx
@@ -58,7 +58,11 @@ export function DefaultAction({
         )}
 
         <div className={classes.actionBody}>
-          <Highlight highlightColor={highlightColor} highlight={highlightQuery ? query : null}>
+          <Highlight
+            highlightColor={highlightColor}
+            className={classes.actionHighlight}
+            highlight={highlightQuery ? query : null}
+          >
             {action.title}
           </Highlight>
 

--- a/src/mantine-spotlight/src/Spotlight/Spotlight.tsx
+++ b/src/mantine-spotlight/src/Spotlight/Spotlight.tsx
@@ -216,7 +216,6 @@ export function Spotlight(props: SpotlightProps) {
         classNames={{ input: classes.searchInput }}
         placeholder={searchPlaceholder}
         icon={searchIcon}
-        onMouseEnter={resetHovered}
       />
       <ActionsWrapper>
         <ScrollAreaComponent>


### PR DESCRIPTION
1、Clear Invalid range value like  `[2023, null]`, while dropdown closed, in v5 there had this logic in DateRangePicker. (I'm not sure this is intentional by design.
![image](https://user-images.githubusercontent.com/1364025/217809639-5ea85911-8e5d-4def-954e-a835e9fd9ab6.png)


2、Add `labelSeprator` to `DatePickerInput` \ `MonthPickerInput` \ `YearPickerInput`.
![image](https://user-images.githubusercontent.com/1364025/217808616-43b753b7-31e9-4ed9-834c-132cf33da295.png)
