### PR TITLE
[@mantine/core] Anchor: prop `underline={false}` should remove the underline on hover as well

### DIFF
--- a/src/mantine-core/src/Anchor/Anchor.story.tsx
+++ b/src/mantine-core/src/Anchor/Anchor.story.tsx
@@ -34,3 +34,15 @@ export function InheritFontSize() {
     </div>
   );
 }
+
+export function WithUnderlineProp() {
+  return (
+    <div style={{ padding: 40 }}>
+      <Anchor href="/">Underline should be ENABLED</Anchor>
+      <br />
+      <Anchor href="/" underline={false}>
+        Underline should be DISABLED
+      </Anchor>
+    </div>
+  );
+}

--- a/src/mantine-core/src/Anchor/Anchor.styles.ts
+++ b/src/mantine-core/src/Anchor/Anchor.styles.ts
@@ -2,6 +2,7 @@ import { createStyles, MantineColor, MantineTheme } from '@mantine/styles';
 
 export interface AnchorStylesParams {
   color: MantineColor;
+  underline: boolean;
 }
 
 interface GetAnchorColor {
@@ -22,13 +23,13 @@ function getAnchorColor({ theme, color }: GetAnchorColor) {
   );
 }
 
-export default createStyles((theme, { color }: AnchorStylesParams) => ({
+export default createStyles((theme, { color, underline }: AnchorStylesParams) => ({
   root: {
     backgroundColor: 'transparent',
     cursor: 'pointer',
     padding: 0,
     border: 0,
     color: getAnchorColor({ theme, color }),
-    ...theme.fn.hover({ textDecoration: 'underline' }),
+    ...theme.fn.hover({ textDecoration: underline ? 'underline' : 'none' }),
   },
 }));

--- a/src/mantine-core/src/Anchor/Anchor.tsx
+++ b/src/mantine-core/src/Anchor/Anchor.tsx
@@ -9,14 +9,19 @@ export interface AnchorProps extends Omit<TextProps, 'variant'> {
   children?: React.ReactNode;
 }
 
-const defaultProps: Partial<AnchorProps> = {};
+const defaultProps: Partial<AnchorProps> = {
+  underline: true,
+};
 
 export const _Anchor = forwardRef<HTMLAnchorElement, AnchorProps & { component: any }>(
   (props, ref) => {
-    const { component, className, unstyled, variant, size, color, ...others } =
+    const { component, className, unstyled, variant, size, color, underline, ...others } =
       useComponentDefaultProps('Anchor', defaultProps as AnchorProps & { component: any }, props);
 
-    const { classes, cx } = useStyles({ color }, { name: 'Anchor', unstyled, variant, size });
+    const { classes, cx } = useStyles(
+      { color, underline },
+      { name: 'Anchor', unstyled, variant, size }
+    );
     const buttonProps = component === 'button' ? { type: 'button' } : null;
 
     return (


### PR DESCRIPTION
should close #3654 by my understanding