### PR TITLE
[@mantine/Core] Modal: fix header inappropriate margin right 

### DIFF
--- a/src/mantine-core/src/Modal/Modal.styles.ts
+++ b/src/mantine-core/src/Modal/Modal.styles.ts
@@ -87,7 +87,6 @@ export default createStyles(
       alignItems: 'center',
       justifyContent: 'space-between',
       marginBottom: theme.spacing.md,
-      marginRight: -9,
     },
 
     body: {


### PR DESCRIPTION
It's just a minor style problem.The original Header has ' margin-right: -9 ' and seems to be used to offset the position of the close button.This works well under the default padding. But  shrinking the padding will result in a very strange style.

Example:
1.Default padding and with ' margin-right: -9 '

<img width="478" alt="image" src="https://user-images.githubusercontent.com/78251524/217860058-2d81cbd3-ab38-49ca-86c8-e1f2fb04775a.png">

2.padding = "sm" and with ' margin-right: -9 '
When hovering over the close button, it will be very close to the modal right.

<img width="507" alt="image" src="https://user-images.githubusercontent.com/78251524/217860896-94982805-23ff-4c67-bcab-a93b5e6d57a4.png">

3.padding = "sm" and without ' margin-right: -9 '


<img width="499" alt="image" src="https://user-images.githubusercontent.com/78251524/217861179-a62385e9-4bb9-4787-89dd-a7bfc35fbb51.png">

It may be a little hasty to delete it directly.It may be possible to set it dynamically based on the padding value passed in, but this requires more testing.



