### PR TITLE
[@mantine/core] Spoiler: Fix control button flickering on rerender

### DIFF
--- a/src/mantine-core/src/SegmentedControl/SegmentedControl.tsx
+++ b/src/mantine-core/src/SegmentedControl/SegmentedControl.tsx
@@ -148,6 +148,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
   const uuid = useId(name);
   const refs = useRef<Record<string, HTMLLabelElement>>({});
   const [observerRef, containerRect] = useResizeObserver();
+  const rootRef = useRef<HTMLDivElement>(null);
 
   useIsomorphicEffect(() => {
     if (!mounted.current) {
@@ -159,7 +160,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
   });
 
   useEffect(() => {
-    if (_value in refs.current && observerRef.current) {
+    if (_value in refs.current && rootRef.current) {
       const element = refs.current[_value];
       const elementRect = element.getBoundingClientRect();
       const scaledValue = element.offsetWidth / elementRect.width;
@@ -211,7 +212,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
     </div>
   ));
 
-  const mergedRef = useMergedRef(observerRef, ref);
+  const mergedRef = useMergedRef(observerRef, ref, rootRef);
 
   if (data.length === 0) {
     return null;

--- a/src/mantine-core/src/Spoiler/Spoiler.tsx
+++ b/src/mantine-core/src/Spoiler/Spoiler.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, forwardRef } from 'react';
+import React, { useState, forwardRef } from 'react';
 import { DefaultProps, Selectors, useComponentDefaultProps, rem } from '@mantine/styles';
 import { useElementSize } from '@mantine/hooks';
 import { Anchor } from '../Anchor';
@@ -60,14 +60,10 @@ export const Spoiler = forwardRef<HTMLDivElement, SpoilerProps>((props, ref) => 
   );
 
   const [show, setShowState] = useState(initialState);
-  const [spoiler, setSpoilerState] = useState(initialState);
   const { ref: contentRef, height } = useElementSize();
+  const spoiler = maxHeight < height;
 
   const spoilerMoreContent = show ? hideLabel : showLabel;
-
-  useEffect(() => {
-    setSpoilerState(maxHeight < height);
-  }, [height, maxHeight, children]);
 
   return (
     <Box className={cx(classes.root, className)} ref={ref} {...others}>


### PR DESCRIPTION
When the Spoiler component is initially rendered, it doesn't know its content's size, so it doesn't show the "Show more" button. This was causing flickering and layout shifts.


https://github.com/mantinedev/mantine/assets/6034931/f253d153-4559-4a28-b7dc-d4334f9d5621



It is possible to know the initial size by implementing `useResizeObserver` hook slightly different. That is what I did.

Some remarks:

- Removed `useEffect` from the Spoiler component which was used for a computed property
- Having `ref.current` in the dependency array of `useEffect` is quite unreliable.
- `useResizeObserver` now returns a callback ref instead of mutable ref. Normally, this is an implementation detail and should not count as a breaking change.
- I had to modify some code in the `SegmentedControl` because it was expecting `useResizeObserver` to return a mutable ref.

Tested with the following code. If you click the rerender button quickly, you will notice the flickering in the old implementation.

```tsx
export function RerenderTest() {
  const [count, setCount] = useState(1);
  const incrementCount = () => setCount((x) => x + 1);

  const content = Array(5)
    .fill(0)
    .map((_, index) => (
      <p key={index}>
        Lorem ipsum dolor sit amet consectetur adipisicing elit. Autem officiis, incidunt libero,
        itaque, quaerat labore quis odio culpa tempore quisquam porro unde omnis tempora nostrum
        nihil eligendi distinctio. Animi, consectetur! des
      </p>
    ));

  return (
    <div style={{ padding: 40 }}>
      <button type="button" onClick={incrementCount}>
        Rerender
      </button>

      <Spoiler maxHeight={120} showLabel="Show more" hideLabel="Hide" key={count}>
        {content}
      </Spoiler>
    </div>
  );
}
```