### PR TITLE
[@mantine/core] Slider: Fix onChange prop updates being ignored

### DIFF
--- a/src/mantine-core/src/Slider/Slider/Slider.tsx
+++ b/src/mantine-core/src/Slider/Slider/Slider.tsx
@@ -179,7 +179,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
         valueRef.current = nextValue;
       }
     },
-    [disabled, min, max, step, precision]
+    [disabled, min, max, step, precision, setValue]
   );
 
   const { ref: container, active } = useMove(


### PR DESCRIPTION
When updating the "onChange" property of a slider, the change was ignored and the old property was still used. This was caused by not adding the "setValue" to the dependency array.