### PR TITLE
Update Pagination.mdx to use correct prop name.

### DIFF
--- a/docs/src/docs/core/Pagination.mdx
+++ b/docs/src/docs/core/Pagination.mdx
@@ -30,7 +30,7 @@ import { Pagination } from '@mantine/core';
 
 function Demo() {
   const [activePage, setPage] = useState(1);
-  return <Pagination value={activePage} onChange={setPage} total={10} />;
+  return <Pagination page={activePage} onChange={setPage} total={10} />;
 }
 ```
 


### PR DESCRIPTION
The `Pagination` component does not have a value prop as the docs show. I updated the `Pagination` component example in the docs to use the correct `page` prop.