### PR TITLE
[@mantine/core] fix slider drag and hover behavior

### DIFF
--- a/src/mantine-core/src/Slider/Marks/Marks.styles.ts
+++ b/src/mantine-core/src/Slider/Marks/Marks.styles.ts
@@ -9,8 +9,9 @@ interface MarksStyles {
 export default createStyles((theme, { color, disabled }: MarksStyles, { size }) => ({
   markWrapper: {
     position: 'absolute',
-    top: 0,
+    top: `calc(${rem(getSize({ sizes, size }))} / 2)`,
     zIndex: 2,
+    height: 0,
   },
 
   mark: {
@@ -23,6 +24,7 @@ export default createStyles((theme, { color, disabled }: MarksStyles, { size }) 
     borderRadius: 1000,
     transform: `translateX(calc(-${getSize({ sizes, size })} / 2))`,
     backgroundColor: theme.white,
+    pointerEvents: 'none',
   },
 
   markFilled: {
@@ -34,10 +36,11 @@ export default createStyles((theme, { color, disabled }: MarksStyles, { size }) 
   },
 
   markLabel: {
-    transform: 'translate(-50%, 0)',
+    transform: `translate(-50%, calc(${theme.spacing.xs} / 2))`,
     fontSize: theme.fontSizes.sm,
     color: theme.colorScheme === 'dark' ? theme.colors.dark[2] : theme.colors.gray[6],
-    marginTop: `calc(${theme.spacing.xs} / 2)`,
     whiteSpace: 'nowrap',
+    cursor: 'pointer',
+    userSelect: 'none',
   },
 }));

--- a/src/mantine-core/src/Slider/RangeSlider/RangeSlider.tsx
+++ b/src/mantine-core/src/Slider/RangeSlider/RangeSlider.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, forwardRef, useEffect } from 'react';
-import { useMove, useUncontrolled, useMergedRef } from '@mantine/hooks';
+import { useMove, useUncontrolled } from '@mantine/hooks';
 import {
   DefaultProps,
   MantineNumberSize,
@@ -253,11 +253,7 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
     theme.dir
   );
 
-  function handleThumbMouseDown(
-    event: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
-    index: number
-  ) {
-    event.stopPropagation();
+  function handleThumbMouseDown(index: number) {
     thumbIndex.current = index;
   }
 
@@ -383,16 +379,7 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
     <SliderRoot
       {...others}
       size={size}
-      ref={useMergedRef(container, ref)}
-      onTouchStartCapture={handleTrackMouseDownCapture}
-      onTouchEndCapture={() => {
-        thumbIndex.current = -1;
-      }}
-      onMouseDownCapture={handleTrackMouseDownCapture}
-      onMouseUpCapture={() => {
-        thumbIndex.current = -1;
-      }}
-      onKeyDownCapture={handleTrackKeydownCapture}
+      ref={ref}
       styles={styles}
       classNames={classNames}
       disabled={disabled}
@@ -413,8 +400,6 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
         value={_value[1]}
         styles={styles}
         classNames={classNames}
-        onMouseEnter={showLabelOnHover ? () => setHovered(true) : undefined}
-        onMouseLeave={showLabelOnHover ? () => setHovered(false) : undefined}
         onChange={(val) => {
           const nearestValue = Math.abs(_value[0] - val) > Math.abs(_value[1] - val) ? 1 : 0;
           const clone: Value = [..._value];
@@ -424,6 +409,20 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
         disabled={disabled}
         unstyled={unstyled}
         variant={variant}
+        containerProps={{
+          ref: container,
+          onMouseEnter: showLabelOnHover ? () => setHovered(true) : undefined,
+          onMouseLeave: showLabelOnHover ? () => setHovered(false) : undefined,
+          onTouchStartCapture: handleTrackMouseDownCapture,
+          onTouchEndCapture: () => {
+            thumbIndex.current = -1;
+          },
+          onMouseDownCapture: handleTrackMouseDownCapture,
+          onMouseUpCapture: () => {
+            thumbIndex.current = -1;
+          },
+          onKeyDownCapture: handleTrackKeydownCapture,
+        }}
       >
         <Thumb
           {...sharedThumbProps}
@@ -435,7 +434,7 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
             thumbs.current[0] = node;
           }}
           thumbLabel={thumbFromLabel}
-          onMouseDown={(event) => handleThumbMouseDown(event, 0)}
+          onMouseDown={() => handleThumbMouseDown(0)}
           onFocus={() => setFocused(0)}
           showLabelOnHover={showLabelOnHover}
           isHovered={hovered}
@@ -457,7 +456,7 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
           ref={(node) => {
             thumbs.current[1] = node;
           }}
-          onMouseDown={(event) => handleThumbMouseDown(event, 1)}
+          onMouseDown={() => handleThumbMouseDown(1)}
           onFocus={() => setFocused(1)}
           showLabelOnHover={showLabelOnHover}
           isHovered={hovered}

--- a/src/mantine-core/src/Slider/Slider/Slider.tsx
+++ b/src/mantine-core/src/Slider/Slider/Slider.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useRef, useState, useCallback } from 'react';
-import { useMergedRef, useMove, useUncontrolled, clamp } from '@mantine/hooks';
+import { useMove, useUncontrolled, clamp, useMergedRef } from '@mantine/hooks';
 import {
   DefaultProps,
   MantineColor,
@@ -163,6 +163,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
   });
 
   const valueRef = useRef(_value);
+  const root = useRef<HTMLDivElement>();
   const thumb = useRef<HTMLDivElement>();
   const position = getPosition({ value: _value, min, max });
   const scaledValue = scale(_value);
@@ -184,12 +185,6 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
     { onScrubEnd: () => onChangeEnd?.(valueRef.current) },
     theme.dir
   );
-
-  const handleThumbMouseDown = (
-    event: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>
-  ) => {
-    event.stopPropagation();
-  };
 
   const handleTrackKeydownCapture = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (!disabled) {
@@ -262,10 +257,10 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
   return (
     <SliderRoot
       {...others}
-      size={size}
-      ref={useMergedRef(container, ref)}
+      ref={useMergedRef(ref, root)}
       onKeyDownCapture={handleTrackKeydownCapture}
-      onMouseDownCapture={() => container.current?.focus()}
+      onMouseDownCapture={() => root.current?.focus()}
+      size={size}
       classNames={classNames}
       styles={styles}
       disabled={disabled}
@@ -284,13 +279,16 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
         max={max}
         value={scaledValue}
         onChange={setValue}
-        onMouseEnter={showLabelOnHover ? () => setHovered(true) : undefined}
-        onMouseLeave={showLabelOnHover ? () => setHovered(false) : undefined}
         classNames={classNames}
         styles={styles}
         disabled={disabled}
         unstyled={unstyled}
         variant={variant}
+        containerProps={{
+          ref: container,
+          onMouseEnter: showLabelOnHover ? () => setHovered(true) : undefined,
+          onMouseLeave: showLabelOnHover ? () => setHovered(false) : undefined,
+        }}
       >
         <Thumb
           max={max}
@@ -302,7 +300,6 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
           size={size}
           label={_label}
           ref={thumb}
-          onMouseDown={handleThumbMouseDown}
           labelTransition={labelTransition}
           labelTransitionDuration={labelTransitionDuration}
           labelTransitionTimingFunction={labelTransitionTimingFunction}

--- a/src/mantine-core/src/Slider/SliderRoot/SliderRoot.styles.ts
+++ b/src/mantine-core/src/Slider/SliderRoot/SliderRoot.styles.ts
@@ -1,9 +1,5 @@
 import { createStyles, rem, getSize } from '@mantine/styles';
 
-interface SliderRootStyles {
-  disabled: boolean;
-}
-
 export const sizes = {
   xs: rem(4),
   sm: rem(6),
@@ -12,15 +8,16 @@ export const sizes = {
   xl: rem(12),
 };
 
-export default createStyles((theme, { disabled }: SliderRootStyles, { size }) => ({
+export default createStyles((theme, _params, { size }) => ({
   root: {
     ...theme.fn.fontStyles(),
     WebkitTapHighlightColor: 'transparent',
     outline: 0,
     height: `calc(${getSize({ sizes, size })} * 2)`,
     display: 'flex',
+    flexDirection: 'column',
     alignItems: 'center',
-    cursor: disabled ? 'not-allowed' : 'pointer',
     touchAction: 'none',
+    position: 'relative',
   },
 }));

--- a/src/mantine-core/src/Slider/SliderRoot/SliderRoot.tsx
+++ b/src/mantine-core/src/Slider/SliderRoot/SliderRoot.tsx
@@ -28,10 +28,14 @@ export const SliderRoot = forwardRef<HTMLDivElement, SliderRootProps>(
     }: SliderRootProps,
     ref
   ) => {
-    const { classes, cx } = useStyles(
-      { disabled },
-      { name: 'Slider', classNames, styles, unstyled, variant, size }
-    );
+    const { classes, cx } = useStyles(null, {
+      name: 'Slider',
+      classNames,
+      styles,
+      unstyled,
+      variant,
+      size,
+    });
     return <Box {...others} tabIndex={-1} className={cx(classes.root, className)} ref={ref} />;
   }
 );

--- a/src/mantine-core/src/Slider/Thumb/Thumb.tsx
+++ b/src/mantine-core/src/Slider/Thumb/Thumb.tsx
@@ -15,7 +15,8 @@ export interface ThumbProps extends DefaultProps<ThumbStylesNames> {
   color: MantineColor;
   size: MantineNumberSize;
   label: React.ReactNode;
-  onMouseDown(event: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>): void;
+  onKeyDownCapture?(event: React.KeyboardEvent<HTMLDivElement>): void;
+  onMouseDown?(event: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>): void;
   labelTransition?: MantineTransition;
   labelTransitionDuration?: number;
   labelTransitionTimingFunction?: string;
@@ -41,6 +42,7 @@ export const Thumb = forwardRef<HTMLDivElement, ThumbProps>(
       label,
       dragging,
       onMouseDown,
+      onKeyDownCapture,
       color,
       classNames,
       styles,
@@ -67,10 +69,8 @@ export const Thumb = forwardRef<HTMLDivElement, ThumbProps>(
       { name: 'Slider', classNames, styles, unstyled, variant, size }
     );
     const [focused, setFocused] = useState(false);
-    const [hovered, setHovered] = useState(false);
 
-    const isVisible =
-      labelAlwaysOn || dragging || focused || (showLabelOnHover && (isHovered || hovered));
+    const isVisible = labelAlwaysOn || dragging || focused || (showLabelOnHover && isHovered);
 
     return (
       <Box<'div'>
@@ -92,8 +92,7 @@ export const Thumb = forwardRef<HTMLDivElement, ThumbProps>(
         }}
         onTouchStart={onMouseDown}
         onMouseDown={onMouseDown}
-        onMouseEnter={showLabelOnHover ? () => setHovered(true) : undefined}
-        onMouseLeave={showLabelOnHover ? () => setHovered(false) : undefined}
+        onKeyDownCapture={onKeyDownCapture}
         onClick={(event) => event.stopPropagation()}
         style={{ [theme.dir === 'rtl' ? 'right' : 'left']: `${position}%` }}
       >

--- a/src/mantine-core/src/Slider/Track/Track.styles.ts
+++ b/src/mantine-core/src/Slider/Track/Track.styles.ts
@@ -10,6 +10,14 @@ interface TrackStyles {
 
 export default createStyles(
   (theme, { radius, color, disabled, inverted }: TrackStyles, { size }) => ({
+    trackContainer: {
+      display: 'flex',
+      alignItems: 'center',
+      width: 'calc(100% + 1rem)',
+      height: '100%',
+      cursor: 'pointer',
+    },
+
     track: {
       position: 'relative',
       height: getSize({ sizes, size }),

--- a/src/mantine-core/src/Slider/Track/Track.tsx
+++ b/src/mantine-core/src/Slider/Track/Track.tsx
@@ -20,11 +20,10 @@ export interface TrackProps extends DefaultProps<TrackStylesNames> {
   value: number;
   children: React.ReactNode;
   onChange(value: number): void;
-  onMouseEnter?(event?: React.MouseEvent<HTMLDivElement>): void;
-  onMouseLeave?(event?: React.MouseEvent<HTMLDivElement>): void;
   disabled: boolean;
   inverted?: boolean;
   variant: string;
+  containerProps?: React.PropsWithRef<React.ComponentProps<'div'>>;
 }
 
 export function Track({
@@ -36,13 +35,12 @@ export function Track({
   radius,
   children,
   offset,
-  onMouseLeave,
-  onMouseEnter,
   disabled,
   marksOffset,
   unstyled,
   inverted,
   variant,
+  containerProps,
   ...others
 }: TrackProps) {
   const { classes } = useStyles(
@@ -51,16 +49,20 @@ export function Track({
   );
 
   return (
-    <div className={classes.track} onMouseLeave={onMouseLeave} onMouseEnter={onMouseEnter}>
-      <Box
-        className={classes.bar}
-        sx={{
-          left: `calc(${offset}% - ${getSize({ size, sizes })})`,
-          width: `calc(${filled}% + ${getSize({ size, sizes })})`,
-        }}
-      />
+    <>
+      <div className={classes.trackContainer} {...containerProps}>
+        <div className={classes.track}>
+          <Box
+            className={classes.bar}
+            sx={{
+              left: `calc(${offset}% - ${getSize({ size, sizes })})`,
+              width: `calc(${filled}% + ${getSize({ size, sizes })})`,
+            }}
+          />
 
-      {children}
+          {children}
+        </div>
+      </div>
 
       <Marks
         {...others}
@@ -74,7 +76,7 @@ export function Track({
         inverted={inverted}
         variant={variant}
       />
-    </div>
+    </>
   );
 }
 

--- a/src/mantine-demos/src/demos/core/Slider/Slider.demo.marks.tsx
+++ b/src/mantine-demos/src/demos/core/Slider/Slider.demo.marks.tsx
@@ -31,9 +31,9 @@ function Demo() {
 
   return (
     <Box maw={400} mx="auto">
-      <Slider defaultValue={40} marks={[{ value: 10 }, { value: 40 }, { value: 95 }]} pb={50} />
-      <Slider defaultValue={40} marks={marks} pb={50} />
-      <RangeSlider defaultValue={[20, 80]} marks={marks} pb={50} />
+      <Slider defaultValue={40} marks={[{ value: 10 }, { value: 40 }, { value: 95 }]} mb={32} />
+      <Slider defaultValue={40} marks={marks} mb={32} />
+      <RangeSlider defaultValue={[20, 80]} marks={marks} mb={32} />
     </Box>
   );
 }

--- a/src/mantine-styles-api/src/styles-api/Slider.styles-api.ts
+++ b/src/mantine-styles-api/src/styles-api/Slider.styles-api.ts
@@ -2,6 +2,7 @@ import type { SliderStylesNames } from '@mantine/core';
 
 export const Slider: Record<SliderStylesNames, string> = {
   root: 'Root element',
+  trackContainer: 'Wrapper around track, handles drag events',
   track: 'Track element, contains all other elements',
   bar: 'Filled part of the track',
   thumb: 'Main control',


### PR DESCRIPTION
Fix some Slider behavior:

- Remove unneeded stopPropagation on mouseDownCapture on the thumb, making it buggy in Preact
- Fix marks label behavior: now you can only click on them to set the value, but they do not trigger hover effect or drag
- Fix area in which drag and hover effect detection is active, to include the whole root without the marks label, by introducing a secondary level container "trackContainer" handling the events