### PR TITLE
[@mantine/core] Modal & Drawer Header: fix content scrolling over the header 

### DIFF
--- a/src/mantine-core/src/Drawer/DrawerRoot/DrawerRoot.styles.ts
+++ b/src/mantine-core/src/Drawer/DrawerRoot/DrawerRoot.styles.ts
@@ -13,6 +13,10 @@ interface DrawerRootStylesParams {
 }
 
 export default createStyles((theme, { position }: DrawerRootStylesParams, { size }) => ({
+  header: {
+    zIndex: 1000,
+  },
+
   content: {
     flex:
       position === 'right' || position === 'left' ? `0 0 ${getSize({ size, sizes })}` : '0 0 100%',

--- a/src/mantine-core/src/ModalBase/ModalBaseHeader/ModalBaseHeader.styles.ts
+++ b/src/mantine-core/src/ModalBase/ModalBaseHeader/ModalBaseHeader.styles.ts
@@ -16,6 +16,7 @@ export default createStyles((theme, { padding }: ModalBaseHeaderStylesParams) =>
       position: 'sticky',
       top: 0,
       backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
+      zIndex: 1000,
     },
   };
 });


### PR DESCRIPTION
This ensures that content does not visibly scroll over the header of the Modal and Drawer components.