### PR TITLE
[@mantine/core] fix multi-select hovered item on last item select

### DIFF
--- a/src/mantine-core/src/MultiSelect/MultiSelect.tsx
+++ b/src/mantine-core/src/MultiSelect/MultiSelect.tsx
@@ -231,7 +231,7 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>((props
   const itemsRefs = useRef<Record<string, HTMLDivElement>>({});
   const uuid = useId(id);
   const [dropdownOpened, setDropdownOpened] = useState(initiallyOpened);
-  const [hovered, setHovered] = useState(-1);
+  const [_hovered, setHovered] = useState(-1);
   const [direction, setDirection] = useState<React.CSSProperties['flexDirection']>('column');
   const [_searchValue, handleSearchChange] = useUncontrolled({
     value: searchValue,
@@ -297,6 +297,8 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>((props
     disableSelectedItemFiltering,
   });
 
+  const hovered = Math.min(_hovered, filteredData.length - 1);
+
   const getNextIndex = (
     index: number,
     nextItem: (index: number) => number,
@@ -356,9 +358,6 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>((props
         if (_value.length === maxSelectedValues - 1) {
           valuesOverflow.current = true;
           setDropdownOpened(false);
-        }
-        if (hovered === filteredData.length - 1) {
-          setHovered(filteredData.length - 2);
         }
         if (filteredData.length === 1) {
           setDropdownOpened(false);


### PR DESCRIPTION
When `disableSelectedItemFiltering` is set to true, selecting the last item will move the focus to the second-to-last instead of keeping it on the last.

This is due to a workaround for selected-item detection needed in normal mode.

This PR changes the workaround: instead of handling it as an edge-case in `handleItemSelect`, I converted it into a rule in the render: `hovered` should never be greater than the last item's index.

This way if the item number does not change on select, the hovered value is not impacted.