### PR TITLE
[@mantine/prism] Prism: use higher specificity for pre element margin

### DIFF
--- a/src/mantine-prism/src/Prism/Prism.styles.ts
+++ b/src/mantine-prism/src/Prism/Prism.styles.ts
@@ -24,8 +24,11 @@ export default createStyles(
       overflowX: native ? 'auto' : undefined,
       borderRadius: theme.fn.radius(radius),
       padding: `${theme.spacing.sm} 0`,
-      marginTop: 0,
-      marginBottom: 0,
+
+      '&.mantine-Prism-code': {
+        marginTop: 0,
+        marginBottom: 0,
+      },
     },
 
     copy: {

--- a/src/mantine-prism/src/Prism/Prism.test.tsx
+++ b/src/mantine-prism/src/Prism/Prism.test.tsx
@@ -36,4 +36,12 @@ describe('@mantine/prism/Prism', () => {
     );
     expect(withoutLineNumbers.querySelectorAll('.mantine-Prism-lineNumber')).toHaveLength(0);
   });
+
+  it('renders pre element without top and bottom margin', () => {
+    const { container: prism } = render(<Prism {...defaultProps} />);
+    expect(prism.querySelector('.mantine-Prism-code')).toHaveStyle({
+      marginTop: 0,
+      marginBottom: 0,
+    });
+  });
 });


### PR DESCRIPTION
This fixes https://github.com/mantinedev/mantine/issues/4429

Wrapping Prism within a `TypographyStylesProvider` that has a selector with the margin values:
```
<class> pre: {
  marginTop: theme.spacing.md,
  marginBottom: theme.spacing.md
}
```
has a higher specificity than Prism's selector with the margin set to 0
```
code: {
  .......
  marginTop: 0,
  marginBottom: 0
}
```
this causes the margin styles from `TypographyStylesProvider` to be utilized by Prism's `pre` element and causes the copy button to move higher than it's normal position. 