### PR TITLE
[@mantine/dates] DatePickerInput: Support withCellSpacing prop

### DIFF
--- a/src/mantine-dates/src/components/Calendar/pick-calendar-levels-props/pick-calendar-levels-props.ts
+++ b/src/mantine-dates/src/components/Calendar/pick-calendar-levels-props/pick-calendar-levels-props.ts
@@ -21,6 +21,7 @@ export function pickCalendarProps<T extends Record<string, any>>(props: T) {
     onPreviousYear,
     onNextDecade,
     onPreviousDecade,
+    withCellSpacing,
     __updateDateOnYearSelect,
     __updateDateOnMonthSelect,
 
@@ -80,6 +81,7 @@ export function pickCalendarProps<T extends Record<string, any>>(props: T) {
       onPreviousYear,
       onNextDecade,
       onPreviousDecade,
+      withCellSpacing,
       __updateDateOnYearSelect,
       __updateDateOnMonthSelect,
 

--- a/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.test.tsx
+++ b/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.test.tsx
@@ -126,4 +126,24 @@ describe('@mantine/dates/DatePickerInput', () => {
     expect(container.querySelector('[data-dates-input]')).toHaveStyle({ borderColor: '#EB4522' });
     expect(container.querySelector('table button')).toHaveStyle({ borderColor: '#EE4533' });
   });
+
+  it('supports withCellSpacing prop', () => {
+    const { container, rerender } = render(
+      <DatePickerInput
+        {...defaultProps}
+        popoverProps={{ opened: true, withinPortal: false, transitionProps: { duration: 0 } }}
+        withCellSpacing
+      />
+    );
+    expect(container.querySelector('tbody tr td')).toHaveAttribute('data-with-spacing', 'true');
+
+    rerender(
+      <DatePickerInput
+        {...defaultProps}
+        popoverProps={{ opened: true, withinPortal: false, transitionProps: { duration: 0 } }}
+        withCellSpacing={false}
+      />
+    );
+    expect(container.querySelector('tbody tr td')).not.toHaveAttribute('data-with-spacing');
+  });
 });


### PR DESCRIPTION
You can see that `data-with-spacing="true"` remains when setting `withCellSpacing={false}` here: https://codesandbox.io/s/compassionate-stonebraker-zq7n52?file=/src/App.tsx

I included a test that failed before the change and passes after.