### PR TITLE
Remove extra 'click' text

### DIFF
--- a/src/mantine-demos/src/demos/dates/TimeInput/TimeInput.demo.picker.tsx
+++ b/src/mantine-demos/src/demos/dates/TimeInput/TimeInput.demo.picker.tsx
@@ -15,7 +15,7 @@ function Demo() {
 
   return (
     <TimeInput
-      label="Click click icon to show browser picker"
+      label="Click icon to show browser picker"
       ref={ref}
       rightSection={
         <ActionIcon onClick={() => ref.current.showPicker()}>
@@ -34,7 +34,7 @@ function Demo() {
 
   return (
     <TimeInput
-      label="Click click icon to show browser picker"
+      label="Click icon to show browser picker"
       ref={ref}
       rightSection={
         <ActionIcon onClick={() => ref.current.showPicker()}>


### PR DESCRIPTION
The `TimeInput` demo had "Click" twice in the text. This PR removes the extra "click" text.