### PR TITLE
[@mantine/core] Switch: fix jumping of viewport on click

### DIFF
--- a/src/mantine-core/src/Switch/Switch.styles.ts
+++ b/src/mantine-core/src/Switch/Switch.styles.ts
@@ -57,6 +57,10 @@ export default createStyles(
     const errorColor = theme.fn.variant({ variant: 'filled', color: 'red' }).background;
 
     return {
+      root: {
+        position: 'relative',
+      },
+
       input: {
         height: 0,
         width: 0,

--- a/src/mantine-core/src/Switch/Switch.tsx
+++ b/src/mantine-core/src/Switch/Switch.tsx
@@ -101,7 +101,7 @@ export const Switch: SwitchComponent = forwardRef<HTMLInputElement, SwitchProps>
   const ctx = useSwitchGroupContext();
   const _size = ctx?.size || size;
 
-  const { classes } = useStyles(
+  const { classes, cx } = useStyles(
     { color, radius, labelPosition, error: !!error },
     { name: 'Switch', classNames, styles, unstyled, size: _size, variant }
   );
@@ -124,7 +124,7 @@ export const Switch: SwitchComponent = forwardRef<HTMLInputElement, SwitchProps>
 
   return (
     <InlineInput
-      className={className}
+      className={cx(className, classes.root)}
       sx={sx}
       style={style}
       id={uuid}


### PR DESCRIPTION
Fixes #3736.

Please keep the following things in mind:
- This can be seen as a breaking change because it applies `position: relative` to the whole component and therefore also to the user-definable label. This would be relevant if e. g. a user uses some label element with `position: absolute`
- Avoiding the breaking change would mean wrapping the `input` element. However this breaks other internal styles that rely on this structure
- I haven't used the styles apis quite much so I don't know if my solution is good. Feel free to point me to a better solution or adjust it yourself.