### PR TITLE
Issue 3919 fix datepicker type changing

### DIFF
--- a/src/mantine-dates/src/hooks/use-uncontrolled-dates/use-uncontrolled-dates.test.ts
+++ b/src/mantine-dates/src/hooks/use-uncontrolled-dates/use-uncontrolled-dates.test.ts
@@ -1,0 +1,145 @@
+import { renderHook } from '@testing-library/react';
+import { useUncontrolledDates } from './use-uncontrolled-dates';
+
+type HookConfig = Parameters<typeof useUncontrolledDates>[0];
+
+const hookDefaults: Omit<HookConfig, 'type'> = {
+  defaultValue: undefined,
+  value: undefined,
+  onChange: () => {},
+};
+
+const defaultTypeValue = new Date();
+const rangeTypeValue = [new Date(), new Date(Date.now() + 86400000)];
+const multipleTypeValue = [
+  new Date(Date.now() - 86400000),
+  new Date(),
+  new Date(Date.now() + 86400000),
+];
+
+const setupHook = (config: Pick<HookConfig, 'type'> & Partial<HookConfig>) =>
+  renderHook<any, HookConfig>((innerConfig) => useUncontrolledDates(innerConfig), {
+    initialProps: {
+      ...hookDefaults,
+      ...config,
+    },
+  });
+
+describe('use-uncontrolled-dates', () => {
+  it('returns correct value for type `default` and uncontrolled use in case no defaultValue has been specified', () => {
+    const hook = setupHook({
+      type: 'default',
+    });
+    expect(hook.result.current[0]).toBe(null);
+  });
+
+  it('returns correct value for type `multiple` and uncontrolled use in case no defaultValue has been specified', () => {
+    const hook = setupHook({
+      type: 'multiple',
+    });
+    expect(hook.result.current[0]).toStrictEqual([]);
+  });
+
+  it('returns correct value for type `range` and uncontrolled use in case no defaultValue has been specified', () => {
+    const hook = setupHook({
+      type: 'range',
+    });
+    expect(hook.result.current[0]).toStrictEqual([null, null]);
+  });
+
+  it('returns defaultValue for type `default` and uncontrolled use', () => {
+    const hook = setupHook({
+      type: 'default',
+      defaultValue: defaultTypeValue,
+    });
+    expect(hook.result.current[0]).toBe(defaultTypeValue);
+  });
+
+  it('returns defaultValue for type `multiple` and uncontrolled use', () => {
+    const hook = setupHook({
+      type: 'multiple',
+      defaultValue: multipleTypeValue,
+    });
+    expect(hook.result.current[0]).toStrictEqual(multipleTypeValue);
+  });
+
+  it('returns defaultValue for type `range` and uncontrolled use', () => {
+    const hook = setupHook({
+      type: 'range',
+      defaultValue: rangeTypeValue,
+    });
+    expect(hook.result.current[0]).toStrictEqual(rangeTypeValue);
+  });
+
+  it('returns value for type `default` and controlled use', () => {
+    const hook = setupHook({
+      type: 'default',
+      value: defaultTypeValue,
+    });
+    expect(hook.result.current[0]).toBe(defaultTypeValue);
+  });
+
+  it('returns value for type `multiple` and controlled use', () => {
+    const hook = setupHook({
+      type: 'multiple',
+      value: multipleTypeValue,
+    });
+    expect(hook.result.current[0]).toStrictEqual(multipleTypeValue);
+  });
+
+  it('returns value for type `range` and controlled use', () => {
+    const hook = setupHook({
+      type: 'range',
+      value: rangeTypeValue,
+    });
+    expect(hook.result.current[0]).toStrictEqual(rangeTypeValue);
+  });
+
+  it('allows changing the type in controlled use', () => {
+    const hook = setupHook({
+      type: 'default',
+      value: defaultTypeValue,
+    });
+
+    hook.rerender({
+      ...hookDefaults,
+      type: 'multiple',
+      value: multipleTypeValue,
+    });
+    expect(hook.result.current[0]).toStrictEqual(multipleTypeValue);
+  });
+
+  it('resets the value when changing the type in uncontrolled use', () => {
+    const hook = setupHook({
+      type: 'default',
+      defaultValue: defaultTypeValue,
+    });
+
+    hook.rerender({
+      ...hookDefaults,
+      type: 'multiple',
+      defaultValue: multipleTypeValue,
+    });
+
+    expect(hook.result.current[0]).toStrictEqual(multipleTypeValue);
+
+    hook.rerender({
+      ...hookDefaults,
+      type: 'default',
+    });
+    expect(hook.result.current[0]).toStrictEqual(null);
+
+    hook.rerender({
+      ...hookDefaults,
+      type: 'range',
+      defaultValue: rangeTypeValue,
+    });
+    expect(hook.result.current[0]).toStrictEqual(rangeTypeValue);
+
+    hook.rerender({
+      ...hookDefaults,
+      type: 'default',
+    });
+    expect(hook.result.current[0]).toStrictEqual(null);
+  });
+});

--- a/src/mantine-dates/src/hooks/use-uncontrolled-dates/use-uncontrolled-dates.ts
+++ b/src/mantine-dates/src/hooks/use-uncontrolled-dates/use-uncontrolled-dates.ts
@@ -34,7 +34,7 @@ export function useUncontrolledDates<Type extends DatePickerType = 'default'>({
     storedType.current = type;
     if (value === undefined) {
       // Reset uncontrolled value as types aren't compatible
-      _finalValue = getEmptyValue(type);
+      _finalValue = defaultValue !== undefined ? defaultValue : getEmptyValue(type);
       _setValue(_finalValue);
     } else if (process.env.NODE_ENV === 'development') {
       // Throw errors in dev mode in case type of value isn't correct

--- a/src/mantine-dates/src/hooks/use-uncontrolled-dates/use-uncontrolled-dates.ts
+++ b/src/mantine-dates/src/hooks/use-uncontrolled-dates/use-uncontrolled-dates.ts
@@ -1,4 +1,5 @@
 import { useUncontrolled } from '@mantine/hooks';
+import { useRef } from 'react';
 import { DatePickerType, DatePickerValue } from '../../types';
 
 interface UseUncontrolledDates<Type extends DatePickerType = 'default'> {
@@ -8,16 +9,63 @@ interface UseUncontrolledDates<Type extends DatePickerType = 'default'> {
   onChange(value: DatePickerValue<Type>): void;
 }
 
+const getEmptyValue = <Type extends DatePickerType = 'default'>(type: Type) =>
+  type === 'range' ? [null, null] : type === 'multiple' ? [] : null;
+
 export function useUncontrolledDates<Type extends DatePickerType = 'default'>({
   type,
   value,
   defaultValue,
   onChange,
 }: UseUncontrolledDates<Type>) {
-  return useUncontrolled<any>({
+  const storedType = useRef<Type>(type);
+  const [_value, _setValue] = useUncontrolled<any>({
     value,
     defaultValue,
     onChange,
-    finalValue: type === 'range' ? [null, null] : type === 'multiple' ? [] : null,
+    finalValue: getEmptyValue(type),
   });
+
+  let _finalValue = _value;
+
+  if (storedType.current !== type) {
+    // Type has changed. Do some checks or resets
+
+    storedType.current = type;
+    if (value === undefined) {
+      // Reset uncontrolled value as types aren't compatible
+      _finalValue = getEmptyValue(type);
+      _setValue(_finalValue);
+    } else if (process.env.NODE_ENV === 'development') {
+      // Throw errors in dev mode in case type of value isn't correct
+      switch (type) {
+        case 'default':
+          if (value !== null && typeof value !== 'string') {
+            // eslint-disable-next-line no-console
+            console.error(
+              '[@mantine/dates/use-uncontrolled-dates] Value must be type of `null` or `string`'
+            );
+          }
+          break;
+        case 'multiple':
+          if (!(value instanceof Array)) {
+            // eslint-disable-next-line no-console
+            console.error(
+              '[@mantine/dates/use-uncontrolled-dates] Value must be type of `string[]`'
+            );
+          }
+          break;
+        case 'range':
+          if (!(value instanceof Array) || value.length !== 2) {
+            // eslint-disable-next-line no-console
+            console.error(
+              '[@mantine/dates/use-uncontrolled-dates] Value must be type of `[string, string]`'
+            );
+          }
+          break;
+      }
+    }
+  }
+
+  return [_finalValue, _setValue];
 }


### PR DESCRIPTION
Fixes #3919.
- For uncontrolled components it resets the internal value to `defaultValue`
- For controlled components it expects the `value` to be compatible to `type`. However it also outputs an error it that's not the case