### PR TITLE
[@mantine/dates]: Prevent page scrolling on ArrowUp/ArrowDown keyboard navigation

### DIFF
--- a/src/mantine-dates/src/utils/handle-control-key-down.ts
+++ b/src/mantine-dates/src/utils/handle-control-key-down.ts
@@ -189,6 +189,8 @@ export function handleControlKeyDown({
   const direction = getDirection(event.key);
 
   if (direction) {
+    event.preventDefault();
+
     const size = getControlsSize(controlsRef);
 
     focusOnNextFocusableControl({


### PR DESCRIPTION
When switching focus between dates with ArrowUp/ArrowDown, page is scrolling. Test it here: https://mantine.dev/dates/date-picker/#usage

This prevents that page scrolling.