### PR TITLE
[@mantine/hooks] Focus trap identity

### DIFF
--- a/src/mantine-hooks/src/use-focus-trap/use-focus-trap.test.tsx
+++ b/src/mantine-hooks/src/use-focus-trap/use-focus-trap.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React, { useState } from 'react';
+import { useFocusTrap } from './use-focus-trap';
+
+describe('@mantine/hooks/use-focus-trap', () => {
+  function InnerComponent({ testId }) {
+    const ref = useFocusTrap();
+    return (
+      <div data-testid={testId}>
+        <div ref={ref} />
+      </div>
+    );
+  }
+  function WrapperComponent({ shouldMount = true }) {
+    const [toggle, setToggle] = useState(false);
+
+    const handleToggle = () => {
+      setToggle(!toggle);
+    };
+
+    return (
+      <>
+        <button type="button" onClick={handleToggle}>
+          Toggle
+        </button>
+        <div data-testid="root-1" />
+        <div data-testid="root-2" />
+        <script data-testid="root-script" />
+        {!toggle && shouldMount && <InnerComponent testId="container-1" />}
+        {toggle && shouldMount && <InnerComponent testId="container-2" />}
+      </>
+    );
+  }
+  it('correctly assigns aria-hidden to non-encompassing root nodes', () => {
+    render(<WrapperComponent />, { container: document.body });
+    // Ensure that aria attributes are added to all applicable root nodes
+    expect(screen.getByTestId('root-1')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByTestId('root-2')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByTestId('root-script')).not.toHaveAttribute('aria-hidden');
+    expect(screen.getByTestId('container-1')).not.toHaveAttribute('aria-hidden');
+  });
+  it('correctly restores aria attributes on unmount', () => {
+    const { rerender } = render(<WrapperComponent />, { container: document.body });
+    rerender(<WrapperComponent shouldMount={false} />);
+    // Ensure that root nodes have their original aria-hidden attribute restored on unmount
+    expect(screen.getByTestId('root-1')).not.toHaveAttribute('aria-hidden');
+    expect(screen.getByTestId('root-2')).not.toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByTestId('root-script')).not.toHaveAttribute('aria-hidden');
+    expect(screen.queryByTestId('container-1')).toBeFalsy();
+  });
+  it('correctly abandons restoration of aria-hidden if another handler has instaantiated before cleanup', () => {
+    const { rerender } = render(<WrapperComponent />, { container: document.body });
+    expect(screen.getByTestId('root-1')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByTestId('root-2')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByTestId('container-1')).not.toHaveAttribute('aria-hidden');
+
+    // Unmount initial container, mount new container
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(screen.queryByTestId('container-1')).toBeFalsy();
+    expect(screen.getByTestId('container-2')).not.toHaveAttribute('aria-hidden');
+
+    // Ensure aria-hidden attributes were maintained
+    expect(screen.getByTestId('root-1')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByTestId('root-2')).toHaveAttribute('aria-hidden', 'true');
+
+    // Unmount new container & ensure all aria-hidden attributes were restored
+    rerender(<WrapperComponent shouldMount={false} />);
+    expect(screen.getByTestId('root-1')).not.toHaveAttribute('aria-hidden');
+    expect(screen.getByTestId('root-2')).not.toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByTestId('root-script')).not.toHaveAttribute('aria-hidden');
+    expect(screen.queryByTestId('container-1')).toBeFalsy();
+    expect(screen.queryByTestId('container-2')).toBeFalsy();
+  });
+});

--- a/src/mantine-hooks/tsconfig.json
+++ b/src/mantine-hooks/tsconfig.json
@@ -9,6 +9,12 @@
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "lib",
-    "composite": true
-  }
+    "composite": true,
+    "paths": {
+      "@mantine/tests": ["../mantine-tests/src"] 
+    }
+  },
+  "references": [
+    { "path": "../mantine-tests" }
+  ]
 }


### PR DESCRIPTION
Fixes #4079 
---

This addresses an edge case with `useFocusTrap` that can cause the [cleanup function](https://github.com/mantinedev/mantine/blob/42df57f888be86f1fa9adb5b1ca64546c3991dfe/src/mantine-hooks/src/use-focus-trap/use-focus-trap.ts#L82-L89) returned by `createAriaHider` to run after another `useFocusTrap` instance has operated on the same set of root nodes. This is due to the `createAriaHider` function being called when the [callback ref](https://github.com/mantinedev/mantine/blob/42df57f888be86f1fa9adb5b1ca64546c3991dfe/src/mantine-hooks/src/use-focus-trap/use-focus-trap.ts#L30-L66) returned by `useFocusTrap` is invoked, which will run before the cleanup function if two elements that utilize `useFocusRoot` are toggled simultaneously. An example of this behavior can be found in the original [issue](https://github.com/mantinedev/mantine/issues/4079) with `Menu.Item`/`Modal`: https://codesandbox.io/s/angry-rgb-x46ub2 

The approach taken was to set a `data-focus-id` attribute to every root node that has it's `aria-hidden` value mutated by `createAriaHider`. In the returned restore function, we are then able to check if the nodes current `data-focus-id` attribute matches the original assigned ID. If not, we know that another `useFocusTrap` instance was rendered & we should not move forward with restoring the `aria-hidden` attributes for that given run. Additionally, a `data-hidden` attribute will also be added to these root nodes so that we are able to keep track of the elements initial `aria-hidden` state between usages of `useFocusTrap`. 

Tests for `use-focus-trap` were also added, including a test case for the above scenario.
