### PR TITLE
[@mantine/dates]: CalendarHeader: Remove disabled level change button from tab order

### DIFF
--- a/src/mantine-dates/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/src/mantine-dates/src/components/CalendarHeader/CalendarHeader.tsx
@@ -156,7 +156,7 @@ export const CalendarHeader = forwardRef<HTMLDivElement, CalendarHeaderProps>((p
         disabled={!hasNextLevel}
         data-static={!hasNextLevel || undefined}
         aria-label={levelControlAriaLabel}
-        tabIndex={__preventFocus ? -1 : 0}
+        tabIndex={__preventFocus || !hasNextLevel ? -1 : 0}
         data-mantine-stop-propagation={__stopPropagation || undefined}
       >
         {label}


### PR DESCRIPTION
The button for changing level is `disabled` but it's still kept in tab order when `maxLevel` should remove it. You can try it out here: https://mantine.dev/dates/date-picker/#max-level

The DatePicker at the right has `maxLevel="month"`, so the level change button is disabled, but it still has `tabIndex={0}` and is therefore kept in tab order.

<img width="867" alt="image" src="https://user-images.githubusercontent.com/44197016/222424900-183f083b-a7db-411c-bb9f-3cfb2c16306b.png">

This worked correctly in v5.x: https://v5.mantine.dev/dates/calendar/#level-change

Let me know if I should create an issue for this instead of opening a PR!

Repro here: https://codesandbox.io/s/silly-forest-fcvs01?file=/src/App.tsx