### PR TITLE
[docs] note re dynamic content in Modals Manager

### DIFF
--- a/docs/src/docs/others/modals.mdx
+++ b/docs/src/docs/others/modals.mdx
@@ -178,3 +178,13 @@ You can open multiple layers of modals. Every opened modal is added as first ele
 To close all opened modals call `modals.closeAll()` function:
 
 <Demo data={ModalsDemos.multipleSteps} />
+
+## Dynamic Content and the modals manager
+
+Note that when using the Modals manager, dynamic content is not supported.  
+Once modal is opened, a snapshot is saved into internal state and cannot be updated.
+
+If you intend to have dynamic content in modals, either:
+- Use internal component state, or
+- Use the modal component instead of modals manager
+


### PR DESCRIPTION
@rtivital 
Thanks for this awesome library :)

While modifying some multi step modals I was caught out by the non-obvious fact that dynamic content is not supported in content modals via the modals manager API.

see #751 and [this discussion](https://github.com/mantinedev/mantine/discussions/2527#discussioncomment-3703202)

It would be fantastic to be able to have dynamic content - but perhaps it is too difficult.
My use case would be using modals for small, multi step configuration interfaces that make sense to be in modals.

Anyway - here is a note so that others do not get caught out.

Cheers

B
