### PR TITLE
Issue 3663 fix number input

### DIFF
--- a/src/mantine-core/src/NumberInput/NumberInput.story.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.story.tsx
@@ -6,27 +6,23 @@ import { NumberInput } from './NumberInput';
 export default { title: 'NumberInput' };
 
 export function Usage() {
-  const [value, setValue] = useState<number | ''>(0);
+  const [value, setValue] = useState<number | '' | undefined>(0);
   return (
     <div style={{ padding: 40, maxWidth: 400 }}>
-      <NumberInput value={value} onChange={setValue} onBlur={() => setValue(15)} mb="md" min={10} />
+      <NumberInput
+        value={value}
+        onChange={setValue}
+        precision={2}
+        decimalSeparator=","
+        mb="md"
+        min={10}
+        defaultValue={12}
+        max={15}
+      />
       <Group>
-        <Button
-          onMouseDown={(event) => {
-            event.preventDefault();
-            setValue('');
-          }}
-        >
-          Set empty value
-        </Button>
-        <Button
-          onMouseDown={(event) => {
-            event.preventDefault();
-            setValue(10);
-          }}
-        >
-          Set 10
-        </Button>
+        <Button onClick={() => setValue('')}>Set empty value</Button>
+        <Button onClick={() => setValue(10)}>Set 10</Button>
+        <Button onClick={() => setValue(undefined)}>Reset to initialValue</Button>
       </Group>
     </div>
   );

--- a/src/mantine-core/src/NumberInput/NumberInput.story.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.story.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useForm } from '@mantine/form';
 import { Group } from '../Group';
 import { Button } from '../Button';
 import { NumberInput } from './NumberInput';
@@ -34,4 +35,13 @@ export function FixedValue() {
       <NumberInput value={4} />
     </div>
   );
+}
+
+export function WithUseFormHook() {
+  const mantineForm = useForm({
+    initialValues: {
+      someNumber: 3,
+    },
+  });
+  return <NumberInput min={1} max={5} step={1} {...mantineForm.getInputProps('someNumber')} />;
 }

--- a/src/mantine-core/src/NumberInput/NumberInput.test.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.test.tsx
@@ -280,12 +280,49 @@ describe('@mantine/core/NumberInput', () => {
     expect(spy).toHaveBeenLastCalledWith(3);
   });
 
-  it('resets displayed value to value prop when input is controlled', async () => {
+  it('propagates the new value when hitting enter', async () => {
+    const spy = jest.fn();
+    render(<NumberInput onChange={spy} />);
+    await enterText('34');
+    expectValue('34');
+    await enterText('{enter}');
+    expectValue('34');
+    expect(spy).toHaveBeenLastCalledWith(34);
+    await enterText('abc');
+    expectValue('34abc');
+    await enterText('{enter}');
+    expectValue('34');
+    expect(spy).toHaveBeenLastCalledWith(34);
+  });
+
+  it('resets displayed value to value prop when input is controlled and component gets blurred', async () => {
     render(<NumberInput value={3} />);
     expectValue('3');
     await enterText('45');
     expectValue('345');
     await userEvent.tab();
     expectValue('3');
+  });
+
+  it('resets displayed value to value prop when input is controlled and enter gets pressed', async () => {
+    render(<NumberInput value={3} />);
+    expectValue('3');
+    await enterText('45');
+    expectValue('345');
+    await enterText('{enter}');
+    expectValue('3');
+  });
+
+  it('reformats displayed value when input is uncontrolled and enter gets pressed', async () => {
+    render(<NumberInput defaultValue={3} />);
+    expectValue('3');
+    await enterText('45');
+    expectValue('345');
+    await enterText('{enter}');
+    expectValue('345');
+    await enterText('abc');
+    expectValue('345abc');
+    await enterText('{enter}');
+    expectValue('345');
   });
 });

--- a/src/mantine-core/src/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, forwardRef } from 'react';
-import { useMergedRef, assignRef, useOs, clamp } from '@mantine/hooks';
+import { useMergedRef, assignRef, useOs, clamp, useDisclosure } from '@mantine/hooks';
 import { DefaultProps, Selectors, useComponentDefaultProps, rem, getSize } from '@mantine/styles';
 import { TextInput } from '../TextInput';
 import { InputStylesNames, InputWrapperStylesNames } from '../Input';
@@ -206,6 +206,8 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
   const formatInternalValue = (val: number | '', allowHigherPrecision?: boolean) =>
     formatNum(parsePrecision(val, allowHigherPrecision));
 
+  const [resetStateValue, resetStateHandlers] = useDisclosure(false);
+
   // Parsed value that will be used for uncontrolled state and for setting the inputValue
   const [internalValue, _setInternalValue] = useState<number | ''>(
     typeof value === 'number' ? value : typeof defaultValue === 'number' ? defaultValue : ''
@@ -272,7 +274,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
     } else if (value === undefined) {
       setInternalValue(defaultValue ?? '', true);
     }
-  }, [value]);
+  }, [value, resetStateValue]);
 
   const shouldUseStepInterval = stepHoldDelay !== undefined && stepHoldInterval !== undefined;
   const onStepTimeoutRef = useRef<number>(null);
@@ -381,9 +383,10 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
       setInternalValue(finalValue);
       onChange?.(finalValue);
     } else {
-      // Reset internal value to reset user input
-      setInternalValue(internalValue);
       onChange?.(finalValue);
+
+      // Force value effect that resets internal value to reformat the input and remove invalid inputs
+      resetStateHandlers.toggle();
     }
 
     onBlur?.(event);

--- a/src/mantine-core/src/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.tsx
@@ -241,7 +241,10 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
       newInternalValue = parseFloat(parsePrecision(clamp(internalValue + step, _min, _max)));
     }
 
-    setInternalValue(newInternalValue);
+    if (value === undefined) {
+      setInternalValue(newInternalValue);
+    }
+
     onChange?.(newInternalValue);
   };
 
@@ -254,7 +257,10 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
       newInternalValue = parseFloat(parsePrecision(clamp(internalValue - step, _min, _max)));
     }
 
-    setInternalValue(newInternalValue);
+    if (value === undefined) {
+      setInternalValue(newInternalValue);
+    }
+
     onChange?.(newInternalValue);
   };
 
@@ -371,10 +377,15 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
     const clampedValue = !noClampOnBlur ? clamp(parsedValue, _min, _max) : parsedValue;
     const finalValue = Number.isNaN(clampedValue) ? '' : clampedValue;
 
-    setInternalValue(finalValue);
-    if (finalValue !== value) {
+    if (value === undefined) {
+      setInternalValue(finalValue);
+      onChange?.(finalValue);
+    } else {
+      // Reset internal value to reset user input
+      setInternalValue(internalValue);
       onChange?.(finalValue);
     }
+
     onBlur?.(event);
   };
 

--- a/src/mantine-core/src/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.tsx
@@ -359,17 +359,10 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
     </div>
   );
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const evt = event.nativeEvent as InputEvent;
-    if (evt.isComposing) {
-      return;
-    }
-
-    const val = event.target.value;
-    setInputValue(val);
-  };
-
-  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+  /**
+   * Parse new value and propagate it via `onChange` to parent.
+   */
+  const propagateNewValue = () => {
     let normalizedInputValue = inputValue;
     if (normalizedInputValue[0] === `${decimalSeparator}` || normalizedInputValue[0] === '.') {
       normalizedInputValue = `0${normalizedInputValue}`;
@@ -388,6 +381,20 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
       // Force value effect that resets internal value to reformat the input and remove invalid inputs
       resetStateHandlers.toggle();
     }
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const evt = event.nativeEvent as InputEvent;
+    if (evt.isComposing) {
+      return;
+    }
+
+    const val = event.target.value;
+    setInputValue(val);
+  };
+
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    propagateNewValue();
 
     onBlur?.(event);
   };
@@ -402,11 +409,14 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
       event.preventDefault();
       return;
     }
+
     if (!readOnly) {
       if (event.key === 'ArrowUp') {
         onStep(event, true);
       } else if (event.key === 'ArrowDown') {
         onStep(event, false);
+      } else if (event.key === 'Enter' && !event.repeat) {
+        propagateNewValue();
       }
     }
   };


### PR DESCRIPTION
This fixes #3663 and #3729.

It's been quite a rework of the internal data handling so please have a closer look at it.

The key changes are:
- Only propagate new values via `onChange()` when bluring the component or using the increment/decrement functionality.
- Therefore while inputting some values nothing will be done to them.
- When using it in controlled mode the value won't change at all and the displayed text will reset as soon as `onChange()` gets called
- The `value` emitted in `onChange()` now already respects precision and min/max.
- When setting a `value` that doesn't match the configuration (either because it's precision is higher than configured or it isn't within the min/max bounds) it will be displayed as is (so not rounded or clamped). However as soon as it has been changed by the user it gets rounded/clamped again.