### PR TITLE
Issue 3979 fix numberinput form validation

### DIFF
--- a/src/mantine-core/src/NumberInput/NumberInput.story.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.story.tsx
@@ -40,8 +40,12 @@ export function FixedValue() {
 export function WithUseFormHook() {
   const mantineForm = useForm({
     initialValues: {
-      someNumber: 3,
+      someNumber: 0,
+    },
+    validateInputOnBlur: true,
+    validate: {
+      someNumber: (val) => (!val ? 'please enter a number greater than zero' : null),
     },
   });
-  return <NumberInput min={1} max={5} step={1} {...mantineForm.getInputProps('someNumber')} />;
+  return <NumberInput min={0} max={5} step={1} {...mantineForm.getInputProps('someNumber')} />;
 }


### PR DESCRIPTION
Fixes #3979 and #3982.

Based on #3756 I reworked the data flow handling to be more in line with other components again.

This means `onChange()` will be triggered on input again but still outputs validated and clamped data.

I've also added a test for the expectation that `onChange()` and `onBlur()` won't get called in the same run which might lead to the `onBlur()` handler working with old data in case it's using data stored via `useState()` hook.

Maybe that's something that should be added to all input components.

I also removed the `higherPrecision` handling introduced in #3756. For controlled components it allowed display values with higher precision than allowed. Like:
```tsx
<NumberInput precision={0} value={1.23} />
```
would output `1.23`. However when changing the value manually afterwards it would fall back to the configured precision.
Because this might be confusing I dropped this behaviour again. Sorry for that.
However if you find this useful I can revert this change.