### PR TITLE
[docs] Update available color formats

### DIFF
--- a/docs/src/docs/core/ColorInput.mdx
+++ b/docs/src/docs/core/ColorInput.mdx
@@ -33,8 +33,8 @@ function Demo() {
 
 ## Formats
 
-Component supports hex, rgb, rgba, hsl and hsla color formats.
-Slider to change opacity is displayed only for rgba and hsla formats:
+Component supports hex, hexa, rgb, rgba, hsl and hsla color formats.
+Slider to change opacity is displayed only for hexa, rgba and hsla formats:
 
 <Demo data={ColorInputDemos.formatsConfigurator} />
 

--- a/docs/src/docs/core/ColorPicker.mdx
+++ b/docs/src/docs/core/ColorPicker.mdx
@@ -21,8 +21,8 @@ import { ColorPickerDemos } from '@mantine/demos';
 
 ## Color format
 
-Component supports hex, rgb, rgba, hsl and hsla color formats.
-Slider to change opacity is displayed only for rgba and hsla formats:
+Component supports hex, hexa, rgb, rgba, hsl and hsla color formats.
+Slider to change opacity is displayed only for hexa, rgba and hsla formats:
 
 <Demo data={ColorPickerDemos.formatsConfigurator} />
 


### PR DESCRIPTION
Noticed that I hadn't updated the documentation text when I added support for 'hexa' format in ColorPicker and ColorInput - this PR fixes that.