### PR TITLE
[docs] Fix missing `multiple` prop on example code at Accordion

### DIFF
--- a/docs/src/docs/core/Accordion.mdx
+++ b/docs/src/docs/core/Accordion.mdx
@@ -74,7 +74,7 @@ import { Accordion } from '@mantine/core';
 function Demo() {
   // Both items will be opened by default
   return (
-    <Accordion defaultValue={['item-1', 'item-2']}>
+    <Accordion multiple defaultValue={['item-1', 'item-2']}>
       <Accordion.Item value="item-1">
         <Accordion.Control>control-1</Accordion.Control>
         <Accordion.Panel>panel-1</Accordion.Panel>


### PR DESCRIPTION
in the section of [Default opened items](https://mantine.dev/core/accordion/#default-opened-items), second code example was wrong. 
when set `defaultValue` as an array of strings, should be add `multiple` prop as `true`.