### PR TITLE
[@mantine/core] add portalProps to all components rendering a portal

### DIFF
--- a/src/mantine-core/src/Affix/Affix.tsx
+++ b/src/mantine-core/src/Affix/Affix.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react';
 import { DefaultProps, getDefaultZIndex, useComponentDefaultProps } from '@mantine/styles';
 import { packSx } from '@mantine/utils';
 import { Box } from '../Box';
-import { OptionalPortal } from '../Portal';
+import { OptionalPortal, PortalProps } from '../Portal';
 
 export interface AffixProps extends DefaultProps, React.ComponentPropsWithoutRef<'div'> {
   /** Element where portal should be rendered, by default new div element is created and appended to document.body */
@@ -13,6 +13,9 @@ export interface AffixProps extends DefaultProps, React.ComponentPropsWithoutRef
 
   /** Determines whether component should be rendered within portal, defaults to true */
   withinPortal?: boolean;
+
+  /** Props to pass down to the portal when withinPortal is true */
+  portalProps?: Omit<PortalProps, 'target'>;
 
   /** Affix position on screen, defaults to { bottom: 0, right: 0 } */
   position?: {
@@ -30,14 +33,11 @@ const defaultProps: Partial<AffixProps> = {
 };
 
 export const Affix = forwardRef<HTMLDivElement, AffixProps>((props: AffixProps, ref) => {
-  const { target, position, zIndex, sx, withinPortal, ...others } = useComponentDefaultProps(
-    'Affix',
-    defaultProps,
-    props
-  );
+  const { target, position, zIndex, sx, withinPortal, portalProps, ...others } =
+    useComponentDefaultProps('Affix', defaultProps, props);
 
   return (
-    <OptionalPortal withinPortal={withinPortal} target={target}>
+    <OptionalPortal withinPortal={withinPortal} target={target} {...portalProps}>
       <Box sx={[{ position: 'fixed', zIndex, ...position }, ...packSx(sx)]} ref={ref} {...others} />
     </OptionalPortal>
   );

--- a/src/mantine-core/src/ColorInput/ColorInput.tsx
+++ b/src/mantine-core/src/ColorInput/ColorInput.tsx
@@ -20,6 +20,7 @@ import {
 import { ColorSwatch } from '../ColorSwatch';
 import { ActionIcon } from '../ActionIcon';
 import { Popover, PopoverStylesNames } from '../Popover';
+import { PortalProps } from '../Portal';
 import { TransitionOverride } from '../Transition';
 import {
   ColorPicker,
@@ -58,6 +59,9 @@ export interface ColorInputProps
 
   /** Whether to render the dropdown in a Portal */
   withinPortal?: boolean;
+
+  /** Props to pass down to the portal when withinPortal is true */
+  portalProps?: PortalProps;
 
   /** Dropdown box-shadow, key of theme.shadows */
   shadow?: MantineShadow;
@@ -123,6 +127,7 @@ export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>((props, 
     transitionProps,
     dropdownZIndex,
     withinPortal,
+    portalProps,
     swatches,
     shadow,
     classNames,
@@ -201,6 +206,7 @@ export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>((props, 
         offset={5}
         zIndex={dropdownZIndex}
         withinPortal={withinPortal}
+        portalProps={portalProps}
         transitionProps={transitionProps}
         opened={dropdownOpened}
         shadow={shadow}

--- a/src/mantine-core/src/ModalBase/ModalBase.tsx
+++ b/src/mantine-core/src/ModalBase/ModalBase.tsx
@@ -11,7 +11,7 @@ import {
   MantineShadow,
   Selectors,
 } from '@mantine/styles';
-import { OptionalPortal } from '../Portal';
+import { OptionalPortal, PortalProps } from '../Portal';
 import { TransitionOverride } from '../Transition';
 import { ModalBaseProvider } from './ModalBase.context';
 import {
@@ -62,6 +62,9 @@ export interface ModalBaseSettings extends React.ComponentPropsWithoutRef<'div'>
 
   /** Determines whether component should be rendered inside Portal, true by default */
   withinPortal?: boolean;
+
+  /** Props to pass down to the portal when withinPortal is true */
+  portalProps?: Omit<PortalProps, 'target'>;
 
   /** Target element or selector where Portal should be rendered, by default new element is created and appended to the document.body */
   target?: HTMLElement | string;
@@ -122,6 +125,7 @@ export function ModalBase(props: ModalBaseProps) {
     __staticSelector,
     transitionProps,
     withinPortal,
+    portalProps,
     keepMounted,
     target,
     zIndex,
@@ -168,7 +172,7 @@ export function ModalBase(props: ModalBaseProps) {
   useFocusReturn({ opened, shouldReturnFocus: trapFocus && returnFocus });
 
   return (
-    <OptionalPortal withinPortal={withinPortal} target={target}>
+    <OptionalPortal withinPortal={withinPortal} target={target} {...portalProps}>
       <ModalBaseProvider
         value={{
           __staticSelector,

--- a/src/mantine-core/src/Popover/Popover.context.ts
+++ b/src/mantine-core/src/Popover/Popover.context.ts
@@ -3,6 +3,7 @@ import { createSafeContext } from '@mantine/utils';
 import { MantineNumberSize, MantineShadow, ClassNames, Styles } from '@mantine/styles';
 import { FloatingPosition, ArrowPosition } from '../Floating';
 import { TransitionOverride } from '../Transition';
+import { PortalProps } from '../Portal';
 import { POPOVER_ERRORS } from './Popover.errors';
 import { PopoverWidth, PopoverStylesNames, PopoverStylesParams } from './Popover.types';
 
@@ -25,6 +26,7 @@ interface PopoverContext {
   trapFocus: boolean;
   placement: FloatingPosition;
   withinPortal: boolean;
+  portalProps?: PortalProps;
   closeOnEscape: boolean;
   zIndex: React.CSSProperties['zIndex'];
   radius?: MantineNumberSize;

--- a/src/mantine-core/src/Popover/Popover.tsx
+++ b/src/mantine-core/src/Popover/Popover.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mantine/styles';
 import { TransitionOverride } from '../Transition';
 import { getFloatingPosition, FloatingPosition, ArrowPosition } from '../Floating';
+import { PortalProps } from '../Portal';
 import { usePopover } from './use-popover';
 import { PopoverContextProvider } from './Popover.context';
 import {
@@ -72,6 +73,9 @@ export interface PopoverBaseProps {
 
   /** Determines whether dropdown should be rendered within Portal, defaults to false */
   withinPortal?: boolean;
+
+  /** Props to pass down to the portal when withinPortal is true */
+  portalProps?: PortalProps;
 
   /** Dropdown z-index */
   zIndex?: React.CSSProperties['zIndex'];
@@ -171,6 +175,7 @@ export function Popover(props: PopoverProps) {
     styles,
     closeOnClickOutside,
     withinPortal,
+    portalProps,
     closeOnEscape,
     clickOutsideEvents,
     trapFocus,
@@ -257,6 +262,7 @@ export function Popover(props: PopoverProps) {
         placement: popover.floating.placement,
         trapFocus,
         withinPortal,
+        portalProps,
         zIndex,
         radius,
         shadow,

--- a/src/mantine-core/src/Popover/PopoverDropdown/PopoverDropdown.tsx
+++ b/src/mantine-core/src/Popover/PopoverDropdown/PopoverDropdown.tsx
@@ -54,7 +54,7 @@ export function PopoverDropdown(props: PopoverDropdownProps) {
   }
 
   return (
-    <OptionalPortal withinPortal={ctx.withinPortal}>
+    <OptionalPortal withinPortal={ctx.withinPortal} {...ctx.portalProps}>
       <Transition
         mounted={ctx.opened}
         {...ctx.transitionProps}

--- a/src/mantine-core/src/Portal/Portal.tsx
+++ b/src/mantine-core/src/Portal/Portal.tsx
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom';
 import { useIsomorphicEffect } from '@mantine/hooks';
 import { useMantineTheme, useComponentDefaultProps } from '@mantine/styles';
 
-export interface PortalProps {
+export interface PortalProps extends React.ComponentPropsWithoutRef<'div'> {
   /** Portal children, for example, modal or popover */
   children: React.ReactNode;
 
@@ -13,10 +13,17 @@ export interface PortalProps {
 
   /** Root element className */
   className?: string;
+
+  /** Root element ref */
+  innerRef?: React.MutableRefObject<HTMLDivElement>;
 }
 
 export function Portal(props: PortalProps): ReactPortal {
-  const { children, target, className } = useComponentDefaultProps('Portal', {}, props);
+  const { children, target, className, innerRef, ...others } = useComponentDefaultProps(
+    'Portal',
+    {},
+    props
+  );
 
   const theme = useMantineTheme();
   const [mounted, setMounted] = useState(false);
@@ -44,7 +51,7 @@ export function Portal(props: PortalProps): ReactPortal {
   }
 
   return createPortal(
-    <div className={className} dir={theme.dir}>
+    <div className={className} dir={theme.dir} {...others} ref={innerRef}>
       {children}
     </div>,
     ref.current

--- a/src/mantine-core/src/Select/Select.tsx
+++ b/src/mantine-core/src/Select/Select.tsx
@@ -3,6 +3,7 @@ import { useUncontrolled, useMergedRef, useDidUpdate, useScrollIntoView } from '
 import { DefaultProps, MantineSize, MantineShadow, getDefaultZIndex } from '@mantine/styles';
 import { groupOptions } from '@mantine/utils';
 import { SelectScrollArea } from './SelectScrollArea/SelectScrollArea';
+import { PortalProps } from '../Portal';
 import { Input, useInputProps } from '../Input';
 import { TransitionOverride } from '../Transition';
 import { DefaultItem } from './DefaultItem/DefaultItem';
@@ -52,6 +53,9 @@ export interface SelectSharedProps<Item, Value> {
 
   /** Whether to render the dropdown in a Portal */
   withinPortal?: boolean;
+
+  /** Props to pass down to the portal when withinPortal is true */
+  portalProps?: PortalProps;
 
   /** Limit amount of items displayed at a time for searchable select */
   limit?: number;
@@ -191,6 +195,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>((props, ref) => 
     onDropdownClose,
     onDropdownOpen,
     withinPortal,
+    portalProps,
     switchDirectionOnFlip,
     zIndex,
     name,
@@ -540,6 +545,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>((props, ref) => 
         transitionProps={transitionProps}
         shadow="sm"
         withinPortal={withinPortal}
+        portalProps={portalProps}
         __staticSelector="Select"
         onDirectionChange={setDirection}
         switchDirectionOnFlip={switchDirectionOnFlip}

--- a/src/mantine-core/src/Select/SelectPopover/SelectPopover.tsx
+++ b/src/mantine-core/src/Select/SelectPopover/SelectPopover.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ClassNames, MantineShadow, Styles, Selectors, DefaultProps, rem } from '@mantine/styles';
 import { SelectScrollArea } from '../SelectScrollArea/SelectScrollArea';
 import { Popover } from '../../Popover';
+import { PortalProps } from '../../Portal';
 import { Box } from '../../Box';
 import { TransitionOverride } from '../../Transition';
 import useStyles from './SelectPopover.styles';
@@ -60,6 +61,7 @@ interface SelectPopoverProps {
   transitionProps: TransitionOverride;
   shadow?: MantineShadow;
   withinPortal?: boolean;
+  portalProps?: PortalProps;
   children: React.ReactNode;
   __staticSelector?: string;
   onDirectionChange?(direction: React.CSSProperties['flexDirection']): void;
@@ -79,6 +81,7 @@ export function SelectPopover({
   transitionProps = { transition: 'fade', duration: 0 },
   shadow,
   withinPortal,
+  portalProps,
   children,
   __staticSelector,
   onDirectionChange,
@@ -106,6 +109,7 @@ export function SelectPopover({
       zIndex={zIndex}
       __staticSelector={__staticSelector}
       withinPortal={withinPortal}
+      portalProps={portalProps}
       transitionProps={transitionProps}
       shadow={shadow}
       disabled={readOnly}

--- a/src/mantine-dropzone/src/DropzoneFullScreen.tsx
+++ b/src/mantine-dropzone/src/DropzoneFullScreen.tsx
@@ -6,6 +6,7 @@ import {
   DefaultProps,
   Selectors,
   getDefaultZIndex,
+  PortalProps,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { DropzoneStylesNames, DropzoneProps, _Dropzone } from './Dropzone';
@@ -26,6 +27,9 @@ export interface DropzoneFullScreenProps
 
   /** Determines whether component should be rendered within Portal, true by default */
   withinPortal?: boolean;
+
+  /** Props to pass down to the portal when withinPortal is true */
+  portalProps?: PortalProps;
 }
 
 const fullScreenDefaultProps: Partial<DropzoneFullScreenProps> = {
@@ -56,6 +60,7 @@ export function DropzoneFullScreen(props: DropzoneFullScreenProps) {
     onReject,
     zIndex,
     withinPortal,
+    portalProps,
     ...others
   } = useComponentDefaultProps('DropzoneFullScreen', fullScreenDefaultProps, props);
 
@@ -96,7 +101,7 @@ export function DropzoneFullScreen(props: DropzoneFullScreenProps) {
   }, [active]);
 
   return (
-    <OptionalPortal withinPortal={withinPortal}>
+    <OptionalPortal withinPortal={withinPortal} {...portalProps}>
       <Box
         className={cx(classes.wrapper, className)}
         sx={sx}

--- a/src/mantine-nprogress/src/NavigationProgress.tsx
+++ b/src/mantine-nprogress/src/NavigationProgress.tsx
@@ -4,6 +4,7 @@ import {
   useMantineTheme,
   getDefaultZIndex,
   MantineColor,
+  PortalProps,
 } from '@mantine/core';
 import { useDidUpdate, useInterval, useReducedMotion } from '@mantine/hooks';
 import React, { useRef, useState } from 'react';
@@ -40,6 +41,9 @@ export interface NavigationProgressProps {
   /** Determines whether progressbar should be rendered within Portal, defaults to true */
   withinPortal?: boolean;
 
+  /** Props to pass down to the portal when withinPortal is true */
+  portalProps?: PortalProps;
+
   /** Progressbar z-index */
   zIndex?: React.CSSProperties['zIndex'];
 
@@ -58,6 +62,7 @@ export function NavigationProgress({
   onFinish,
   autoReset = false,
   withinPortal = true,
+  portalProps,
   zIndex = getDefaultZIndex('max'),
   progressLabel,
 }: NavigationProgressProps) {
@@ -143,7 +148,7 @@ export function NavigationProgress({
   useNavigationProgressEvents({ start, stop, set, increment, decrement, reset, complete });
 
   return (
-    <OptionalPortal withinPortal={withinPortal}>
+    <OptionalPortal withinPortal={withinPortal} {...portalProps}>
       {!unmountProgress && (
         <Progress
           radius={0}


### PR DESCRIPTION
This PR adds spreadable `div` props to the Portal component, that get spread to the root div mounted in the portal.

It further adds a `portalProps` property to all components accepting `withinPortal`, so that spreadable props can be passed through to the rendered portal.

This allows for instance passing a custom className to the portal rendered inside a component, or add custom ID or data-attributes to the portal root for manipulation/styling hooks.