### PR TITLE
fix(core): anchor color not working

### DIFF
--- a/src/mantine-core/src/Anchor/Anchor.styles.ts
+++ b/src/mantine-core/src/Anchor/Anchor.styles.ts
@@ -6,7 +6,6 @@ export default createStyles((theme) => ({
     cursor: 'pointer',
     padding: 0,
     border: 0,
-    color: theme.colors[theme.primaryColor][theme.colorScheme === 'dark' ? 4 : 7],
     ...theme.fn.hover({ textDecoration: 'underline' }),
   },
 }));


### PR DESCRIPTION
The color style overwrites the `props.color`.