### PR TITLE
Update renderToPipeableStream docs link

### DIFF
--- a/docs/src/docs/guides/remix.mdx
+++ b/docs/src/docs/guides/remix.mdx
@@ -117,7 +117,7 @@ npm run dev
 
 ## Server streaming support
 
-Mantine is based on [emotion](https://emotion.sh/) which currently does not support [renderToPipeableStream](https://reactjs.org/docs/react-dom-server.html#rendertopipeablestream),
+Mantine is based on [emotion](https://emotion.sh/) which currently does not support [renderToPipeableStream](https://react.dev/reference/react-dom/server/renderToPipeableStream),
 default Remix boilerplate will not support Mantine (and other component libraries based on css-in-js). It is important to replace your `entry.server.tsx`
 with code provided in this guide in order for server side rendering to work.
 


### PR DESCRIPTION
The React team released new `renderToPipeableStream` documentation in their large docs release recently