### PR TITLE
[@mantine/core] MultiSelect: Fix lineHeight styles affecting input on Safari

### DIFF
--- a/src/mantine-core/src/MultiSelect/MultiSelect.styles.ts
+++ b/src/mantine-core/src/MultiSelect/MultiSelect.styles.ts
@@ -40,7 +40,6 @@ export default createStyles((theme, { invalid }: MultiSelectStylesParams, { size
     marginLeft: `calc(${theme.spacing.xs} / 2)`,
     appearance: 'none',
     color: 'inherit',
-    lineHeight: `calc(${getSize({ size, sizes: INPUT_SIZES })} - ${rem(2)})`,
     maxHeight: getSize({ size, sizes: DEFAULT_VALUE_SIZES }),
 
     '&::placeholder': {


### PR DESCRIPTION
The issue seemed to be that effective lineHeight calculation resulted in `34px` for `sm` size - which was bigger than input itself (22px) which caused cursor and text to be pushed down.

Removing this style fixed the issue - as would lowering down lineHeight to 22px or below - but this seemed to not have any visual effect even when I played with lower values like 10px or 1px.

 Removal did not affect `Size XS Line Height` story and looks correct on `Multiple Rows`. Tested on both Safari and Chrome.
 
 Fixes https://github.com/mantinedev/mantine/issues/3968
 
 It's my first PR here, hopefully adhered to all standards - let me know if I could improve anything, cheers!