### PR TITLE
[@mantine/core] ColorInput: execute `onChange()` before `onBlur()` #3280

### DIFF
--- a/src/mantine-core/src/ColorInput/ColorInput.test.tsx
+++ b/src/mantine-core/src/ColorInput/ColorInput.test.tsx
@@ -8,11 +8,16 @@ import {
   itSupportsProviderVariant,
   itSupportsProviderSize,
 } from '@mantine/tests';
+import { fireEvent, screen, render } from '@testing-library/react';
 import { ColorInput, ColorInputProps } from './ColorInput';
 
 const defaultProps: ColorInputProps = {
   label: 'test-label',
 };
+
+const getInput = () => screen.getByRole('textbox');
+const blurInput = () => fireEvent.blur(getInput());
+const focusInput = () => fireEvent.focus(getInput());
 
 describe('@mantine/core/ColorInput', () => {
   checkAccessibility([<ColorInput label="Color input" />, <ColorInput aria-label="Color input" />]);
@@ -28,5 +33,19 @@ describe('@mantine/core/ColorInput', () => {
     refType: HTMLInputElement,
     othersSelector: 'input',
     providerName: 'ColorInput',
+  });
+
+  it('does not trigger onChange after onBlur', () => {
+    const executions: ('change' | 'blur')[] = [];
+    render(
+      <ColorInput
+        onChange={() => executions.push('change')}
+        onBlur={() => executions.push('blur')}
+      />
+    );
+    focusInput();
+    blurInput();
+
+    expect(executions).toStrictEqual(['change', 'blur']);
   });
 });

--- a/src/mantine-core/src/ColorInput/ColorInput.tsx
+++ b/src/mantine-core/src/ColorInput/ColorInput.tsx
@@ -176,9 +176,9 @@ export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>((props, 
   };
 
   const handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    fixOnBlur && setValue(lastValidValue);
     onBlur?.(event);
     setDropdownOpened(false);
-    fixOnBlur && setValue(lastValidValue);
   };
 
   const handleInputClick = (event: React.MouseEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Fixes #3280.

`ColorInput` currently triggers an additional `onChange()` after `onBlur()`. This conflicts with form validations that have a disabled `onChange()` validation because in this case the error will be resetted immediately.

@rtivital Can you describe the reason behind this additional `onChange()` trigger and `fixOnBlur`? Maybe it can be removed completely.