### PR TITLE
[@mantine/core] MultiSelect: fix safari display with height 0 in flex

### DIFF
--- a/src/mantine-core/src/MultiSelect/MultiSelect.styles.ts
+++ b/src/mantine-core/src/MultiSelect/MultiSelect.styles.ts
@@ -61,9 +61,9 @@ export default createStyles((theme, { invalid }: MultiSelectStylesParams, { size
   },
 
   searchInputInputHidden: {
+    flex: 0,
     width: 0,
     minWidth: 0,
-    height: 0,
     margin: 0,
     overflow: 'hidden',
   },


### PR DESCRIPTION
Set flex to 0 to hidden the item
fix safari display with height 0 in flex
#4220 