### PR TITLE
Add default values to initial state

### DIFF
--- a/src/mantine-hooks/src/use-viewport-size/use-viewport-size.ts
+++ b/src/mantine-hooks/src/use-viewport-size/use-viewport-size.ts
@@ -7,8 +7,8 @@ const eventListerOptions = {
 
 export function useViewportSize() {
   const [windowSize, setWindowSize] = useState({
-    width: 0,
-    height: 0,
+    width: window.innerWidth || 0,
+    height: window.innerHeight || 0,
   });
 
   const setSize = useCallback(() => {


### PR DESCRIPTION
It would be helpful to have an initial value set to the window dimensions rather than 0. When using this hook to make formatting decisions, the initial 0 on component load causes flashes of incorrectly formatted content until the useEffect is fired.