### PR TITLE
[@mantine/dates] DatePickerInput: fix `type` field always displaying …

### DIFF
--- a/src/mantine-dates/src/types/PickerBaseProps.ts
+++ b/src/mantine-dates/src/types/PickerBaseProps.ts
@@ -2,7 +2,7 @@ import type { DatePickerType, DatePickerValue } from './DatePickerValue';
 
 export interface PickerBaseProps<Type extends DatePickerType = 'default'> {
   /** Picker type: range, multiple or default */
-  type?: Type;
+  type?: DatePickerType | Type;
 
   /** Value for controlled component */
   value?: DatePickerValue<Type>;


### PR DESCRIPTION
…default in autocompletion

The `type` field in `DatePickerInput` was always showing `default` in the list.

**before change:**
<img width="613" alt="image" src="https://user-images.githubusercontent.com/14811347/230328554-b09751e5-846b-4125-be90-43e8b1309bf1.png">

**after change:**
<img width="614" alt="image" src="https://user-images.githubusercontent.com/14811347/230328766-7c990639-7b4c-4708-ac0a-e1edc843a821.png">

