### PR TITLE
[@mantine/dates] PickerInputBase: Pass input error/invalid state to Input.Placeholder

### DIFF
--- a/src/mantine-dates/src/components/PickerInputBase/PickerInputBase.tsx
+++ b/src/mantine-dates/src/components/PickerInputBase/PickerInputBase.tsx
@@ -179,7 +179,12 @@ export const PickerInputBase = forwardRef<HTMLButtonElement, PickerInputBaseProp
               {...others}
             >
               {formattedValue || (
-                <Input.Placeholder className={classes.placeholder}>{placeholder}</Input.Placeholder>
+                <Input.Placeholder
+                  className={classes.placeholder}
+                  sx={{ color: inputProps.error ? 'inherit' : undefined }}
+                >
+                  {placeholder}
+                </Input.Placeholder>
               )}
             </Input>
           </Popover.Target>


### PR DESCRIPTION
This fixes #4467 by passing `inputProps.error` to `Input.Placeholder` to match the placeholder color.