### PR TITLE
[@mantine/dates]: Support function as weekdayFormat prop

### DIFF
--- a/src/mantine-dates/src/components/Month/Month.tsx
+++ b/src/mantine-dates/src/components/Month/Month.tsx
@@ -47,7 +47,7 @@ export interface MonthSettings {
   firstDayOfWeek?: DayOfWeek;
 
   /** dayjs format for weekdays names, defaults to "dd" */
-  weekdayFormat?: string;
+  weekdayFormat?: string | ((date: Date) => React.ReactNode);
 
   /** Indices of weekend days, 0-6, where 0 is Sunday and 6 is Saturday, defaults to value defined in DatesProvider */
   weekendDays?: DayOfWeek[];

--- a/src/mantine-dates/src/components/WeekdaysRow/WeekdaysRow.tsx
+++ b/src/mantine-dates/src/components/WeekdaysRow/WeekdaysRow.tsx
@@ -23,7 +23,7 @@ export interface WeekdaysRowProps
   firstDayOfWeek?: DayOfWeek;
 
   /** dayjs format to get weekday name, defaults to "dd" */
-  weekdayFormat?: string;
+  weekdayFormat?: string | ((date: Date) => React.ReactNode);
 
   /** Choose cell type that will be used to render weekdays, defaults to th */
   cellComponent?: 'td' | 'th';

--- a/src/mantine-dates/src/components/WeekdaysRow/get-weekdays-names/get-weekdays-names.test.ts
+++ b/src/mantine-dates/src/components/WeekdaysRow/get-weekdays-names/get-weekdays-names.test.ts
@@ -40,6 +40,19 @@ describe('@mantine/dates/get-weekday-names', () => {
     ]);
   });
 
+  it('supports custom format function', () => {
+    expect(
+      getWeekdayNames({ locale: 'en', format: (date) => dayjs(date).format('dd')[0] })
+    ).toStrictEqual(['M', 'T', 'W', 'T', 'F', 'S', 'S']);
+
+    expect(
+      getWeekdayNames({
+        locale: 'ru',
+        format: (date) => dayjs(date).locale('ru').format('dd')[0].toUpperCase(),
+      })
+    ).toStrictEqual(['П', 'В', 'С', 'Ч', 'П', 'С', 'В']);
+  });
+
   it('supports custom first day of week', () => {
     expect(getWeekdayNames({ locale: 'en', firstDayOfWeek: 0 })).toStrictEqual([
       'Su',

--- a/src/mantine-dates/src/components/WeekdaysRow/get-weekdays-names/get-weekdays-names.ts
+++ b/src/mantine-dates/src/components/WeekdaysRow/get-weekdays-names/get-weekdays-names.ts
@@ -1,9 +1,10 @@
+import React from 'react';
 import dayjs from 'dayjs';
 import type { DayOfWeek } from '../../../types';
 
 interface GetWeekdaysNamesInput {
   locale: string;
-  format?: string;
+  format?: string | ((date: Date) => React.ReactNode);
   firstDayOfWeek?: DayOfWeek;
 }
 
@@ -13,10 +14,14 @@ export function getWeekdayNames({
   firstDayOfWeek = 1,
 }: GetWeekdaysNamesInput) {
   const baseDate = dayjs().day(firstDayOfWeek);
-  const labels: string[] = [];
+  const labels: Array<string | React.ReactNode> = [];
 
   for (let i = 0; i < 7; i += 1) {
-    labels.push(dayjs(baseDate).add(i, 'days').locale(locale).format(format));
+    if (typeof format === 'string') {
+      labels.push(dayjs(baseDate).add(i, 'days').locale(locale).format(format));
+    } else {
+      labels.push(format(dayjs(baseDate).add(i, 'days').toDate()));
+    }
   }
 
   return labels;

--- a/src/mantine-dates/src/tests/it-supports-weekdays-props.tsx
+++ b/src/mantine-dates/src/tests/it-supports-weekdays-props.tsx
@@ -1,6 +1,7 @@
 import 'dayjs/locale/ru';
 import React from 'react';
 import { screen, render } from '@testing-library/react';
+import dayjs from 'dayjs';
 import { DatesProvider } from '../components/DatesProvider';
 
 export function expectWeekdaysNames(names: string[]) {
@@ -9,7 +10,7 @@ export function expectWeekdaysNames(names: string[]) {
 
 export interface WeekdaysTestProps {
   locale?: string;
-  weekdayFormat?: string;
+  weekdayFormat?: string | ((date: Date) => React.ReactNode);
   firstDayOfWeek?: number;
 }
 
@@ -48,6 +49,13 @@ export function itSupportsWeekdaysProps(
       'Saturday',
       'Sunday',
     ]);
+  });
+
+  it('supports changing weekday format function', () => {
+    render(
+      <Component {...requiredProps} weekdayFormat={(date: Date) => dayjs(date).format('dd')[0]} />
+    );
+    expectWeekdaysNames(['M', 'T', 'W', 'T', 'F', 'S', 'S']);
   });
 
   it('changes weekdays order based on firstDayOfWeek prop', () => {


### PR DESCRIPTION
Extended `weekdayFormat` property to support function, similar to `yeaLabelFormat`. It allows us to either render a custom node or implement a format that does not support by dayJS library, like in our case, where the labels should be just the first letter of the weekday name.