### PR TITLE
[@mantine/core] Autocomplete: Fix for input has no accessible name a11y error

### DIFF
--- a/src/mantine-core/src/Autocomplete/Autocomplete.tsx
+++ b/src/mantine-core/src/Autocomplete/Autocomplete.tsx
@@ -221,11 +221,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>((pro
         <SelectPopover.Target>
           <div
             className={classes.wrapper}
-            role="combobox"
-            aria-haspopup="listbox"
-            aria-owns={shouldRenderDropdown ? `${inputProps.id}-items` : null}
             aria-controls={inputProps.id}
-            aria-expanded={shouldRenderDropdown}
             onMouseLeave={() => setHovered(-1)}
             tabIndex={-1}
           >
@@ -251,6 +247,10 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>((pro
               onClick={handleInputClick}
               onCompositionStart={() => setIMEOpen(true)}
               onCompositionEnd={() => setIMEOpen(false)}
+              role="combobox"
+              aria-haspopup="listbox"
+              aria-owns={shouldRenderDropdown ? `${inputProps.id}-items` : null}
+              aria-expanded={shouldRenderDropdown}
               aria-autocomplete="list"
               aria-controls={shouldRenderDropdown ? `${inputProps.id}-items` : null}
               aria-activedescendant={hovered >= 0 ? `${inputProps.id}-${hovered}` : null}


### PR DESCRIPTION
Proposed fix for #3866

Moved aria attributes and role attribute from wrapper div to input so that JAWS and other screen readers will pick up on the Autocomplete's label correctly. I'm not at all an expert on aria stuff, so please make sure what I've done is correct.