### PR TITLE
[docs] Update Jumbotron hooks count

### DIFF
--- a/docs/src/components/HomePage/Jumbotron/Jumbotron.tsx
+++ b/docs/src/components/HomePage/Jumbotron/Jumbotron.tsx
@@ -34,7 +34,7 @@ export function Jumbotron() {
 
         <Text className={classes.description}>
           Build fully functional accessible web applications faster than ever – Mantine includes
-          more than 100 customizable components and 40 hooks to cover you in any situation
+          more than 100 customizable components and 50 hooks to cover you in any situation
         </Text>
 
         <SimpleGrid


### PR DESCRIPTION
There are now more than 50 hooks. "100 components and 50 hooks" make nice even numbers for presentation.