### PR TITLE
[@mantine/core] Drawer: Fix typo from Modal to Drawer

### DIFF
--- a/src/mantine-core/src/Drawer/DrawerRoot/DrawerRoot.tsx
+++ b/src/mantine-core/src/Drawer/DrawerRoot/DrawerRoot.tsx
@@ -38,7 +38,7 @@ export function DrawerRoot(props: DrawerRootProps) {
   const { classNames, variant, size, scrollAreaComponent, position, transitionProps, ...others } =
     useComponentDefaultProps('DrawerRoot', defaultProps, props);
 
-  const { classes, cx, theme } = useStyles({ position }, { name: 'Modal', variant, size });
+  const { classes, cx, theme } = useStyles({ position }, { name: 'Drawer', variant, size });
 
   const drawerTransition = (theme.dir === 'rtl' ? rtlTransitions : transitions)[position];
 


### PR DESCRIPTION
Drawer default styles props not working correctly.
I found that it was not retrieving the default styles props of Drawer, but instead retrieving the default styles of Modal.
After fixing the typo, it worked correctly.