### PR TITLE
[@mantine/form] Add setInitialValues function, allow modify initialValues after useForm was called

### DIFF
--- a/docs/src/docs/form/use-form.mdx
+++ b/docs/src/docs/form/use-form.mdx
@@ -77,6 +77,9 @@ form.setFieldValue('path', value);
 // Set value of nested field
 form.setFieldValue('user.firstName', 'Jane');
 
+// set initial values
+form.setInitialValues(values);
+
 // Resets form.values to initialValues,
 // clears all validation errors,
 // resets touched and dirty state

--- a/docs/src/docs/form/values.mdx
+++ b/docs/src/docs/form/values.mdx
@@ -51,6 +51,32 @@ form.values; // -> { name: 'John', email: '', age: 21 }
 
 <Demo data={FormDemos.setFieldValue} />
 
+## setInitialValues handler
+
+`form.setInitialValues` handler allows to set initialValues after `form.useForm` was called.
+
+It is mainly used when a form needs to deal with two operations, such as create and update, After changing the operation between update and create, the form's initialValue needs to be updated to the new value for `form.reset()` to work.
+
+```tsx
+
+<Demo data={FormDemos.setInitialValues} />
+
+## setInitialValues partial
+
+`form.setInitialValues` can also be used to set multiple values at once, payload will be shallow merged with current initialValues state:
+
+```tsx
+import { useForm } from '@mantine/form';
+
+const form = useForm({ initialValues: { name: '', email: '', age: 0 } });
+
+form.setInitialValues({ name: 'John', age: 21 });
+
+form.reset();
+
+form.values; // -> { name: 'John', email: '', age: 21 }
+```
+
 ## reset handler
 
 `form.reset` handler sets values to `initialValues` and clear all errors:

--- a/src/mantine-demos/src/demos/form/Form.demo.setInitialValues.tsx
+++ b/src/mantine-demos/src/demos/form/Form.demo.setInitialValues.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { useForm } from '@mantine/form';
+import { TextInput, Button, Group, Box } from '@mantine/core';
+import { MantineDemo } from '@mantine/ds';
+import { randomId } from '@mantine/hooks';
+
+const code = `
+import { useForm } from '@mantine/form';
+import { TextInput, Button, Group, Box } from '@mantine/core';
+import { randomId } from '@mantine/hooks';
+
+function Demo() {
+  const form = useForm({
+    initialValues: {
+      name: '',
+      email: '',
+    },
+  });
+
+  return (
+    <Box maw={320} mx="auto">
+      <TextInput label="Name" placeholder="Name" {...form.getInputProps('name')} />
+      <TextInput mt="md" label="Email" placeholder="Email" {...form.getInputProps('email')} />
+
+      <Group position="center" mt="xl">
+        <Button
+          variant="outline"
+          onClick={() =>
+            form.setValues({
+              name: randomId(),
+              email: \`\${randomId()}@test.com\`,
+            })
+          }
+        >
+          Set random values
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() =>
+            form.setInitialValues({
+              name: 'John Doe',
+              email: 'mantine-s14hvw8de@test.com',
+            })
+          }
+        >
+          Set Initial Values
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() =>
+            form.reset()
+          }
+        >
+          Reset
+        </Button>
+      </Group>
+    </Box>
+  );
+}
+`;
+
+function Demo() {
+  const form = useForm({
+    initialValues: {
+      name: '',
+      email: '',
+    },
+  });
+
+  return (
+    <Box maw={320} mx="auto">
+      <TextInput label="Name" placeholder="Name" {...form.getInputProps('name')} />
+      <TextInput mt="md" label="Email" placeholder="Email" {...form.getInputProps('email')} />
+
+      <Group position="center" mt="xl">
+        <Button
+          variant="outline"
+          onClick={() =>
+            form.setValues({
+              name: randomId(),
+              email: `${randomId()}@test.com`,
+            })
+          }
+        >
+          Set random values
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() =>
+            form.setInitialValues({
+              name: 'John Doe',
+              email: 'mantine-s14hvw8de@test.com',
+            })
+          }
+        >
+          Set Initial Values
+        </Button>
+        <Button variant="outline" onClick={() => form.reset()}>
+          Reset
+        </Button>
+      </Group>
+    </Box>
+  );
+}
+
+export const setInitialValues: MantineDemo = {
+  type: 'demo',
+  component: Demo,
+  code,
+};

--- a/src/mantine-demos/src/demos/form/index.ts
+++ b/src/mantine-demos/src/demos/form/index.ts
@@ -16,6 +16,7 @@ export { onSubmitErrors } from './Form.demo.onSubmitErrors';
 export { asyncSetValues } from './Form.demo.asyncSetValues';
 export { stepper } from './Form.demo.stepper';
 export { setFieldValue } from './Form.demo.setFieldValue';
+export { setInitialValues } from './Form.demo.setInitialValues';
 export { setValues } from './Form.demo.setValues';
 export { reset } from './Form.demo.reset';
 export { status } from './Form.demo.status';

--- a/src/mantine-form/src/tests/setInitialValues.test.ts
+++ b/src/mantine-form/src/tests/setInitialValues.test.ts
@@ -1,0 +1,35 @@
+import { act, renderHook } from '@testing-library/react';
+import { useForm } from '../use-form';
+
+interface Values {
+  a: number;
+  b: number;
+}
+
+describe('@mantine/form/setInitalValues', () => {
+  it('reset initial values normal', () => {
+    const hook = renderHook(() => useForm<Values>({ initialValues: { a: 1, b: 2 } }));
+    act(() => {
+      hook.result.current.setValues({ a: 5, b: 6 });
+      hook.result.current.setInitialValues({ a: 3, b: 4 });
+    });
+    expect(hook.result.current.values).toStrictEqual({ a: 5, b: 6 });
+    act(() => {
+      hook.result.current.reset();
+    });
+    expect(hook.result.current.values).toStrictEqual({ a: 3, b: 4 });
+  });
+
+  it('allows setting initial values partial', () => {
+    const hook = renderHook(() => useForm<Values>({ initialValues: { a: 1, b: 2 } }));
+    act(() => {
+      hook.result.current.setValues({ a: 5 });
+      hook.result.current.setInitialValues({ a: 3 });
+    });
+    expect(hook.result.current.values).toStrictEqual({ a: 5, b: 2 });
+    act(() => {
+      hook.result.current.reset();
+    });
+    expect(hook.result.current.values).toStrictEqual({ a: 3, b: 2 });
+  });
+});

--- a/src/mantine-form/src/types.ts
+++ b/src/mantine-form/src/types.ts
@@ -134,6 +134,7 @@ export interface UseFormReturnType<
   errors: FormErrors;
   setValues: SetValues<Values>;
   setErrors: SetErrors;
+  setInitialValues: SetValues<Values>;
   setFieldValue: SetFieldValue<Values>;
   setFieldError: SetFieldError<Values>;
   clearFieldError: ClearFieldError;

--- a/src/mantine-form/src/use-form.ts
+++ b/src/mantine-form/src/use-form.ts
@@ -49,6 +49,7 @@ export function useForm<
   const [touched, setTouched] = useState(initialTouched);
   const [dirty, setDirty] = useState(initialDirty);
   const [values, _setValues] = useState(initialValues);
+  const [innerInitialValues, _setInnerInitialValues] = useState(initialValues);
   const [errors, _setErrors] = useState(filterErrors(initialErrors));
 
   const valuesSnapshot = useRef<Values>(initialValues);
@@ -71,12 +72,12 @@ export function useForm<
 
   const clearErrors: ClearErrors = useCallback(() => _setErrors({}), []);
   const reset: Reset = useCallback(() => {
-    _setValues(initialValues);
+    _setValues(innerInitialValues);
     clearErrors();
-    setValuesSnapshot(initialValues);
+    setValuesSnapshot(innerInitialValues);
     setDirty({});
     resetTouched();
-  }, []);
+  }, [innerInitialValues]);
 
   const setFieldError: SetFieldError<Values> = useCallback(
     (path, error) => setErrors((current) => ({ ...current, [path]: error })),
@@ -110,6 +111,14 @@ export function useForm<
       }),
     []
   );
+
+  // eslint-disable-next-line @typescript-eslint/no-shadow
+  const setInitialValues = (newInitialValues: Partial<Values>) => {
+    _setInnerInitialValues({
+      ...initialValues,
+      ...newInitialValues,
+    });
+  };
 
   const setFieldValue: SetFieldValue<Values> = useCallback((path, value) => {
     const shouldValidate = shouldValidateOnChange(path, validateInputOnChange);
@@ -263,6 +272,7 @@ export function useForm<
     errors,
     setValues,
     setErrors,
+    setInitialValues,
     setFieldValue,
     setFieldError,
     clearFieldError,


### PR DESCRIPTION
## Description

When use a form to process two operations, such as create and update, initialValues can only be set once, after `useForm` has been called, there is no way to modify initialValues.

The reason why need to modify initialValues is when use a form to process two operations, such as create and update, initialValues can only be set once, after `useForm` has been called, there is no way to modify initialValues.

This leads to switching to the update operation after the form is initialized, and the initialValues of the update operation form cannot be set.


## `use-form`
- Add setInitialValues function, allow modify initialValues after useForm was called

## Work

- [x] Code Changed
- [x] Lint
- [x] Test
- [x] Docs