### PR TITLE
[docs] Add link to v5 docs to About page

### DIFF
--- a/docs/src/docs/pages/about.mdx
+++ b/docs/src/docs/pages/about.mdx
@@ -48,6 +48,7 @@ All `@mantine/*` packages follow [semver](https://semver.org/):
 - v2 (2.5.1) – [v2.mantine.dev](https://v2.mantine.dev/)
 - v3 (3.6.14) – [v3.mantine.dev](https://v3.mantine.dev/)
 - v4 (4.2.12) – [v4.mantine.dev](https://v4.mantine.dev/)
+- v5 (5.10.5) – [v5.mantine.dev](https://v5.mantine.dev/)
 
 ## Project maintenance
 


### PR DESCRIPTION
This patch adds the v5 link to the about page, as suggested on [discord](https://discord.com/channels/854810300876062770/1048155338152624198/1081226402990403686)