### PR TITLE
[docs] Clarify docs for SegmentedControl

### DIFF
--- a/docs/src/docs/core/SegmentedControl.mdx
+++ b/docs/src/docs/core/SegmentedControl.mdx
@@ -5,7 +5,7 @@ title: SegmentedControl
 order: 1
 slug: /core/segmented-control/
 category: 'inputs'
-description: 'Horizontal control with multiple segments'
+description: 'A linear set of two or more segments'
 props: ['SegmentedControl']
 import: "import { SegmentedControl } from '@mantine/core';"
 source: 'mantine-core/src/SegmentedControl/SegmentedControl.tsx'

--- a/src/mantine-core/src/SegmentedControl/SegmentedControl.tsx
+++ b/src/mantine-core/src/SegmentedControl/SegmentedControl.tsx
@@ -35,7 +35,7 @@ export interface SegmentedControlProps
     Omit<React.ComponentPropsWithoutRef<'div'>, 'value' | 'onChange'> {
   variant?: string;
 
-  /** Data based on which controls are rendered */
+  /** Segments to render */
   data: string[] | SegmentedControlItem[];
 
   /** Current selected value */
@@ -71,7 +71,7 @@ export interface SegmentedControlProps
   /** Default value for uncontrolled component */
   defaultValue?: string;
 
-  /** Display Vertically */
+  /** The orientation of the component */
   orientation?: 'vertical' | 'horizontal';
 
   /** Determines whether the user can change value */


### PR DESCRIPTION
Since you can control the orientation of `<SegmentedControl>` with the `orientation` prop, it doesn't make sense to say to describe it as horizontal in the description.

Also improve some other documentation.