### PR TITLE
[@mantine/core] fix slider styles linked to thumb size

### DIFF
--- a/src/mantine-core/src/Slider/Marks/Marks.styles.ts
+++ b/src/mantine-core/src/Slider/Marks/Marks.styles.ts
@@ -4,13 +4,14 @@ import { sizes } from '../SliderRoot/SliderRoot.styles';
 interface MarksStyles {
   color: MantineColor;
   disabled: boolean;
+  thumbSize?: number;
 }
 
-export default createStyles((theme, { color, disabled }: MarksStyles, { size }) => ({
+export default createStyles((theme, { color, disabled, thumbSize }: MarksStyles, { size }) => ({
   marksContainer: {
     position: 'absolute',
-    right: getSize({ sizes, size }),
-    left: getSize({ sizes, size }),
+    right: thumbSize ? rem(thumbSize / 2) : getSize({ sizes, size }),
+    left: thumbSize ? rem(thumbSize / 2) : getSize({ sizes, size }),
   },
 
   markWrapper: {

--- a/src/mantine-core/src/Slider/Marks/Marks.tsx
+++ b/src/mantine-core/src/Slider/Marks/Marks.tsx
@@ -10,6 +10,7 @@ export type MarksStylesNames = Selectors<typeof useStyles>;
 export interface MarksProps extends DefaultProps<MarksStylesNames> {
   marks: { value: number; label?: React.ReactNode }[];
   size: MantineNumberSize;
+  thumbSize?: number;
   color: MantineColor;
   min: number;
   max: number;
@@ -25,6 +26,7 @@ export function Marks({
   marks,
   color,
   size,
+  thumbSize,
   min,
   max,
   value,
@@ -38,7 +40,7 @@ export function Marks({
   variant,
 }: MarksProps) {
   const { classes, cx } = useStyles(
-    { color, disabled },
+    { color, disabled, thumbSize },
     { name: 'Slider', classNames, styles, unstyled, variant, size }
   );
 

--- a/src/mantine-core/src/Slider/RangeSlider/RangeSlider.tsx
+++ b/src/mantine-core/src/Slider/RangeSlider/RangeSlider.tsx
@@ -393,6 +393,7 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>((props, 
         marks={marks}
         inverted={inverted}
         size={size}
+        thumbSize={thumbSize}
         radius={radius}
         color={color}
         min={min}

--- a/src/mantine-core/src/Slider/Slider/Slider.tsx
+++ b/src/mantine-core/src/Slider/Slider/Slider.tsx
@@ -273,6 +273,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
         filled={position}
         marks={marks}
         size={size}
+        thumbSize={thumbSize}
         radius={radius}
         color={color}
         min={min}

--- a/src/mantine-core/src/Slider/SliderRoot/SliderRoot.styles.ts
+++ b/src/mantine-core/src/Slider/SliderRoot/SliderRoot.styles.ts
@@ -1,4 +1,4 @@
-import { createStyles, rem, getSize } from '@mantine/styles';
+import { createStyles, rem } from '@mantine/styles';
 
 export const sizes = {
   xs: rem(4),
@@ -8,12 +8,11 @@ export const sizes = {
   xl: rem(12),
 };
 
-export default createStyles((theme, _params, { size }) => ({
+export default createStyles((theme) => ({
   root: {
     ...theme.fn.fontStyles(),
     WebkitTapHighlightColor: 'transparent',
     outline: 0,
-    height: `calc(${getSize({ sizes, size })} * 2)`,
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',

--- a/src/mantine-core/src/Slider/Track/Track.styles.ts
+++ b/src/mantine-core/src/Slider/Track/Track.styles.ts
@@ -1,4 +1,4 @@
-import { createStyles, MantineNumberSize, MantineColor, getSize } from '@mantine/styles';
+import { createStyles, MantineNumberSize, MantineColor, getSize, rem } from '@mantine/styles';
 import { sizes } from '../SliderRoot/SliderRoot.styles';
 
 interface TrackStyles {
@@ -6,15 +6,16 @@ interface TrackStyles {
   color: MantineColor;
   disabled: boolean;
   inverted: boolean;
+  thumbSize?: number;
 }
 
 export default createStyles(
-  (theme, { radius, color, disabled, inverted }: TrackStyles, { size }) => ({
+  (theme, { radius, color, disabled, inverted, thumbSize }: TrackStyles, { size }) => ({
     trackContainer: {
       display: 'flex',
       alignItems: 'center',
       width: '100%',
-      height: '100%',
+      height: `calc(${getSize({ sizes, size })} * 2)`,
       cursor: 'pointer',
     },
 
@@ -22,8 +23,8 @@ export default createStyles(
       position: 'relative',
       height: getSize({ sizes, size }),
       width: '100%',
-      marginRight: getSize({ size, sizes }),
-      marginLeft: getSize({ size, sizes }),
+      marginRight: thumbSize ? rem(thumbSize / 2) : getSize({ size, sizes }),
+      marginLeft: thumbSize ? rem(thumbSize / 2) : getSize({ size, sizes }),
 
       '&::before': {
         content: '""',
@@ -31,8 +32,8 @@ export default createStyles(
         top: 0,
         bottom: 0,
         borderRadius: theme.fn.radius(radius),
-        right: `calc(${getSize({ size, sizes })} * -1)`,
-        left: `calc(${getSize({ size, sizes })} * -1)`,
+        right: `calc(${thumbSize ? rem(thumbSize / 2) : getSize({ size, sizes })} * -1)`,
+        left: `calc(${thumbSize ? rem(thumbSize / 2) : getSize({ size, sizes })} * -1)`,
         backgroundColor: inverted
           ? disabled
             ? theme.colorScheme === 'dark'

--- a/src/mantine-core/src/Slider/Track/Track.tsx
+++ b/src/mantine-core/src/Slider/Track/Track.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { DefaultProps, MantineNumberSize, MantineColor, Selectors, getSize } from '@mantine/styles';
+import {
+  DefaultProps,
+  MantineNumberSize,
+  MantineColor,
+  Selectors,
+  getSize,
+  rem,
+} from '@mantine/styles';
 import { Box } from '../../Box';
 import { Marks, MarksStylesNames } from '../Marks/Marks';
 import { sizes } from '../SliderRoot/SliderRoot.styles';
@@ -13,6 +20,7 @@ export interface TrackProps extends DefaultProps<TrackStylesNames> {
   marksOffset?: number;
   marks: { value: number; label?: React.ReactNode }[];
   size: MantineNumberSize;
+  thumbSize?: number;
   radius: MantineNumberSize;
   color: MantineColor;
   min: number;
@@ -29,6 +37,7 @@ export interface TrackProps extends DefaultProps<TrackStylesNames> {
 export function Track({
   filled,
   size,
+  thumbSize,
   color,
   classNames,
   styles,
@@ -44,7 +53,7 @@ export function Track({
   ...others
 }: TrackProps) {
   const { classes } = useStyles(
-    { color, radius, disabled, inverted },
+    { color, radius, disabled, inverted, thumbSize },
     { name: 'Slider', classNames, styles, unstyled, variant, size }
   );
 
@@ -55,8 +64,12 @@ export function Track({
           <Box
             className={classes.bar}
             sx={{
-              left: `calc(${offset}% - ${getSize({ size, sizes })})`,
-              width: `calc(${filled}% + ${getSize({ size, sizes })})`,
+              left: `calc(${offset}% - ${
+                thumbSize ? rem(thumbSize / 2) : getSize({ size, sizes })
+              })`,
+              width: `calc(${filled}% + 2 * ${
+                thumbSize ? rem(thumbSize / 2) : getSize({ size, sizes })
+              })`,
             }}
           />
 
@@ -67,6 +80,7 @@ export function Track({
       <Marks
         {...others}
         size={size}
+        thumbSize={thumbSize}
         color={color}
         offset={marksOffset}
         classNames={classNames}


### PR DESCRIPTION
As discussed in #4112 and Discord, here are the relevant fixes to Slider:

- Remove fixed height from the `root` container to allow style props such as padding to have correct effect on the document flow
- Add fixed height to the `trackContainer` instead
- Change offsets linked to thumb size to actually use `thumbSize` instead of only `size`