### PR TITLE
[@mantine/core] ColorInput: Trigger `onChangeEnd` event with eyedropper

### DIFF
--- a/src/mantine-core/src/ColorInput/ColorInput.tsx
+++ b/src/mantine-core/src/ColorInput/ColorInput.tsx
@@ -160,7 +160,11 @@ export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>((props, 
       size={inputProps.size}
       onClick={() =>
         openEyeDropper()
-          .then(({ sRGBHex }) => setValue(convertHsvaTo(format, parseColor(sRGBHex))))
+          .then(({ sRGBHex }) => {
+            const color = convertHsvaTo(format, parseColor(sRGBHex));
+            setValue(color);
+            onChangeEnd?.(color);
+          })
           .catch(noop)
       }
     >


### PR DESCRIPTION
This pull request adds the `onChangeEnd` event to the `ColorInput` component when the user selects a colour using the eyedropper.