### PR TITLE
[docs] Ensure `PasswordInputDemos.strengthMeter` example is correctly positioned

### DIFF
--- a/docs/src/docs/core/Progress.mdx
+++ b/docs/src/docs/core/Progress.mdx
@@ -52,7 +52,7 @@ In previous examples colors from `theme.colors` were used, but any other css col
 
 Password strength meter example with Progress component:
 
-<Demo data={PasswordInputDemos.strengthMeter} />
+<Demo data={PasswordInputDemos.strengthMeter} demoProps={{ zIndex: 4 }} />
 
 ## With label
 

--- a/src/mantine-ds/src/Demo/types.ts
+++ b/src/mantine-ds/src/Demo/types.ts
@@ -30,6 +30,7 @@ interface MantineDemoBase {
 interface MantineCodeDemo extends MantineDemoBase {
   type: 'demo';
   demoProps?: {
+    zIndex?: React.CSSProperties['zIndex'];
     spacing?: boolean;
     demoBackground?: string;
     toggle?: boolean;


### PR DESCRIPTION
Closes https://github.com/mantinedev/mantine/issues/4101

Before this PR:
![image](https://user-images.githubusercontent.com/35242329/235314455-9781f188-b8b8-4225-897c-388982bf57bd.png)

After this PR:
![image](https://user-images.githubusercontent.com/35242329/235314464-fd7b30c8-0c1a-453a-b60e-dacad66987bb.png)

