### PR TITLE
[@mantine/core] Popover: fix dropdown position without key prop

### DIFF
--- a/src/mantine-core/src/Floating/use-floating-auto-update.ts
+++ b/src/mantine-core/src/Floating/use-floating-auto-update.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { autoUpdate } from '@floating-ui/react';
 import { useDidUpdate } from '@mantine/hooks';
+import { FloatingPosition } from './types';
 
 interface Payload {
   opened: boolean;
@@ -12,9 +13,15 @@ interface Payload {
     };
   };
   positionDependencies: any[];
+  position: FloatingPosition;
 }
 
-export function useFloatingAutoUpdate({ opened, floating, positionDependencies }: Payload) {
+export function useFloatingAutoUpdate({
+  opened,
+  floating,
+  position,
+  positionDependencies,
+}: Payload) {
   const [delayedUpdate, setDelayedUpdate] = useState(0);
 
   useEffect(() => {
@@ -27,7 +34,13 @@ export function useFloatingAutoUpdate({ opened, floating, positionDependencies }
     }
 
     return undefined;
-  }, [floating.refs.reference.current, floating.refs.floating.current, opened, delayedUpdate]);
+  }, [
+    floating.refs.reference.current,
+    floating.refs.floating.current,
+    opened,
+    delayedUpdate,
+    position,
+  ]);
 
   useDidUpdate(() => {
     floating.update();

--- a/src/mantine-core/src/Popover/PopoverDropdown/PopoverDropdown.tsx
+++ b/src/mantine-core/src/Popover/PopoverDropdown/PopoverDropdown.tsx
@@ -72,7 +72,6 @@ export function PopoverDropdown(props: PopoverDropdownProps) {
             <Box
               {...accessibleProps}
               tabIndex={-1}
-              key={ctx.placement}
               ref={ctx.floating}
               style={{
                 ...style,

--- a/src/mantine-core/src/Popover/use-popover.ts
+++ b/src/mantine-core/src/Popover/use-popover.ts
@@ -92,6 +92,7 @@ export function usePopover(options: UsePopoverOptions) {
 
   useFloatingAutoUpdate({
     opened: options.opened,
+    position: options.position,
     positionDependencies: options.positionDependencies,
     floating,
   });

--- a/src/mantine-core/src/Tooltip/use-tooltip.ts
+++ b/src/mantine-core/src/Tooltip/use-tooltip.ts
@@ -90,6 +90,7 @@ export function useTooltip(settings: UseTooltip) {
 
   useFloatingAutoUpdate({
     opened,
+    position: settings.position,
     positionDependencies: settings.positionDependencies,
     floating: { refs, update },
   });


### PR DESCRIPTION
This PR fixes #3643, by removing the need of a `key` prop on the Popover floating element, instead relying on Floating UI `autoUpdate` call with an added dependency on `position`.