### PR TITLE
[@mantine/core] Tooltip.Floating: Fix `disabled` behaviour

### DIFF
--- a/src/mantine-core/src/Tooltip/Tooltip.story.tsx
+++ b/src/mantine-core/src/Tooltip/Tooltip.story.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Tooltip } from './Tooltip';
 import { Button } from '../Button';
 import { Group } from '../Group';
+import { Box } from '../Box';
 
 export default { title: 'Tooltip' };
 
@@ -58,6 +59,34 @@ export const Floating = () => (
     </Tooltip.Floating>
   </div>
 );
+
+export const FloatingAndDisabled = () => {
+  const [tooltipEnabled, setTooltipEnabled] = useState(true);
+
+  return (
+    <div style={{ padding: 0 }}>
+      <Tooltip.Floating label="test" disabled={!tooltipEnabled}>
+        <Group>
+          <Box bg="red" w={100} h={100}>
+            Enabled
+          </Box>
+          <Box
+            bg="green"
+            w={100}
+            h={100}
+            onMouseEnter={() => setTooltipEnabled(false)}
+            onMouseLeave={() => setTooltipEnabled(true)}
+          >
+            Disabled
+          </Box>
+          <Box bg="blue" w={100} h={100}>
+            Enabled
+          </Box>
+        </Group>
+      </Tooltip.Floating>
+    </div>
+  );
+};
 
 export const Unmount = () => {
   const [mounted, setMounted] = useState(true);

--- a/src/mantine-core/src/Tooltip/TooltipFloating/TooltipFloating.tsx
+++ b/src/mantine-core/src/Tooltip/TooltipFloating/TooltipFloating.tsx
@@ -71,10 +71,6 @@ export function TooltipFloating(props: TooltipFloatingProps) {
     setOpened(false);
   };
 
-  if (disabled) {
-    return <>{children}</>;
-  }
-
   return (
     <>
       <OptionalPortal withinPortal={withinPortal}>
@@ -85,7 +81,7 @@ export function TooltipFloating(props: TooltipFloatingProps) {
           style={{
             ...style,
             zIndex,
-            display: opened ? 'block' : 'none',
+            display: !disabled && opened ? 'block' : 'none',
             top: y ?? '',
             left: Math.round(x) ?? '',
           }}

--- a/src/mantine-core/src/Tooltip/TooltipFloating/use-floating-tooltip.ts
+++ b/src/mantine-core/src/Tooltip/TooltipFloating/use-floating-tooltip.ts
@@ -75,7 +75,7 @@ export function useFloatingTooltip<T extends HTMLElement = any>({
     }
 
     return undefined;
-  }, [reference, refs.floating, update, handleMouseMove, opened]);
+  }, [reference, refs.floating.current, update, handleMouseMove, opened]);
 
   return { handleMouseMove, x, y, opened, setOpened, boundaryRef, floating };
 }


### PR DESCRIPTION
Fixes #3605 and adds a Storybook demo for it.