### PR TITLE
Mirror uncontrolled events to controlled component

### DIFF
--- a/src/mantine-core/src/Popover/Popover.story.tsx
+++ b/src/mantine-core/src/Popover/Popover.story.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Box } from '../Box';
 import { Popover } from './Popover';
 import { Button } from '../Button';
 import { MultiSelect } from '../MultiSelect';
@@ -194,6 +195,54 @@ export function Inline() {
       </Popover>
       , eum voluptate, perferendis placeat repudiandae nesciunt explicabo quibusdam deserunt, animi
       dicta.
+    </div>
+  );
+}
+
+export function PopoverEvents() {
+  const [opened, setState] = useState(false);
+  const [toggle1, setToggle1] = useState(false);
+  const [toggle2, setToggle2] = useState(false);
+
+  return (
+    <div style={{ padding: 100, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <Group>
+        <Popover
+          opened={opened}
+          onChange={setState}
+          onOpen={() => setToggle1(true)}
+          onClose={() => setToggle1(false)}
+          middlewares={{ shift: false, flip: false }}
+          position="bottom"
+          withArrow
+          trapFocus
+          radius="md"
+          returnFocus
+        >
+          <Popover.Target>
+            <Box>
+              <Button onClick={() => setState((c) => !c)}>Toggle controlled popover</Button>
+              <br />
+              <div>Controlled State: {toggle1 ? 'Open' : 'Closed'}</div>
+            </Box>
+          </Popover.Target>
+
+          <Popover.Dropdown>
+            <Button onClick={() => setState(false)}>Close</Button>
+          </Popover.Dropdown>
+        </Popover>
+        <Popover onOpen={() => setToggle2(true)} onClose={() => setToggle2(false)}>
+          <Popover.Target>
+            <Box>
+              <Button>Toggle uncontrolled popover</Button>
+              <br />
+              <div>Uncontrolled State: {toggle2 ? 'Open' : 'Closed'}</div>
+            </Box>
+          </Popover.Target>
+
+          <Popover.Dropdown>Dropdown</Popover.Dropdown>
+        </Popover>
+      </Group>
     </div>
   );
 }

--- a/src/mantine-core/src/Popover/use-popover.ts
+++ b/src/mantine-core/src/Popover/use-popover.ts
@@ -100,6 +100,14 @@ export function usePopover(options: UsePopoverOptions) {
     options.onPositionChange?.(floating.placement);
   }, [floating.placement]);
 
+  useDidUpdate(() => {
+    if (!options.opened) {
+      options.onClose?.();
+    } else {
+      options.onOpen?.();
+    }
+  }, [options.opened]);
+
   return {
     floating,
     controlled: typeof options.opened === 'boolean',


### PR DESCRIPTION
When changing a component from uncontrolled to controlled.  It no longer fires the (onOpen and onClose) events based on the open state.

This PR resolves that.  

I have also updated the storybook to showcase this.

One thing to be aware about:

Line 60 of use-popover.ts:
```
const onClose = () => {
    options.onClose?.();
    setOpened(false);
  };
```

Since my change depends on useDidUpdate.  I am worried that options.onClose will fire twice.  But it seems that is not the case.  Maintainer, please confirm.  

Thanks!