### PR TITLE
[@mantine/core] PinInput: shift focus to prev element on backspace

### DIFF
--- a/src/mantine-core/src/PinInput/PinInput.test.tsx
+++ b/src/mantine-core/src/PinInput/PinInput.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   checkAccessibility,
   itDisablesInputInsideDisabledFieldset,
@@ -37,5 +38,41 @@ describe('@mantine/core/PinInput', () => {
     });
 
     expect(spy).toHaveBeenCalledWith('1111');
+  });
+
+  it('stay focused on last element on initial backspace press', async () => {
+    const { container } = render(<PinInput {...defaultProps} length={5} />);
+    expect(container.querySelectorAll('.mantine-PinInput-input')).toHaveLength(5);
+
+    container.querySelectorAll('.mantine-PinInput-input').forEach((element, key) => {
+      fireEvent.change(element, { target: { value: key } });
+    });
+
+    await userEvent.keyboard('{Backspace}');
+    expect(container.querySelectorAll('.mantine-PinInput-input')[4]).toHaveFocus();
+  });
+
+  it('inputs except the last element should not need two backspace press to shift focus to prev element', async () => {
+    const { container } = render(<PinInput {...defaultProps} length={5} />);
+    expect(container.querySelectorAll('.mantine-PinInput-input')).toHaveLength(5);
+
+    container.querySelectorAll('.mantine-PinInput-input').forEach((element, key) => {
+      fireEvent.change(element, { target: { value: key } });
+    });
+
+    await userEvent.keyboard('{Backspace}');
+    expect(container.querySelectorAll('.mantine-PinInput-input')[4]).toHaveFocus();
+
+    await userEvent.keyboard('{Backspace}');
+    expect(container.querySelectorAll('.mantine-PinInput-input')[3]).toHaveFocus();
+
+    await userEvent.keyboard('{Backspace}');
+    expect(container.querySelectorAll('.mantine-PinInput-input')[2]).toHaveFocus();
+
+    await userEvent.keyboard('{Backspace}');
+    expect(container.querySelectorAll('.mantine-PinInput-input')[1]).toHaveFocus();
+
+    await userEvent.keyboard('{Backspace}');
+    expect(container.querySelectorAll('.mantine-PinInput-input')[0]).toHaveFocus();
   });
 });

--- a/src/mantine-core/src/PinInput/PinInput.tsx
+++ b/src/mantine-core/src/PinInput/PinInput.tsx
@@ -215,9 +215,11 @@ export const PinInput = forwardRef<HTMLDivElement, PinInputProps>((props, ref) =
       setFieldValue('', index);
     } else if (event.key === 'Backspace') {
       event.preventDefault();
-
-      if ((event.target as HTMLInputElement).value !== '') {
-        setFieldValue('', index);
+      setFieldValue('', index);
+      if (length === index + 1) {
+        if ((event.target as HTMLInputElement).value === '') {
+          focusInputField('prev', index);
+        }
       } else {
         focusInputField('prev', index);
       }


### PR DESCRIPTION
This fixes https://github.com/mantinedev/mantine/issues/4432

### Scenarios:
- If the focus is on the last element and there is a value, hitting the backspace will remove the value and stay focused on that element.
- If the focus is on the last element and there is no value, hitting the backspace will shift the focus to the previous element.
- If the focus is on any input element except the last element, hitting the backspace will remove the value and shift the focus to the previous element. 

https://github.com/mantinedev/mantine/assets/45745778/eb125f31-00f0-40e8-ae09-d4861ced90d2

