### PR TITLE
[@mantine/core] Select & MultiSelect: Prevent dropdown open when clearable

### DIFF
--- a/src/mantine-core/src/MultiSelect/MultiSelect.tsx
+++ b/src/mantine-core/src/MultiSelect/MultiSelect.tsx
@@ -285,7 +285,7 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>((props
 
   const handleInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {
     typeof onFocus === 'function' && onFocus(event);
-    !disabled && !valuesOverflow.current && searchable && setDropdownOpened(true);
+    !disabled && !valuesOverflow.current && searchable && !clearable && setDropdownOpened(true);
   };
 
   const filteredData = filterData({

--- a/src/mantine-core/src/Select/Select.tsx
+++ b/src/mantine-core/src/Select/Select.tsx
@@ -510,7 +510,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>((props, ref) => 
 
   const handleInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {
     typeof onFocus === 'function' && onFocus(event);
-    if (searchable) {
+    if (searchable && !clearable) {
       setDropdownOpened(true);
     }
   };


### PR DESCRIPTION
Updated the condition in the handleInputFocus function in MultiSelect.tsx & Select.tsx to prevent the dropdown menu from opening when the input field is focused, in case the select list is clearable.
This change enhances the usability by preventing unnecessary dropdown menu opening, specifically when the user intends to clear the select list. It will be working similar to https://ant.design/components/select#components-select-demo-multiple