### PR TITLE
[@mantine/dates]: date-input with time blur fix for 1 char removal

### DIFF
--- a/src/mantine-dates/src/components/DateInput/DateInput.test.tsx
+++ b/src/mantine-dates/src/components/DateInput/DateInput.test.tsx
@@ -300,6 +300,21 @@ describe('@mantine/dates/DateInput', () => {
     expectValue(container, 'April 11, 2022');
   });
 
+  it('Prevents us-iso reformatting on blur when removing 1 character', async () => {
+    const { container } = render(
+      <DateInput
+        {...defaultProps}
+        valueFormat="DD/MM/YYYY HH:mm"
+        defaultValue={new Date(2023, 5, 1, 0, 0, 0)}
+      />
+    );
+    expectValue(container, '01/06/2023 00:00');
+    await userEvent.clear(getInput(container));
+    await userEvent.type(getInput(container), '01/06/2023 00:0');
+    await userEvent.tab();
+    expectValue(container, '01/06/2023 00:00');
+  });
+
   it('supports custom date parser', async () => {
     const { container } = render(
       <DateInput

--- a/src/mantine-dates/src/components/DateInput/DateInput.tsx
+++ b/src/mantine-dates/src/components/DateInput/DateInput.tsx
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import React, { forwardRef, useState, useEffect } from 'react';
 import {
   DefaultProps,
@@ -88,6 +89,8 @@ const defaultProps: Partial<DateInputProps> = {
   size: 'sm',
 };
 
+dayjs.extend(customParseFormat);
+
 export const DateInput = forwardRef<HTMLInputElement, DateInputProps>((props, ref) => {
   const {
     inputProps,
@@ -125,7 +128,8 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>((props, re
   const { calendarProps, others } = pickCalendarProps(rest);
   const ctx = useDatesContext();
   const defaultDateParser = (val: string) => {
-    const parsedDate = dayjs(val, valueFormat, ctx.getLocale(locale)).toDate();
+    dayjs.extend(customParseFormat);
+    const parsedDate = dayjs(val, valueFormat).toDate();
     return Number.isNaN(parsedDate.getTime()) ? dateStringParser(val) : parsedDate;
   };
 

--- a/src/mantine-dates/src/components/DateInput/DateInput.tsx
+++ b/src/mantine-dates/src/components/DateInput/DateInput.tsx
@@ -128,7 +128,6 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>((props, re
   const { calendarProps, others } = pickCalendarProps(rest);
   const ctx = useDatesContext();
   const defaultDateParser = (val: string) => {
-    dayjs.extend(customParseFormat);
     const parsedDate = dayjs(val, valueFormat).toDate();
     return Number.isNaN(parsedDate.getTime()) ? dateStringParser(val) : parsedDate;
   };


### PR DESCRIPTION
Addressing this issue for 1 character removal: https://github.com/mantinedev/mantine/issues/4255

When filling invalid dates, we fall into the `Date(val)` case which may lead to uncontrolled behaviors 