### PR TITLE
[@mantine/core] ScrollArea.Autosize: A missing viewportProps property

### DIFF
--- a/src/mantine-core/src/ScrollArea/ScrollArea.tsx
+++ b/src/mantine-core/src/ScrollArea/ScrollArea.tsx
@@ -141,6 +141,7 @@ const ScrollAreaAutosize = forwardRef<HTMLDivElement, ScrollAreaAutosizeProps>((
     unstyled,
     sx,
     variant,
+    viewportProps,
     ...others
   } = useComponentDefaultProps<ScrollAreaAutosizeProps>('ScrollAreaAutosize', defaultProps, props);
   return (
@@ -158,6 +159,7 @@ const ScrollAreaAutosize = forwardRef<HTMLDivElement, ScrollAreaAutosizeProps>((
           onScrollPositionChange={onScrollPositionChange}
           unstyled={unstyled}
           variant={variant}
+          viewportProps={viewportProps}
         >
           {children}
         </_ScrollArea>


### PR DESCRIPTION
`viewportProps` was missing for ScrollArea.Autosize so I added it. Never tested it but obviously will.