### PR TITLE
[@mantine/core] fix portal props typings and override order

### DIFF
--- a/src/mantine-core/src/Affix/Affix.tsx
+++ b/src/mantine-core/src/Affix/Affix.tsx
@@ -15,7 +15,7 @@ export interface AffixProps extends DefaultProps, React.ComponentPropsWithoutRef
   withinPortal?: boolean;
 
   /** Props to pass down to the portal when withinPortal is true */
-  portalProps?: Omit<PortalProps, 'target'>;
+  portalProps?: Omit<PortalProps, 'children' | 'withinPortal' | 'target'>;
 
   /** Affix position on screen, defaults to { bottom: 0, right: 0 } */
   position?: {
@@ -37,7 +37,7 @@ export const Affix = forwardRef<HTMLDivElement, AffixProps>((props: AffixProps, 
     useComponentDefaultProps('Affix', defaultProps, props);
 
   return (
-    <OptionalPortal withinPortal={withinPortal} target={target} {...portalProps}>
+    <OptionalPortal {...portalProps} withinPortal={withinPortal} target={target}>
       <Box sx={[{ position: 'fixed', zIndex, ...position }, ...packSx(sx)]} ref={ref} {...others} />
     </OptionalPortal>
   );

--- a/src/mantine-core/src/ColorInput/ColorInput.tsx
+++ b/src/mantine-core/src/ColorInput/ColorInput.tsx
@@ -61,7 +61,7 @@ export interface ColorInputProps
   withinPortal?: boolean;
 
   /** Props to pass down to the portal when withinPortal is true */
-  portalProps?: PortalProps;
+  portalProps?: Omit<PortalProps, 'children' | 'withinPortal'>;
 
   /** Dropdown box-shadow, key of theme.shadows */
   shadow?: MantineShadow;

--- a/src/mantine-core/src/ModalBase/ModalBase.tsx
+++ b/src/mantine-core/src/ModalBase/ModalBase.tsx
@@ -64,7 +64,7 @@ export interface ModalBaseSettings extends React.ComponentPropsWithoutRef<'div'>
   withinPortal?: boolean;
 
   /** Props to pass down to the portal when withinPortal is true */
-  portalProps?: Omit<PortalProps, 'target'>;
+  portalProps?: Omit<PortalProps, 'children' | 'withinPortal' | 'target'>;
 
   /** Target element or selector where Portal should be rendered, by default new element is created and appended to the document.body */
   target?: HTMLElement | string;
@@ -172,7 +172,7 @@ export function ModalBase(props: ModalBaseProps) {
   useFocusReturn({ opened, shouldReturnFocus: trapFocus && returnFocus });
 
   return (
-    <OptionalPortal withinPortal={withinPortal} target={target} {...portalProps}>
+    <OptionalPortal {...portalProps} withinPortal={withinPortal} target={target}>
       <ModalBaseProvider
         value={{
           __staticSelector,

--- a/src/mantine-core/src/Popover/Popover.context.ts
+++ b/src/mantine-core/src/Popover/Popover.context.ts
@@ -26,7 +26,7 @@ interface PopoverContext {
   trapFocus: boolean;
   placement: FloatingPosition;
   withinPortal: boolean;
-  portalProps?: PortalProps;
+  portalProps?: Omit<PortalProps, 'children' | 'withinPortal'>;
   closeOnEscape: boolean;
   zIndex: React.CSSProperties['zIndex'];
   radius?: MantineNumberSize;

--- a/src/mantine-core/src/Popover/Popover.tsx
+++ b/src/mantine-core/src/Popover/Popover.tsx
@@ -80,7 +80,7 @@ export interface PopoverBaseProps {
   withinPortal?: boolean;
 
   /** Props to pass down to the portal when withinPortal is true */
-  portalProps?: PortalProps;
+  portalProps?: Omit<PortalProps, 'children' | 'withinPortal'>;
 
   /** Dropdown z-index */
   zIndex?: React.CSSProperties['zIndex'];

--- a/src/mantine-core/src/Popover/PopoverDropdown/PopoverDropdown.tsx
+++ b/src/mantine-core/src/Popover/PopoverDropdown/PopoverDropdown.tsx
@@ -54,7 +54,7 @@ export function PopoverDropdown(props: PopoverDropdownProps) {
   }
 
   return (
-    <OptionalPortal withinPortal={ctx.withinPortal} {...ctx.portalProps}>
+    <OptionalPortal {...ctx.portalProps} withinPortal={ctx.withinPortal}>
       <Transition
         mounted={ctx.opened}
         {...ctx.transitionProps}

--- a/src/mantine-core/src/Select/Select.tsx
+++ b/src/mantine-core/src/Select/Select.tsx
@@ -55,7 +55,7 @@ export interface SelectSharedProps<Item, Value> {
   withinPortal?: boolean;
 
   /** Props to pass down to the portal when withinPortal is true */
-  portalProps?: PortalProps;
+  portalProps?: Omit<PortalProps, 'children' | 'withinPortal'>;
 
   /** Limit amount of items displayed at a time for searchable select */
   limit?: number;

--- a/src/mantine-core/src/Select/SelectPopover/SelectPopover.tsx
+++ b/src/mantine-core/src/Select/SelectPopover/SelectPopover.tsx
@@ -62,7 +62,7 @@ interface SelectPopoverProps {
   transitionProps: TransitionOverride;
   shadow?: MantineShadow;
   withinPortal?: boolean;
-  portalProps?: PortalProps;
+  portalProps?: Omit<PortalProps, 'children' | 'withinPortal'>;
   children: React.ReactNode;
   __staticSelector?: string;
   onDirectionChange?(direction: React.CSSProperties['flexDirection']): void;

--- a/src/mantine-core/src/Tooltip/Tooltip.tsx
+++ b/src/mantine-core/src/Tooltip/Tooltip.tsx
@@ -91,6 +91,7 @@ const _Tooltip = forwardRef<HTMLElement, TooltipProps>((props, ref) => {
     onPositionChange,
     opened,
     withinPortal,
+    portalProps,
     radius,
     color,
     classNames,
@@ -147,7 +148,7 @@ const _Tooltip = forwardRef<HTMLElement, TooltipProps>((props, ref) => {
 
   return (
     <>
-      <OptionalPortal withinPortal={withinPortal}>
+      <OptionalPortal {...portalProps} withinPortal={withinPortal}>
         <Transition
           keepMounted={keepMounted}
           mounted={!disabled && tooltip.opened}

--- a/src/mantine-core/src/Tooltip/Tooltip.types.ts
+++ b/src/mantine-core/src/Tooltip/Tooltip.types.ts
@@ -1,5 +1,6 @@
 import { DefaultProps, Selectors, MantineNumberSize, MantineColor } from '@mantine/styles';
 import { FloatingPosition } from '../Floating';
+import { PortalProps } from '../Portal';
 import useStyles, { TooltipStylesParams } from './Tooltip.styles';
 
 export type TooltipStylesNames = Selectors<typeof useStyles>;
@@ -21,6 +22,9 @@ export interface TooltipBaseProps
 
   /** Determines whether tooltip should be rendered within Portal */
   withinPortal?: boolean;
+
+  /** Props to pass down to the portal when withinPortal is true */
+  portalProps?: Omit<PortalProps, 'children' | 'withinPortal'>;
 
   /** Key of theme.radius or any valid CSS value to set border-radius, theme.defaultRadius by default */
   radius?: MantineNumberSize;

--- a/src/mantine-core/src/Tooltip/TooltipFloating/TooltipFloating.tsx
+++ b/src/mantine-core/src/Tooltip/TooltipFloating/TooltipFloating.tsx
@@ -29,6 +29,7 @@ export function TooltipFloating(props: TooltipFloatingProps) {
     children,
     refProp,
     withinPortal,
+    portalProps,
     style,
     className,
     classNames,
@@ -76,7 +77,7 @@ export function TooltipFloating(props: TooltipFloatingProps) {
 
   return (
     <>
-      <OptionalPortal withinPortal={withinPortal}>
+      <OptionalPortal {...portalProps} withinPortal={withinPortal}>
         <Box
           {...others}
           ref={floating}

--- a/src/mantine-dropzone/src/DropzoneFullScreen.tsx
+++ b/src/mantine-dropzone/src/DropzoneFullScreen.tsx
@@ -29,7 +29,7 @@ export interface DropzoneFullScreenProps
   withinPortal?: boolean;
 
   /** Props to pass down to the portal when withinPortal is true */
-  portalProps?: PortalProps;
+  portalProps?: Omit<PortalProps, 'children' | 'withinPortal'>;
 }
 
 const fullScreenDefaultProps: Partial<DropzoneFullScreenProps> = {
@@ -101,7 +101,7 @@ export function DropzoneFullScreen(props: DropzoneFullScreenProps) {
   }, [active]);
 
   return (
-    <OptionalPortal withinPortal={withinPortal} {...portalProps}>
+    <OptionalPortal {...portalProps} withinPortal={withinPortal}>
       <Box
         className={cx(classes.wrapper, className)}
         sx={sx}

--- a/src/mantine-nprogress/src/NavigationProgress.tsx
+++ b/src/mantine-nprogress/src/NavigationProgress.tsx
@@ -42,7 +42,7 @@ export interface NavigationProgressProps {
   withinPortal?: boolean;
 
   /** Props to pass down to the portal when withinPortal is true */
-  portalProps?: PortalProps;
+  portalProps?: Omit<PortalProps, 'children' | 'withinPortal'>;
 
   /** Progressbar z-index */
   zIndex?: React.CSSProperties['zIndex'];
@@ -148,7 +148,7 @@ export function NavigationProgress({
   useNavigationProgressEvents({ start, stop, set, increment, decrement, reset, complete });
 
   return (
-    <OptionalPortal withinPortal={withinPortal} {...portalProps}>
+    <OptionalPortal {...portalProps} withinPortal={withinPortal}>
       {!unmountProgress && (
         <Progress
           radius={0}


### PR DESCRIPTION
Current implementation of `portalProps` requires `children` to be specified, when we don't want or need them here. There is also an override order that is wrong if `withinPortal` is passed both to `portalProps` and the component props itself.

For TypeScript users:
- `children` is now removed from the prop types everywhere
- `withinPortal` is removed from the prop types when it exists on the component type (which is always the case for now I think)
- `target` is removed from the prop types if it's overwritten inside the component implementation

For JavaScript users:
- `withinPortal` and `target` passed through `portalProps` do not override internal `target` and component-level `withinPortal` anymore