### PR TITLE
[docs] Update SimpleGrid component docs usage section

### DIFF
--- a/docs/src/docs/core/SimpleGrid.mdx
+++ b/docs/src/docs/core/SimpleGrid.mdx
@@ -16,7 +16,7 @@ import { SimpleGridDemos } from '@mantine/demos';
 
 ## Usage
 
-SimpleGrid is a simple flexbox container where each child is treated as a column.
+SimpleGrid is a simple css grid container where each child is treated as a column.
 Each column takes equal amount of space and unlike [Grid](/core/grid/) component you do not control column span,
 instead you specify number of columns per row:
 


### PR DESCRIPTION
This pr aims to fix the SimpleGrid component docs page issue, which creates confusion about CSS grid and flexbox. 
A detailed explanation can be found in the issue #4203 