### PR TITLE
[docs] Fix verison 5 link typo

### DIFF
--- a/docs/src/docs/changelog/6-0-0.mdx
+++ b/docs/src/docs/changelog/6-0-0.mdx
@@ -495,4 +495,4 @@ You can now fully control search query:
 - [2.x version documentation (2.5.1)](https://v2.mantine.dev/)
 - [3.x version documentation (3.6.14)](https://v3.mantine.dev/)
 - [4.x version documentation (4.2.12)](https://v4.mantine.dev/)
-- [4.x version documentation (5.10.5)](https://v5.mantine.dev/)
+- [5.x version documentation (5.10.5)](https://v5.mantine.dev/)

--- a/docs/src/docs/pages/changelog.mdx
+++ b/docs/src/docs/pages/changelog.mdx
@@ -41,7 +41,7 @@ Note that when following links of 1.x – 5.x changelogs you will be redirected 
 
 ## 6.x changelogs
 
-- [Version 6.0.0](https://v5.mantine.dev/changelog/6-0-0/) – March 2nd, 2023
+- [Version 6.0.0](https://mantine.dev/changelog/6-0-0/) – March 2nd, 2023
 
 ## Previous documentation versions
 

--- a/docs/src/docs/pages/changelog.mdx
+++ b/docs/src/docs/pages/changelog.mdx
@@ -49,4 +49,4 @@ Note that when following links of 1.x – 5.x changelogs you will be redirected 
 - [2.x version documentation (2.5.1)](https://v2.mantine.dev/)
 - [3.x version documentation (3.6.14)](https://v3.mantine.dev/)
 - [4.x version documentation (4.2.12)](https://v4.mantine.dev/)
-- [4.x version documentation (5.10.5)](https://v5.mantine.dev/)
+- [5.x version documentation (5.10.5)](https://v5.mantine.dev/)


### PR DESCRIPTION
Fixed typos as noted in:

https://discord.com/channels/854810300876062770/861521000985264138/1081796340029337713
