### PR TITLE
[@mantine/core] Input: Add paddingRight to unstyled variant when righ…

### DIFF
--- a/src/mantine-core/src/Input/Input.styles.ts
+++ b/src/mantine-core/src/Input/Input.styles.ts
@@ -1,10 +1,4 @@
-import {
-  createStyles,
-  MantineNumberSize,
-  MantineTheme,
-  rem,
-  getSize,
-} from "@mantine/styles";
+import { createStyles, MantineNumberSize, MantineTheme, rem, getSize } from '@mantine/styles';
 
 export interface InputStylesParams {
   radius: MantineNumberSize;
@@ -26,7 +20,7 @@ export const sizes = {
   xl: rem(60),
 };
 
-const INPUT_VARIANTS = ["default", "filled", "unstyled"];
+const INPUT_VARIANTS = ['default', 'filled', 'unstyled'];
 
 interface GetVariantStylesInput {
   theme: MantineTheme;
@@ -38,49 +32,43 @@ function getVariantStyles({ theme, variant }: GetVariantStylesInput) {
     return null;
   }
 
-  if (variant === "default") {
+  if (variant === 'default') {
     return {
       border: `${rem(1)} solid ${
-        theme.colorScheme === "dark"
-          ? theme.colors.dark[4]
-          : theme.colors.gray[4]
+        theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[4]
       }`,
-      backgroundColor:
-        theme.colorScheme === "dark" ? theme.colors.dark[6] : theme.white,
-      transition: "border-color 100ms ease",
-      "&:focus, &:focus-within": theme.focusRingStyles.inputStyles(theme),
+      backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.white,
+      transition: 'border-color 100ms ease',
+      '&:focus, &:focus-within': theme.focusRingStyles.inputStyles(theme),
     };
   }
 
-  if (variant === "filled") {
+  if (variant === 'filled') {
     return {
       border: `${rem(1)} solid transparent`,
-      backgroundColor:
-        theme.colorScheme === "dark"
-          ? theme.colors.dark[5]
-          : theme.colors.gray[1],
-      "&:focus, &:focus-within": theme.focusRingStyles.inputStyles(theme),
+      backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.gray[1],
+      '&:focus, &:focus-within': theme.focusRingStyles.inputStyles(theme),
     };
   }
 
   return {
     borderWidth: 0,
-    color: theme.colorScheme === "dark" ? theme.colors.dark[0] : theme.black,
-    backgroundColor: "transparent",
+    color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
+    backgroundColor: 'transparent',
     minHeight: rem(28),
     outline: 0,
 
-    "&:focus, &:focus-within": {
-      outline: "none",
-      borderColor: "transparent",
+    '&:focus, &:focus-within': {
+      outline: 'none',
+      borderColor: 'transparent',
     },
 
-    "&:disabled": {
-      backgroundColor: "transparent",
+    '&:disabled': {
+      backgroundColor: 'transparent',
 
-      "&:focus, &:focus-within": {
-        outline: "none",
-        borderColor: "transparent",
+      '&:focus, &:focus-within': {
+        outline: 'none',
+        borderColor: 'transparent',
       },
     },
   };
@@ -103,11 +91,11 @@ export default createStyles(
     { variant, size }
   ) => {
     const invalidColor = theme.fn.variant({
-      variant: "filled",
-      color: "red",
+      variant: 'filled',
+      color: 'red',
     }).background;
     const sizeStyles =
-      variant === "default" || variant === "filled"
+      variant === 'default' || variant === 'filled'
         ? {
             minHeight: getSize({ size, sizes }),
             paddingLeft: `calc(${getSize({ size, sizes })}  / 3)`,
@@ -116,7 +104,7 @@ export default createStyles(
               : `calc(${getSize({ size, sizes })}  / 3)`,
             borderRadius: theme.fn.radius(radius),
           }
-        : variant === "unstyled" && withRightSection
+        : variant === 'unstyled' && withRightSection
         ? {
             paddingRight: rightSectionWidth || getSize({ size, sizes }),
           }
@@ -124,109 +112,99 @@ export default createStyles(
 
     return {
       wrapper: {
-        position: "relative",
+        position: 'relative',
         marginTop: offsetTop ? `calc(${theme.spacing.xs} / 2)` : undefined,
-        marginBottom: offsetBottom
-          ? `calc(${theme.spacing.xs} / 2)`
-          : undefined,
+        marginBottom: offsetBottom ? `calc(${theme.spacing.xs} / 2)` : undefined,
       },
 
       input: {
         ...theme.fn.fontStyles(),
         height: multiline
-          ? variant === "unstyled"
+          ? variant === 'unstyled'
             ? undefined
-            : "auto"
+            : 'auto'
           : getSize({ size, sizes }),
-        WebkitTapHighlightColor: "transparent",
-        lineHeight: multiline
-          ? theme.lineHeight
-          : `calc(${getSize({ size, sizes })} - ${rem(2)})`,
-        appearance: "none",
-        resize: "none",
-        boxSizing: "border-box",
+        WebkitTapHighlightColor: 'transparent',
+        lineHeight: multiline ? theme.lineHeight : `calc(${getSize({ size, sizes })} - ${rem(2)})`,
+        appearance: 'none',
+        resize: 'none',
+        boxSizing: 'border-box',
         fontSize: getSize({ size, sizes: theme.fontSizes }),
-        width: "100%",
-        color:
-          theme.colorScheme === "dark" ? theme.colors.dark[0] : theme.black,
-        display: "block",
-        textAlign: "left",
-        cursor: pointer ? "pointer" : undefined,
+        width: '100%',
+        color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
+        display: 'block',
+        textAlign: 'left',
+        cursor: pointer ? 'pointer' : undefined,
         ...getVariantStyles({ theme, variant }),
         ...sizeStyles,
 
-        "&:disabled, &[data-disabled]": {
+        '&:disabled, &[data-disabled]': {
           backgroundColor:
-            theme.colorScheme === "dark"
-              ? theme.colors.dark[6]
-              : theme.colors.gray[1],
+            theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[1],
           color: theme.colors.dark[2],
           opacity: 0.6,
-          cursor: "not-allowed",
+          cursor: 'not-allowed',
 
-          "&::placeholder": {
+          '&::placeholder': {
             color: theme.colors.dark[2],
           },
         },
 
-        "&[data-invalid]": {
+        '&[data-invalid]': {
           color: invalidColor,
           borderColor: invalidColor,
 
-          "&::placeholder": {
+          '&::placeholder': {
             opacity: 1,
             color: invalidColor,
           },
         },
 
-        "&[data-with-icon]": {
-          paddingLeft:
-            typeof iconWidth === "number"
-              ? rem(iconWidth)
-              : getSize({ size, sizes }),
+        '&[data-with-icon]': {
+          paddingLeft: typeof iconWidth === 'number' ? rem(iconWidth) : getSize({ size, sizes }),
         },
 
-        "&::placeholder": {
+        '&::placeholder': {
           ...theme.fn.placeholderStyles(),
           opacity: 1,
         },
 
-        "&::-webkit-inner-spin-button, &::-webkit-outer-spin-button, &::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button, &::-webkit-search-results-decoration":
+        '&::-webkit-inner-spin-button, &::-webkit-outer-spin-button, &::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button, &::-webkit-search-results-decoration':
           {
-            appearance: "none",
+            appearance: 'none',
           },
 
-        "&[type=number]": {
-          MozAppearance: "textfield",
+        '&[type=number]': {
+          MozAppearance: 'textfield',
         },
       },
 
       icon: {
-        pointerEvents: "none",
-        position: "absolute",
+        pointerEvents: 'none',
+        position: 'absolute',
         zIndex: 1,
         left: 0,
         top: 0,
         bottom: 0,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
         width: iconWidth ? rem(iconWidth) : getSize({ size, sizes }),
         color: invalid
-          ? theme.colors.red[theme.colorScheme === "dark" ? 6 : 7]
-          : theme.colorScheme === "dark"
+          ? theme.colors.red[theme.colorScheme === 'dark' ? 6 : 7]
+          : theme.colorScheme === 'dark'
           ? theme.colors.dark[2]
           : theme.colors.gray[5],
       },
 
       rightSection: {
-        position: "absolute",
+        position: 'absolute',
         top: 0,
         bottom: 0,
         right: 0,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
         width: rightSectionWidth || getSize({ size, sizes }),
       },
     };

--- a/src/mantine-core/src/Input/Input.styles.ts
+++ b/src/mantine-core/src/Input/Input.styles.ts
@@ -1,4 +1,10 @@
-import { createStyles, MantineNumberSize, MantineTheme, rem, getSize } from '@mantine/styles';
+import {
+  createStyles,
+  MantineNumberSize,
+  MantineTheme,
+  rem,
+  getSize,
+} from "@mantine/styles";
 
 export interface InputStylesParams {
   radius: MantineNumberSize;
@@ -20,7 +26,7 @@ export const sizes = {
   xl: rem(60),
 };
 
-const INPUT_VARIANTS = ['default', 'filled', 'unstyled'];
+const INPUT_VARIANTS = ["default", "filled", "unstyled"];
 
 interface GetVariantStylesInput {
   theme: MantineTheme;
@@ -32,43 +38,49 @@ function getVariantStyles({ theme, variant }: GetVariantStylesInput) {
     return null;
   }
 
-  if (variant === 'default') {
+  if (variant === "default") {
     return {
       border: `${rem(1)} solid ${
-        theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[4]
+        theme.colorScheme === "dark"
+          ? theme.colors.dark[4]
+          : theme.colors.gray[4]
       }`,
-      backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.white,
-      transition: 'border-color 100ms ease',
-      '&:focus, &:focus-within': theme.focusRingStyles.inputStyles(theme),
+      backgroundColor:
+        theme.colorScheme === "dark" ? theme.colors.dark[6] : theme.white,
+      transition: "border-color 100ms ease",
+      "&:focus, &:focus-within": theme.focusRingStyles.inputStyles(theme),
     };
   }
 
-  if (variant === 'filled') {
+  if (variant === "filled") {
     return {
       border: `${rem(1)} solid transparent`,
-      backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.gray[1],
-      '&:focus, &:focus-within': theme.focusRingStyles.inputStyles(theme),
+      backgroundColor:
+        theme.colorScheme === "dark"
+          ? theme.colors.dark[5]
+          : theme.colors.gray[1],
+      "&:focus, &:focus-within": theme.focusRingStyles.inputStyles(theme),
     };
   }
 
   return {
     borderWidth: 0,
-    color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
-    backgroundColor: 'transparent',
+    color: theme.colorScheme === "dark" ? theme.colors.dark[0] : theme.black,
+    backgroundColor: "transparent",
     minHeight: rem(28),
     outline: 0,
 
-    '&:focus, &:focus-within': {
-      outline: 'none',
-      borderColor: 'transparent',
+    "&:focus, &:focus-within": {
+      outline: "none",
+      borderColor: "transparent",
     },
 
-    '&:disabled': {
-      backgroundColor: 'transparent',
+    "&:disabled": {
+      backgroundColor: "transparent",
 
-      '&:focus, &:focus-within': {
-        outline: 'none',
-        borderColor: 'transparent',
+      "&:focus, &:focus-within": {
+        outline: "none",
+        borderColor: "transparent",
       },
     },
   };
@@ -90,9 +102,12 @@ export default createStyles(
     }: InputStylesParams,
     { variant, size }
   ) => {
-    const invalidColor = theme.fn.variant({ variant: 'filled', color: 'red' }).background;
+    const invalidColor = theme.fn.variant({
+      variant: "filled",
+      color: "red",
+    }).background;
     const sizeStyles =
-      variant === 'default' || variant === 'filled'
+      variant === "default" || variant === "filled"
         ? {
             minHeight: getSize({ size, sizes }),
             paddingLeft: `calc(${getSize({ size, sizes })}  / 3)`,
@@ -101,7 +116,7 @@ export default createStyles(
               : `calc(${getSize({ size, sizes })}  / 3)`,
             borderRadius: theme.fn.radius(radius),
           }
-        : variant === 'unstyled' && withRightSection 
+        : variant === "unstyled" && withRightSection
         ? {
             paddingRight: rightSectionWidth || getSize({ size, sizes }),
           }
@@ -109,99 +124,109 @@ export default createStyles(
 
     return {
       wrapper: {
-        position: 'relative',
+        position: "relative",
         marginTop: offsetTop ? `calc(${theme.spacing.xs} / 2)` : undefined,
-        marginBottom: offsetBottom ? `calc(${theme.spacing.xs} / 2)` : undefined,
+        marginBottom: offsetBottom
+          ? `calc(${theme.spacing.xs} / 2)`
+          : undefined,
       },
 
       input: {
         ...theme.fn.fontStyles(),
         height: multiline
-          ? variant === 'unstyled'
+          ? variant === "unstyled"
             ? undefined
-            : 'auto'
+            : "auto"
           : getSize({ size, sizes }),
-        WebkitTapHighlightColor: 'transparent',
-        lineHeight: multiline ? theme.lineHeight : `calc(${getSize({ size, sizes })} - ${rem(2)})`,
-        appearance: 'none',
-        resize: 'none',
-        boxSizing: 'border-box',
+        WebkitTapHighlightColor: "transparent",
+        lineHeight: multiline
+          ? theme.lineHeight
+          : `calc(${getSize({ size, sizes })} - ${rem(2)})`,
+        appearance: "none",
+        resize: "none",
+        boxSizing: "border-box",
         fontSize: getSize({ size, sizes: theme.fontSizes }),
-        width: '100%',
-        color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
-        display: 'block',
-        textAlign: 'left',
-        cursor: pointer ? 'pointer' : undefined,
+        width: "100%",
+        color:
+          theme.colorScheme === "dark" ? theme.colors.dark[0] : theme.black,
+        display: "block",
+        textAlign: "left",
+        cursor: pointer ? "pointer" : undefined,
         ...getVariantStyles({ theme, variant }),
         ...sizeStyles,
 
-        '&:disabled, &[data-disabled]': {
+        "&:disabled, &[data-disabled]": {
           backgroundColor:
-            theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[1],
+            theme.colorScheme === "dark"
+              ? theme.colors.dark[6]
+              : theme.colors.gray[1],
           color: theme.colors.dark[2],
           opacity: 0.6,
-          cursor: 'not-allowed',
+          cursor: "not-allowed",
 
-          '&::placeholder': {
+          "&::placeholder": {
             color: theme.colors.dark[2],
           },
         },
 
-        '&[data-invalid]': {
+        "&[data-invalid]": {
           color: invalidColor,
           borderColor: invalidColor,
 
-          '&::placeholder': {
+          "&::placeholder": {
             opacity: 1,
             color: invalidColor,
           },
         },
 
-        '&[data-with-icon]': {
-          paddingLeft: typeof iconWidth === 'number' ? rem(iconWidth) : getSize({ size, sizes }),
+        "&[data-with-icon]": {
+          paddingLeft:
+            typeof iconWidth === "number"
+              ? rem(iconWidth)
+              : getSize({ size, sizes }),
         },
 
-        '&::placeholder': {
+        "&::placeholder": {
           ...theme.fn.placeholderStyles(),
           opacity: 1,
         },
 
-        '&::-webkit-inner-spin-button, &::-webkit-outer-spin-button, &::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button, &::-webkit-search-results-decoration':
+        "&::-webkit-inner-spin-button, &::-webkit-outer-spin-button, &::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button, &::-webkit-search-results-decoration":
           {
-            appearance: 'none',
+            appearance: "none",
           },
 
-        '&[type=number]': {
-          MozAppearance: 'textfield',
+        "&[type=number]": {
+          MozAppearance: "textfield",
         },
       },
 
       icon: {
-        pointerEvents: 'none',
-        position: 'absolute',
+        pointerEvents: "none",
+        position: "absolute",
         zIndex: 1,
         left: 0,
         top: 0,
         bottom: 0,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
         width: iconWidth ? rem(iconWidth) : getSize({ size, sizes }),
         color: invalid
-          ? theme.colors.red[theme.colorScheme === 'dark' ? 6 : 7]
-          : theme.colorScheme === 'dark'
+          ? theme.colors.red[theme.colorScheme === "dark" ? 6 : 7]
+          : theme.colorScheme === "dark"
           ? theme.colors.dark[2]
           : theme.colors.gray[5],
       },
 
       rightSection: {
-        position: 'absolute',
+        position: "absolute",
         top: 0,
         bottom: 0,
         right: 0,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
         width: rightSectionWidth || getSize({ size, sizes }),
       },
     };

--- a/src/mantine-core/src/Input/Input.styles.ts
+++ b/src/mantine-core/src/Input/Input.styles.ts
@@ -101,11 +101,11 @@ export default createStyles(
               : `calc(${getSize({ size, sizes })}  / 3)`,
             borderRadius: theme.fn.radius(radius),
           }
-        : (variant === 'unstyled' && withRightSection) 
-            ? {
-                paddingRight: rightSectionWidth || getSize({ size, sizes })
-              }
-            : null;
+        : variant === 'unstyled' && withRightSection 
+        ? {
+            paddingRight: rightSectionWidth || getSize({ size, sizes }),
+          }
+        : null;
 
     return {
       wrapper: {

--- a/src/mantine-core/src/Input/Input.styles.ts
+++ b/src/mantine-core/src/Input/Input.styles.ts
@@ -101,7 +101,11 @@ export default createStyles(
               : `calc(${getSize({ size, sizes })}  / 3)`,
             borderRadius: theme.fn.radius(radius),
           }
-        : null;
+        : (variant === 'unstyled' && withRightSection) 
+            ? {
+                paddingRight: rightSectionWidth || getSize({ size, sizes })
+              }
+            : null;
 
     return {
       wrapper: {


### PR DESCRIPTION
…tSection is present

Add paddingRight to the unstyled variant only when withRightSection is true otherwise returns null styles.

Prevents text from overlapping rightSection on an unstyled variant of TextInput.

Example:
![image](https://user-images.githubusercontent.com/36969747/233770159-ebb88fc7-30f0-4d44-9a5f-0640ee7285a0.png)
