### PR TITLE
[@mantine/dates]: Consider hideOutsideDates when determining tab order

### DIFF
--- a/src/mantine-dates/src/components/Month/Month.tsx
+++ b/src/mantine-dates/src/components/Month/Month.tsx
@@ -157,7 +157,15 @@ export const Month = forwardRef<HTMLTableElement, MonthProps>((props, ref) => {
 
   const dates = getMonthDays(month, ctx.getFirstDayOfWeek(firstDayOfWeek));
 
-  const dateInTabOrder = getDateInTabOrder(dates, minDate, maxDate, getDayProps, excludeDate);
+  const dateInTabOrder = getDateInTabOrder(
+    dates,
+    minDate,
+    maxDate,
+    getDayProps,
+    excludeDate,
+    hideOutsideDates,
+    month
+  );
 
   const rows = dates.map((row, rowIndex) => {
     const cells = row.map((date, cellIndex) => {

--- a/src/mantine-dates/src/components/Month/get-date-in-tab-order/get-date-in-tab-order.test.ts
+++ b/src/mantine-dates/src/components/Month/get-date-in-tab-order/get-date-in-tab-order.test.ts
@@ -8,6 +8,8 @@ const defaultMaxDate = new Date(2100, 0);
 const defaultSelectedDate = new Date(2010, 5, 5);
 const defaultControlProps = () => ({});
 const defaultExcludeDate = () => false;
+const defaultHideOutsideDates = false;
+const defaultMonth = new Date(2010, 5);
 
 describe('@mantine/dates/get-date-in-tab-order', () => {
   it('returns selected date', () => {
@@ -19,7 +21,9 @@ describe('@mantine/dates/get-date-in-tab-order', () => {
         (date) => ({
           selected: dayjs(date).isSame(defaultSelectedDate, 'date'),
         }),
-        defaultExcludeDate
+        defaultExcludeDate,
+        defaultHideOutsideDates,
+        defaultMonth
       )
     ).toStrictEqual(defaultSelectedDate);
   });
@@ -31,7 +35,9 @@ describe('@mantine/dates/get-date-in-tab-order', () => {
         defaultMinDate,
         defaultMaxDate,
         defaultControlProps,
-        defaultExcludeDate
+        defaultExcludeDate,
+        defaultHideOutsideDates,
+        defaultMonth
       )
     ).toStrictEqual(
       new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate())
@@ -45,7 +51,9 @@ describe('@mantine/dates/get-date-in-tab-order', () => {
         defaultMinDate,
         defaultMaxDate,
         defaultControlProps,
-        defaultExcludeDate
+        defaultExcludeDate,
+        defaultHideOutsideDates,
+        defaultMonth
       )
     ).toStrictEqual(new Date(2010, 1, 1));
     expect(
@@ -54,7 +62,9 @@ describe('@mantine/dates/get-date-in-tab-order', () => {
         new Date(2010, 5, 5),
         defaultMaxDate,
         defaultControlProps,
-        defaultExcludeDate
+        defaultExcludeDate,
+        defaultHideOutsideDates,
+        defaultMonth
       )
     ).toStrictEqual(new Date(2010, 5, 5));
   });
@@ -66,8 +76,36 @@ describe('@mantine/dates/get-date-in-tab-order', () => {
         defaultMinDate,
         defaultMaxDate,
         defaultControlProps,
-        (date) => dayjs(new Date(2010, 1, 1)).isSame(date, 'date')
+        (date) => dayjs(new Date(2010, 1, 1)).isSame(date, 'date'),
+        defaultHideOutsideDates,
+        defaultMonth
       )
     ).toStrictEqual(new Date(2010, 1, 2));
+  });
+
+  it('handles hidden outside dates', () => {
+    expect(
+      getDateInTabOrder(
+        defaultDates,
+        defaultMinDate,
+        defaultMaxDate,
+        defaultControlProps,
+        defaultExcludeDate,
+        defaultHideOutsideDates,
+        defaultMonth
+      )
+    ).toStrictEqual(new Date(2010, 4, 31));
+
+    expect(
+      getDateInTabOrder(
+        defaultDates,
+        defaultMinDate,
+        defaultMaxDate,
+        defaultControlProps,
+        defaultExcludeDate,
+        true,
+        defaultMonth
+      )
+    ).toStrictEqual(new Date(2010, 5, 1));
   });
 });

--- a/src/mantine-dates/src/components/Month/get-date-in-tab-order/get-date-in-tab-order.ts
+++ b/src/mantine-dates/src/components/Month/get-date-in-tab-order/get-date-in-tab-order.ts
@@ -2,13 +2,16 @@ import dayjs from 'dayjs';
 import { DayProps } from '../../Day';
 import { isAfterMinDate } from '../is-after-min-date/is-after-min-date';
 import { isBeforeMaxDate } from '../is-before-max-date/is-before-max-date';
+import { isSameMonth } from '../is-same-month/is-same-month';
 
 export function getDateInTabOrder(
   dates: Date[][],
   minDate: Date,
   maxDate: Date,
   getDateControlProps: (date: Date) => Partial<DayProps>,
-  excludeDate: (date: Date) => boolean
+  excludeDate: (date: Date) => boolean,
+  hideOutsideDates: boolean,
+  month: Date
 ) {
   const enabledDates = dates
     .flat()
@@ -17,7 +20,8 @@ export function getDateInTabOrder(
         isBeforeMaxDate(date, maxDate) &&
         isAfterMinDate(date, minDate) &&
         !excludeDate?.(date) &&
-        !getDateControlProps?.(date)?.disabled
+        !getDateControlProps?.(date)?.disabled &&
+        (!hideOutsideDates || isSameMonth(date, month))
     );
 
   const selectedDate = enabledDates.find((date) => getDateControlProps?.(date)?.selected);


### PR DESCRIPTION
I noticed no date is added to tab order when:

- No date in month is selected
- Current date is not in month
- First non-disabled date in month is hidden because of `hideOutsideDates={true}`

Can be tested here in February 2023 for example: https://mantine.dev/dates/date-picker/#hide-outside-dates. This fixes it.

As a side-note, I was expecting be to be able to use `!getDateControlProps?.(date)?.outside` instead of `isSameMonth(date, month)`, but turns out `outside` is never set here: https://github.com/mantinedev/mantine/blob/master/src/mantine-dates/src/hooks/use-dates-state/use-dates-state.ts#L158 Maybe that could be something to look into in the future?