### PR TITLE
[core] NumberInput: Adding ability to compose NumberInput.tsx rightSection with the defau…

### DIFF
--- a/docs/src/docs/core/NumberInput.mdx
+++ b/docs/src/docs/core/NumberInput.mdx
@@ -101,6 +101,12 @@ You can use it to create custom controls:
 
 <Demo data={NumberInputDemos.handlers} />
 
+## Custom RightSection composing with default controls
+
+This requires your right section to have constant width since you have to calculate it and pass it to `rightSectionWidth` prop.
+
+<Demo data={NumberInputDemos.customControls} />
+
 ## Invalid state and error
 
 <Demo data={NumberInputDemos.validation} />

--- a/src/mantine-core/src/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.tsx
@@ -25,7 +25,7 @@ export interface NumberInputProps
   extends DefaultProps<NumberInputStylesNames>,
     Omit<
       React.ComponentPropsWithoutRef<typeof TextInput>,
-      'onChange' | 'value' | 'classNames' | 'styles' | 'type'
+      'onChange' | 'value' | 'classNames' | 'rightSection' | 'styles' | 'type'
     > {
   /** Called when value changes */
   onChange?(value: number | ''): void;
@@ -83,6 +83,9 @@ export interface NumberInputProps
 
   /** Input type, defaults to text */
   type?: 'text' | 'number';
+
+  /** Right section of input, similar to icon but on the right **/
+  rightSection?: React.ReactNode | ((defaultControls)=>React.ReactNode);
 }
 
 const defaultFormatter: Formatter = (value) => value || '';
@@ -446,7 +449,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
       onKeyDown={handleKeyDown}
       onKeyUp={handleKeyUp}
       rightSection={
-        rightSection ||
+        (rightSection && (typeof rightSection === 'function' ? rightSection(controls) : rightSection)) ||
         (disabled || readOnly || hideControls || variant === 'unstyled' ? null : controls)
       }
       rightSectionWidth={

--- a/src/mantine-demos/src/demos/core/NumberInput/NumberInput.demo.customControls.tsx
+++ b/src/mantine-demos/src/demos/core/NumberInput/NumberInput.demo.customControls.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { MantineDemo } from '@mantine/ds';
+import { NumberInput, Box, ActionIcon } from '@mantine/core';
+import { IconRefresh } from '@tabler/icons-react';
+
+const code = `
+import { NumberInput } from '@mantine/core';
+
+function Demo() {
+  return (
+    <>
+      <NumberInput label="You can compose a custom rightSection including default controls" rightSection={(controls) => <><ActionIcon size="xs" variant="subtle" mr="xs"><IconRefresh /></ActionIcon>{controls}</>} rightSectionWidth="3.25rem" />
+    </>
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <Box maw={420} mx="auto">
+      <NumberInput label="You can compose a custom rightSection including default controls" rightSection={(controls) => <><ActionIcon size="xs" variant="subtle" mr="xs"><IconRefresh /></ActionIcon>{controls}</>} rightSectionWidth="3.25rem" />
+    </Box>
+  );
+}
+
+export const customControls: MantineDemo = {
+  type: 'demo',
+  code,
+  component: Demo,
+};

--- a/src/mantine-demos/src/demos/core/NumberInput/index.ts
+++ b/src/mantine-demos/src/demos/core/NumberInput/index.ts
@@ -1,6 +1,7 @@
 export { configurator } from './NumberInput.demo.configurator';
 export { step } from './NumberInput.demo.step';
 export { controls } from './NumberInput.demo.controls';
+export { customControls } from './NumberInput.demo.customControls';
 export { handlers } from './NumberInput.demo.handlers';
 export { validation } from './NumberInput.demo.validation';
 export { disabled } from './NumberInput.demo.disabled';


### PR DESCRIPTION
## Why ?

i would like to be able to add a custom button on the left of the default right controls of Mantine number input, this can be useful in a lot of situation:

- recompute a value from other ones in a complex form with relation between each others.
- refresh a value
- add a randomize button
- For an hour input: switch between UTC and legal time.

## How ?

Simply change the actual API so that rightSection can take both `React.ReactNode` or a function `defaultControls => React.ReactNode` allowing you to compose whatever you want, including the default controls.

## Issues :

One tricky point is the handling of the rightSectionWidth. As its computed by a function by default, composing the rightSection require the developer to keep a constant width and calculate it properly.

