### PR TITLE
[@mantine/core]Menu: Removing code that may cause dead loops 

### DIFF
--- a/src/mantine-core/src/Menu/Menu.story.tsx
+++ b/src/mantine-core/src/Menu/Menu.story.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { IconTable, IconSearch } from '@tabler/icons-react';
 import { WithinOverlays } from '@mantine/storybook';
+import { useDisclosure } from '@mantine/hooks';
 import { Menu } from './Menu';
 import { Button } from '../Button';
 import { Tooltip } from '../Tooltip';
@@ -95,6 +96,24 @@ export function Controlled() {
       <Menu opened={opened} onChange={setOpened}>
         <Menu.Target>
           <Button>Toggle controlled menu</Button>
+        </Menu.Target>
+        <Menu.Dropdown>
+          <Menu.Item>Item 1</Menu.Item>
+          <Menu.Item>Item 2</Menu.Item>
+        </Menu.Dropdown>
+      </Menu>
+    </div>
+  );
+}
+
+export function WithUseDisclosure() {
+  const [opened, handle] = useDisclosure(false);
+
+  return (
+    <div style={{ padding: 40 }}>
+      <Menu opened={opened} onChange={() => handle.toggle()}>
+        <Menu.Target>
+          <Button>UseDisclosureToggle controlled menu</Button>
         </Menu.Target>
         <Menu.Dropdown>
           <Menu.Item>Item 1</Menu.Item>

--- a/src/mantine-core/src/Menu/Menu.tsx
+++ b/src/mantine-core/src/Menu/Menu.tsx
@@ -79,7 +79,6 @@ const defaultProps: Partial<MenuProps> = {
   openDelay: 0,
   closeDelay: 100,
 };
-
 export function Menu(props: MenuProps) {
   const {
     children,
@@ -157,7 +156,7 @@ export function Menu(props: MenuProps) {
         {...others}
         radius={radius}
         opened={_opened}
-        onChange={setOpened}
+        onChange={toggleDropdown}
         defaultOpened={defaultOpened}
         trapFocus={trigger === 'click'}
         closeOnEscape={closeOnEscape && trigger === 'click'}

--- a/src/mantine-core/src/Menu/Menu.tsx
+++ b/src/mantine-core/src/Menu/Menu.tsx
@@ -165,8 +165,6 @@ export function Menu(props: MenuProps) {
         classNames={{ ...classNames, dropdown: cx(classes.dropdown, classNames?.dropdown) }}
         styles={styles}
         unstyled={unstyled}
-        onClose={close}
-        onOpen={open}
         variant={variant}
       >
         {children}


### PR DESCRIPTION
**I have already raised the issue and hope it can be helpful~**
The following is a description of the problem：
When Menu uses the toggle method provided internally by useDisclosure to control unfolding and collapsing, it can lead to dependency rendering exceeding the maximum update depth and falling into a dead loop. The following is the error message from the console: "Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either does not have a dependency array, or one of the dependency changes on every render.


