### PR TITLE
[@mantine/core] Anchor: Fix dimmed color not working

### DIFF
--- a/src/mantine-core/src/Anchor/Anchor.styles.ts
+++ b/src/mantine-core/src/Anchor/Anchor.styles.ts
@@ -1,7 +1,25 @@
-import { createStyles, MantineColor } from '@mantine/styles';
+import { createStyles, MantineColor, MantineTheme } from '@mantine/styles';
 
 export interface AnchorStylesParams {
   color: MantineColor;
+}
+
+interface GetAnchorColor {
+  theme: MantineTheme;
+  color: 'dimmed' | MantineColor;
+}
+
+function getAnchorColor({ theme, color }: GetAnchorColor) {
+  if (color === 'dimmed') {
+    return theme.fn.dimmed();
+  }
+
+  return theme.fn.themeColor(
+    color || theme.primaryColor,
+    theme.colorScheme === 'dark' ? 4 : 7,
+    false,
+    true
+  );
 }
 
 export default createStyles((theme, { color }: AnchorStylesParams) => ({
@@ -10,12 +28,7 @@ export default createStyles((theme, { color }: AnchorStylesParams) => ({
     cursor: 'pointer',
     padding: 0,
     border: 0,
-    color: theme.fn.themeColor(
-      color || theme.primaryColor,
-      theme.colorScheme === 'dark' ? 4 : 7,
-      false,
-      true
-    ),
+    color: getAnchorColor({ theme, color }),
     ...theme.fn.hover({ textDecoration: 'underline' }),
   },
 }));


### PR DESCRIPTION
After updating to v6.0.0, the "dimmed" color prop of the Anchor component was not reflected.

Reproduction: https://codesandbox.io/s/icy-star-25zg89?file=/src/App.tsx

![スクリーンショット 2023-03-04 3 31 36](https://user-images.githubusercontent.com/62416191/222799782-a05ac3f4-96e3-4fe8-85fd-e3c66fc404de.png)


Therefore, I added a check if the color prop is "dimmed" or not.

After this PR:
![スクリーンショット 2023-03-04 3 31 43](https://user-images.githubusercontent.com/62416191/222799853-b508c204-9d58-4933-a6f8-10e4c6eb3847.png)


I'm enjoying the update to version 6! Thank you!