### PR TITLE
Add timezone support to dates context

### DIFF
--- a/src/mantine-dates/src/components/Calendar/Calendar.tsx
+++ b/src/mantine-dates/src/components/Calendar/Calendar.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/no-unused-prop-types */
-import dayjs from 'dayjs';
 import React, { forwardRef } from 'react';
 import { Box, DefaultProps, Selectors, useComponentDefaultProps } from '@mantine/core';
 import { useUncontrolled } from '@mantine/hooks';
@@ -12,6 +11,7 @@ import useStyles from './Calendar.styles';
 import { MonthLevelSettings } from '../MonthLevel';
 import { YearLevelSettings } from '../YearLevel';
 import { DecadeLevelSettings } from '../DecadeLevel';
+import { useDatesContext } from '../DatesProvider';
 
 export type CalendarStylesNames =
   | Selectors<typeof useStyles>
@@ -201,6 +201,8 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>((props, ref) =
     ...others
   } = useComponentDefaultProps('Calendar', defaultProps, props);
 
+  const ctx = useDatesContext({ locale });
+
   const { classes, cx } = useStyles(null, {
     name: ['Calendar', __staticSelector],
     classNames,
@@ -237,31 +239,32 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>((props, ref) =
   const currentDate = _date || new Date();
 
   const handleNextMonth = () => {
-    const nextDate = dayjs(currentDate).add(_columnsToScroll, 'month').toDate();
+    const nextDate = ctx.dayjs(currentDate).add(_columnsToScroll, 'month').toDate();
     onNextMonth?.(nextDate);
     setDate(nextDate);
   };
 
   const handlePreviousMonth = () => {
-    const nextDate = dayjs(currentDate).subtract(_columnsToScroll, 'month').toDate();
+    const nextDate = ctx.dayjs(currentDate).subtract(_columnsToScroll, 'month').toDate();
     onPreviousMonth?.(nextDate);
     setDate(nextDate);
   };
 
   const handleNextYear = () => {
-    const nextDate = dayjs(currentDate).add(_columnsToScroll, 'year').toDate();
+    const nextDate = ctx.dayjs(currentDate).add(_columnsToScroll, 'year').toDate();
     onNextYear?.(nextDate);
     setDate(nextDate);
   };
 
   const handlePreviousYear = () => {
-    const nextDate = dayjs(currentDate).subtract(_columnsToScroll, 'year').toDate();
+    const nextDate = ctx.dayjs(currentDate).subtract(_columnsToScroll, 'year').toDate();
     onPreviousYear?.(nextDate);
     setDate(nextDate);
   };
 
   const handleNextDecade = () => {
-    const nextDate = dayjs(currentDate)
+    const nextDate = ctx
+      .dayjs(currentDate)
       .add(10 * _columnsToScroll, 'year')
       .toDate();
     onNextDecade?.(nextDate);
@@ -269,7 +272,8 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>((props, ref) =
   };
 
   const handlePreviousDecade = () => {
-    const nextDate = dayjs(currentDate)
+    const nextDate = ctx
+      .dayjs(currentDate)
       .subtract(10 * _columnsToScroll, 'year')
       .toDate();
     onPreviousDecade?.(nextDate);

--- a/src/mantine-dates/src/components/DateInput/is-date-valid/is-date-valid.test.ts
+++ b/src/mantine-dates/src/components/DateInput/is-date-valid/is-date-valid.test.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { isDateValid } from './is-date-valid';
 
 describe('@mantine/dates/is-date-valid', () => {
@@ -5,6 +6,7 @@ describe('@mantine/dates/is-date-valid', () => {
     expect(
       isDateValid({
         date: new Date('Invalid date'),
+        dayjs,
         maxDate: new Date(2025, 3, 11),
         minDate: new Date(2022, 3, 11),
       })
@@ -12,15 +14,16 @@ describe('@mantine/dates/is-date-valid', () => {
   });
 
   it('detects valid date when minDate/maxDate are not provided', () => {
-    expect(isDateValid({ date: new Date(2023, 3, 11), maxDate: null, minDate: undefined })).toBe(
-      true
-    );
+    expect(
+      isDateValid({ date: new Date(2023, 3, 11), dayjs, maxDate: null, minDate: undefined })
+    ).toBe(true);
   });
 
   it('detects date that is before given minDate', () => {
     expect(
       isDateValid({
         date: new Date(2023, 3, 11),
+        dayjs,
         maxDate: undefined,
         minDate: new Date(2025, 3, 11),
       })
@@ -31,6 +34,7 @@ describe('@mantine/dates/is-date-valid', () => {
     expect(
       isDateValid({
         date: new Date(2028, 3, 11),
+        dayjs,
         maxDate: new Date(2025, 3, 11),
         minDate: undefined,
       })

--- a/src/mantine-dates/src/components/DateInput/is-date-valid/is-date-valid.ts
+++ b/src/mantine-dates/src/components/DateInput/is-date-valid/is-date-valid.ts
@@ -1,12 +1,13 @@
-import dayjs from 'dayjs';
+import { Dayjs } from 'dayjs';
 
 interface IsDateValid {
   date: Date;
+  dayjs: (d: Date) => Dayjs;
   maxDate: Date;
   minDate: Date;
 }
 
-export function isDateValid({ date, maxDate, minDate }: IsDateValid) {
+export function isDateValid({ date, dayjs, maxDate, minDate }: IsDateValid) {
   if (date == null) {
     return false;
   }

--- a/src/mantine-dates/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/src/mantine-dates/src/components/DateTimePicker/DateTimePicker.tsx
@@ -1,5 +1,4 @@
-import dayjs from 'dayjs';
-import React, { forwardRef, useState, useRef } from 'react';
+import React, { forwardRef, useState, useRef, useCallback } from 'react';
 import {
   useComponentDefaultProps,
   CheckIcon,
@@ -96,7 +95,7 @@ export const DateTimePicker = forwardRef<HTMLButtonElement, DateTimePickerProps>
     others,
   } = pickCalendarProps(rest);
 
-  const ctx = useDatesContext();
+  const ctx = useDatesContext({ locale });
   const [_value, setValue] = useUncontrolled({
     value,
     defaultValue,
@@ -104,16 +103,14 @@ export const DateTimePicker = forwardRef<HTMLButtonElement, DateTimePickerProps>
     onChange,
   });
 
-  const formatTime = (dateValue: Date) =>
-    dateValue ? dayjs(dateValue).format(withSeconds ? 'HH:mm:ss' : 'HH:mm') : '';
+  const format = withSeconds ? 'HH:mm:ss' : 'HH:mm';
+  const formatTime = useCallback((d: Date) => ctx.formatDate(d, format), [ctx.formatDate, format]);
 
   const [timeValue, setTimeValue] = useState(formatTime(_value));
   const [currentLevel, setCurrentLevel] = useState(level || defaultLevel || 'month');
 
   const [dropdownOpened, dropdownHandlers] = useDisclosure(false);
-  const formattedValue = _value
-    ? dayjs(_value).locale(ctx.getLocale(locale)).format(_valueFormat)
-    : '';
+  const formattedValue = ctx.formatDate(_value, _valueFormat);
 
   const handleTimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     timeInputProps?.onChange?.(event);

--- a/src/mantine-dates/src/components/DatesProvider/DatesProvider.tsx
+++ b/src/mantine-dates/src/components/DatesProvider/DatesProvider.tsx
@@ -3,6 +3,7 @@ import { DayOfWeek } from '../../types';
 
 export interface DatesProviderValue {
   locale: string;
+  timezone: string | null; // TODO: This doesn't work with partial
   firstDayOfWeek: DayOfWeek;
   weekendDays: DayOfWeek[];
   labelSeparator: string;
@@ -12,6 +13,7 @@ export type DatesProviderSettings = Partial<DatesProviderValue>;
 
 export const DATES_PROVIDER_DEFAULT_SETTINGS: DatesProviderValue = {
   locale: 'en',
+  timezone: null,
   firstDayOfWeek: 1,
   weekendDays: [0, 6],
   labelSeparator: '–',

--- a/src/mantine-dates/src/components/DatesProvider/use-dates-context.test.tsx
+++ b/src/mantine-dates/src/components/DatesProvider/use-dates-context.test.tsx
@@ -5,42 +5,79 @@ import { useDatesContext } from './use-dates-context';
 
 describe('@mantine/dates/use-dates-context', () => {
   it('returns default values from context if hook is called without DatesProvider', () => {
-    const hook = renderHook(() => useDatesContext());
+    const hook = renderHook(() => useDatesContext({}));
     expect(hook.result.current.locale).toBe('en');
+    expect(hook.result.current.timezone).toBe(null);
     expect(hook.result.current.firstDayOfWeek).toBe(1);
     expect(hook.result.current.weekendDays).toStrictEqual([0, 6]);
+    expect(hook.result.current.labelSeparator).toBe('-');
 
-    expect(hook.result.current.getLocale()).toBe('en');
-    expect(hook.result.current.getLocale('ru')).toBe('ru');
-
-    expect(hook.result.current.getFirstDayOfWeek()).toBe(1);
-    expect(hook.result.current.getFirstDayOfWeek(0)).toBe(0);
-    expect(hook.result.current.getFirstDayOfWeek(6)).toBe(6);
-
-    expect(hook.result.current.getWeekendDays()).toStrictEqual([0, 6]);
-    expect(hook.result.current.getWeekendDays([1, 5])).toStrictEqual([1, 5]);
+    expect(hook.result.current.locale).toBe('en');
   });
 
   it('returns correct values from DatesProvider context', () => {
-    const hook = renderHook(() => useDatesContext(), {
+    const hook = renderHook(() => useDatesContext({}), {
       wrapper: ({ children }) => (
-        <DatesProvider settings={{ locale: 'ru', firstDayOfWeek: 0, weekendDays: [1, 2] }}>
+        <DatesProvider
+          settings={{
+            locale: 'ru',
+            timezone: 'Etc/UTC',
+            firstDayOfWeek: 0,
+            weekendDays: [1, 2],
+            labelSeparator: ',',
+          }}
+        >
           {children}
         </DatesProvider>
       ),
     });
 
     expect(hook.result.current.locale).toBe('ru');
+    expect(hook.result.current.timezone).toBe('Etc/UTC');
     expect(hook.result.current.firstDayOfWeek).toBe(0);
     expect(hook.result.current.weekendDays).toStrictEqual([1, 2]);
+    expect(hook.result.current.labelSeparator).toBe(',');
+  });
 
-    expect(hook.result.current.getLocale()).toBe('ru');
-    expect(hook.result.current.getLocale('en')).toBe('en');
+  it('returns local values if hook is called without DatesProvider', () => {
+    const hook = renderHook(() =>
+      useDatesContext({
+        locale: 'ru',
+        timezone: 'Etc/UTC',
+        firstDayOfWeek: 0,
+        weekendDays: [1, 2],
+        labelSeparator: ',',
+      })
+    );
 
-    expect(hook.result.current.getFirstDayOfWeek()).toBe(0);
-    expect(hook.result.current.getFirstDayOfWeek(1)).toBe(1);
+    expect(hook.result.current.locale).toBe('ru');
+    expect(hook.result.current.timezone).toBe('Etc/UTC');
+    expect(hook.result.current.firstDayOfWeek).toBe(0);
+    expect(hook.result.current.weekendDays).toStrictEqual([1, 2]);
+    expect(hook.result.current.labelSeparator).toBe(',');
+  });
 
-    expect(hook.result.current.getWeekendDays()).toStrictEqual([1, 2]);
-    expect(hook.result.current.getWeekendDays([1, 5])).toStrictEqual([1, 5]);
+  it('returns local values if hooks is valled within DatesProvider', () => {
+    const hook = renderHook(() => useDatesContext({ locale: 'en', timezone: null }), {
+      wrapper: ({ children }) => (
+        <DatesProvider
+          settings={{
+            locale: 'ru',
+            timezone: 'Etc/UTC',
+            firstDayOfWeek: 0,
+            weekendDays: [1, 2],
+            labelSeparator: ',',
+          }}
+        >
+          {children}
+        </DatesProvider>
+      ),
+    });
+
+    expect(hook.result.current.locale).toBe('en');
+    expect(hook.result.current.timezone).toBe(null);
+    expect(hook.result.current.firstDayOfWeek).toBe(0);
+    expect(hook.result.current.weekendDays).toStrictEqual([1, 2]);
+    expect(hook.result.current.labelSeparator).toBe(',');
   });
 });

--- a/src/mantine-dates/src/components/Day/Day.tsx
+++ b/src/mantine-dates/src/components/Day/Day.tsx
@@ -7,8 +7,8 @@ import {
   Selectors,
   MantineSize,
 } from '@mantine/core';
-import dayjs from 'dayjs';
 import useStyles, { DayStylesParams } from './Day.styles';
+import { useDatesContext } from '../DatesProvider';
 
 export type DayStylesNames = Selectors<typeof useStyles>;
 
@@ -84,6 +84,8 @@ export const Day = forwardRef<HTMLButtonElement, DayProps>((props, ref) => {
     ...others
   } = useComponentDefaultProps('Day', defaultProps, props);
 
+  const ctx = useDatesContext({});
+
   const { classes, cx } = useStyles(
     { radius, isStatic },
     { name: ['Day', __staticSelector], classNames, styles, unstyled, variant, size }
@@ -95,7 +97,8 @@ export const Day = forwardRef<HTMLButtonElement, DayProps>((props, ref) => {
       ref={ref}
       className={cx(classes.day, className)}
       disabled={disabled}
-      data-today={dayjs(date).isSame(new Date(), 'day') || undefined}
+      // TODO: isSame depends on timezone
+      data-today={ctx.dayjs(date).isSame(new Date(), 'day') || undefined}
       data-hidden={hidden || undefined}
       data-disabled={disabled || undefined}
       data-weekend={(!disabled && !outside && weekend) || undefined}

--- a/src/mantine-dates/src/components/DecadeLevel/DecadeLevel.tsx
+++ b/src/mantine-dates/src/components/DecadeLevel/DecadeLevel.tsx
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import React, { forwardRef } from 'react';
 import { Box, DefaultProps, useComponentDefaultProps, Selectors } from '@mantine/core';
 import {
@@ -94,7 +93,7 @@ export const DecadeLevel = forwardRef<HTMLDivElement, DecadeLevelProps>((props, 
     size,
   });
 
-  const ctx = useDatesContext();
+  const ctx = useDatesContext({ locale });
   const [startOfDecade, endOfDecade] = getDecadeRange(decade);
 
   const stylesApiProps = {
@@ -110,20 +109,15 @@ export const DecadeLevel = forwardRef<HTMLDivElement, DecadeLevelProps>((props, 
     typeof nextDisabled === 'boolean'
       ? nextDisabled
       : maxDate
-      ? !dayjs(endOfDecade).endOf('year').isBefore(maxDate)
+      ? !ctx.dayjs(endOfDecade).endOf('year').isBefore(maxDate)
       : false;
 
   const _previousDisabled =
     typeof previousDisabled === 'boolean'
       ? previousDisabled
       : minDate
-      ? !dayjs(startOfDecade).startOf('year').isAfter(minDate)
+      ? !ctx.dayjs(startOfDecade).startOf('year').isAfter(minDate)
       : false;
-
-  const formatDecade = (date: Date, format: string) =>
-    dayjs(date)
-      .locale(locale || ctx.locale)
-      .format(format);
 
   return (
     <Box className={cx(classes.decadeLevel, className)} data-decade-level ref={ref} {...others}>
@@ -131,7 +125,7 @@ export const DecadeLevel = forwardRef<HTMLDivElement, DecadeLevelProps>((props, 
         label={
           typeof decadeLabelFormat === 'function'
             ? decadeLabelFormat(startOfDecade, endOfDecade)
-            : `${formatDecade(startOfDecade, decadeLabelFormat)} – ${formatDecade(
+            : `${ctx.formatDate(startOfDecade, decadeLabelFormat)} – ${ctx.formatDate(
                 endOfDecade,
                 decadeLabelFormat
               )}`

--- a/src/mantine-dates/src/components/DecadeLevelGroup/DecadeLevelGroup.tsx
+++ b/src/mantine-dates/src/components/DecadeLevelGroup/DecadeLevelGroup.tsx
@@ -1,9 +1,9 @@
 import React, { forwardRef, useRef } from 'react';
 import { DefaultProps, Box, Selectors, useComponentDefaultProps } from '@mantine/core';
-import dayjs from 'dayjs';
 import { DecadeLevel, DecadeLevelStylesNames, DecadeLevelSettings } from '../DecadeLevel';
 import { handleControlKeyDown } from '../../utils';
 import useStyles from './DecadeLevelGroup.styles';
+import { useDatesContext } from '../DatesProvider';
 
 export type DecadeLevelGroupStylesNames = Selectors<typeof useStyles> | DecadeLevelStylesNames;
 
@@ -79,12 +79,15 @@ export const DecadeLevelGroup = forwardRef<HTMLDivElement, DecadeLevelGroupProps
     size,
   });
 
+  const ctx = useDatesContext({ locale });
+
   const controlsRefs = useRef<HTMLButtonElement[][][]>([]);
 
   const decades = Array(numberOfColumns)
     .fill(0)
     .map((_, decadeIndex) => {
-      const currentDecade = dayjs(decade)
+      const currentDecade = ctx
+        .dayjs(decade)
         .add(decadeIndex * 10, 'years')
         .toDate();
 

--- a/src/mantine-dates/src/components/Month/Month.tsx
+++ b/src/mantine-dates/src/components/Month/Month.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/no-unused-prop-types */
-import dayjs from 'dayjs';
 import React, { forwardRef } from 'react';
 import { DefaultProps, Selectors, Box, useComponentDefaultProps, MantineSize } from '@mantine/core';
 import { useDatesContext } from '../DatesProvider';
@@ -134,7 +133,7 @@ export const Month = forwardRef<HTMLTableElement, MonthProps>((props, ref) => {
     ...others
   } = useComponentDefaultProps('Month', defaultProps, props);
 
-  const ctx = useDatesContext();
+  const ctx = useDatesContext({ firstDayOfWeek, weekendDays });
 
   const { classes, cx } = useStyles(null, {
     name: ['Month', __staticSelector],
@@ -154,14 +153,10 @@ export const Month = forwardRef<HTMLTableElement, MonthProps>((props, ref) => {
     size,
   };
 
-  const rows = getMonthDays(month, ctx.getFirstDayOfWeek(firstDayOfWeek)).map((row, rowIndex) => {
+  const rows = getMonthDays(month, ctx.firstDayOfWeek).map((row, rowIndex) => {
     const cells = row.map((date, cellIndex) => {
       const outside = !isSameMonth(date, month);
-      const ariaLabel =
-        getDayAriaLabel?.(date) ||
-        dayjs(date)
-          .locale(locale || ctx.locale)
-          .format('D MMMM YYYY');
+      const ariaLabel = getDayAriaLabel?.(date) || ctx.formatDate(date, 'D MMMM YYYY');
       const dayProps = getDayProps?.(date);
 
       return (
@@ -175,7 +170,7 @@ export const Month = forwardRef<HTMLTableElement, MonthProps>((props, ref) => {
             data-mantine-stop-propagation={__stopPropagation || undefined}
             renderDay={renderDay}
             date={date}
-            weekend={ctx.getWeekendDays(weekendDays).includes(date.getDay() as DayOfWeek)}
+            weekend={ctx.weekendDays.includes(date.getDay() as DayOfWeek)}
             outside={outside}
             hidden={hideOutsideDates ? outside : false}
             aria-label={ariaLabel}

--- a/src/mantine-dates/src/components/MonthLevel/MonthLevel.tsx
+++ b/src/mantine-dates/src/components/MonthLevel/MonthLevel.tsx
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import React, { forwardRef } from 'react';
 import { Box, DefaultProps, useComponentDefaultProps, Selectors } from '@mantine/core';
 import {
@@ -104,7 +103,7 @@ export const MonthLevel = forwardRef<HTMLDivElement, MonthLevelProps>((props, re
     size,
   });
 
-  const ctx = useDatesContext();
+  const ctx = useDatesContext({ locale });
 
   const stylesApiProps = {
     __staticSelector: __staticSelector || 'MonthLevel',
@@ -119,14 +118,14 @@ export const MonthLevel = forwardRef<HTMLDivElement, MonthLevelProps>((props, re
     typeof nextDisabled === 'boolean'
       ? nextDisabled
       : maxDate
-      ? !dayjs(month).endOf('month').isBefore(maxDate)
+      ? !ctx.dayjs(month).endOf('month').isBefore(maxDate)
       : false;
 
   const _previousDisabled =
     typeof previousDisabled === 'boolean'
       ? previousDisabled
       : minDate
-      ? !dayjs(month).startOf('month').isAfter(minDate)
+      ? !ctx.dayjs(month).startOf('month').isAfter(minDate)
       : false;
 
   return (
@@ -135,9 +134,7 @@ export const MonthLevel = forwardRef<HTMLDivElement, MonthLevelProps>((props, re
         label={
           typeof monthLabelFormat === 'function'
             ? monthLabelFormat(month)
-            : dayjs(month)
-                .locale(locale || ctx.locale)
-                .format(monthLabelFormat)
+            : ctx.formatDate(month, monthLabelFormat)
         }
         className={classes.calendarHeader}
         __preventFocus={__preventFocus}

--- a/src/mantine-dates/src/components/MonthLevelGroup/MonthLevelGroup.tsx
+++ b/src/mantine-dates/src/components/MonthLevelGroup/MonthLevelGroup.tsx
@@ -1,9 +1,9 @@
 import React, { forwardRef, useRef } from 'react';
 import { DefaultProps, Box, Selectors, useComponentDefaultProps } from '@mantine/core';
-import dayjs from 'dayjs';
 import { MonthLevel, MonthLevelStylesNames, MonthLevelSettings } from '../MonthLevel';
 import { handleControlKeyDown } from '../../utils';
 import useStyles from './MonthLevelGroup.styles';
+import { useDatesContext } from '../DatesProvider';
 
 export type MonthLevelGroupStylesNames = Selectors<typeof useStyles> | MonthLevelStylesNames;
 
@@ -89,12 +89,14 @@ export const MonthLevelGroup = forwardRef<HTMLDivElement, MonthLevelGroupProps>(
     size,
   });
 
+  const ctx = useDatesContext({ locale });
+
   const daysRefs = useRef<HTMLButtonElement[][][]>([]);
 
   const months = Array(numberOfColumns)
     .fill(0)
     .map((_, monthIndex) => {
-      const currentMonth = dayjs(month).add(monthIndex, 'months').toDate();
+      const currentMonth = ctx.dayjs(month).add(monthIndex, 'months').toDate();
 
       return (
         <MonthLevel

--- a/src/mantine-dates/src/components/MonthsList/MonthsList.tsx
+++ b/src/mantine-dates/src/components/MonthsList/MonthsList.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/no-unused-prop-types */
-import dayjs from 'dayjs';
 import React, { forwardRef } from 'react';
 import { DefaultProps, Box, Selectors, useComponentDefaultProps, MantineSize } from '@mantine/core';
 import { PickerControl, PickerControlStylesNames, PickerControlProps } from '../PickerControl';
@@ -81,7 +80,7 @@ export const MonthsList = forwardRef<HTMLTableElement, MonthsListProps>((props, 
     size,
   });
 
-  const ctx = useDatesContext();
+  const ctx = useDatesContext({ locale });
 
   const months = getMonthsData(year);
 
@@ -123,7 +122,7 @@ export const MonthsList = forwardRef<HTMLTableElement, MonthsListProps>((props, 
             }}
             tabIndex={__preventFocus ? -1 : 0}
           >
-            {dayjs(month).locale(ctx.getLocale(locale)).format(monthsListFormat)}
+            {ctx.formatDate(month, monthsListFormat)}
           </PickerControl>
         </td>
       );

--- a/src/mantine-dates/src/components/MonthsList/get-months-data/get-months-data.ts
+++ b/src/mantine-dates/src/components/MonthsList/get-months-data/get-months-data.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 
 export function getMonthsData(year: Date) {
+  // TODO: Tz dependent
   const startOfYear = dayjs(year).startOf('year').toDate();
 
   const results: Date[][] = [[], [], [], []];

--- a/src/mantine-dates/src/components/WeekdaysRow/WeekdaysRow.tsx
+++ b/src/mantine-dates/src/components/WeekdaysRow/WeekdaysRow.tsx
@@ -51,7 +51,7 @@ export const WeekdaysRow = forwardRef<HTMLTableRowElement, WeekdaysRowProps>((pr
     ...others
   } = useComponentDefaultProps('WeekdaysRow', defaultProps, props);
 
-  const ctx = useDatesContext();
+  const ctx = useDatesContext({ locale, firstDayOfWeek });
 
   const { classes, cx } = useStyles(null, {
     name: ['WeekdaysRow', __staticSelector],
@@ -63,9 +63,9 @@ export const WeekdaysRow = forwardRef<HTMLTableRowElement, WeekdaysRowProps>((pr
   });
 
   const weekdays = getWeekdayNames({
-    locale: ctx.getLocale(locale),
+    locale: ctx.locale,
     format: weekdayFormat,
-    firstDayOfWeek: ctx.getFirstDayOfWeek(firstDayOfWeek),
+    firstDayOfWeek: ctx.firstDayOfWeek,
   }).map((weekday, index) => (
     <CellComponent key={index} className={classes.weekday}>
       {weekday}

--- a/src/mantine-dates/src/components/WeekdaysRow/get-weekdays-names/get-weekdays-names.ts
+++ b/src/mantine-dates/src/components/WeekdaysRow/get-weekdays-names/get-weekdays-names.ts
@@ -1,5 +1,8 @@
 import dayjs from 'dayjs';
+import localeDataPlugin from 'dayjs/plugin/localeData';
 import type { DayOfWeek } from '../../../types';
+
+dayjs.extend(localeDataPlugin);
 
 interface GetWeekdaysNamesInput {
   locale: string;

--- a/src/mantine-dates/src/components/YearLevel/YearLevel.tsx
+++ b/src/mantine-dates/src/components/YearLevel/YearLevel.tsx
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import React, { forwardRef } from 'react';
 import { Box, DefaultProps, useComponentDefaultProps, Selectors } from '@mantine/core';
 import {
@@ -94,7 +93,7 @@ export const YearLevel = forwardRef<HTMLDivElement, YearLevelProps>((props, ref)
     variant,
   });
 
-  const ctx = useDatesContext();
+  const ctx = useDatesContext({ locale });
 
   const stylesApiProps = {
     __staticSelector: __staticSelector || 'YearLevel',
@@ -109,14 +108,14 @@ export const YearLevel = forwardRef<HTMLDivElement, YearLevelProps>((props, ref)
     typeof nextDisabled === 'boolean'
       ? nextDisabled
       : maxDate
-      ? !dayjs(year).endOf('year').isBefore(maxDate)
+      ? !ctx.dayjs(year).endOf('year').isBefore(maxDate)
       : false;
 
   const _previousDisabled =
     typeof previousDisabled === 'boolean'
       ? previousDisabled
       : minDate
-      ? !dayjs(year).startOf('year').isAfter(minDate)
+      ? !ctx.dayjs(year).startOf('year').isAfter(minDate)
       : false;
 
   return (
@@ -125,9 +124,7 @@ export const YearLevel = forwardRef<HTMLDivElement, YearLevelProps>((props, ref)
         label={
           typeof yearLabelFormat === 'function'
             ? yearLabelFormat(year)
-            : dayjs(year)
-                .locale(locale || ctx.locale)
-                .format(yearLabelFormat)
+            : ctx.formatDate(year, yearLabelFormat)
         }
         className={classes.calendarHeader}
         __preventFocus={__preventFocus}

--- a/src/mantine-dates/src/components/YearLevelGroup/YearLevelGroup.tsx
+++ b/src/mantine-dates/src/components/YearLevelGroup/YearLevelGroup.tsx
@@ -1,9 +1,9 @@
 import React, { forwardRef, useRef } from 'react';
 import { DefaultProps, Box, Selectors, useComponentDefaultProps } from '@mantine/core';
-import dayjs from 'dayjs';
 import { YearLevel, YearLevelStylesNames, YearLevelSettings } from '../YearLevel';
 import { handleControlKeyDown } from '../../utils';
 import useStyles from './YearLevelGroup.styles';
+import { useDatesContext } from '../DatesProvider';
 
 export type YearLevelGroupStylesNames = Selectors<typeof useStyles> | YearLevelStylesNames;
 
@@ -79,12 +79,14 @@ export const YearLevelGroup = forwardRef<HTMLDivElement, YearLevelGroupProps>((p
     size,
   });
 
+  const ctx = useDatesContext({ locale });
+
   const controlsRefs = useRef<HTMLButtonElement[][][]>([]);
 
   const years = Array(numberOfColumns)
     .fill(0)
     .map((_, yearIndex) => {
-      const currentYear = dayjs(year).add(yearIndex, 'years').toDate();
+      const currentYear = ctx.dayjs(year).add(yearIndex, 'years').toDate();
 
       return (
         <YearLevel

--- a/src/mantine-dates/src/components/YearsList/YearsList.tsx
+++ b/src/mantine-dates/src/components/YearsList/YearsList.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/no-unused-prop-types */
-import dayjs from 'dayjs';
 import React, { forwardRef } from 'react';
 import { DefaultProps, Box, Selectors, useComponentDefaultProps, MantineSize } from '@mantine/core';
 import { PickerControl, PickerControlStylesNames, PickerControlProps } from '../PickerControl';
@@ -82,7 +81,7 @@ export const YearsList = forwardRef<HTMLTableElement, YearsListProps>((props, re
     size,
   });
 
-  const ctx = useDatesContext();
+  const ctx = useDatesContext({ locale });
 
   const years = getYearsData(decade);
 
@@ -124,7 +123,7 @@ export const YearsList = forwardRef<HTMLTableElement, YearsListProps>((props, re
             }}
             tabIndex={__preventFocus ? -1 : 0}
           >
-            {dayjs(year).locale(ctx.getLocale(locale)).format(yearsListFormat)}
+            {ctx.formatDate(year, yearsListFormat)}
           </PickerControl>
         </td>
       );

--- a/src/mantine-dates/src/hooks/use-dates-input/use-dates-input.ts
+++ b/src/mantine-dates/src/hooks/use-dates-input/use-dates-input.ts
@@ -1,4 +1,5 @@
 import { useDisclosure } from '@mantine/hooks';
+import { useCallback } from 'react';
 import { DatePickerType, DatePickerValue } from '../../types';
 import { useDatesContext } from '../../components/DatesProvider';
 import { useUncontrolledDates } from '../use-uncontrolled-dates/use-uncontrolled-dates';
@@ -27,7 +28,7 @@ export function useDatesInput<Type extends DatePickerType = 'default'>({
   sortDates,
   labelSeparator,
 }: UseDatesInput<Type>) {
-  const ctx = useDatesContext();
+  const ctx = useDatesContext({ locale, labelSeparator });
 
   const [dropdownOpened, dropdownHandlers] = useDisclosure(false);
 
@@ -38,12 +39,13 @@ export function useDatesInput<Type extends DatePickerType = 'default'>({
     onChange,
   });
 
+  const formatter = useCallback((d: Date) => ctx.formatDate(d, format), [ctx.formatDate, format]);
+
   const formattedValue = getFormattedDate({
     type,
     date: _value,
-    locale: ctx.getLocale(locale),
-    format,
-    labelSeparator: ctx.getLabelSeparator(labelSeparator),
+    formatter,
+    labelSeparator: ctx.labelSeparator,
   });
 
   const setValue = (val: any) => {

--- a/src/mantine-dates/src/hooks/use-dates-state/use-dates-state.ts
+++ b/src/mantine-dates/src/hooks/use-dates-state/use-dates-state.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import { useState } from 'react';
+import { useDatesContext } from '../../components/DatesProvider';
 import { DatePickerType, PickerBaseProps } from '../../types';
 import { useUncontrolledDates } from '../use-uncontrolled-dates/use-uncontrolled-dates';
 
@@ -28,6 +29,7 @@ export function useDatesState<Type extends DatePickerType = 'default'>({
   allowDeselect,
   onMouseLeave,
 }: UseDatesRangeInput<Type>) {
+  const ctx = useDatesContext({});
   const [_value, setValue] = useUncontrolledDates({ type, value, defaultValue, onChange });
 
   const [pickedDate, setPickedDate] = useState<Date>(
@@ -38,7 +40,7 @@ export function useDatesState<Type extends DatePickerType = 'default'>({
   const onDateChange = (date: Date) => {
     if (type === 'range') {
       if (pickedDate instanceof Date && !_value[1]) {
-        if (dayjs(date).isSame(pickedDate, level) && !allowSingleDateInRange) {
+        if (ctx.dayjs(date).isSame(pickedDate, level) && !allowSingleDateInRange) {
           setPickedDate(null);
           setHoveredDate(null);
           setValue([null, null]);
@@ -56,7 +58,7 @@ export function useDatesState<Type extends DatePickerType = 'default'>({
       if (
         _value[0] &&
         !_value[1] &&
-        dayjs(date).isSame(_value[0], level) &&
+        ctx.dayjs(date).isSame(_value[0], level) &&
         !allowSingleDateInRange
       ) {
         setPickedDate(null);
@@ -72,8 +74,8 @@ export function useDatesState<Type extends DatePickerType = 'default'>({
     }
 
     if (type === 'multiple') {
-      if (_value.some((selected: Date) => dayjs(selected).isSame(date, level))) {
-        setValue(_value.filter((selected: Date) => !dayjs(selected).isSame(date, level)));
+      if (_value.some((selected: Date) => ctx.dayjs(selected).isSame(date, level))) {
+        setValue(_value.filter((selected: Date) => !ctx.dayjs(selected).isSame(date, level)));
       } else {
         setValue([..._value, date]);
       }
@@ -81,7 +83,7 @@ export function useDatesState<Type extends DatePickerType = 'default'>({
       return;
     }
 
-    if (_value && allowDeselect && dayjs(date).isSame(_value, level)) {
+    if (_value && allowDeselect && ctx.dayjs(date).isSame(_value, level)) {
       setValue(null);
     } else {
       setValue(date);
@@ -113,8 +115,8 @@ export function useDatesState<Type extends DatePickerType = 'default'>({
       return false;
     }
 
-    if (dayjs(date).isSame(_value[0], level)) {
-      return !(hoveredDate && dayjs(hoveredDate).isBefore(_value[0]));
+    if (ctx.dayjs(date).isSame(_value[0], level)) {
+      return !(hoveredDate && ctx.dayjs(hoveredDate).isBefore(_value[0]));
     }
 
     return false;
@@ -122,39 +124,39 @@ export function useDatesState<Type extends DatePickerType = 'default'>({
 
   const isLastInRange = (date: Date) => {
     if (_value[1] instanceof Date) {
-      return dayjs(date).isSame(_value[1], level);
+      return ctx.dayjs(date).isSame(_value[1], level);
     }
 
     if (!(_value[0] instanceof Date) || !hoveredDate) {
       return false;
     }
 
-    return dayjs(hoveredDate).isBefore(_value[0]) && dayjs(date).isSame(_value[0], level);
+    return ctx.dayjs(hoveredDate).isBefore(_value[0]) && ctx.dayjs(date).isSame(_value[0], level);
   };
 
   const getControlProps = (date: Date) => {
     if (type === 'range') {
       return {
         selected: _value.some(
-          (selection: Date) => selection && dayjs(selection).isSame(date, level)
+          (selection: Date) => selection && ctx.dayjs(selection).isSame(date, level)
         ),
         inRange: isDateInRange(date),
         firstInRange: isFirstInRange(date),
         lastInRange: isLastInRange(date),
-        'data-autofocus': (!!_value[0] && dayjs(_value[0]).isSame(date, level)) || undefined,
+        'data-autofocus': (!!_value[0] && ctx.dayjs(_value[0]).isSame(date, level)) || undefined,
       };
     }
 
     if (type === 'multiple') {
       return {
         selected: _value.some(
-          (selection: Date) => selection && dayjs(selection).isSame(date, level)
+          (selection: Date) => selection && ctx.dayjs(selection).isSame(date, level)
         ),
-        'data-autofocus': (!!_value[0] && dayjs(_value[0]).isSame(date, level)) || undefined,
+        'data-autofocus': (!!_value[0] && ctx.dayjs(_value[0]).isSame(date, level)) || undefined,
       };
     }
 
-    const selected = dayjs(_value).isSame(date, level);
+    const selected = ctx.dayjs(_value).isSame(date, level);
     return { selected, 'data-autofocus': selected || undefined };
   };
 

--- a/src/mantine-dates/src/utils/get-formatted-date.ts
+++ b/src/mantine-dates/src/utils/get-formatted-date.ts
@@ -1,38 +1,33 @@
-import dayjs from 'dayjs';
 import { DatePickerType, DatePickerValue } from '../types';
 
 interface GetFormattedDate<Type extends DatePickerType = 'default'> {
   type: Type;
   date: DatePickerValue<Type>;
-  locale: string;
-  format: string;
+  formatter: (d: Date) => string;
   labelSeparator: string;
 }
 
 export function getFormattedDate<Type extends DatePickerType>({
   type,
   date,
-  locale,
-  format,
+  formatter,
   labelSeparator,
 }: GetFormattedDate<Type>) {
-  const formatDate = (value: Date) => dayjs(value).locale(locale).format(format);
-
   if (type === 'default') {
-    return date === null ? '' : formatDate(date as Date);
+    return date === null ? '' : formatter(date as Date);
   }
 
   if (type === 'multiple') {
-    return (date as Date[]).map(formatDate).join(', ');
+    return (date as Date[]).map(formatter).join(', ');
   }
 
   if (type === 'range') {
     if (date[0] && date[1]) {
-      return `${formatDate(date[0])} ${labelSeparator} ${formatDate(date[1])}`;
+      return `${formatter(date[0])} ${labelSeparator} ${formatter(date[1])}`;
     }
 
     if (date[0]) {
-      return `${formatDate(date[0])} ${labelSeparator} `;
+      return `${formatter(date[0])} ${labelSeparator} `;
     }
 
     return '';


### PR DESCRIPTION
Addresses #3432 

## Current design & approach

Currently the `DatesProviderContext` has functions for getting the various settings given an optional local 'override'. Whenever a `Dayjs` object is constructed, the caller is responsible for passing these settings off to `dayjs`. It's pretty easy to forget to set the `locale`, and the addition of timezone information through the same mechanism would open the door for much less obvious bugs. 

This PR modifies `useDatesContext` so that it takes the local overrides (from props) as an argument and merges them with the values from the context. In the current code, the tasks of going from `string` to `Date` with a `format` and vice-versa were common, so I factored those tasks out into the context. Other components do varying tasks that require briefly transitioning a `Date` to a `Dayjs` object to compute something. In order to always apply the `locale` and `timezone` information, the context exposes a `dayjs: (date: Date) => Dayjs` function which always applies the `locale` and `timezone`. With this approach, components that want to use `dayjs` should always use `ctx.dayjs` instead.

There were several instances in the code where the `locale` was not applied before formatting so I believe this fixed those issues as well.

### Design choices I'm unsure of 
- naming of `ctx.dayjs`. 
  - I could see this being confusing if somebody chose to do `const { dayjs } = useDatesContext(...)`.
  - Alternative names could be like `dateToDayjs`, `asDayjs`, `toDayjs`, etc. to avoid confusion
- `dayjs.extend()` location for `utc` and `timezone` plugins
  - Is it fine to set this in the dates context file? It seems like it would be, but I'm not sure if adding extensions should be somewhere higher in scope to avoid race conditions or something.
- awkwardness in utility functions
  - several previously pure utility functions now need timezone information, but it seems suboptimal to have those not constructed with `ctx.dayjs` due to the aforementioned risks of forgetting to set locale/timezone when it's important. 

## Questions

I'm confused about this snippet of code:
```
// DateInput.tsx
const defaultDateParser = (val: string) => {
  const parsedDate = dayjs(val, valueFormat, ctx.getLocale(locale)).toDate();
  return Number.isNaN(parsedDate.getTime()) ? dateStringParser(val) : parsedDate;
};

// date-string-parser.ts
export function dateStringParser(dateString: string) {
  const date = new Date(dateString);

  if (Number.isNaN(date.getTime()) || !dateString) {
    return null;
  }

  return date;
}
```

Why is `new Date(dateString)` done if the `dayjs` parsing fails? It's unclear to me how to make this behave correctly in the presence of timezones. Can it be removed?

## Remaining work

- a few of the utility functions that live outside of components have not been made timezone aware yet
- tests
- docs

## Extensions

It would be fairly straightforward to introduce a `timezone` prop, just like the `locale` prop for local overrides of the timezone on a per-component basis. It would be really nice to have this (for me at least) since I require a lot of different timezones for date time entry which doesn't always cleanly align with a context. 