### PR TITLE
[@mantine/core] Separate handle breakpoints override in mergeTheme

### DIFF
--- a/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.test.ts
+++ b/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.test.ts
@@ -37,9 +37,11 @@ describe('@mantine/styles/merge-theme', () => {
   it('merges breakpoints with valid order', () => {
     const themeBase = getThemeBase();
 
-    expect(mergeTheme(themeBase, { breakpoints: { min: '1em', xxl: '999em' } })).toStrictEqual({
+    expect(
+      mergeTheme(themeBase, { breakpoints: { xxl: '999em', min: '1em', xs: '10em' } })
+    ).toStrictEqual({
       ...themeBase,
-      breakpoints: { min: '1em', ...themeBase.breakpoints, xxl: '999em' },
+      breakpoints: { min: '1em', ...{ ...themeBase.breakpoints, xs: '10em' }, xxl: '999em' },
     });
   });
 

--- a/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.test.ts
+++ b/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.test.ts
@@ -34,6 +34,15 @@ describe('@mantine/styles/merge-theme', () => {
     });
   });
 
+  it('merges breakpoints with valid order', () => {
+    const themeBase = getThemeBase();
+
+    expect(mergeTheme(themeBase, { breakpoints: { min: '1em', xxl: '999em' } })).toStrictEqual({
+      ...themeBase,
+      breakpoints: { min: '1em', ...themeBase.breakpoints, xxl: '999em' },
+    });
+  });
+
   it('merges headings correctly', () => {
     const themeBase = getThemeBase();
     expect(

--- a/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.ts
+++ b/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.ts
@@ -32,6 +32,27 @@ export function mergeTheme(
       };
     }
 
+    if (key === 'breakpoints' && themeOverride.breakpoints) {
+      const themeBreakpointsKeys = Object.keys(currentTheme.breakpoints);
+      const themeOverrideBreakpointsKeys = Object.keys(themeOverride.breakpoints);
+
+      // If overriden theme has extented breakpoints
+      if (themeBreakpointsKeys.length !== themeOverrideBreakpointsKeys.length) {
+        const missedKeys = themeBreakpointsKeys.filter(
+          (bp) => !themeOverrideBreakpointsKeys.includes(bp));
+
+        if (missedKeys.length === 0) {
+          return themeOverride.breakpoints;
+        }
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[@mantine/core] It looks like you overrided the `theme.config` but forgot to specify the required breakpoints keys',
+          missedKeys,
+          'Fix the missing keys or the final configuration will have sorting issues'
+        );
+      }
+    }
+
     acc[key] =
       typeof themeOverride[key] === 'object'
         ? { ...currentTheme[key], ...themeOverride[key] }

--- a/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.ts
+++ b/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.ts
@@ -1,5 +1,6 @@
 import { MantineThemeOverride, MantineThemeBase, MantineTheme } from '../../types';
 import { attachFunctions } from '../../functions/attach-functions';
+import { getBreakpointValue } from '../../functions/fns/breakpoints/breakpoints';
 
 export function mergeTheme(
   currentTheme: MantineThemeBase,
@@ -33,25 +34,11 @@ export function mergeTheme(
     }
 
     if (key === 'breakpoints' && themeOverride.breakpoints) {
-      const themeBreakpointsKeys = Object.keys(currentTheme.breakpoints);
-      const themeOverrideBreakpointsKeys = Object.keys(themeOverride.breakpoints);
+      const mergedBreakpoints = { ...currentTheme.breakpoints, ...themeOverride.breakpoints };
 
-      // If overriden theme has extented breakpoints
-      if (themeBreakpointsKeys.length !== themeOverrideBreakpointsKeys.length) {
-        const missedKeys = themeBreakpointsKeys.filter(
-          (bp) => !themeOverrideBreakpointsKeys.includes(bp)
-        );
-
-        if (missedKeys.length === 0) {
-          return themeOverride.breakpoints;
-        }
-        // eslint-disable-next-line no-console
-        console.warn(
-          '[@mantine/core] It looks like you overrided the `theme.config` but forgot to specify the required breakpoints keys',
-          missedKeys,
-          'Fix the missing keys or the final configuration will have sorting issues'
-        );
-      }
+      return Object.entries(mergedBreakpoints)
+        .sort((a, b) => getBreakpointValue(a[1]) - getBreakpointValue(b[1]))
+        .reduce((obj, [k, value]) => ({ ...obj, [k]: value }), {});
     }
 
     acc[key] =

--- a/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.ts
+++ b/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.ts
@@ -36,11 +36,14 @@ export function mergeTheme(
     if (key === 'breakpoints' && themeOverride.breakpoints) {
       const mergedBreakpoints = { ...currentTheme.breakpoints, ...themeOverride.breakpoints };
 
-      return Object.fromEntries(
-        Object.entries(mergedBreakpoints).sort(
-          (a, b) => getBreakpointValue(a[1]) - getBreakpointValue(b[1])
-        )
-      );
+      return {
+        ...acc,
+        breakpoints: Object.fromEntries(
+          Object.entries(mergedBreakpoints).sort(
+            (a, b) => getBreakpointValue(a[1]) - getBreakpointValue(b[1])
+          )
+        ),
+      };
     }
 
     acc[key] =

--- a/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.ts
+++ b/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.ts
@@ -39,7 +39,8 @@ export function mergeTheme(
       // If overriden theme has extented breakpoints
       if (themeBreakpointsKeys.length !== themeOverrideBreakpointsKeys.length) {
         const missedKeys = themeBreakpointsKeys.filter(
-          (bp) => !themeOverrideBreakpointsKeys.includes(bp));
+          (bp) => !themeOverrideBreakpointsKeys.includes(bp)
+        );
 
         if (missedKeys.length === 0) {
           return themeOverride.breakpoints;

--- a/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.ts
+++ b/src/mantine-styles/src/theme/utils/merge-theme/merge-theme.ts
@@ -36,9 +36,11 @@ export function mergeTheme(
     if (key === 'breakpoints' && themeOverride.breakpoints) {
       const mergedBreakpoints = { ...currentTheme.breakpoints, ...themeOverride.breakpoints };
 
-      return Object.entries(mergedBreakpoints)
-        .sort((a, b) => getBreakpointValue(a[1]) - getBreakpointValue(b[1]))
-        .reduce((obj, [k, value]) => ({ ...obj, [k]: value }), {});
+      return Object.fromEntries(
+        Object.entries(mergedBreakpoints).sort(
+          (a, b) => getBreakpointValue(a[1]) - getBreakpointValue(b[1])
+        )
+      );
     }
 
     acc[key] =


### PR DESCRIPTION
Related issues:
#4050 

Instead of merge breakpoints, use breakpoints from override if provided (with an additional check for required keys).