### PR TITLE
[@mantine/core] Select: fix tab focus loss when dropdown is scrollable

### DIFF
--- a/src/mantine-core/src/Select/SelectPopover/SelectPopover.tsx
+++ b/src/mantine-core/src/Select/SelectPopover/SelectPopover.tsx
@@ -45,6 +45,7 @@ function SelectPopoverDropdown({
           onMouseDown={(event) => event.preventDefault()}
           style={{ flex: 1, overflowY: component !== SelectScrollArea ? 'auto' : undefined }}
           data-combobox-popover
+          tabIndex={-1}
           ref={innerRef}
         >
           <div className={classes.itemsWrapper} style={{ flexDirection: direction }}>

--- a/src/mantine-core/src/Select/SelectScrollArea/SelectScrollArea.tsx
+++ b/src/mantine-core/src/Select/SelectScrollArea/SelectScrollArea.tsx
@@ -3,7 +3,12 @@ import { ScrollArea, ScrollAreaProps } from '../../ScrollArea';
 
 export const SelectScrollArea = forwardRef<HTMLDivElement, ScrollAreaProps>(
   ({ style, ...others }: ScrollAreaProps, ref) => (
-    <ScrollArea {...others} style={{ width: '100%', ...style }} viewportRef={ref}>
+    <ScrollArea
+      {...others}
+      style={{ width: '100%', ...style }}
+      viewportProps={{ tabIndex: -1 }}
+      viewportRef={ref}
+    >
       {others.children}
     </ScrollArea>
   )


### PR DESCRIPTION
Fixes #3734.

#### Changes

- Add `tabIndex={-1}` to `SelectPopover` which fixes it for `dropdownComponent="div"`
- Add another `tabIndex: -1` to `SelectScrollArea` to address the issue for default `dropdownComponent` as well

I tested this manually by playing around with `Select.demo.large.tsx` and verified that the behaviour is as expected also without `withinPortal`.

I'm not sure if unit / component tests are needed for this change and also whether the change itself will get approved so this is all I'm submitting for now.
