### PR TITLE
[@mantine/modals] Fix endless `closeAll()` loop

### DIFF
--- a/docs/src/docs/core/ColorInput.mdx
+++ b/docs/src/docs/core/ColorInput.mdx
@@ -33,8 +33,8 @@ function Demo() {
 
 ## Formats
 
-Component supports hex, rgb, rgba, hsl and hsla color formats.
-Slider to change opacity is displayed only for rgba and hsla formats:
+Component supports hex, hexa, rgb, rgba, hsl and hsla color formats.
+Slider to change opacity is displayed only for hexa, rgba and hsla formats:
 
 <Demo data={ColorInputDemos.formatsConfigurator} />
 

--- a/docs/src/docs/core/ColorPicker.mdx
+++ b/docs/src/docs/core/ColorPicker.mdx
@@ -21,8 +21,8 @@ import { ColorPickerDemos } from '@mantine/demos';
 
 ## Color format
 
-Component supports hex, rgb, rgba, hsl and hsla color formats.
-Slider to change opacity is displayed only for rgba and hsla formats:
+Component supports hex, hexa, rgb, rgba, hsl and hsla color formats.
+Slider to change opacity is displayed only for hexa, rgba and hsla formats:
 
 <Demo data={ColorPickerDemos.formatsConfigurator} />
 

--- a/src/mantine-modals/src/Modals.story.tsx
+++ b/src/mantine-modals/src/Modals.story.tsx
@@ -9,6 +9,7 @@ import {
   closeAllModals,
   closeModal,
   ContextModalProps,
+  useModals,
 } from './index';
 
 export default { title: 'Modals manager' };
@@ -134,6 +135,40 @@ export function NestedInsideModal() {
           Open confirm modal
         </Button>
       </Modal>
+    </ModalsProvider>
+  );
+}
+
+function CloseAllApp() {
+  const modals = useModals();
+
+  const handleClick = () => {
+    const modalId = Date.now();
+    console.log('Open modal', modalId);
+
+    modals.openModal({
+      title: `Created at ${modalId}`,
+      children: (
+        <div>
+          <p>Modal content...</p>
+          <Button onClick={handleClick}>Open other modal</Button>
+        </div>
+      ),
+      centered: true,
+      onClose: () => {
+        console.log('Close modal', modalId);
+        modals.closeAll();
+      },
+    });
+  };
+
+  return <Button onClick={handleClick}>Open modal</Button>;
+}
+
+export function closeAll() {
+  return (
+    <ModalsProvider>
+      <CloseAllApp />
     </ModalsProvider>
   );
 }

--- a/src/mantine-modals/src/ModalsProvider.tsx
+++ b/src/mantine-modals/src/ModalsProvider.tsx
@@ -74,14 +74,7 @@ export function ModalsProvider({ children, modalProps, labels, modals }: ModalsP
 
   const closeAll = useCallback(
     (canceled?: boolean) => {
-      stateRef.current.modals.forEach((modal) => {
-        if (modal.type === 'confirm' && canceled) {
-          modal.props.onCancel?.();
-        }
-
-        modal.props.onClose?.();
-      });
-      dispatch({ type: 'CLOSE_ALL' });
+      dispatch({ type: 'CLOSE_ALL', canceled });
     },
     [stateRef, dispatch]
   );
@@ -92,7 +85,7 @@ export function ModalsProvider({ children, modalProps, labels, modals }: ModalsP
 
       dispatch({
         type: 'OPEN',
-        payload: {
+        modal: {
           id,
           type: 'content',
           props,
@@ -108,7 +101,7 @@ export function ModalsProvider({ children, modalProps, labels, modals }: ModalsP
       const id = modalId || randomId();
       dispatch({
         type: 'OPEN',
-        payload: {
+        modal: {
           id,
           type: 'confirm',
           props,
@@ -124,7 +117,7 @@ export function ModalsProvider({ children, modalProps, labels, modals }: ModalsP
       const id = modalId || randomId();
       dispatch({
         type: 'OPEN',
-        payload: {
+        modal: {
           id,
           type: 'context',
           props,
@@ -138,16 +131,7 @@ export function ModalsProvider({ children, modalProps, labels, modals }: ModalsP
 
   const closeModal = useCallback(
     (id: string, canceled?: boolean) => {
-      const modal = stateRef.current.modals.find((item) => item.id === id);
-      if (!modal) {
-        return;
-      }
-
-      if (modal.type === 'confirm' && canceled) {
-        modal.props.onCancel?.();
-      }
-      modal.props.onClose?.();
-      dispatch({ type: 'CLOSE', payload: modal.id });
+      dispatch({ type: 'CLOSE', modalId: id, canceled });
     },
     [stateRef, dispatch]
   );

--- a/src/mantine-modals/src/reducer.ts
+++ b/src/mantine-modals/src/reducer.ts
@@ -12,16 +12,26 @@ interface ModalsState {
 
 interface OpenAction {
   type: 'OPEN';
-  payload: ModalState;
+  modal: ModalState;
 }
 
 interface CloseAction {
   type: 'CLOSE';
-  payload: string;
+  modalId: string;
+  canceled?: boolean;
 }
 
 interface CloseAllAction {
   type: 'CLOSE_ALL';
+  canceled?: boolean;
+}
+
+function handleCloseModal(modal: ModalState, canceled?: boolean) {
+  if (canceled && modal.type === 'confirm') {
+    modal.props.onCancel?.();
+  }
+
+  modal.props.onClose?.();
 }
 
 export function modalsReducer(
@@ -31,18 +41,38 @@ export function modalsReducer(
   switch (action.type) {
     case 'OPEN': {
       return {
-        current: action.payload,
-        modals: [...state.modals, action.payload],
+        current: action.modal,
+        modals: [...state.modals, action.modal],
       };
     }
     case 'CLOSE': {
-      const modals = state.modals.filter((m) => m.id !== action.payload);
+      const modal = state.modals.find((m) => m.id === action.modalId);
+      if (!modal) {
+        return state;
+      }
+
+      handleCloseModal(modal, action.canceled);
+
+      const remainingModals = state.modals.filter((m) => m.id !== action.modalId);
+
       return {
-        current: modals[modals.length - 1] || state.current,
-        modals,
+        current: remainingModals[remainingModals.length - 1] || state.current,
+        modals: remainingModals,
       };
     }
     case 'CLOSE_ALL': {
+      if (!state.modals.length) {
+        return state;
+      }
+
+      // Resolve modal stack from top to bottom
+      state.modals
+        .concat()
+        .reverse()
+        .forEach((modal) => {
+          handleCloseModal(modal, action.canceled);
+        });
+
       return {
         current: state.current,
         modals: [],


### PR DESCRIPTION
Fixes #3623.

Reason was that the `onClose()` method got called before the new state has been applied therefore it resulted in an endless loop.
Swapping the method execution order unfortunately isn't enough as it's not clear when React does apply the state update.

So I moved some logic to the reducer because it will be run for each action in sequence.

In earlier versions this usecase didn't crash the whole application because the methods might not use the current modal state. Therefore an endless loop couldn't occur. However it also lead to other issues:
See this sandbox for `v5.10.0`:
https://codesandbox.io/s/modals-state-issue-3623-ppqfjr?file=/src/App.tsx

Open the console, open some modals and then close them.
Despite all modals being closed only one callback will be called.

So despite once again breaking things (sorry for that!) I'm optimistic the whole component is on a good way and looses more of its hidden issues.

I've also tested this against `v6` and can confirm that it works there too.

Also thanks for giving me the opportunity to get it right!