### PR TITLE
[docs] Fixed import typo for Switch.Group

### DIFF
--- a/docs/src/docs/core/Switch.mdx
+++ b/docs/src/docs/core/Switch.mdx
@@ -52,7 +52,7 @@ function Demo() {
 
 ```tsx
 import { useState } from 'react';
-import { Checkbox } from '@mantine/core';
+import { Switch } from '@mantine/core';
 
 function Demo() {
   const [value, setValue] = useState<string[]>([]);


### PR DESCRIPTION
Fixing issue highlighted here: https://github.com/mantinedev/mantine/issues/3599