### PR TITLE
[@mantine/dropzone]: Export FileRejection type

### DIFF
--- a/src/mantine-dropzone/src/index.ts
+++ b/src/mantine-dropzone/src/index.ts
@@ -9,4 +9,4 @@ export type { DropzoneFullScreenProps, DropzoneFullScreenStylesName } from './Dr
 export type { DropzoneStylesParams } from './Dropzone.styles';
 export type { DropzoneAcceptProps, DropzoneRejectProps, DropzoneIdleProps } from './DropzoneStatus';
 export * from './mime-types';
-export type { FileWithPath } from 'react-dropzone';
+export type { FileWithPath, FileRejection } from 'react-dropzone';


### PR DESCRIPTION
I'm currently needing to add `react-dropzone` as a dependency to my project in order to import the `FileRejection` type. I'd love to be able to import it directly from `@mantine/dropzone`, just like I'm able to import `FileWithPath`.

Cheers!