### PR TITLE
[docs] Fix typo in Style props page

### DIFF
--- a/docs/src/docs/styles/style-props.mdx
+++ b/docs/src/docs/styles/style-props.mdx
@@ -91,7 +91,7 @@ Responsive values are calculated the following way:
 ```tsx
 import { Box } from '@mantine/core';
 
-<Box w={{ base: 320, sm: 480, lg: 640 }}} />
+<Box w={{ base: 320, sm: 480, lg: 640 }} />
 ```
 
 In this case the element will have the following styles:


### PR DESCRIPTION
I removed an extra closing brace `}` that was present.