### PR TITLE
doc(others): add `@tiptap/pm` to tiptap installation

### DIFF
--- a/docs/src/docs/others/tiptap.mdx
+++ b/docs/src/docs/others/tiptap.mdx
@@ -21,13 +21,13 @@ import { TipTapDemos } from '@mantine/demos';
 Install with yarn:
 
 ```bash
-yarn add @mantine/tiptap @mantine/core @mantine/hooks @tabler/icons@1.119.0 @tiptap/react @tiptap/extension-link @tiptap/starter-kit
+yarn add @mantine/tiptap @mantine/core @mantine/hooks @tabler/icons@1.119.0 @tiptap/react @tiptap/pm @tiptap/extension-link @tiptap/starter-kit
 ```
 
 Install with npm:
 
 ```bash
-npm install @mantine/tiptap @mantine/core @mantine/hooks @tabler/icons@1.119.0 @tiptap/react @tiptap/extension-link @tiptap/starter-kit
+npm install @mantine/tiptap @mantine/core @mantine/hooks @tabler/icons@1.119.0 @tiptap/react @tiptap/pm @tiptap/extension-link @tiptap/starter-kit
 ```
 
 ## TipTap editor


### PR DESCRIPTION
According to the https://github.com/ueberdosis/tiptap/releases/tag/v2.0.0-beta.210 , `@tiptap/pm` is needed now.