### PR TITLE
[@mantine/modals] Fix jumping of centered modals on close (#3409)

### DIFF
--- a/src/mantine-modals/src/reducer.ts
+++ b/src/mantine-modals/src/reducer.ts
@@ -2,6 +2,11 @@ import { ModalState } from './context';
 
 interface ModalsState {
   modals: ModalState[];
+
+  /**
+   * Modal that is currently open or was the last open one.
+   * Keeping the last one is necessary for providing a clean exit transition.
+   */
   current: ModalState | null;
 }
 
@@ -33,13 +38,13 @@ export function modalsReducer(
     case 'CLOSE': {
       const modals = state.modals.filter((m) => m.id !== action.payload);
       return {
-        current: modals[modals.length - 1] || null,
+        current: modals[modals.length - 1] || state.current,
         modals,
       };
     }
     case 'CLOSE_ALL': {
       return {
-        current: null,
+        current: state.current,
         modals: [],
       };
     }


### PR DESCRIPTION
This fixes #3409.

Originally when closing the **last** modal the action `CLOSE_ALL` got called which cleaned the `modals` state but kept the last one around in `current`. Therefore when rendering the `ModalsProvider` the last modal had been rendered but with a closed state.

In my previous PR I changed this behaviour as in my opinion when a modal has been closed it shouldn't stay in `current` - even if it's the last one. Therefore during rendering the `ModalsProvider` a closed modal with default props got rendered instead. However because closing the modal isn't immediate because of an exit transition this default modal rendering was visible.

Therefore this PR partially reverts the last one and makes sure the last modal always will be kept around (not only in `CLOSE_ALL` but also in `CLOSE`. It also documents this behaviour to make sure other devs won't trip over it again.