### PR TITLE
[@mantine/core] ColorPicker: Fix rounding in rgba and hex parsing (#4154)

### DIFF
--- a/src/mantine-core/src/ColorPicker/converters/parsers.test.ts
+++ b/src/mantine-core/src/ColorPicker/converters/parsers.test.ts
@@ -1,0 +1,28 @@
+import { parseHex, parseHexa } from './parsers';
+
+describe('@mantine/core/ColorPicker/converters/parsers', () => {
+  it('distinguishly parses nearly identical 24bit hex colors', () => {
+    expect(parseHex('#123456')).not.toStrictEqual(parseHex('#123457'));
+    expect(parseHex('#123456')).not.toStrictEqual(parseHex('#123455'));
+
+    expect(parseHex('#123456')).not.toStrictEqual(parseHex('#123556'));
+    expect(parseHex('#123456')).not.toStrictEqual(parseHex('#123356'));
+
+    expect(parseHex('#123456')).not.toStrictEqual(parseHex('#133456'));
+    expect(parseHex('#123456')).not.toStrictEqual(parseHex('#113456'));
+  });
+
+  it('distinguishly parses nearly identical 32bit hex colors', () => {
+    expect(parseHexa('#12345678')).not.toStrictEqual(parseHexa('#12345679'));
+    expect(parseHexa('#12345678')).not.toStrictEqual(parseHexa('#12345677'));
+
+    expect(parseHexa('#12345678')).not.toStrictEqual(parseHexa('#12345778'));
+    expect(parseHexa('#12345678')).not.toStrictEqual(parseHexa('#12345578'));
+
+    expect(parseHexa('#12345678')).not.toStrictEqual(parseHexa('#12355678'));
+    expect(parseHexa('#12345678')).not.toStrictEqual(parseHexa('#12335678'));
+
+    expect(parseHexa('#12345678')).not.toStrictEqual(parseHexa('#13345678'));
+    expect(parseHexa('#12345678')).not.toStrictEqual(parseHexa('#11345678'));
+  });
+});

--- a/src/mantine-core/src/ColorPicker/converters/parsers.ts
+++ b/src/mantine-core/src/ColorPicker/converters/parsers.ts
@@ -56,9 +56,9 @@ function rgbaToHsva({ r, g, b, a }: RgbaColor): HsvaColor {
     : 0;
 
   return {
-    h: round(60 * (hh < 0 ? hh + 6 : hh)),
-    s: round(max ? (delta / max) * 100 : 0),
-    v: round((max / 255) * 100),
+    h: round(60 * (hh < 0 ? hh + 6 : hh), 3),
+    s: round(max ? (delta / max) * 100 : 0, 3),
+    v: round((max / 255) * 100, 3),
     a,
   };
 }
@@ -86,7 +86,7 @@ export function parseHex(color: string): HsvaColor {
 export function parseHexa(color: string): HsvaColor {
   const hex = color[0] === '#' ? color.slice(1) : color;
 
-  const roundA = (a: string) => Math.round((parseInt(a, 16) / 255) * 100) / 100;
+  const roundA = (a: string) => round(parseInt(a, 16) / 255, 3);
   if (hex.length === 4) {
     const withoutOpacity = hex.slice(0, 3);
     const a = roundA(hex[3] + hex[3]);


### PR DESCRIPTION
Fixes #4154