### PR TITLE
[@mantine/core] AppShell: Fix wrong padding when `navbarOffsetBreakpoint` and `asideOffsetBreakpoint` have the same value

### DIFF
--- a/src/mantine-core/src/AppShell/AppShell.styles.ts
+++ b/src/mantine-core/src/AppShell/AppShell.styles.ts
@@ -34,13 +34,12 @@ function getPositionStyles(props: AppShellStylesParams, theme: MantineTheme): CS
   const asideBreakpointValue = getBreakpointValue(asideOffset);
 
   return {
-    ...{
-      minHeight: '100vh',
-      paddingTop: `calc(var(--mantine-header-height, 0px) + ${padding})`,
-      paddingBottom: `calc(var(--mantine-footer-height, 0px) + ${padding})`,
-      paddingLeft: `calc(var(--mantine-navbar-width, 0px) + ${padding})`,
-      paddingRight: `calc(var(--mantine-aside-width, 0px) + ${padding})`,
-    },
+    minHeight: '100vh',
+    paddingTop: `calc(var(--mantine-header-height, 0px) + ${padding})`,
+    paddingBottom: `calc(var(--mantine-footer-height, 0px) + ${padding})`,
+    paddingLeft: `calc(var(--mantine-navbar-width, 0px) + ${padding})`,
+    paddingRight: `calc(var(--mantine-aside-width, 0px) + ${padding})`,
+
     ...(navbarBreakpointValue === asideBreakpointValue
       ? {
           [`@media (max-width: ${em(navbarBreakpointValue - 1)})`]: {

--- a/src/mantine-core/src/AppShell/AppShell.styles.ts
+++ b/src/mantine-core/src/AppShell/AppShell.styles.ts
@@ -30,20 +30,33 @@ function getPositionStyles(props: AppShellStylesParams, theme: MantineTheme): CS
     return { padding };
   }
 
+  const navbarBreakpointValue = getBreakpointValue(navbarOffset);
+  const asideBreakpointValue = getBreakpointValue(asideOffset);
+
   return {
-    minHeight: '100vh',
-    paddingTop: `calc(var(--mantine-header-height, 0px) + ${padding})`,
-    paddingBottom: `calc(var(--mantine-footer-height, 0px) + ${padding})`,
-    paddingLeft: `calc(var(--mantine-navbar-width, 0px) + ${padding})`,
-    paddingRight: `calc(var(--mantine-aside-width, 0px) + ${padding})`,
-
-    [`@media (max-width: ${em(getBreakpointValue(navbarOffset) - 1)})`]: {
-      paddingLeft: padding,
+    ...{
+      minHeight: '100vh',
+      paddingTop: `calc(var(--mantine-header-height, 0px) + ${padding})`,
+      paddingBottom: `calc(var(--mantine-footer-height, 0px) + ${padding})`,
+      paddingLeft: `calc(var(--mantine-navbar-width, 0px) + ${padding})`,
+      paddingRight: `calc(var(--mantine-aside-width, 0px) + ${padding})`,
     },
+    ...(navbarBreakpointValue === asideBreakpointValue
+      ? {
+          [`@media (max-width: ${em(navbarBreakpointValue - 1)})`]: {
+            paddingLeft: padding,
+            paddingRight: padding,
+          },
+        }
+      : {
+          [`@media (max-width: ${em(navbarBreakpointValue - 1)})`]: {
+            paddingLeft: padding,
+          },
 
-    [`@media (max-width: ${em(getBreakpointValue(asideOffset) - 1)})`]: {
-      paddingRight: padding,
-    },
+          [`@media (max-width: ${em(asideBreakpointValue - 1)})`]: {
+            paddingRight: padding,
+          },
+        }),
   };
 }
 


### PR DESCRIPTION
When the `navbarOffsetBreakpoint` and `asideOffsetBreakpoint` values in the `AppShell` component are set to the same value, only the aside padding is correctly overridden with `padding-right: 1rem`.

![style](https://github.com/mantinedev/mantine/assets/22608727/5ab50624-60dd-4fb8-bce5-af7adf64f787)

Therefore, I have made adjustments to ensure that `padding-left: 1rem;` is correctly applied as well. With this change, both the aside and navbar will have the intended padding.

Fixes #4269 