### PR TITLE
[@mantine/core] Modal: Fix prop to DOM leak #3731 #3702

### DIFF
--- a/src/mantine-core/src/ModalBase/ModalBase.tsx
+++ b/src/mantine-core/src/ModalBase/ModalBase.tsx
@@ -143,7 +143,7 @@ export function ModalBase(props: ModalBaseProps) {
     styles,
     className,
     ...others
-  } = useComponentDefaultProps(props.__staticSelector, ModalBaseDefaultProps, props);
+  } = useComponentDefaultProps('ModalBase', ModalBaseDefaultProps, props);
 
   const { classes, cx } = useStyles(null, {
     name: __staticSelector,


### PR DESCRIPTION
This fixes the leaks mentioned in #3702 #3731 by acknowleding that `ModalBase` can receive `Modal` props.