### PR TITLE
[@mantine/core] MultiSelect: Fix `disableSelectedItemFiltering` prop not working for `searchable` input

### DIFF
--- a/docs/src/docs/core/MultiSelect.mdx
+++ b/docs/src/docs/core/MultiSelect.mdx
@@ -161,6 +161,22 @@ Apart from `itemComponent` you can customize appearance of label by providing `v
 
 <Demo data={MultiSelectDemos.maxSelectedValues} />
 
+## Disable selected item filtering
+
+<Demo data={MultiSelectDemos.disableSelectedItemFiltering} />
+
+When used along `filter`, be aware that the second parameter `selected` will always be `false`.
+
+```tsx
+<MultiSelect
+  disableSelectedItemFiltering
+  filter={(value, selected, item) => {
+    console.log(selected); // false
+  }}
+  searchable
+/>
+```
+
 ## Dropdown position
 
 By default, dropdown is placed below the input and when there is not enough space, it flips to be above the input.

--- a/src/mantine-core/src/MultiSelect/filter-data/filter-data.test.ts
+++ b/src/mantine-core/src/MultiSelect/filter-data/filter-data.test.ts
@@ -24,6 +24,47 @@ describe('@mantine/core/MultiSelect/filter-data', () => {
     ).toStrictEqual(data.filter((item) => item.value !== 'vue' && item.value !== 'ng'));
   });
 
+  it('keeps selected items in input that is not searchable and has disabled selected item filtering', () => {
+    expect(
+      filterData({
+        ...baseOptions,
+        disableSelectedItemFiltering: true,
+        searchable: false,
+        searchValue: '',
+        value: ['vue', 'ng'],
+      })
+    ).toStrictEqual(data);
+  });
+
+  it('keeps selected items in input that is searchable and has disabled selected item filtering', () => {
+    expect(
+      filterData({
+        ...baseOptions,
+        disableSelectedItemFiltering: true,
+        searchable: true,
+        searchValue: '',
+        value: ['vue', 'ng'],
+      })
+    ).toStrictEqual(data);
+  });
+
+  it('sends filter selected parameter as false when input has disabled selected item filtering', () => {
+    const spy = jest.fn();
+
+    filterData({
+      ...baseOptions,
+      disableSelectedItemFiltering: true,
+      filter: spy,
+      searchable: true,
+      searchValue: '',
+      value: ['vue', 'ng'],
+    });
+
+    spy.mock.calls.forEach((call) => {
+      expect(call[1]).toStrictEqual(false);
+    });
+  });
+
   it('filters items with given filter function', () => {
     const filter = (searchValue: string, selected: boolean, item: SelectItem) =>
       item.name.includes(searchValue);

--- a/src/mantine-core/src/MultiSelect/filter-data/filter-data.ts
+++ b/src/mantine-core/src/MultiSelect/filter-data/filter-data.ts
@@ -42,7 +42,8 @@ export function filterData({
     if (
       filter(
         searchValue,
-        value.some((val) => val === data[i].value && !data[i].disabled),
+        !disableSelectedItemFiltering &&
+          value.some((val) => val === data[i].value && !data[i].disabled),
         data[i]
       )
     ) {

--- a/src/mantine-demos/src/demos/core/MultiSelect/MultiSelect.demo.disableSelectedItemFiltering.tsx
+++ b/src/mantine-demos/src/demos/core/MultiSelect/MultiSelect.demo.disableSelectedItemFiltering.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { MultiSelect } from '@mantine/core';
+import { MantineDemo } from '@mantine/ds';
+import { data } from './_data';
+
+const code = `
+import { MultiSelect } from '@mantine/core';
+
+function Demo() {
+  return (
+    <MultiSelect
+      data={['React', 'Angular', 'Svelte', 'Vue', 'Riot', 'Next.js', 'Blitz.js']}
+      disableSelectedItemFiltering
+      label="Your favorite frameworks/libraries"
+      nothingFound="Nothing found"
+      placeholder="Pick all that you like"
+      searchable
+    />
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <MultiSelect
+      data={data}
+      disableSelectedItemFiltering
+      label="Your favorite frameworks/libraries"
+      maw={400}
+      mx="auto"
+      nothingFound="Nothing found"
+      placeholder="Pick all that you like"
+      searchable
+    />
+  );
+}
+
+export const disableSelectedItemFiltering: MantineDemo = {
+  type: 'demo',
+  code,
+  component: Demo,
+};

--- a/src/mantine-demos/src/demos/core/MultiSelect/index.ts
+++ b/src/mantine-demos/src/demos/core/MultiSelect/index.ts
@@ -17,5 +17,6 @@ export { icon } from './MultiSelect.demo.icon';
 export { rightSection } from './MultiSelect.demo.rightSection';
 export { scrollbars } from './MultiSelect.demo.scrollbars';
 export { maxSelectedValues } from './MultiSelect.demo.maxSelectedValues';
+export { disableSelectedItemFiltering } from './MultiSelect.demo.disableSelectedItemFiltering';
 export { readOnly } from './MultiSelect.demo.readOnly';
 export { hoverOnSearchChange } from './MultiSelect.demo.hoverOnSearchChange';


### PR DESCRIPTION
Solves #3877 

It enables the `disableSelectedItemFiltering` feature for `searchable` inputs by always setting the `filter` function's `selected` parameter to `false`.

This works for the internal `defaultFilter` and should work for any custom `filter` function that relies on the `selected` parameter to remove from the list.

Lastly, I added some tests to assert:
- `disableSelectedItemFiltering` when input is `not searchable`
- `disableSelectedItemFiltering` when input is `searchable` (uses `defaultFilter`)
- `filter` function's `selected` paramater is always`false` when `disableSelectedItemFiltering` and `searchable` are enabled (generic test for any custom `filter` function)