### PR TITLE
Fix a couple regressions found on V6 + Improve Slider hover UX

### DIFF
--- a/src/mantine-core/src/Floating/FloatingArrow/FloatingArrow.tsx
+++ b/src/mantine-core/src/Floating/FloatingArrow/FloatingArrow.tsx
@@ -4,7 +4,6 @@ import { getArrowPositionStyles } from './get-arrow-position-styles';
 import { ArrowPosition, FloatingPosition } from '../types';
 
 interface FloatingArrowProps extends React.ComponentPropsWithoutRef<'div'> {
-  withBorder: boolean;
   position: FloatingPosition;
   arrowSize: number;
   arrowOffset: number;
@@ -18,7 +17,6 @@ interface FloatingArrowProps extends React.ComponentPropsWithoutRef<'div'> {
 export const FloatingArrow = forwardRef<HTMLDivElement, FloatingArrowProps>(
   (
     {
-      withBorder,
       position,
       arrowSize,
       arrowOffset,
@@ -41,7 +39,6 @@ export const FloatingArrow = forwardRef<HTMLDivElement, FloatingArrowProps>(
         {...others}
         ref={ref}
         style={getArrowPositionStyles({
-          withBorder,
           position,
           arrowSize,
           arrowOffset,

--- a/src/mantine-core/src/Floating/FloatingArrow/get-arrow-position-styles.ts
+++ b/src/mantine-core/src/Floating/FloatingArrow/get-arrow-position-styles.ts
@@ -90,7 +90,7 @@ export function getArrowPositionStyles({
     [radiusByFloatingSide[side]]: rem(arrowRadius),
   };
 
-  const arrowPlacement = withBorder ? -arrowSize / 2 - 1 : -arrowSize / 2;
+  const arrowPlacement = rem(withBorder ? -arrowSize / 2 - 1 : -arrowSize / 2);
 
   if (side === 'left') {
     return {

--- a/src/mantine-core/src/Floating/FloatingArrow/get-arrow-position-styles.ts
+++ b/src/mantine-core/src/Floating/FloatingArrow/get-arrow-position-styles.ts
@@ -62,7 +62,6 @@ const radiusByFloatingSide: Record<
 
 export function getArrowPositionStyles({
   position,
-  withBorder,
   arrowSize,
   arrowOffset,
   arrowRadius,
@@ -72,7 +71,6 @@ export function getArrowPositionStyles({
   dir,
 }: {
   position: FloatingPosition;
-  withBorder: boolean;
   arrowSize: number;
   arrowOffset: number;
   arrowRadius: number;
@@ -90,7 +88,7 @@ export function getArrowPositionStyles({
     [radiusByFloatingSide[side]]: rem(arrowRadius),
   };
 
-  const arrowPlacement = rem(withBorder ? -arrowSize / 2 - 1 : -arrowSize / 2);
+  const arrowPlacement = rem(-arrowSize / 2);
 
   if (side === 'left') {
     return {

--- a/src/mantine-core/src/InlineInput/InlineInput.tsx
+++ b/src/mantine-core/src/InlineInput/InlineInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { DefaultProps, MantineNumberSize, Selectors } from '@mantine/styles';
 import { Box } from '../Box';
 import { Input } from '../Input';
@@ -20,51 +20,56 @@ export interface InlineInputProps
   labelPosition: 'left' | 'right';
 }
 
-export function InlineInput({
-  __staticSelector,
-  className,
-  classNames,
-  styles,
-  unstyled,
-  children,
-  label,
-  description,
-  id,
-  disabled,
-  error,
-  size,
-  labelPosition,
-  variant,
-  ...others
-}: InlineInputProps) {
-  const { classes, cx } = useStyles(
-    { labelPosition },
-    { name: __staticSelector, styles, classNames, unstyled, variant, size }
-  );
+export const InlineInput = forwardRef<HTMLDivElement, InlineInputProps>(
+  (
+    {
+      __staticSelector,
+      className,
+      classNames,
+      styles,
+      unstyled,
+      children,
+      label,
+      description,
+      id,
+      disabled,
+      error,
+      size,
+      labelPosition,
+      variant,
+      ...others
+    },
+    ref
+  ) => {
+    const { classes, cx } = useStyles(
+      { labelPosition },
+      { name: __staticSelector, styles, classNames, unstyled, variant, size }
+    );
 
-  return (
-    <Box className={cx(classes.root, className)} {...others}>
-      <div className={cx(classes.body)}>
-        {children}
+    return (
+      <Box className={cx(classes.root, className)} ref={ref} {...others}>
+        <div className={cx(classes.body)}>
+          {children}
 
-        <div className={classes.labelWrapper}>
-          {label && (
-            <label className={classes.label} data-disabled={disabled || undefined} htmlFor={id}>
-              {label}
-            </label>
-          )}
+          <div className={classes.labelWrapper}>
+            {label && (
+              <label className={classes.label} data-disabled={disabled || undefined} htmlFor={id}>
+                {label}
+              </label>
+            )}
 
-          {description && (
-            <Input.Description className={classes.description}>{description}</Input.Description>
-          )}
+            {description && (
+              <Input.Description className={classes.description}>{description}</Input.Description>
+            )}
 
-          {error && error !== 'boolean' && (
-            <Input.Error className={classes.error}>{error}</Input.Error>
-          )}
+            {error && error !== 'boolean' && (
+              <Input.Error className={classes.error}>{error}</Input.Error>
+            )}
+          </div>
         </div>
-      </div>
-    </Box>
-  );
-}
+      </Box>
+    );
+  }
+);
 
 InlineInput.displayName = '@mantine/core/InlineInput';

--- a/src/mantine-core/src/Popover/PopoverDropdown/PopoverDropdown.tsx
+++ b/src/mantine-core/src/Popover/PopoverDropdown/PopoverDropdown.tsx
@@ -98,7 +98,6 @@ export function PopoverDropdown(props: PopoverDropdownProps) {
                 arrowX={ctx.arrowX}
                 arrowY={ctx.arrowY}
                 visible={ctx.withArrow}
-                withBorder
                 position={ctx.placement}
                 arrowSize={ctx.arrowSize}
                 arrowRadius={ctx.arrowRadius}

--- a/src/mantine-core/src/Slider/RangeSlider/RangeSlider.tsx
+++ b/src/mantine-core/src/Slider/RangeSlider/RangeSlider.tsx
@@ -437,7 +437,8 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
           thumbLabel={thumbFromLabel}
           onMouseDown={(event) => handleThumbMouseDown(event, 0)}
           onFocus={() => setFocused(0)}
-          showLabelOnHover={showLabelOnHover && hovered}
+          showLabelOnHover={showLabelOnHover}
+          isHovered={hovered}
           disabled={disabled}
           unstyled={unstyled}
           thumbSize={thumbSize}
@@ -458,7 +459,8 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
           }}
           onMouseDown={(event) => handleThumbMouseDown(event, 1)}
           onFocus={() => setFocused(1)}
-          showLabelOnHover={showLabelOnHover && hovered}
+          showLabelOnHover={showLabelOnHover}
+          isHovered={hovered}
           disabled={disabled}
           unstyled={unstyled}
           thumbSize={thumbSize}

--- a/src/mantine-core/src/Slider/Slider/Slider.tsx
+++ b/src/mantine-core/src/Slider/Slider/Slider.tsx
@@ -310,7 +310,8 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
           classNames={classNames}
           styles={styles}
           thumbLabel={thumbLabel}
-          showLabelOnHover={showLabelOnHover && hovered}
+          showLabelOnHover={showLabelOnHover}
+          isHovered={hovered}
           disabled={disabled}
           unstyled={unstyled}
           thumbSize={thumbSize}

--- a/src/mantine-core/src/Slider/Thumb/Thumb.tsx
+++ b/src/mantine-core/src/Slider/Thumb/Thumb.tsx
@@ -24,6 +24,7 @@ export interface ThumbProps extends DefaultProps<ThumbStylesNames> {
   onFocus?(): void;
   onBlur?(): void;
   showLabelOnHover?: boolean;
+  isHovered?: boolean;
   children?: React.ReactNode;
   disabled: boolean;
   thumbSize: number;
@@ -52,6 +53,7 @@ export const Thumb = forwardRef<HTMLDivElement, ThumbProps>(
       onFocus,
       onBlur,
       showLabelOnHover,
+      isHovered,
       children = null,
       disabled,
       unstyled,
@@ -65,7 +67,10 @@ export const Thumb = forwardRef<HTMLDivElement, ThumbProps>(
       { name: 'Slider', classNames, styles, unstyled, variant, size }
     );
     const [focused, setFocused] = useState(false);
-    const isVisible = labelAlwaysOn || dragging || focused || showLabelOnHover;
+    const [hovered, setHovered] = useState(false);
+
+    const isVisible =
+      labelAlwaysOn || dragging || focused || (showLabelOnHover && (isHovered || hovered));
 
     return (
       <Box<'div'>
@@ -87,6 +92,8 @@ export const Thumb = forwardRef<HTMLDivElement, ThumbProps>(
         }}
         onTouchStart={onMouseDown}
         onMouseDown={onMouseDown}
+        onMouseEnter={showLabelOnHover ? () => setHovered(true) : undefined}
+        onMouseLeave={showLabelOnHover ? () => setHovered(false) : undefined}
         onClick={(event) => event.stopPropagation()}
         style={{ [theme.dir === 'rtl' ? 'right' : 'left']: `${position}%` }}
       >

--- a/src/mantine-core/src/Tooltip/Tooltip.tsx
+++ b/src/mantine-core/src/Tooltip/Tooltip.tsx
@@ -177,7 +177,6 @@ const _Tooltip = forwardRef<HTMLElement, TooltipProps>((props, ref) => {
                 arrowX={tooltip.arrowX}
                 arrowY={tooltip.arrowY}
                 visible={withArrow}
-                withBorder={false}
                 position={tooltip.placement}
                 arrowSize={arrowSize}
                 arrowOffset={arrowOffset}

--- a/src/mantine-styles/src/theme/functions/fns/darken/darken.test.ts
+++ b/src/mantine-styles/src/theme/functions/fns/darken/darken.test.ts
@@ -22,4 +22,8 @@ describe('@mantine/styles/darken', () => {
     expect(darken(RGB, 1)).toBe('rgba(0, 0, 0, 1)');
     expect(darken(RGBA, 1)).toBe('rgba(0, 0, 0, 0.6)');
   });
+
+  it('returns color as-is if it is a CSS variable', () => {
+    expect(darken('var(--css-custom-property)', 0.5)).toBe('var(--css-custom-property)');
+  });
 });

--- a/src/mantine-styles/src/theme/functions/fns/darken/darken.ts
+++ b/src/mantine-styles/src/theme/functions/fns/darken/darken.ts
@@ -1,6 +1,10 @@
 import { toRgba } from '../../../utils/to-rgba/to-rgba';
 
 export function darken(color: string, alpha: number) {
+  if (typeof color === 'string' && color.startsWith('var(--')) {
+    return color;
+  }
+
   const { r, g, b, a } = toRgba(color);
   const f = 1 - alpha;
 

--- a/src/mantine-styles/src/theme/functions/fns/lighten/lighten.test.ts
+++ b/src/mantine-styles/src/theme/functions/fns/lighten/lighten.test.ts
@@ -22,4 +22,8 @@ describe('@mantine/styles/lighten', () => {
     expect(lighten(RGB, 1)).toBe('rgba(255, 255, 255, 1)');
     expect(lighten(RGBA, 1)).toBe('rgba(255, 255, 255, 0.6)');
   });
+
+  it('returns color as-is if it is a CSS variable', () => {
+    expect(lighten('var(--css-custom-property)', 0.5)).toBe('var(--css-custom-property)');
+  });
 });

--- a/src/mantine-styles/src/theme/functions/fns/lighten/lighten.ts
+++ b/src/mantine-styles/src/theme/functions/fns/lighten/lighten.ts
@@ -1,6 +1,10 @@
 import { toRgba } from '../../../utils/to-rgba/to-rgba';
 
 export function lighten(color: string, alpha: number) {
+  if (typeof color === 'string' && color.startsWith('var(--')) {
+    return color;
+  }
+
   const { r, g, b, a } = toRgba(color);
 
   const light = (input: number) => Math.round(input + (255 - input) * alpha);

--- a/src/mantine-styles/src/theme/functions/fns/rgba/rgba.test.ts
+++ b/src/mantine-styles/src/theme/functions/fns/rgba/rgba.test.ts
@@ -18,12 +18,16 @@ describe('@mantine/styles/rgba', () => {
     expect(rgba('rgba(1, 23, 124, 0.5)', 0.3)).toBe('rgba(1, 23, 124, 0.3)');
   });
 
-  it('returns empty string for incorrect values', () => {
+  it('returns black color for incorrect values', () => {
     expect(rgba(null, 0.74)).toBe('rgba(0, 0, 0, 1)');
     expect(rgba('#000000', -12)).toBe('rgba(0, 0, 0, 1)');
     expect(rgba('#00000', 1)).toBe('rgba(0, 0, 0, 1)');
     expect(rgba('#000', 1)).toBe('rgba(0, 0, 0, 1)');
     expect(rgba('#000000', 24)).toBe('rgba(0, 0, 0, 1)');
     expect(rgba('#000000', 1.01)).toBe('rgba(0, 0, 0, 1)');
+  });
+
+  it('returns color as-is if it is a CSS variable', () => {
+    expect(rgba('var(--css-custom-property)', 0.5)).toBe('var(--css-custom-property)');
   });
 });

--- a/src/mantine-styles/src/theme/functions/fns/rgba/rgba.ts
+++ b/src/mantine-styles/src/theme/functions/fns/rgba/rgba.ts
@@ -6,6 +6,10 @@ export function rgba(color: string, alpha: number) {
     return 'rgba(0, 0, 0, 1)';
   }
 
+  if (color.startsWith('var(--')) {
+    return color;
+  }
+
   const { r, g, b } = toRgba(color);
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }


### PR DESCRIPTION
Hi :) 

As discussed on Discord, here are some quick fixes for some regressions I found while updating my app from v5 to v6. I

I implemented each of them in individual commits; if you prefer I split those in individual PRs, I can too.

Here is a list of what's fixed:
- Arrow function positioning was using the raw pixel value, while the size of the arrow was using the new rem() helper. So arrow was not positioned correctly if the rem value was anything other than 16. Fixed by using rem() on positioning too.
- Still arrow function : removed the extra offset when there is a border, see comment below. I think a display might have changed from content box to border box somewhere.
- fn.rgba is used in more places, preventing CSS variables to be passed to some `color` props, instead it used a default black value. Added a check for CSS variables in fn.rgba, fn.lighten and fn.darken to prevent that.
- Added forwardRef to InlineInput so that it works like InputWrapper

The last commit is not a regression, it was something I already wanted to fix in v5: 
- In Slider, when showLabelOnHover is true, it only works when hovering the track, not the thumb. Since the thumb is larger than the track, I added a listener on the thumb too, otherwise it was a bit awkward.