### PR TITLE
Fix the issue where the Menu will open when clicking anywhere on the screen other than the target

### DIFF
--- a/src/mantine-core/src/Menu/Menu.story.tsx
+++ b/src/mantine-core/src/Menu/Menu.story.tsx
@@ -123,3 +123,20 @@ export function WithUseDisclosure() {
     </div>
   );
 }
+
+export function WithKeepMounted() {
+  return (
+    <div style={{ padding: 40 }}>
+      <Menu id="new-notification-menu" keepMounted position="bottom-end">
+        <Menu.Target>
+          <Button>Open Menu</Button>
+        </Menu.Target>
+        <Menu.Dropdown>
+          <Menu.Item>Menu Item 1</Menu.Item>
+          <Menu.Item>Menu Item 2</Menu.Item>
+          <Menu.Item>Menu Item 3</Menu.Item>
+        </Menu.Dropdown>
+      </Menu>
+    </div>
+  );
+}

--- a/src/mantine-core/src/Menu/Menu.test.tsx
+++ b/src/mantine-core/src/Menu/Menu.test.tsx
@@ -146,4 +146,91 @@ describe('@mantine/core/Menu', () => {
   it('has correct displayName', () => {
     expect(Menu.displayName).toEqual('@mantine/core/Menu');
   });
+  it('correctly calls callbacks when opening and closing the uncontrolled menu via target click', async () => {
+    const onOpen = jest.fn();
+    const onClose = jest.fn();
+    const onChange = jest.fn();
+
+    render(<TestContainer onChange={onChange} onOpen={onOpen} onClose={onClose} />);
+    expectClosed();
+
+    await userEvent.click(getControl());
+    expectOpened();
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith(true);
+
+    onOpen.mockReset();
+    onClose.mockReset();
+    onChange.mockReset();
+    await userEvent.click(getControl());
+    expectClosed();
+
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('correctly calls callbacks when opening and closing the controlled menu only via prop', async () => {
+    const onOpen = jest.fn();
+    const onClose = jest.fn();
+    const onChange = jest.fn();
+
+    render(<TestContainer onChange={onChange} onOpen={onOpen} onClose={onClose} opened={false} />);
+    expectClosed();
+
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+
+    render(<TestContainer onChange={onChange} onOpen={onOpen} onClose={onClose} opened />);
+    expectOpened();
+
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+
+    render(<TestContainer onChange={onChange} onOpen={onOpen} onClose={onClose} opened={false} />);
+
+    () => expect(screen.queryAllByRole('menu')).toHaveLength(1);
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('correctly calls callbacks when opening and closing the controlled menu via target click', async () => {
+    const onOpen = jest.fn();
+    const onClose = jest.fn();
+    const onChange = jest.fn();
+
+    render(<TestContainer onChange={onChange} onOpen={onOpen} onClose={onClose} opened={false} />);
+
+    await userEvent.click(getControl());
+
+    expectClosed();
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith(true);
+
+    onOpen.mockReset();
+    onClose.mockReset();
+    onChange.mockReset();
+    render(<TestContainer onChange={onChange} onOpen={onOpen} onClose={onClose} opened />);
+
+    expectOpened();
+    await userEvent.click(getControl());
+
+    expectOpened();
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith(false);
+
+    render(<TestContainer onChange={onChange} onOpen={onOpen} onClose={onClose} opened={false} />);
+    () => expect(screen.queryAllByRole('menu')).toHaveLength(1);
+  });
 });

--- a/src/mantine-core/src/Popover/Popover.test.tsx
+++ b/src/mantine-core/src/Popover/Popover.test.tsx
@@ -80,14 +80,14 @@ describe('@mantine/core/Popover', () => {
 
   it('correctly handles closeOnClickOutside={false}', async () => {
     const spy = jest.fn();
-    render(<TestContainer defaultOpened closeOnClickOutside={false} onClose={spy} />);
+    render(<TestContainer opened closeOnClickOutside={false} onClose={spy} />);
     await userEvent.click(document.body);
     expect(spy).not.toHaveBeenCalled();
   });
 
   it('correctly handles closeOnClickOutside={true}', async () => {
     const spy = jest.fn();
-    render(<TestContainer defaultOpened closeOnClickOutside onClose={spy} />);
+    render(<TestContainer opened closeOnClickOutside onClose={spy} />);
     await userEvent.click(document.body);
     expect(spy).toHaveBeenCalled();
   });

--- a/src/mantine-core/src/Popover/Popover.tsx
+++ b/src/mantine-core/src/Popover/Popover.tsx
@@ -222,7 +222,7 @@ export function Popover(props: PopoverProps) {
     onClose,
   });
 
-  useClickOutside(() => closeOnClickOutside && popover.onClose(), clickOutsideEvents, [
+  useClickOutside(() => opened && closeOnClickOutside && popover.onClose(), clickOutsideEvents, [
     targetNode,
     dropdownNode,
   ]);


### PR DESCRIPTION
When clicking anywhere on the screen that is not a target, the Menu also performs opening and closing.
​https://codesandbox.io/s/nifty-curran-fy1nlu?file=/src/App.tsx

Based on my humble opinion, it may be caused by two reasons:

![image](https://user-images.githubusercontent.com/105474651/233619537-77be8b0c-d3db-4d77-b04c-d206351746ab.png)

- The `dropdown`  is only hidden and has not been completely uninstalled, resulting in its lifecycle methods and other methods still existing.

- `clickOutside` is not controlled based on the `opened` state, so both the open and closed states will trigger `onClose`.

In version 6.0.8, in order for `Menu` to be properly controlled and simultaneously call `onClose` and `onOpen`, I made `clickOutside` call the `toggleDropdown` method of `Menu`, resulting in a situation where clicking on an external button can also control the switch state.


Here are the fixes I made:
 `clickOutside` only executes the `onClose` method when `opened: true`.

```
useClickOutside(() => opened && closeOnClickOutside && popover.onClose(), clickOutsideEvents, [
    targetNode,
    dropdownNode,
  ]) 
 ```
 At the same time, I also modified the test file for `closeOnClickOutside` in `Popover`:
 ```
   it('correctly handles closeOnClickOutside={false}', async () => {
    const spy = jest.fn();
    render(<TestContainer opened closeOnClickOutside={false} onClose={spy} />);
    await userEvent.click(document.body);
    expect(spy).not.toHaveBeenCalled();
  });

  it('correctly handles closeOnClickOutside={true}', async () => {
    const spy = jest.fn();
    render(<TestContainer opened closeOnClickOutside onClose={spy} />);
    await userEvent.click(document.body);
    expect(spy).toHaveBeenCalled();
  });
  ```
Finally, I have added detailed testing files for `Menu` in both controlled and uncontrolled states. Feel free to rework or adjust them~