### PR TITLE
fix(Select): add whiteSpace:pre  to SelectItem

### DIFF
--- a/src/mantine-core/src/Select/SelectItems/SelectItems.styles.ts
+++ b/src/mantine-core/src/Select/SelectItems/SelectItems.styles.ts
@@ -4,6 +4,7 @@ export default createStyles((theme, _params, { size }) => ({
   item: {
     ...theme.fn.fontStyles(),
     boxSizing: 'border-box',
+    whiteSpace: 'pre',
     textAlign: 'left',
     width: '100%',
     padding: `calc(${getSize({ size, sizes: theme.spacing })} / 1.5) ${getSize({


### PR DESCRIPTION
<img width="334" alt="image" src="https://user-images.githubusercontent.com/124666577/232695640-c2868c4c-577a-45ce-b17b-41a61043372c.png">


When there are multiple spaces in the middle of a character, the space will be swallowed up