### PR TITLE
[@mantine/dates]: Change tab order behavior to match native date pickers

### DIFF
--- a/src/mantine-dates/src/components/DecadeLevelGroup/DecadeLevelGroup.tsx
+++ b/src/mantine-dates/src/components/DecadeLevelGroup/DecadeLevelGroup.tsx
@@ -79,7 +79,7 @@ export const DecadeLevelGroup = forwardRef<HTMLDivElement, DecadeLevelGroupProps
     size,
   });
 
-  const controlsRefs = useRef<HTMLButtonElement[][][]>([]);
+  const controlsRef = useRef<HTMLButtonElement[][][]>([]);
 
   const decades = Array(numberOfColumns)
     .fill(0)
@@ -106,19 +106,19 @@ export const DecadeLevelGroup = forwardRef<HTMLDivElement, DecadeLevelGroupProps
               rowIndex: payload.rowIndex,
               cellIndex: payload.cellIndex,
               event,
-              controlsRefs,
+              controlsRef,
             })
           }
           __getControlRef={(rowIndex, cellIndex, node) => {
-            if (!Array.isArray(controlsRefs.current[decadeIndex])) {
-              controlsRefs.current[decadeIndex] = [];
+            if (!Array.isArray(controlsRef.current[decadeIndex])) {
+              controlsRef.current[decadeIndex] = [];
             }
 
-            if (!Array.isArray(controlsRefs.current[decadeIndex][rowIndex])) {
-              controlsRefs.current[decadeIndex][rowIndex] = [];
+            if (!Array.isArray(controlsRef.current[decadeIndex][rowIndex])) {
+              controlsRef.current[decadeIndex][rowIndex] = [];
             }
 
-            controlsRefs.current[decadeIndex][rowIndex][cellIndex] = node;
+            controlsRef.current[decadeIndex][rowIndex][cellIndex] = node;
           }}
           levelControlAriaLabel={
             typeof levelControlAriaLabel === 'function'

--- a/src/mantine-dates/src/components/DecadeLevelGroup/DecadeLevelGroup.tsx
+++ b/src/mantine-dates/src/components/DecadeLevelGroup/DecadeLevelGroup.tsx
@@ -102,12 +102,11 @@ export const DecadeLevelGroup = forwardRef<HTMLDivElement, DecadeLevelGroupProps
           __onControlMouseEnter={__onControlMouseEnter}
           __onControlKeyDown={(event, payload) =>
             handleControlKeyDown({
-              index: decadeIndex,
+              levelIndex: decadeIndex,
+              rowIndex: payload.rowIndex,
+              cellIndex: payload.cellIndex,
               event,
-              payload,
-              controlsRef: controlsRefs,
-              numberOfColumns,
-              controlsPerRow: [3, 3, 3, 1],
+              controlsRefs,
             })
           }
           __getControlRef={(rowIndex, cellIndex, node) => {

--- a/src/mantine-dates/src/components/MonthLevelGroup/MonthLevelGroup.tsx
+++ b/src/mantine-dates/src/components/MonthLevelGroup/MonthLevelGroup.tsx
@@ -112,7 +112,7 @@ export const MonthLevelGroup = forwardRef<HTMLDivElement, MonthLevelGroupProps>(
               rowIndex: payload.rowIndex,
               cellIndex: payload.cellIndex,
               event,
-              controlsRefs: daysRefs,
+              controlsRef: daysRefs,
             })
           }
           __getDayRef={(rowIndex, cellIndex, node) => {

--- a/src/mantine-dates/src/components/MonthLevelGroup/MonthLevelGroup.tsx
+++ b/src/mantine-dates/src/components/MonthLevelGroup/MonthLevelGroup.tsx
@@ -108,12 +108,11 @@ export const MonthLevelGroup = forwardRef<HTMLDivElement, MonthLevelGroupProps>(
           __onDayMouseEnter={__onDayMouseEnter}
           __onDayKeyDown={(event, payload) =>
             handleControlKeyDown({
-              index: monthIndex,
+              levelIndex: monthIndex,
+              rowIndex: payload.rowIndex,
+              cellIndex: payload.cellIndex,
               event,
-              payload,
-              controlsRef: daysRefs,
-              numberOfColumns,
-              controlsPerRow: 7,
+              controlsRefs: daysRefs,
             })
           }
           __getDayRef={(rowIndex, cellIndex, node) => {

--- a/src/mantine-dates/src/components/YearLevelGroup/YearLevelGroup.tsx
+++ b/src/mantine-dates/src/components/YearLevelGroup/YearLevelGroup.tsx
@@ -101,12 +101,11 @@ export const YearLevelGroup = forwardRef<HTMLDivElement, YearLevelGroupProps>((p
           __onControlMouseEnter={__onControlMouseEnter}
           __onControlKeyDown={(event, payload) =>
             handleControlKeyDown({
-              index: yearIndex,
+              levelIndex: yearIndex,
+              rowIndex: payload.rowIndex,
+              cellIndex: payload.cellIndex,
               event,
-              payload,
-              controlsRef: controlsRefs,
-              numberOfColumns,
-              controlsPerRow: 3,
+              controlsRefs,
             })
           }
           __getControlRef={(rowIndex, cellIndex, node) => {

--- a/src/mantine-dates/src/components/YearLevelGroup/YearLevelGroup.tsx
+++ b/src/mantine-dates/src/components/YearLevelGroup/YearLevelGroup.tsx
@@ -79,7 +79,7 @@ export const YearLevelGroup = forwardRef<HTMLDivElement, YearLevelGroupProps>((p
     size,
   });
 
-  const controlsRefs = useRef<HTMLButtonElement[][][]>([]);
+  const controlsRef = useRef<HTMLButtonElement[][][]>([]);
 
   const years = Array(numberOfColumns)
     .fill(0)
@@ -105,19 +105,19 @@ export const YearLevelGroup = forwardRef<HTMLDivElement, YearLevelGroupProps>((p
               rowIndex: payload.rowIndex,
               cellIndex: payload.cellIndex,
               event,
-              controlsRefs,
+              controlsRef,
             })
           }
           __getControlRef={(rowIndex, cellIndex, node) => {
-            if (!Array.isArray(controlsRefs.current[yearIndex])) {
-              controlsRefs.current[yearIndex] = [];
+            if (!Array.isArray(controlsRef.current[yearIndex])) {
+              controlsRef.current[yearIndex] = [];
             }
 
-            if (!Array.isArray(controlsRefs.current[yearIndex][rowIndex])) {
-              controlsRefs.current[yearIndex][rowIndex] = [];
+            if (!Array.isArray(controlsRef.current[yearIndex][rowIndex])) {
+              controlsRef.current[yearIndex][rowIndex] = [];
             }
 
-            controlsRefs.current[yearIndex][rowIndex][cellIndex] = node;
+            controlsRef.current[yearIndex][rowIndex][cellIndex] = node;
           }}
           levelControlAriaLabel={
             typeof levelControlAriaLabel === 'function'

--- a/src/mantine-dates/src/tests/it-handles-controls-keyboard-events.tsx
+++ b/src/mantine-dates/src/tests/it-handles-controls-keyboard-events.tsx
@@ -41,17 +41,23 @@ export function itHandlesControlsKeyboardEvents(
     await userEvent.click(firstColumnControls[1]);
     expect(firstColumnControls[1]).toHaveFocus();
 
-    await userEvent.type(firstColumnControls[1], '{ArrowRight}', { skipClick: true });
+    await userEvent.type(firstColumnControls[1], '{ArrowRight}');
     expect(firstColumnControls[2]).toHaveFocus();
 
-    await userEvent.type(firstColumnControls[2], '{ArrowRight}', { skipClick: true });
+    await userEvent.type(firstColumnControls[2], '{ArrowRight}');
+    expect(firstColumnControls[3]).toHaveFocus();
+
+    await userEvent.type(firstColumnControls[firstColumnControls.length - 1], '{ArrowRight}');
     expect(secondColumnControls[0]).toHaveFocus();
 
-    await userEvent.type(secondColumnControls[0], '{ArrowDown}', { skipClick: true });
+    await userEvent.type(secondColumnControls[0], '{ArrowDown}');
     expect(secondColumnControls[3]).toHaveFocus();
 
-    await userEvent.type(secondColumnControls[3], '{ArrowLeft}', { skipClick: true });
-    expect(firstColumnControls[5]).toHaveFocus();
+    await userEvent.type(secondColumnControls[3], '{ArrowLeft}');
+    expect(secondColumnControls[2]).toHaveFocus();
+
+    await userEvent.type(secondColumnControls[0], '{ArrowLeft}');
+    expect(firstColumnControls[firstColumnControls.length - 1]).toHaveFocus();
   });
 
   it(`handles ${name} arrow keyboard events correctly at edges`, async () => {
@@ -59,7 +65,7 @@ export function itHandlesControlsKeyboardEvents(
     const controls = container.querySelectorAll('table button');
 
     await userEvent.type(controls[2], '{ArrowRight}');
-    expect(controls[2]).toHaveFocus();
+    expect(controls[3]).toHaveFocus();
 
     await userEvent.type(controls[0], '{ArrowLeft}');
     expect(controls[0]).toHaveFocus();

--- a/src/mantine-dates/src/tests/it-handles-month-keyboard-events.tsx
+++ b/src/mantine-dates/src/tests/it-handles-month-keyboard-events.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import React from 'react';
 
 export interface ComponentTestProps {
   numberOfColumns?: number;
@@ -17,17 +17,17 @@ export function itHandlesMonthKeyboardEvents(
     await userEvent.click(days[0]);
     expect(days[0]).toHaveFocus();
 
-    await userEvent.type(days[0], '{ArrowRight}', { skipClick: true });
-    expect(days[1]).toHaveFocus();
+    await userEvent.type(days[4], '{ArrowRight}');
+    expect(days[5]).toHaveFocus();
 
-    await userEvent.type(days[1], '{ArrowDown}', { skipClick: true });
-    expect(days[8]).toHaveFocus();
+    await userEvent.type(days[4], '{ArrowDown}');
+    expect(days[11]).toHaveFocus();
 
-    await userEvent.type(days[8], '{ArrowLeft}', { skipClick: true });
+    await userEvent.type(days[8], '{ArrowLeft}');
     expect(days[7]).toHaveFocus();
 
-    await userEvent.type(days[7], '{ArrowUp}', { skipClick: true });
-    expect(days[0]).toHaveFocus();
+    await userEvent.type(days[11], '{ArrowUp}');
+    expect(days[4]).toHaveFocus();
   });
 
   it('handles month arrow keyboard events correctly (numberOfColumns=2)', async () => {
@@ -39,17 +39,20 @@ export function itHandlesMonthKeyboardEvents(
     await userEvent.click(firstMonthDays[5]);
     expect(firstMonthDays[5]).toHaveFocus();
 
-    await userEvent.type(firstMonthDays[5], '{ArrowRight}', { skipClick: true });
+    await userEvent.type(firstMonthDays[5], '{ArrowRight}');
     expect(firstMonthDays[6]).toHaveFocus();
 
-    await userEvent.type(firstMonthDays[6], '{ArrowRight}', { skipClick: true });
-    expect(secondMonthDays[0]).toHaveFocus();
+    await userEvent.type(firstMonthDays[6], '{ArrowRight}');
+    expect(firstMonthDays[7]).toHaveFocus();
 
-    await userEvent.type(secondMonthDays[0], '{ArrowDown}', { skipClick: true });
+    await userEvent.type(secondMonthDays[0], '{ArrowDown}');
     expect(secondMonthDays[7]).toHaveFocus();
 
-    await userEvent.type(secondMonthDays[7], '{ArrowLeft}', { skipClick: true });
-    expect(firstMonthDays[13]).toHaveFocus();
+    await userEvent.type(secondMonthDays[7], '{ArrowLeft}');
+    expect(secondMonthDays[6]).toHaveFocus();
+
+    await userEvent.type(secondMonthDays[14], '{ArrowUp}');
+    expect(secondMonthDays[7]).toHaveFocus();
   });
 
   it('handles month arrow keyboard events correctly at month edges', async () => {
@@ -57,7 +60,7 @@ export function itHandlesMonthKeyboardEvents(
     const days = container.querySelectorAll('table button');
 
     await userEvent.type(days[6], '{ArrowRight}');
-    expect(days[6]).toHaveFocus();
+    expect(days[7]).toHaveFocus();
 
     await userEvent.type(days[0], '{ArrowLeft}');
     expect(days[0]).toHaveFocus();

--- a/src/mantine-dates/src/utils/handle-control-key-down.ts
+++ b/src/mantine-dates/src/utils/handle-control-key-down.ts
@@ -1,112 +1,196 @@
 import { RefObject } from 'react';
-import type { ControlKeydownPayload } from '../types';
 
-type ControlsRef = RefObject<HTMLButtonElement[][][]>;
+type ControlsRefs = RefObject<HTMLButtonElement[][][]>;
+type Direction = 'up' | 'down' | 'left' | 'right';
+
+function getControlsSize(controlsRef: ControlsRefs) {
+  return controlsRef.current.map((column) => column.map((row) => row.length));
+}
+
+type NextIndexInput = Omit<ShiftFocusInput, 'controlsRefs'>;
+
+function getNextIndex({ direction, levelIndex, rowIndex, cellIndex, size }: NextIndexInput) {
+  switch (direction) {
+    case 'up':
+      if (levelIndex === 0 && rowIndex === 0) {
+        return null;
+      }
+      if (rowIndex === 0) {
+        return {
+          levelIndex: levelIndex - 1,
+          rowIndex:
+            cellIndex <= size[levelIndex - 1][size[levelIndex - 1].length - 1] - 1
+              ? size[levelIndex - 1].length - 1
+              : size[levelIndex - 1].length - 2,
+          cellIndex,
+        };
+      }
+      return {
+        levelIndex,
+        rowIndex: rowIndex - 1,
+        cellIndex,
+      };
+
+    case 'down':
+      if (rowIndex === size[levelIndex].length - 1) {
+        return {
+          levelIndex: levelIndex + 1,
+          rowIndex: 0,
+          cellIndex,
+        };
+      }
+      if (
+        rowIndex === size[levelIndex].length - 2 &&
+        cellIndex >= size[levelIndex][size[levelIndex].length - 1]
+      ) {
+        return {
+          levelIndex: levelIndex + 1,
+          rowIndex: 0,
+          cellIndex,
+        };
+      }
+      return {
+        levelIndex,
+        rowIndex: rowIndex + 1,
+        cellIndex,
+      };
+
+    case 'left':
+      if (levelIndex === 0 && rowIndex === 0 && cellIndex === 0) {
+        return null;
+      }
+      if (rowIndex === 0 && cellIndex === 0) {
+        return {
+          levelIndex: levelIndex - 1,
+          rowIndex: size[levelIndex - 1].length - 1,
+          cellIndex: size[levelIndex - 1][size[levelIndex - 1].length - 1] - 1,
+        };
+      }
+      if (cellIndex === 0) {
+        return {
+          levelIndex,
+          rowIndex: rowIndex - 1,
+          cellIndex: size[levelIndex][rowIndex - 1] - 1,
+        };
+      }
+      return {
+        levelIndex,
+        rowIndex,
+        cellIndex: cellIndex - 1,
+      };
+    case 'right':
+      if (
+        rowIndex === size[levelIndex].length - 1 &&
+        cellIndex === size[levelIndex][rowIndex] - 1
+      ) {
+        return {
+          levelIndex: levelIndex + 1,
+          rowIndex: 0,
+          cellIndex: 0,
+        };
+      }
+      if (cellIndex === size[levelIndex][rowIndex] - 1) {
+        return {
+          levelIndex,
+          rowIndex: rowIndex + 1,
+          cellIndex: 0,
+        };
+      }
+      return {
+        levelIndex,
+        rowIndex,
+        cellIndex: cellIndex + 1,
+      };
+    default:
+      return { levelIndex, rowIndex, cellIndex };
+  }
+}
 
 interface ShiftFocusInput {
-  controlsRef: ControlsRef;
-  direction: 'down' | 'up' | 'left' | 'right';
-  index: number;
-  payload: ControlKeydownPayload;
-  count?: number;
+  controlsRefs: ControlsRefs;
+  direction: Direction;
+  levelIndex: number;
+  rowIndex: number;
+  cellIndex: number;
+  size: number[][];
 }
 
 function focusOnNextFocusableControl({
+  controlsRefs,
   direction,
-  index,
-  payload,
-  count = 1,
-  controlsRef,
+  levelIndex,
+  rowIndex,
+  cellIndex,
+  size,
 }: ShiftFocusInput) {
-  const changeRow = ['down', 'up'].includes(direction);
+  const nextIndex = getNextIndex({ direction, size, rowIndex, cellIndex, levelIndex });
 
-  const rowIndex = changeRow
-    ? payload.rowIndex + (direction === 'down' ? count : -count)
-    : payload.rowIndex;
+  if (!nextIndex) {
+    return;
+  }
 
-  const cellIndex = changeRow
-    ? payload.cellIndex
-    : payload.cellIndex + (direction === 'right' ? count : -count);
-
-  const controlToFocus = controlsRef.current[index][rowIndex]?.[cellIndex];
+  const controlToFocus =
+    controlsRefs.current[nextIndex.levelIndex]?.[nextIndex.rowIndex]?.[nextIndex.cellIndex];
 
   if (!controlToFocus) {
     return;
   }
 
-  if (controlToFocus.disabled) {
-    focusOnNextFocusableControl({ direction, index, payload, controlsRef, count: count + 1 });
+  if (controlToFocus.disabled || controlToFocus.getAttribute('data-hidden')) {
+    focusOnNextFocusableControl({
+      controlsRefs,
+      direction,
+      levelIndex: nextIndex.levelIndex,
+      cellIndex: nextIndex.cellIndex,
+      rowIndex: nextIndex.rowIndex,
+      size,
+    });
   } else {
     controlToFocus.focus();
   }
 }
 
-interface HandleControlKeydownInput {
-  controlsRef: ControlsRef;
-  numberOfColumns: number;
-  index: number;
-  payload: ControlKeydownPayload;
+function getDirection(key: KeyboardEvent['key']): Direction {
+  switch (key) {
+    case 'ArrowDown':
+      return 'down';
+    case 'ArrowUp':
+      return 'up';
+    case 'ArrowRight':
+      return 'right';
+    case 'ArrowLeft':
+      return 'left';
+    default:
+      return null;
+  }
+}
+interface HandleControlKeyDownInput {
+  controlsRefs: ControlsRefs;
+  levelIndex: number;
+  rowIndex: number;
+  cellIndex: number;
   event: React.KeyboardEvent<HTMLButtonElement>;
-  controlsPerRow: number | number[];
 }
 
 export function handleControlKeyDown({
-  controlsRef,
-  index,
-  payload,
+  controlsRefs,
+  levelIndex,
+  rowIndex,
+  cellIndex,
   event,
-  numberOfColumns,
-  controlsPerRow,
-}: HandleControlKeydownInput) {
-  const _controlsPerRow = Array.isArray(controlsPerRow)
-    ? controlsPerRow[payload.rowIndex]
-    : controlsPerRow;
+}: HandleControlKeyDownInput) {
+  const direction = getDirection(event.key);
 
-  switch (event.key) {
-    case 'ArrowDown': {
-      event.preventDefault();
+  if (direction) {
+    const size = getControlsSize(controlsRefs);
 
-      const hasRowBelow = payload.rowIndex + 1 < controlsRef.current[index].length;
-      if (hasRowBelow) {
-        focusOnNextFocusableControl({ direction: 'down', index, payload, controlsRef });
-      }
-      break;
-    }
-
-    case 'ArrowUp': {
-      event.preventDefault();
-
-      const hasRowAbove = payload.rowIndex > 0;
-      if (hasRowAbove) {
-        focusOnNextFocusableControl({ direction: 'up', index, payload, controlsRef });
-      }
-      break;
-    }
-
-    case 'ArrowRight': {
-      event.preventDefault();
-
-      if (payload.cellIndex !== _controlsPerRow - 1) {
-        focusOnNextFocusableControl({ direction: 'right', index, payload, controlsRef });
-      } else if (index + 1 < numberOfColumns) {
-        if (controlsRef.current[index + 1][payload.rowIndex]) {
-          controlsRef.current[index + 1][payload.rowIndex][0]?.focus();
-        }
-      }
-
-      break;
-    }
-
-    case 'ArrowLeft': {
-      event.preventDefault();
-
-      if (payload.cellIndex !== 0) {
-        focusOnNextFocusableControl({ direction: 'left', index, payload, controlsRef });
-      } else if (index > 0) {
-        if (controlsRef.current[index - 1][payload.rowIndex]) {
-          controlsRef.current[index - 1][payload.rowIndex][_controlsPerRow - 1].focus();
-        }
-      }
-    }
+    focusOnNextFocusableControl({
+      controlsRefs,
+      direction,
+      levelIndex,
+      rowIndex,
+      cellIndex,
+      size,
+    });
   }
 }

--- a/src/mantine-dates/src/utils/handle-control-key-down.ts
+++ b/src/mantine-dates/src/utils/handle-control-key-down.ts
@@ -136,7 +136,11 @@ function focusOnNextFocusableControl({
     return;
   }
 
-  if (controlToFocus.disabled || controlToFocus.getAttribute('data-hidden')) {
+  if (
+    controlToFocus.disabled ||
+    controlToFocus.getAttribute('data-hidden') ||
+    controlToFocus.getAttribute('data-outside')
+  ) {
     focusOnNextFocusableControl({
       controlsRefs,
       direction,

--- a/src/mantine-dates/src/utils/handle-control-key-down.ts
+++ b/src/mantine-dates/src/utils/handle-control-key-down.ts
@@ -1,13 +1,9 @@
 import { RefObject } from 'react';
 
-type ControlsRefs = RefObject<HTMLButtonElement[][][]>;
+type ControlsRef = RefObject<HTMLButtonElement[][][]>;
 type Direction = 'up' | 'down' | 'left' | 'right';
 
-function getControlsSize(controlsRef: ControlsRefs) {
-  return controlsRef.current.map((column) => column.map((row) => row.length));
-}
-
-type NextIndexInput = Omit<ShiftFocusInput, 'controlsRefs'>;
+type NextIndexInput = Omit<ShiftFocusInput, 'controlsRef'>;
 
 function getNextIndex({ direction, levelIndex, rowIndex, cellIndex, size }: NextIndexInput) {
   switch (direction) {
@@ -78,6 +74,7 @@ function getNextIndex({ direction, levelIndex, rowIndex, cellIndex, size }: Next
         rowIndex,
         cellIndex: cellIndex - 1,
       };
+
     case 'right':
       if (
         rowIndex === size[levelIndex].length - 1 &&
@@ -101,13 +98,14 @@ function getNextIndex({ direction, levelIndex, rowIndex, cellIndex, size }: Next
         rowIndex,
         cellIndex: cellIndex + 1,
       };
+
     default:
       return { levelIndex, rowIndex, cellIndex };
   }
 }
 
 interface ShiftFocusInput {
-  controlsRefs: ControlsRefs;
+  controlsRef: ControlsRef;
   direction: Direction;
   levelIndex: number;
   rowIndex: number;
@@ -116,7 +114,7 @@ interface ShiftFocusInput {
 }
 
 function focusOnNextFocusableControl({
-  controlsRefs,
+  controlsRef,
   direction,
   levelIndex,
   rowIndex,
@@ -130,7 +128,7 @@ function focusOnNextFocusableControl({
   }
 
   const controlToFocus =
-    controlsRefs.current[nextIndex.levelIndex]?.[nextIndex.rowIndex]?.[nextIndex.cellIndex];
+    controlsRef.current[nextIndex.levelIndex]?.[nextIndex.rowIndex]?.[nextIndex.cellIndex];
 
   if (!controlToFocus) {
     return;
@@ -142,7 +140,7 @@ function focusOnNextFocusableControl({
     controlToFocus.getAttribute('data-outside')
   ) {
     focusOnNextFocusableControl({
-      controlsRefs,
+      controlsRef,
       direction,
       levelIndex: nextIndex.levelIndex,
       cellIndex: nextIndex.cellIndex,
@@ -168,8 +166,13 @@ function getDirection(key: KeyboardEvent['key']): Direction {
       return null;
   }
 }
+
+function getControlsSize(controlsRef: ControlsRef) {
+  return controlsRef.current.map((column) => column.map((row) => row.length));
+}
+
 interface HandleControlKeyDownInput {
-  controlsRefs: ControlsRefs;
+  controlsRef: ControlsRef;
   levelIndex: number;
   rowIndex: number;
   cellIndex: number;
@@ -177,7 +180,7 @@ interface HandleControlKeyDownInput {
 }
 
 export function handleControlKeyDown({
-  controlsRefs,
+  controlsRef,
   levelIndex,
   rowIndex,
   cellIndex,
@@ -186,10 +189,10 @@ export function handleControlKeyDown({
   const direction = getDirection(event.key);
 
   if (direction) {
-    const size = getControlsSize(controlsRefs);
+    const size = getControlsSize(controlsRef);
 
     focusOnNextFocusableControl({
-      controlsRefs,
+      controlsRef,
       direction,
       levelIndex,
       rowIndex,


### PR DESCRIPTION
Fixes https://github.com/mantinedev/mantine/issues/3662.

This changes keyboard navigation behavior pretty drastically.

- ArrowRight moves focus to the closest succeeding non-disabled cell. If current focus is on last non-disabled cell in row, focus is moved to first non-disabled cell in next row.
- ArrowLeft moves focus to the closest preceding non-disabled cell. If current focus is on first non-disabled cell in row, focus is moved to last non-disabled cell in previous row.
- ArrowDown moves focus to closest succeeding non-disabled cell in the same column.
- ArrowUp moves focus to closest preceding non-disabled cell in the same column.

The other major change is behavior when multiple pickers are rendered side-by-side. Take this one as an example: https://mantine.dev/dates/date-picker/#number-of-columns

![image](https://user-images.githubusercontent.com/44197016/227221634-80bb4d41-70d4-4dcf-81c2-f2c19021f2fd.png)

Behavior before: 

- When focus is on March 5, clicking ArrowRight won't move focus.
- When focus is on March 12, clicking ArrowRight moves focus to April 3.
- When focus is on March 31, clicking ArrowRight won't move focus.
- When focus is on March 31, clicking ArrowDown won't move focus.
- When focus is on April 1, clicking ArrowLeft won't move focus.
- When focus is on April 3, clicking ArrowLeft moves focus to March 12.
- When focus is on April 24, clicking ArrowLeft won't move focus.
- When focus is on April 1, clicking ArrowUp won't move focus.

Summary of behavior:

- Focus can only be moved to an adjacent cell.
- Focus can only be moved from a cell in one picker to a cell in another picker if the latter cell happen to be non-disabled and non-hidden.

There is an inconsistency in that if a date is disabled or hidden, focus is moved to the next date if that date is within the picker, otherwise focus is not moved.

Behavior after:
- When focus is on March 5, clicking ArrowRight moves focus to March 6 (the next date).
- When focus is on March 12, clicking ArrowRight moves focus to March 13 (the next date).
- When focus is on March 31, clicking ArrowRight moves focus to April 1 (the next date).
- When focus is on March 31, clicking ArrowDown moves focus to April 7 (the next week).
- When focus is on April 1, clicking ArrowLeft moves focus to March 31 (the previous date).
- When focus is on April 3, clicking ArrowLeft moves focus to April 2 (the previous date).
- When focus is on April 24, clicking ArrowLeft moves focus to April 23 (the previous date.
- When focus is on April 1, clicking ArrowUp moves focus to March 25 (the previous week).

Summary of behavior:

- Focus is always moved to the next non-disabled date with ArrowRight, the previous non-disabled date with ArrowLeft, the next non-disabled week with ArrowDown and the previous non-disabled week with ArrowUp.
- Only exception is that you can only move focus within the currently rendered pickers. I.e., when focus is on March 1 in the example above, clicking ArrowLeft won't change the displayed months. This could potentially be something to implement in the future.

Behavior after matches with native date picker behavior, with [guidelines for date grids](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/) and with [Spectrum's date picker](https://react-spectrum.adobe.com/react-spectrum/DatePicker.html).