### PR TITLE
[docs] Auto open spotlight

### DIFF
--- a/docs/src/components/Layout/LayoutInner.tsx
+++ b/docs/src/components/Layout/LayoutInner.tsx
@@ -101,7 +101,7 @@ function AutoOpenSpotlight() {
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     if (params.has(searchParamName)) {
-      spotlight.openSpotlight('button');
+      spotlight.openSpotlight();
     }
   }, []);
 


### PR DESCRIPTION
For any page in docs site: 

- `?search` will open spotlight search.
- `?search=button` will open spotlight search, prefilled with `button`.


E.g. on local site:
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/8950327/226163918-0be218b9-59e1-42db-9a1c-c47de3921870.png">


Should work on all pages in docs site.