### PR TITLE
[@mantine/core] Transition: Update transition duration when unmounting

### DIFF
--- a/src/mantine-core/src/Transition/use-transition.ts
+++ b/src/mantine-core/src/Transition/use-transition.ts
@@ -34,8 +34,8 @@ export function useTransition({
   const theme = useMantineTheme();
   const shouldReduceMotion = useReducedMotion();
   const reduceMotion = theme.respectReducedMotion ? shouldReduceMotion : false;
+  const [transitionDuration, setTransitionDuration] = useState(reduceMotion ? 0 : duration);
   const [transitionStatus, setStatus] = useState<TransitionStatus>(mounted ? 'entered' : 'exited');
-  let transitionDuration = reduceMotion ? 0 : duration;
   const timeoutRef = useRef<number>(-1);
 
   const handleStateChange = (shouldMount: boolean) => {
@@ -44,9 +44,11 @@ export function useTransition({
 
     setStatus(shouldMount ? 'pre-entering' : 'pre-exiting');
     window.clearTimeout(timeoutRef.current);
-    transitionDuration = reduceMotion ? 0 : shouldMount ? duration : exitDuration;
 
-    if (transitionDuration === 0) {
+    const newTransitionDuration = reduceMotion ? 0 : shouldMount ? duration : exitDuration;
+    setTransitionDuration(newTransitionDuration);
+
+    if (newTransitionDuration === 0) {
       typeof preHandler === 'function' && preHandler();
       typeof handler === 'function' && handler();
       setStatus(shouldMount ? 'entered' : 'exited');
@@ -60,7 +62,7 @@ export function useTransition({
         window.clearTimeout(preStateTimeout);
         typeof handler === 'function' && handler();
         setStatus(shouldMount ? 'entered' : 'exited');
-      }, transitionDuration);
+      }, newTransitionDuration);
     }
   };
 


### PR DESCRIPTION
Solves #3626

Stores the `transitionDuration` in `useTransition`'s state so that upon changing its value, the element's `transition-duration` style property gets updated as well.

Below you'll find a short video of the `duration` (200ms) and `exitDuration` (2000ms) after applying this fix.

https://user-images.githubusercontent.com/20128985/222743880-095fb575-18f5-4783-b639-b28fe0bf2f18.mov