### PR TITLE
[@mantine/dates] DateInput: clear input value on clearButton click

### DIFF
--- a/src/mantine-dates/src/components/DateInput/DateInput.tsx
+++ b/src/mantine-dates/src/components/DateInput/DateInput.tsx
@@ -220,6 +220,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>((props, re
         onClick={() => {
           setValue(null);
           !controlled && setInputValue('');
+          setDropdownOpened(false);
         }}
         unstyled={unstyled}
         {...clearButtonProps}


### PR DESCRIPTION
This fixes https://github.com/mantinedev/mantine/issues/4481.

When `Calendar Dropdown` is open then the user clicks on the `clear` button, the following code won't run causing the input value to not be cleared. 

```
useDidUpdate(() => {
    value !== undefined && !dropdownOpened && setInputValue(formatValue(value));
  }, [value]);
```

So when user clicks on the `clear` button we also closes the `Calendar Dropdown` which fixes the issue. 


As other `Date` components, clicking the `clear` button closes the `Calendar Dropdown`, this should also make the behavior consistent across components.