### PR TITLE
Fix use-hash: wrong value being set on hashchange

### DIFF
--- a/src/mantine-hooks/src/use-hash/use-hash.ts
+++ b/src/mantine-hooks/src/use-hash/use-hash.ts
@@ -13,7 +13,7 @@ export function useHash() {
   useWindowEvent('hashchange', () => {
     const newHash = window.location.hash;
     if (hash !== newHash) {
-      setHashValue(hash);
+      setHashValue(newHash);
     }
   });
 


### PR DESCRIPTION
setHashValue is being set to `hash` again instead of the `newHash` value. Sometimes it worked, but this fixes an issue where when hashchange is triggered the hash is reset to the old hash.