### PR TITLE
Improve Popover offset to include all Axis

### DIFF
--- a/src/mantine-core/src/Floating/index.ts
+++ b/src/mantine-core/src/Floating/index.ts
@@ -3,4 +3,10 @@ export { useFloatingAutoUpdate } from './use-floating-auto-update';
 export { getFloatingPosition } from './get-floating-position/get-floating-position';
 export { FloatingArrow } from './FloatingArrow/FloatingArrow';
 
-export type { FloatingPosition, FloatingPlacement, FloatingSide, ArrowPosition } from './types';
+export type {
+  FloatingPosition,
+  FloatingPlacement,
+  FloatingSide,
+  ArrowPosition,
+  FloatingAxesOffsets,
+} from './types';

--- a/src/mantine-core/src/Floating/types.ts
+++ b/src/mantine-core/src/Floating/types.ts
@@ -2,3 +2,8 @@ export type FloatingPlacement = 'end' | 'start';
 export type FloatingSide = 'top' | 'right' | 'bottom' | 'left';
 export type FloatingPosition = FloatingSide | `${FloatingSide}-${FloatingPlacement}`;
 export type ArrowPosition = 'center' | 'side';
+export type FloatingAxesOffsets = {
+  mainAxis?: number;
+  crossAxis?: number;
+  alignmentAxis?: number | null;
+};

--- a/src/mantine-core/src/Popover/Popover.story.tsx
+++ b/src/mantine-core/src/Popover/Popover.story.tsx
@@ -246,3 +246,17 @@ export function PopoverEvents() {
     </div>
   );
 }
+
+export function AxisOffset() {
+  return (
+    <div style={{ padding: 40 }}>
+      <Popover offset={{ mainAxis: 50, crossAxis: 50 }}>
+        <Popover.Target>
+          <Button>Toggle popover</Button>
+        </Popover.Target>
+
+        <Popover.Dropdown>Dropdown</Popover.Dropdown>
+      </Popover>
+    </div>
+  );
+}

--- a/src/mantine-core/src/Popover/Popover.tsx
+++ b/src/mantine-core/src/Popover/Popover.tsx
@@ -12,7 +12,12 @@ import {
   useComponentDefaultProps,
 } from '@mantine/styles';
 import { TransitionOverride } from '../Transition';
-import { getFloatingPosition, FloatingPosition, ArrowPosition } from '../Floating';
+import {
+  getFloatingPosition,
+  FloatingAxesOffsets,
+  FloatingPosition,
+  ArrowPosition,
+} from '../Floating';
 import { PortalProps } from '../Portal';
 import { usePopover } from './use-popover';
 import { PopoverContextProvider } from './Popover.context';
@@ -30,7 +35,7 @@ export interface PopoverBaseProps {
   position?: FloatingPosition;
 
   /** Space between target element and dropdown */
-  offset?: number;
+  offset?: number | FloatingAxesOffsets;
 
   /** Called when dropdown position changes */
   onPositionChange?(position: FloatingPosition): void;
@@ -205,7 +210,7 @@ export function Popover(props: PopoverProps) {
     middlewares,
     width,
     position: getFloatingPosition(theme.dir, position),
-    offset: offset + (withArrow ? arrowSize / 2 : 0),
+    offset: typeof offset === 'number' ? offset + (withArrow ? arrowSize / 2 : 0) : offset,
     arrowRef,
     arrowOffset,
     onPositionChange,

--- a/src/mantine-core/src/Popover/Popover.tsx
+++ b/src/mantine-core/src/Popover/Popover.tsx
@@ -34,7 +34,7 @@ export interface PopoverBaseProps {
   /** Dropdown position relative to target */
   position?: FloatingPosition;
 
-  /** Space between target element and dropdown */
+  /** Default Y axis or either (main, cross, alignment) X and Y axis space between target element and dropdown  */
   offset?: number | FloatingAxesOffsets;
 
   /** Called when dropdown position changes */

--- a/src/mantine-core/src/Popover/use-popover.ts
+++ b/src/mantine-core/src/Popover/use-popover.ts
@@ -10,11 +10,11 @@ import {
   inline,
   limitShift,
 } from '@floating-ui/react';
-import { FloatingPosition, useFloatingAutoUpdate } from '../Floating';
+import { FloatingAxesOffsets, FloatingPosition, useFloatingAutoUpdate } from '../Floating';
 import { PopoverWidth, PopoverMiddlewares } from './Popover.types';
 
 interface UsePopoverOptions {
-  offset: number;
+  offset: number | FloatingAxesOffsets;
   position: FloatingPosition;
   positionDependencies: any[];
   onPositionChange?(position: FloatingPosition): void;


### PR DESCRIPTION
This PR adds the full axis ability to popover.

See the docs here: https://floating-ui.com/docs/offset

Instead of the default Y axis, now the dev can specify both X and Y axis.  This is beneficial in case there needs to be more precise adjustments for UI.

An additional story has been added to reflect this change.

This should not be a breaking change because it retains the default number param.

If this PR is accepted, then I will also update the docs to mirror the change.