### PR TITLE
Feature/mantine form partial reset

### DIFF
--- a/src/mantine-form/src/tests/reset.test.ts
+++ b/src/mantine-form/src/tests/reset.test.ts
@@ -31,4 +31,18 @@ describe('@mantine/form/reset', () => {
     expect(hook.result.current.isDirty()).toBe(false);
     expect(hook.result.current.isTouched()).toBe(false);
   });
+
+  it('resets values without keeping added values', () => {
+    const hook = renderHook(() =>
+      useForm<{ a: number; b?: number; c?: number }>({ initialValues: { a: 1, b: 2 } })
+    );
+
+    act(() => hook.result.current.setFieldValue('c', 3));
+    expect(hook.result.current.isDirty()).toBe(true);
+    expect(hook.result.current.values).toStrictEqual({ a: 1, b: 2, c: 3 });
+
+    act(() => hook.result.current.reset());
+    expect(hook.result.current.isDirty()).toBe(false);
+    expect(hook.result.current.values).toStrictEqual({ a: 1, b: 2 });
+  });
 });

--- a/src/mantine-form/src/tests/reset.test.ts
+++ b/src/mantine-form/src/tests/reset.test.ts
@@ -45,4 +45,18 @@ describe('@mantine/form/reset', () => {
     expect(hook.result.current.isDirty()).toBe(false);
     expect(hook.result.current.values).toStrictEqual({ a: 1, b: 2 });
   });
+
+  it('resets form with passed values', () => {
+    const hook = renderHook(() =>
+      useForm<{ a: number; b?: number; c?: number }>({ initialValues: { a: 1, b: 2 } })
+    );
+
+    act(() => hook.result.current.setFieldValue('c', 3));
+    expect(hook.result.current.isDirty()).toBe(true);
+    expect(hook.result.current.values).toStrictEqual({ a: 1, b: 2, c: 3 });
+
+    act(() => hook.result.current.reset({ a: 4, b: 5, c: 6 }));
+    expect(hook.result.current.isDirty()).toBe(false);
+    expect(hook.result.current.values).toStrictEqual({ a: 4, b: 5, c: 6 });
+  });
 });

--- a/src/mantine-form/src/tests/resetDirty.test.ts
+++ b/src/mantine-form/src/tests/resetDirty.test.ts
@@ -18,4 +18,19 @@ describe('@mantine/form/resetDirty', () => {
     act(() => hook.result.current.setFieldValue('a', 3));
     expect(hook.result.current.isDirty()).toBe(false);
   });
+
+  it('correctly handles partial values', () => {
+    const hook = renderHook(() =>
+      useForm<{ a: number; b?: number }>({ initialValues: { a: 1, b: 2 } })
+    );
+
+    expect(hook.result.current.isDirty()).toBe(false);
+
+    act(() => {
+      hook.result.current.setValues({ a: 2 });
+      hook.result.current.resetDirty({ a: 2 });
+    });
+
+    expect(hook.result.current.isDirty()).toBe(false);
+  });
 });

--- a/src/mantine-form/src/types.ts
+++ b/src/mantine-form/src/types.ts
@@ -76,7 +76,7 @@ export type SetFieldValue<Values> = <Field extends LooseKeys<Values>>(
 export type ClearFieldError = (path: unknown) => void;
 export type ClearFieldDirty = (path: unknown) => void;
 export type ClearErrors = () => void;
-export type Reset = () => void;
+export type Reset<Values> = (values?: Values) => void;
 export type Validate = () => FormValidationResult;
 export type ValidateField<Values> = <Field extends LooseKeys<Values>>(
   path: Field
@@ -138,7 +138,7 @@ export interface UseFormReturnType<
   setFieldError: SetFieldError<Values>;
   clearFieldError: ClearFieldError;
   clearErrors: ClearErrors;
-  reset: Reset;
+  reset: Reset<Values>;
   validate: Validate;
   validateField: ValidateField<Values>;
   reorderListItem: ReorderListItem<Values>;

--- a/src/mantine-form/src/use-form.ts
+++ b/src/mantine-form/src/use-form.ts
@@ -50,14 +50,16 @@ export function useForm<
   const [dirty, setDirty] = useState(initialDirty);
   const [values, _setValues] = useState(initialValues);
   const [errors, _setErrors] = useState(filterErrors(initialErrors));
-  const _dirtyValues = useRef<Values>(initialValues);
-  const _setDirtyValues = (_values: Values) => {
-    _dirtyValues.current = _values;
+
+  const valuesSnapshot = useRef<Values>(initialValues);
+  const setValuesSnapshot = (_values: Values) => {
+    valuesSnapshot.current = _values;
   };
 
   const resetTouched = useCallback(() => setTouched({}), []);
   const resetDirty: ResetDirty<Values> = (_values) => {
-    _setDirtyValues(_values || values);
+    const newSnapshot = _values ? { ...values, ..._values } : values;
+    setValuesSnapshot(newSnapshot);
     setDirty({});
   };
 
@@ -228,7 +230,7 @@ export function useForm<
       }
 
       const sliceOfValues = getPath(path, values);
-      const sliceOfInitialValues = getPath(path, _dirtyValues.current);
+      const sliceOfInitialValues = getPath(path, valuesSnapshot.current);
       return !isEqual(sliceOfValues, sliceOfInitialValues);
     }
 
@@ -237,7 +239,7 @@ export function useForm<
       return getStatus(dirty);
     }
 
-    return !isEqual(values, _dirtyValues.current);
+    return !isEqual(values, valuesSnapshot.current);
   };
 
   const isTouched: GetFieldStatus<Values> = useCallback(

--- a/src/mantine-form/src/use-form.ts
+++ b/src/mantine-form/src/use-form.ts
@@ -70,10 +70,11 @@ export function useForm<
   );
 
   const clearErrors: ClearErrors = useCallback(() => _setErrors({}), []);
-  const reset: Reset = useCallback(() => {
-    _setValues(initialValues);
+  const reset: Reset<Values> = useCallback((_values) => {
+    _setValues(_values ?? initialValues);
     clearErrors();
-    resetDirty(initialValues);
+    setValuesSnapshot(_values ?? initialValues);
+    setDirty({});
     resetTouched();
   }, []);
 


### PR DESCRIPTION
fixes https://github.com/mantinedev/mantine/issues/3896

# Changes
- Renamed file resert.test.ts to reset.test.ts
- Renamed internal _dirtyValues ref to valuesSnapshot as a naming suggestion
- Changed resetDirty to spread passed values with the current values to allow passing a subset of the form value structure. (e.g. when some of the form values can be undefined)
- Added optional values parameter to `reset` to allow reliably resetting the form with new data in one go.

With these changes the resetDirty call mimics the spread behaviour of setValues and avoids unexpected dirty states when updating the form with async data that does not completely override the initialValues.

Additionally with the optional argument of reset it is possible to switch the context of the form in one reliable state update. A specific use case could be when the resource for the data is switched on the same page as the form (e.g. data for different users). Right now when using form.setValues the data would be merged and introduce unexpected form state when values from the previous data are kept (e.g. ids that might only exist for entities that have alread been persisted). 
If we just run form.reset() before form.setValues() we still have stale values from before form.reset() since React state updates work asynchronous.