### PR TITLE
[@mantine/core] SegmentedControl: fixed transparent border color

### DIFF
--- a/src/mantine-core/src/SegmentedControl/SegmentedControl.styles.ts
+++ b/src/mantine-core/src/SegmentedControl/SegmentedControl.styles.ts
@@ -138,8 +138,7 @@ export default createStyles(
         borderTopColor: 'transparent !important',
 
         [`& + .${getStylesRef('control')}`]: {
-          borderLeftColor: 'transparent !important',
-          borderTopColor: 'transparent !important',
+          [vertical ? 'borderTopColor' : 'borderLeftColor']: 'transparent !important',
         },
         borderRadius: theme.fn.radius(radius),
         boxShadow: shouldAnimate


### PR DESCRIPTION
Fixes https://github.com/mantinedev/mantine/issues/3669!

`SegmentedControl` only sets the left border color of the `ref-control` class to transparent if horizontal, or only the top border color if vertical.