### PR TITLE
[@mantine/hooks] use-timeout: Memoize `clear` and `start` functions

### DIFF
--- a/src/mantine-hooks/src/use-timeout/use-timeout.test.ts
+++ b/src/mantine-hooks/src/use-timeout/use-timeout.test.ts
@@ -70,6 +70,31 @@ describe('@mantine/hooks/use-timeout', () => {
     expect(setTimeout).toHaveBeenCalled();
   });
 
+  it('callback should fire without calling start when autoInvoke is true and delay changed', () => {
+    const { timeout, advanceTimerToNextTick } = setupTimer();
+    const hook = renderHook((props) => useTimeout(callback, props.timeout, { autoInvoke: true }), {
+      initialProps: {
+        timeout,
+      },
+    });
+
+    advanceTimerToNextTick();
+
+    expect(callback).toHaveBeenCalled();
+    expect(setTimeout).toHaveBeenCalled();
+
+    jest.clearAllMocks();
+
+    act(() => {
+      hook.rerender({ timeout: 1000 });
+    });
+
+    advanceTimerToNextTick();
+
+    expect(callback).toHaveBeenCalled();
+    expect(setTimeout).toHaveBeenCalled();
+  });
+
   it('timeout is cleared on calling clear', () => {
     const { timeout, advanceTimerToNextTick } = setupTimer(10);
     const hook = renderHook(() => useTimeout(callback, timeout, { autoInvoke: false }));

--- a/src/mantine-hooks/src/use-timeout/use-timeout.test.ts
+++ b/src/mantine-hooks/src/use-timeout/use-timeout.test.ts
@@ -103,4 +103,19 @@ describe('@mantine/hooks/use-timeout', () => {
     expect(setTimeout).toHaveBeenCalled();
     expect(callback).toHaveBeenCalledWith([MOCK_CALLBACK_VALUE]);
   });
+
+  it('start and clear functions remain memoized across re-renders', () => {
+    const { timeout, advanceTimerToNextTick } = setupTimer(10);
+    const hook = renderHook(() => useTimeout(callback, timeout));
+
+    const { clear, start } = hook.result.current;
+
+    act(() => {
+      hook.rerender();
+    });
+
+    expect(hook.result.current.clear).toEqual(clear);
+    expect(hook.result.current.start).toEqual(start);
+    advanceTimerToNextTick();
+  });
 });

--- a/src/mantine-hooks/src/use-timeout/use-timeout.ts
+++ b/src/mantine-hooks/src/use-timeout/use-timeout.ts
@@ -1,27 +1,35 @@
-import { useRef, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 export function useTimeout(
   callback: (...callbackParams: any[]) => void,
   delay: number,
   options: { autoInvoke: boolean } = { autoInvoke: false }
 ) {
+  const callbackRef = useRef<Function>(null);
   const timeoutRef = useRef<number>(null);
 
-  const start = (...callbackParams: any[]) => {
-    if (!timeoutRef.current) {
-      timeoutRef.current = window.setTimeout(() => {
-        callback(callbackParams);
-        timeoutRef.current = null;
-      }, delay);
-    }
-  };
+  const start = useCallback(
+    (...callbackParams: any[]) => {
+      if (!timeoutRef.current) {
+        timeoutRef.current = window.setTimeout(() => {
+          callbackRef.current(callbackParams);
+          timeoutRef.current = null;
+        }, delay);
+      }
+    },
+    [delay]
+  );
 
-  const clear = () => {
+  const clear = useCallback(() => {
     if (timeoutRef.current) {
       window.clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
 
   useEffect(() => {
     if (options.autoInvoke) {

--- a/src/mantine-hooks/src/use-timeout/use-timeout.ts
+++ b/src/mantine-hooks/src/use-timeout/use-timeout.ts
@@ -37,7 +37,7 @@ export function useTimeout(
     }
 
     return clear;
-  }, [delay]);
+  }, [clear, delay, options.autoInvoke, start]);
 
   return { start, clear };
 }


### PR DESCRIPTION
Solves #3789

1. Wrap both `clear()` and `start()` functions with the `useCallback()` hook so that they won't change across re-renders (unless they have to, e.g. `start()` depends on `delay`).
2. Add missing test case for `autoInvoke` effect when `delay` changes.
3. Correct `autoInvoke` effect dependencies to include `clear()` and `start()` as well as `options.autoInvoke`.

As far as I could check, the above changes shouldn't affect anyone using this hook. However, there's a separate commit (see point 3) that changes `autoInvoke` effect dependencies and I'm not 100% sure of relying on `options.autoInvoke`. People shouldn't really change that setting after the first render, so I'd think it's safe, but I'm open to suggestions.