### PR TITLE
[docs] Add pnpm and refactor out PackageInstallation

### DIFF
--- a/docs/src/components/PackageInstallation/PackageInstallation.tsx
+++ b/docs/src/components/PackageInstallation/PackageInstallation.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { rem } from '@mantine/core';
+import { Prism } from '@mantine/prism';
+import { NpmIcon, PnpmIcon, YarnIcon } from '@mantine/ds';
+
+const packageManagerPrefixes = new Map([
+  ['yarn', 'yarn add'],
+  ['npm', 'npm install'],
+  ['pnpm', 'pnpm i'],
+]);
+
+function getInstallationCommand(packages: string[], type: 'yarn' | 'npm' | 'pnpm') {
+  const prefix = packageManagerPrefixes.get(type);
+  const packagesString = packages.join(' ');
+  return `${prefix} ${packagesString}`;
+}
+
+interface PackageInstallationProps {
+  packages?: string[];
+}
+
+export function PackageInstallation({ packages = [] }: PackageInstallationProps) {
+  return (
+    <Prism.Tabs defaultValue="yarn" styles={{ tabIcon: { marginRight: `${rem(12)} !important` } }}>
+      <Prism.TabsList>
+        <Prism.Tab value="yarn" icon={<YarnIcon size={16} />}>
+          yarn
+        </Prism.Tab>
+        <Prism.Tab value="npm" icon={<NpmIcon size={16} />}>
+          npm
+        </Prism.Tab>
+        <Prism.Tab value="pnpm" icon={<PnpmIcon size={16} />}>
+          pnpm
+        </Prism.Tab>
+      </Prism.TabsList>
+
+      <Prism.Panel value="yarn" language="bash">
+        {getInstallationCommand(packages, 'yarn')}
+      </Prism.Panel>
+      <Prism.Panel value="npm" language="bash">
+        {getInstallationCommand(packages, 'npm')}
+      </Prism.Panel>
+      <Prism.Panel value="pnpm" language="bash">
+        {getInstallationCommand(packages, 'pnpm')}
+      </Prism.Panel>
+    </Prism.Tabs>
+  );
+}

--- a/docs/src/components/PackagesInstallation/PackagesInstallation.tsx
+++ b/docs/src/components/PackagesInstallation/PackagesInstallation.tsx
@@ -1,31 +1,7 @@
 import React, { useState } from 'react';
-import { Table, Checkbox, Code, Text, Box, rem } from '@mantine/core';
-import { Prism } from '@mantine/prism';
-import { NpmIcon, PnpmIcon, YarnIcon } from '@mantine/ds';
+import { Table, Checkbox, Code, Text, Box } from '@mantine/core';
 import { PACKAGES_DATA } from './data';
-
-const packageManagerPrefixes = new Map([
-  ['yarn', 'yarn add'],
-  ['npm', 'npm install'],
-  ['pnpm', 'pnpm i'],
-]);
-
-function getInstallationCommand(
-  selection: string[],
-  extraPackages: string[],
-  type: 'yarn' | 'npm' | 'pnpm'
-) {
-  const packages = selection.reduce<string[]>((acc, item) => {
-    acc.push(...PACKAGES_DATA.find((i) => i.package === item).dependencies);
-    return acc;
-  }, []);
-
-  const unique = Array.from(
-    new Set(['@mantine/core', '@mantine/hooks', ...packages, ...extraPackages, '@emotion/react'])
-  );
-  const prefix = packageManagerPrefixes.get(type);
-  return `${prefix} ${unique.join(' ')}`;
-}
+import { PackageInstallation } from '../PackageInstallation/PackageInstallation';
 
 interface PackagesInstallationProps {
   extraPackages?: string[];
@@ -98,32 +74,7 @@ export function PackagesInstallation({ extraPackages = [] }: PackagesInstallatio
         Install dependencies:
       </Box>
 
-      <Prism.Tabs
-        defaultValue="yarn"
-        styles={{ tabIcon: { marginRight: `${rem(12)} !important` } }}
-      >
-        <Prism.TabsList>
-          <Prism.Tab value="yarn" icon={<YarnIcon size={16} />}>
-            yarn
-          </Prism.Tab>
-          <Prism.Tab value="npm" icon={<NpmIcon size={16} />}>
-            npm
-          </Prism.Tab>
-          <Prism.Tab value="pnpm" icon={<PnpmIcon size={16} />}>
-            pnpm
-          </Prism.Tab>
-        </Prism.TabsList>
-
-        <Prism.Panel value="yarn" language="bash">
-          {getInstallationCommand(selection, extraPackages, 'yarn')}
-        </Prism.Panel>
-        <Prism.Panel value="npm" language="bash">
-          {getInstallationCommand(selection, extraPackages, 'npm')}
-        </Prism.Panel>
-        <Prism.Panel value="pnpm" language="bash">
-          {getInstallationCommand(selection, extraPackages, 'pnpm')}
-        </Prism.Panel>
-      </Prism.Tabs>
+      <PackageInstallation packages={[...selection, ...extraPackages]} />
     </>
   );
 }

--- a/docs/src/components/PackagesInstallation/PackagesInstallation.tsx
+++ b/docs/src/components/PackagesInstallation/PackagesInstallation.tsx
@@ -1,13 +1,19 @@
 import React, { useState } from 'react';
 import { Table, Checkbox, Code, Text, Box, rem } from '@mantine/core';
 import { Prism } from '@mantine/prism';
-import { NpmIcon, YarnIcon } from '@mantine/ds';
+import { NpmIcon, PnpmIcon, YarnIcon } from '@mantine/ds';
 import { PACKAGES_DATA } from './data';
+
+const packageManagerPrefixes = new Map([
+  ['yarn', 'yarn add'],
+  ['npm', 'npm install'],
+  ['pnpm', 'pnpm i'],
+]);
 
 function getInstallationCommand(
   selection: string[],
   extraPackages: string[],
-  type: 'yarn' | 'npm'
+  type: 'yarn' | 'npm' | 'pnpm'
 ) {
   const packages = selection.reduce<string[]>((acc, item) => {
     acc.push(...PACKAGES_DATA.find((i) => i.package === item).dependencies);
@@ -17,7 +23,7 @@ function getInstallationCommand(
   const unique = Array.from(
     new Set(['@mantine/core', '@mantine/hooks', ...packages, ...extraPackages, '@emotion/react'])
   );
-  const prefix = type === 'yarn' ? 'yarn add' : 'npm install';
+  const prefix = packageManagerPrefixes.get(type);
   return `${prefix} ${unique.join(' ')}`;
 }
 
@@ -103,6 +109,9 @@ export function PackagesInstallation({ extraPackages = [] }: PackagesInstallatio
           <Prism.Tab value="npm" icon={<NpmIcon size={16} />}>
             npm
           </Prism.Tab>
+          <Prism.Tab value="pnpm" icon={<PnpmIcon size={16} />}>
+            pnpm
+          </Prism.Tab>
         </Prism.TabsList>
 
         <Prism.Panel value="yarn" language="bash">
@@ -110,6 +119,9 @@ export function PackagesInstallation({ extraPackages = [] }: PackagesInstallatio
         </Prism.Panel>
         <Prism.Panel value="npm" language="bash">
           {getInstallationCommand(selection, extraPackages, 'npm')}
+        </Prism.Panel>
+        <Prism.Panel value="pnpm" language="bash">
+          {getInstallationCommand(selection, extraPackages, 'pnpm')}
         </Prism.Panel>
       </Prism.Tabs>
     </>

--- a/docs/src/docs/form/use-form.mdx
+++ b/docs/src/docs/form/use-form.mdx
@@ -11,23 +11,14 @@ source: 'mantine-form/src'
 license: MIT
 ---
 
+import { PackageInstallation } from '../../components/PackageInstallation/PackageInstallation';
 import { FormDemos } from '@mantine/demos';
 
 ## Installation
 
 `@mantine/form` package does not depend on any other libraries, you can use it with or without `@mantine/core` inputs:
 
-Install with npm:
-
-```bash
-npm install @mantine/form
-```
-
-Install with yarn:
-
-```bash
-yarn add @mantine/form
-```
+<PackageInstallation packages={['@mantine/form']} />
 
 ## Usage
 

--- a/docs/src/docs/guides/ssr.mdx
+++ b/docs/src/docs/guides/ssr.mdx
@@ -5,6 +5,8 @@ slug: /guides/ssr/
 search: 'General approach to SSR'
 ---
 
+import { PackageInstallation } from '../../components/PackageInstallation/PackageInstallation';
+
 # Server side rendering
 
 This guide covers server side rendering with custom server, [Next.js](/guides/next/) and [Gatsby](/guides/gatsby/)
@@ -12,11 +14,7 @@ usage guides are available separately.
 
 1. Install `@mantine/ssr` package
 
-```bash
-yarn add @mantine/ssr
-
-npm install @mantine/ssr
-```
+<PackageInstallation packages={['@mantine/ssr']} />
 
 2. Create `App` component with `MantineProvider`
 

--- a/docs/src/docs/others/dropzone.mdx
+++ b/docs/src/docs/others/dropzone.mdx
@@ -23,23 +23,14 @@ import {
   MS_EXCEL_MIME_TYPE,
   MS_POWERPOINT_MIME_TYPE,
 } from '@mantine/dropzone';
+import { PackageInstallation } from '../../components/PackageInstallation/PackageInstallation';
 import { DropzoneDemos } from '@mantine/demos';
 
 ## Installation
 
 Package depends on `@mantine/core` and `@mantine/hooks`.
 
-Install with yarn:
-
-```bash
-yarn add @mantine/dropzone
-```
-
-Install with npm:
-
-```bash
-npm install @mantine/dropzone
-```
+<PackageInstallation packages={['@mantine/dropzone']} />
 
 ## Usage
 

--- a/docs/src/docs/others/modals.mdx
+++ b/docs/src/docs/others/modals.mdx
@@ -13,23 +13,14 @@ installation: '@mantine/modals'
 license: MIT
 ---
 
+import { PackageInstallation } from '../../components/PackageInstallation/PackageInstallation';
 import { ModalsDemos } from '@mantine/demos';
 
 ## Installation
 
 Package depends on `@mantine/core` and `@mantine/hooks`.
 
-Install with yarn:
-
-```bash
-yarn add @mantine/modals
-```
-
-Install with npm:
-
-```bash
-npm install @mantine/modals
-```
+<PackageInstallation packages={['@mantine/modals']} />
 
 ## Setup ModalsProvider
 

--- a/docs/src/docs/others/notifications.mdx
+++ b/docs/src/docs/others/notifications.mdx
@@ -13,23 +13,14 @@ installation: '@mantine/notifications'
 license: MIT
 ---
 
+import { PackageInstallation } from '../../components/PackageInstallation/PackageInstallation';
 import { NotificationDemos, NotificationsDemos } from '@mantine/demos';
 
 ## Installation
 
 Package depends on `@mantine/core` and `@mantine/hooks`.
 
-Install with yarn:
-
-```bash
-yarn add @mantine/notifications
-```
-
-Install with npm:
-
-```bash
-npm install @mantine/notifications
-```
+<PackageInstallation packages={['@mantine/notifications']} />
 
 ## Demo
 

--- a/docs/src/docs/others/nprogress.mdx
+++ b/docs/src/docs/others/nprogress.mdx
@@ -13,23 +13,14 @@ installation: '@mantine/nprogress'
 license: MIT
 ---
 
+import { PackageInstallation } from '../../components/PackageInstallation/PackageInstallation';
 import { NProgressDemos } from '@mantine/demos';
 
 ## Installation
 
 Package depends on `@mantine/core` and `@mantine/hooks`.
 
-Install with yarn:
-
-```bash
-yarn add @mantine/nprogress
-```
-
-Install with npm:
-
-```bash
-npm install @mantine/nprogress
-```
+<PackageInstallation packages={['@mantine/nprogress']} />
 
 ## Setup NavigationProgress
 

--- a/docs/src/docs/others/prism.mdx
+++ b/docs/src/docs/others/prism.mdx
@@ -14,23 +14,14 @@ license: MIT
 styles: ['Prism', 'PrismTabs']
 ---
 
+import { PackageInstallation } from '../../components/PackageInstallation/PackageInstallation';
 import { PrismDemos } from '@mantine/demos';
 
 ## Installation
 
 Package depends on `@mantine/core` and `@mantine/hooks`.
 
-Install with yarn:
-
-```bash
-yarn add @mantine/prism
-```
-
-Install with npm:
-
-```bash
-npm install @mantine/prism
-```
+<PackageInstallation packages={['@mantine/prism']} />
 
 ## Usage
 

--- a/docs/src/docs/others/spotlight.mdx
+++ b/docs/src/docs/others/spotlight.mdx
@@ -14,23 +14,14 @@ license: MIT
 styles: ['SpotlightProvider']
 ---
 
+import { PackageInstallation } from '../../components/PackageInstallation/PackageInstallation';
 import { SpotlightDemos } from '@mantine/demos';
 
 ## Installation
 
 Package depends on `@mantine/core` and `@mantine/hooks`.
 
-Install with yarn:
-
-```bash
-yarn add @mantine/spotlight
-```
-
-Install with npm:
-
-```bash
-npm install @mantine/spotlight
-```
+<PackageInstallation packages={['@mantine/spotlight']} />
 
 ## Usage
 

--- a/docs/src/docs/others/tiptap.mdx
+++ b/docs/src/docs/others/tiptap.mdx
@@ -14,21 +14,23 @@ license: MIT
 styles: ['RichTextEditor']
 ---
 
+import { PackageInstallation } from '../../components/PackageInstallation/PackageInstallation';
 import { TipTapDemos } from '@mantine/demos';
 
 ## Installation
 
-Install with yarn:
-
-```bash
-yarn add @mantine/tiptap @mantine/core @mantine/hooks @tabler/icons-react @tiptap/react @tiptap/pm @tiptap/extension-link @tiptap/starter-kit
-```
-
-Install with npm:
-
-```bash
-npm install @mantine/tiptap @mantine/core @mantine/hooks @tabler/icons-react @tiptap/react @tiptap/pm @tiptap/extension-link @tiptap/starter-kit
-```
+<PackageInstallation
+  packages={[
+    '@mantine/tiptap',
+    '@mantine/core',
+    '@mantine/hooks',
+    '@tabler/icons-react',
+    '@tiptap/react',
+    '@tiptap/pm',
+    '@tiptap/extension-link',
+    '@tiptap/starter-kit',
+  ]}
+/>
 
 ## TipTap editor
 
@@ -51,13 +53,7 @@ you should look for documentation on [tiptap.dev](https://tiptap.dev/) website.
 Some controls require installation of additional [Tiptap extensions](https://tiptap.dev/extensions).
 For example, if you want to use `RichTextEditor.Underline` control, you will need to install `@tiptap/extension-underline` package:
 
-```bash
-yarn add @tiptap/extension-underline
-```
-
-```bash
-npm install @tiptap/extension-underline
-```
+<PackageInstallation packages={['@tiptap/extension-underline']} />
 
 Included with `@tiptap/starter-kit` (should be installed by default):
 
@@ -107,13 +103,7 @@ Other controls with required extensions:
 
 To use placeholder you will need to install [@tiptap/extension-placeholder](https://www.npmjs.com/package/@tiptap/extension-placeholder) package:
 
-```bash
-yarn add @tiptap/extension-placeholder
-```
-
-```bash
-npm install @tiptap/extension-placeholder
-```
+<PackageInstallation packages={['@tiptap/extension-placeholder']} />
 
 <Demo data={TipTapDemos.placeholder} />
 
@@ -143,13 +133,7 @@ function Demo() {
 
 To use text color you will need to install additional packages:
 
-```bash
-yarn add @tiptap/extension-color @tiptap/extension-text-style
-```
-
-```bash
-npm install @tiptap/extension-color @tiptap/extension-text-style
-```
+<PackageInstallation packages={['@tiptap/extension-color', '@tiptap/extension-text-style']} />
 
 You can use the following controls to change text color:
 
@@ -163,13 +147,7 @@ You can use the following controls to change text color:
 
 To use code highlight you will need to install additional packages:
 
-```bash
-yarn add lowlight @tiptap/extension-code-block-lowlight
-```
-
-```bash
-npm install lowlight @tiptap/extension-code-block-lowlight
-```
+<PackageInstallation packages={['lowlight', '@tiptip/extension-code-block-lowlight']} />
 
 <Demo data={TipTapDemos.codeHighlight} />
 

--- a/docs/src/docs/pages/about.mdx
+++ b/docs/src/docs/pages/about.mdx
@@ -3,6 +3,7 @@ title: About Mantine
 ---
 
 import { MantineLogoDemos } from '@mantine/demos';
+import { PackageInstallation } from '../../components/PackageInstallation/PackageInstallation';
 import { LogoAssets } from '../../components/LogoAssets/LogoAssets.tsx';
 
 # About Mantine
@@ -69,10 +70,6 @@ Download Mantine logos in `.svg` format:
 
 You can also install `@mantine/ds` package and import `MantineLogo` component:
 
-```bash
-yarn add @mantine/ds
-
-npm install @mantine/ds
-```
+<PackageInstallation packages={['@mantine/ds']} />
 
 <Demo data={MantineLogoDemos.configurator} />

--- a/docs/src/docs/styles/styled.mdx
+++ b/docs/src/docs/styles/styled.mdx
@@ -6,21 +6,16 @@ order: 5
 search: 'Add styles to components with styled components syntax'
 ---
 
+import { PackageInstallation } from '../../components/PackageInstallation/PackageInstallation';
 import { StyledDemos } from '@mantine/demos';
 
 ## Installation
 
 To use styled components syntax, install [@emotion/styled package](https://emotion.sh/docs/styled):
 
-```bash
-yarn add @emotion/styled
-```
+<PackageInstallation packages={['@emotion/styled']} />
 
-```bash
-npm install @emotion/styled
-```
-
-**!important** You will need to wrap your application with [MantineProvider](/theming/mantine-provider/)
+**Important:** You will need to wrap your application with [MantineProvider](/theming/mantine-provider/)
 to access [theme](/theming/theme-object/) in styles.
 
 ```tsx

--- a/src/mantine-ds/src/Icons/Icons.story.tsx
+++ b/src/mantine-ds/src/Icons/Icons.story.tsx
@@ -4,6 +4,7 @@ import { GithubIcon } from './GithubIcon';
 import { TwitterIcon } from './TwitterIcon';
 import { NpmIcon } from './NpmIcon';
 import { YarnIcon } from './YarnIcon';
+import { PnpmIcon } from './PnpmIcon';
 
 export default { title: 'DS/Icons' };
 
@@ -15,6 +16,7 @@ export function Usage() {
       <TwitterIcon size={40} />
       <NpmIcon size={40} />
       <YarnIcon size={40} />
+      <PnpmIcon size={40} />
     </div>
   );
 }

--- a/src/mantine-ds/src/Icons/PnpmIcon.tsx
+++ b/src/mantine-ds/src/Icons/PnpmIcon.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { rem } from '@mantine/core';
+
+interface PnpmIconProps extends React.ComponentPropsWithoutRef<'svg'> {
+  size?: number | string;
+}
+
+export function PnpmIcon({ size, ...others }: PnpmIconProps) {
+  return (
+    <svg
+      {...others}
+      width={rem(size)}
+      height={rem(size)}
+      viewBox="0 0 32 32"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>file_type_pnpm</title>
+      <path d="M30,10.75H21.251V2H30Z" style={{ fill: '#f9ad00' }} />
+      <path d="M20.374,10.75h-8.75V2h8.75Z" style={{ fill: '#f9ad00' }} />
+      <path d="M10.749,10.75H2V2h8.749Z" style={{ fill: '#f9ad00' }} />
+      <path d="M30,20.375H21.251v-8.75H30Z" style={{ fill: '#f9ad00' }} />
+      <path d="M20.374,20.375h-8.75v-8.75h8.75Z" style={{ fill: '#fff' }} />
+      <path d="M20.374,30h-8.75V21.25h8.75Z" style={{ fill: '#fff' }} />
+      <path d="M30,30H21.251V21.25H30Z" style={{ fill: '#fff' }} />
+      <path d="M10.749,30H2V21.25h8.749Z" style={{ fill: '#fff' }} />
+    </svg>
+  );
+}

--- a/src/mantine-ds/src/Icons/index.ts
+++ b/src/mantine-ds/src/Icons/index.ts
@@ -3,3 +3,4 @@ export { TwitterIcon } from './TwitterIcon';
 export { GithubIcon } from './GithubIcon';
 export { NpmIcon } from './NpmIcon';
 export { YarnIcon } from './YarnIcon';
+export { PnpmIcon } from './PnpmIcon';


### PR DESCRIPTION
Adds `pnpm` to the tab list of package managers via the `PackagesInstallation.tsx` component.
![image](https://github.com/mantinedev/mantine/assets/11603625/df045e3d-e40d-452b-8507-35f7c221847a)

Have also refactored a `PackageInstallation` component out of `PackagesInstallation`, for use across the wider MDX docs files for any given package(s).