### PR TITLE
Update MantineProvider.tsx

### DIFF
--- a/src/mantine-styles/src/theme/MantineProvider.tsx
+++ b/src/mantine-styles/src/theme/MantineProvider.tsx
@@ -18,6 +18,8 @@ const MantineProviderContext = createContext<MantineProviderContextType>({
   theme: DEFAULT_THEME,
 });
 
+export { MantineProviderContext as UNSAFE_MantineProviderContext };
+
 export function useMantineTheme() {
   return useContext(MantineProviderContext)?.theme || DEFAULT_THEME;
 }


### PR DESCRIPTION
Added an export for `MantineProviderContext`.

Sometimes accessing the MantineProviderContext is needed to make theming Mantine components work in certain reconcilers. (e.g. https://github.com/pmndrs/drei#usecontextbridge)

[react-router](https://github.com/remix-run/react-router/blob/853a9382b748466f9bf1af5c4c7e5571670f8b97/packages/react-router/index.ts#L43) marks their context exports as `UNSAFE_`, so I decided to use this pattern here. 
That said, the react-router guys make sure in their source code how unsafe and breaking using this might be.

Is it still possible to provide this change for using mantine with custom reconcilers?