### PR TITLE
[@mantine/tiptap] fixed default color of color picker from Rich Text Editor to change based on theme

### DIFF
--- a/src/mantine-tiptap/src/controls/ColorPickerControl/ColorPickerControl.tsx
+++ b/src/mantine-tiptap/src/controls/ColorPickerControl/ColorPickerControl.tsx
@@ -11,6 +11,7 @@ import {
   Tooltip,
   ColorPickerProps,
   useComponentDefaultProps,
+  useMantineTheme,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconCircleOff, IconColorPicker, IconX, IconPalette, IconCheck } from '@tabler/icons-react';
@@ -43,7 +44,8 @@ export const ColorPickerControl = forwardRef<HTMLButtonElement, ColorPickerContr
     const { editor, labels, unstyled } = useRichTextEditorContext();
     const [opened, { toggle, close }] = useDisclosure(false);
     const [state, setState] = useState<'palette' | 'colorPicker'>('palette');
-    const currentColor = editor?.getAttributes('textStyle').color || '#000';
+    const theme = useMantineTheme();
+    const currentColor = editor?.getAttributes('textStyle').color || theme.colorScheme === 'dark' ? theme.colors.dark[1] : theme.colors.blue[1];
 
     const handleChange = (value: string, shouldClose = true) => {
       (editor.chain() as any).focus().setColor(value).run();

--- a/src/mantine-tiptap/src/controls/ColorPickerControl/ColorPickerControl.tsx
+++ b/src/mantine-tiptap/src/controls/ColorPickerControl/ColorPickerControl.tsx
@@ -45,7 +45,10 @@ export const ColorPickerControl = forwardRef<HTMLButtonElement, ColorPickerContr
     const [opened, { toggle, close }] = useDisclosure(false);
     const [state, setState] = useState<'palette' | 'colorPicker'>('palette');
     const theme = useMantineTheme();
-    const currentColor = editor?.getAttributes('textStyle').color || theme.colorScheme === 'dark' ? theme.colors.dark[1] : theme.colors.blue[1];
+    const currentColor =
+      editor?.getAttributes('textStyle').color || theme.colorScheme === 'dark'
+        ? theme.colors.dark[1]
+        : theme.colors.blue[1];
 
     const handleChange = (value: string, shouldClose = true) => {
       (editor.chain() as any).focus().setColor(value).run();

--- a/src/mantine-tiptap/src/controls/ColorPickerControl/ColorPickerControl.tsx
+++ b/src/mantine-tiptap/src/controls/ColorPickerControl/ColorPickerControl.tsx
@@ -44,8 +44,8 @@ export const ColorPickerControl = forwardRef<HTMLButtonElement, ColorPickerContr
     const { editor, labels, unstyled } = useRichTextEditorContext();
     const [opened, { toggle, close }] = useDisclosure(false);
     const [state, setState] = useState<'palette' | 'colorPicker'>('palette');
-    const theme = useMantineTheme();
-    const currentColor = editor?.getAttributes('textStyle').color || theme.colorScheme === 'dark' ? theme.colors.dark[1] : theme.colors.blue[1];
+    const colorTheme = useMantineTheme();
+    const currentColor = editor?.getAttributes('textStyle').color || colorTheme.colorScheme === 'dark' ? colorTheme.colors.dark[1] : colorTheme.colors.blue[1];
 
     const handleChange = (value: string, shouldClose = true) => {
       (editor.chain() as any).focus().setColor(value).run();

--- a/src/mantine-tiptap/src/controls/ColorPickerControl/ColorPickerControl.tsx
+++ b/src/mantine-tiptap/src/controls/ColorPickerControl/ColorPickerControl.tsx
@@ -44,8 +44,8 @@ export const ColorPickerControl = forwardRef<HTMLButtonElement, ColorPickerContr
     const { editor, labels, unstyled } = useRichTextEditorContext();
     const [opened, { toggle, close }] = useDisclosure(false);
     const [state, setState] = useState<'palette' | 'colorPicker'>('palette');
-    const colorTheme = useMantineTheme();
-    const currentColor = editor?.getAttributes('textStyle').color || colorTheme.colorScheme === 'dark' ? colorTheme.colors.dark[1] : colorTheme.colors.blue[1];
+    const theme = useMantineTheme();
+    const currentColor = editor?.getAttributes('textStyle').color || theme.colorScheme === 'dark' ? theme.colors.dark[1] : theme.colors.blue[1];
 
     const handleChange = (value: string, shouldClose = true) => {
       (editor.chain() as any).focus().setColor(value).run();
@@ -94,7 +94,7 @@ export const ColorPickerControl = forwardRef<HTMLButtonElement, ColorPickerContr
         </Popover.Target>
 
         <Popover.Dropdown
-          sx={(theme) => ({
+          sx={() => ({
             backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
           })}
         >


### PR DESCRIPTION
Updated ColorPickerControl.tsx to resolve the issue "Rich Text Editor's color picker now showing black color as default in dark color scheme"

Sorry this is my first pull request on an open source project I don't really know what I'm doing any pointers would be appreciated.