### PR TITLE
Update use-clipboard.ts/Copying error on some devices

### DIFF
--- a/src/mantine-hooks/src/use-clipboard/use-clipboard.ts
+++ b/src/mantine-hooks/src/use-clipboard/use-clipboard.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { useState } from 'react';
 
 export function useClipboard({ timeout = 2000 } = {}) {

--- a/src/mantine-hooks/src/use-clipboard/use-clipboard.ts
+++ b/src/mantine-hooks/src/use-clipboard/use-clipboard.ts
@@ -11,12 +11,24 @@ export function useClipboard({ timeout = 2000 } = {}) {
     setCopied(value);
   };
 
-  const copy = (valueToCopy: any) => {
+  const copy = async (valueToCopy: any) => {
     if ('clipboard' in navigator) {
-      navigator.clipboard
-        .writeText(valueToCopy)
-        .then(() => handleCopyResult(true))
-        .catch((err) => setError(err));
+      try {
+        await navigator.clipboard.writeText(valueToCopy);
+        handleCopyResult(true);
+      } catch (error) {
+        try {
+          const textArea = document.createElement('textarea');
+          textArea.value = valueToCopy;
+          document.body.appendChild(textArea);
+          textArea.select();
+          document.execCommand('copy');
+          document.body.removeChild(textArea);
+          handleCopyResult(true);
+        } catch {
+          setError(error);
+        }
+      }
     } else {
       setError(new Error('useClipboard: navigator.clipboard is not supported'));
     }


### PR DESCRIPTION
On some devices it is not possible to copy the value with navigator.clipboard.writeText(), for example on Apple devices. Sometimes it is not possible to copy a value while working in coding sandboxes.

I propose a solution that increases the probability that the value will be copied. To do this, I've added double error handling, just in case navigator.clipboard.writeText() fails, then the code will automatically run the second option to copy the value.