### PR TITLE
[@mantine/form] use-form: add submitting and submitError + methods

### DIFF
--- a/docs/src/docs/form/use-form.mdx
+++ b/docs/src/docs/form/use-form.mdx
@@ -225,6 +225,43 @@ As second parameter options can be passed.
 <Checkbox {...form.getInputProps('accepted', { type: 'checkbox' })} />
 ```
 
+### async onSubmit
+
+If `onSubmit` handler returns a promise it will be awaited and `form.submitting` will be set to `true` until the promise is settled.
+Should the promise be rejected, `form.submitError` will be set to the error.
+
+While the promise is pending, any new calls to `form.submit` will be ignored.
+
+```tsx
+const form = useForm();
+
+// example onSubmit handler that returns a promise
+async function onSubmit() {
+  // do something async
+}
+
+// true while promise is pending
+form.submitting;
+
+// error object if promise was rejected (null otherwise)
+form.submitError;
+
+// manually set submitting
+form.setSubmitting(true);
+
+// manually set submitError
+form.setSubmitError(new Error('Something went wrong'));
+
+// reset submitError
+form.resetSubmitError();
+
+// example usages
+<Button loading={form.submitting}>Submit</Button>
+<LoadingOverlay visible={form.submitting} />
+{form.submitError && <Text color="red">Error: {form.submitError.message}</Text>}
+```
+
+
 ## UseFormReturnType
 
 `UseFormReturnType` can be used when you want to pass `form` as a prop to another component:

--- a/src/mantine-demos/src/demos/form/Form.demo.asyncSubmitting.tsx
+++ b/src/mantine-demos/src/demos/form/Form.demo.asyncSubmitting.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { useForm } from '@mantine/form';
+import { MantineDemo } from '@mantine/ds';
+import { TextInput, Box, PasswordInput, Button, Group, Alert } from '@mantine/core';
+
+const code = `
+import { useForm } from '@mantine/form';
+import { TextInput, Box, PasswordInput, Button, Group, Alert } from '@mantine/core';
+
+interface FormValues {
+  email: string;
+  password: string;
+}
+
+function Demo() {
+  const form = useForm<FormValues>({ initialValues: { email: 'test@test.com', password: 'test' } });
+
+  async function onSubmit() {
+    await new Promise((resolve, reject) => {
+      setTimeout(() => reject(new Error('random error')), 1000);
+    });
+  }
+
+  return (
+    <Box maw={320} mx="auto">
+      {form.submitError ? <Alert color="red">Submit error</Alert> : null}
+
+      <form onSubmit={form.onSubmit(onSubmit)}>
+        <TextInput label="Email" placeholder="Email" {...form.getInputProps('email')} />
+        <PasswordInput
+          mt="sm"
+          label="Password"
+          placeholder="Password"
+          {...form.getInputProps('password')}
+        />
+
+        <Group>
+          <Button mt="sm" type="submit" loading={form.submitting}>
+            Login
+          </Button>
+        </Group>
+      </form>
+    </Box>
+  );
+}
+`;
+
+interface FormValues {
+  email: string;
+  password: string;
+}
+
+function Demo() {
+  const form = useForm<FormValues>({ initialValues: { email: 'test@test.com', password: 'test' } });
+
+  async function onSubmit() {
+    await new Promise((resolve, reject) => {
+      setTimeout(() => reject(new Error('random error')), 3000);
+    });
+  }
+
+  return (
+    <Box maw={320} mx="auto">
+      {form.submitError ? <Alert color="red">Submit error</Alert> : null}
+
+      <form onSubmit={form.onSubmit(onSubmit)}>
+        <TextInput label="Email" placeholder="Email" {...form.getInputProps('email')} />
+        <PasswordInput
+          mt="sm"
+          label="Password"
+          placeholder="Password"
+          {...form.getInputProps('password')}
+        />
+
+        <Group>
+          <Button mt="sm" type="submit" loading={form.submitting}>
+            Login
+          </Button>
+        </Group>
+      </form>
+    </Box>
+  );
+}
+
+export const asyncSubmitting: MantineDemo = {
+  type: 'demo',
+  component: Demo,
+  code,
+};

--- a/src/mantine-demos/src/demos/form/index.ts
+++ b/src/mantine-demos/src/demos/form/index.ts
@@ -25,3 +25,4 @@ export { transformValues } from './Form.demo.transformValues';
 export { validators } from './Form.demo.validators';
 export { validatorsEmpty } from './Form.demo.validatorsEmpty';
 export { superstruct } from './Form.demo.superstruct';
+export { asyncSubmitting } from './Form.demo.asyncSubmitting';

--- a/src/mantine-form/src/types.ts
+++ b/src/mantine-form/src/types.ts
@@ -49,7 +49,7 @@ export type OnSubmit<Values, TransformValues extends _TransformValues<Values>> =
   handleSubmit: (
     values: ReturnType<TransformValues>,
     event: React.FormEvent<HTMLFormElement>
-  ) => void,
+  ) => void | Promise<unknown>,
   handleValidationFailure?: (
     errors: FormErrors,
     values: Values,
@@ -111,6 +111,11 @@ export type IsValid<Values> = <Field extends LooseKeys<Values>>(path?: Field) =>
 
 export type _TransformValues<Values> = (values: Values) => unknown;
 
+export type SubmitError = any | null;
+export type SetSubmitting = (submitting: boolean) => void;
+export type SetSubmitError = (error: SubmitError) => void;
+export type ResetSubmitError = () => void;
+
 export interface UseFormInput<
   Values,
   TransformValues extends _TransformValues<Values> = (values: Values) => Values
@@ -132,6 +137,11 @@ export interface UseFormReturnType<
 > {
   values: Values;
   errors: FormErrors;
+  submitting: boolean;
+  submitError: any;
+  setSubmitting: SetSubmitting;
+  setSubmitError: SetSubmitError;
+  resetSubmitError: ResetSubmitError;
   setValues: SetValues<Values>;
   setErrors: SetErrors;
   setFieldValue: SetFieldValue<Values>;


### PR DESCRIPTION
as per #4011 

### use-form

* Added `submitting`, `submitError` fields
* Added `setSubmitting`, `setSubmitError` and `resetSubmitError` methods

