### PR TITLE
[@mantine/core] Rating: fix add custom color

### DIFF
--- a/src/mantine-core/src/Rating/StarSymbol/StarSymbol.styles.ts
+++ b/src/mantine-core/src/Rating/StarSymbol/StarSymbol.styles.ts
@@ -15,7 +15,11 @@ const sizes = {
 
 export default createStyles((theme, { type, color }: StarSymbolStylesParams, { size }) => {
   const emptyColor = theme.colorScheme === 'light' ? theme.colors.gray[3] : theme.colors.gray[8];
-  const fullColor = theme.fn.variant({ variant: 'filled', color, primaryFallback: false }).background;
+  const fullColor = theme.fn.variant({
+    variant: 'filled',
+    color,
+    primaryFallback: false,
+  }).background;
 
   return {
     icon: {

--- a/src/mantine-core/src/Rating/StarSymbol/StarSymbol.styles.ts
+++ b/src/mantine-core/src/Rating/StarSymbol/StarSymbol.styles.ts
@@ -15,7 +15,7 @@ const sizes = {
 
 export default createStyles((theme, { type, color }: StarSymbolStylesParams, { size }) => {
   const emptyColor = theme.colorScheme === 'light' ? theme.colors.gray[3] : theme.colors.gray[8];
-  const fullColor = theme.fn.variant({ variant: 'filled', color }).background;
+  const fullColor = theme.fn.variant({ variant: 'filled', color, primaryFallback: false }).background;
 
   return {
     icon: {


### PR DESCRIPTION
I see the props color desc: Key of theme.colors or any CSS color value, yellow by default
so to fix to get the custom color #4245 