### PR TITLE
[@mantine/core] ButtonGroup: Use :first-child and :last-child in css selector instead of :first-of-type and :last-of-type

### DIFF
--- a/src/mantine-core/src/Button/ButtonGroup/ButtonGroup.styles.ts
+++ b/src/mantine-core/src/Button/ButtonGroup/ButtonGroup.styles.ts
@@ -12,7 +12,7 @@ export default createStyles(
       flexDirection: orientation === 'vertical' ? 'column' : 'row',
 
       '& [data-button]': {
-        '&:first-of-type:not(:last-of-type)': {
+        '&:first-child:not(:last-child)': {
           borderBottomRightRadius: 0,
           [orientation === 'vertical' ? 'borderBottomLeftRadius' : 'borderTopRightRadius']: 0,
           [orientation === 'vertical' ? 'borderBottomWidth' : 'borderRightWidth']: `calc(${rem(
@@ -20,7 +20,7 @@ export default createStyles(
           )} / 2)`,
         },
 
-        '&:last-of-type:not(:first-of-type)': {
+        '&:last-child:not(:first-child)': {
           borderTopLeftRadius: 0,
           [orientation === 'vertical' ? 'borderTopRightRadius' : 'borderBottomLeftRadius']: 0,
           [orientation === 'vertical' ? 'borderTopWidth' : 'borderLeftWidth']: `calc(${rem(
@@ -28,7 +28,7 @@ export default createStyles(
           )} / 2)`,
         },
 
-        '&:not(:first-of-type):not(:last-of-type)': {
+        '&:not(:first-child):not(:last-child)': {
           borderRadius: 0,
           [orientation === 'vertical' ? 'borderTopWidth' : 'borderLeftWidth']: `calc(${rem(
             buttonBorderWidth


### PR DESCRIPTION
Pull request for the issue and its proposed fix in #4182

This allows buttons polymorphic buttons with different components to group. E.g. a button with normal button element can group with a button with an a element.



closes #4182