### PR TITLE
[@mantine/core] Popover: fix floating-auto-update issue

### DIFF
--- a/src/mantine-core/src/Floating/use-floating-auto-update.ts
+++ b/src/mantine-core/src/Floating/use-floating-auto-update.ts
@@ -27,7 +27,7 @@ export function useFloatingAutoUpdate({ opened, floating, positionDependencies }
     }
 
     return undefined;
-  }, [floating.refs.reference, floating.refs.floating, opened, delayedUpdate]);
+  }, [floating.refs.reference.current, floating.refs.floating.current, opened, delayedUpdate]);
 
   useDidUpdate(() => {
     floating.update();

--- a/src/mantine-core/src/Popover/Popover.story.tsx
+++ b/src/mantine-core/src/Popover/Popover.story.tsx
@@ -21,6 +21,22 @@ export function Uncontrolled() {
   );
 }
 
+export function withFloatingAutoUpdate() {
+  return (
+    <div style={{ padding: 40, height: 400, overflow: 'scroll' }}>
+      <div style={{ height: 150 }} />
+      <Popover>
+        <Popover.Target>
+          <Button>Toggle popover</Button>
+        </Popover.Target>
+
+        <Popover.Dropdown>Dropdown</Popover.Dropdown>
+      </Popover>
+      <div style={{ height: 300 }} />
+    </div>
+  );
+}
+
 export function Disabled() {
   return (
     <div style={{ padding: 40 }}>


### PR DESCRIPTION
## Description

Popover drop-down not following target.

Issue link: [https://github.com/mantinedev/mantine/issues/3351](https://github.com/mantinedev/mantine/issues/3351)

## Details
`autoUpdate` in `useFloatingAutoUpdate` wasn't registering the `floating.refs.floating` changes