### PR TITLE
[@mantine/core] Pagination: Add disabled styles

### DIFF
--- a/src/mantine-core/src/Pagination/PaginationControl/PaginationControl.styles.ts
+++ b/src/mantine-core/src/Pagination/PaginationControl/PaginationControl.styles.ts
@@ -47,6 +47,7 @@ export default createStyles(
         '&[data-disabled]': {
           opacity: 0.4,
           cursor: 'not-allowed',
+          pointerEvents: 'none',
         },
 
         '&[data-active]': {


### PR DESCRIPTION
Fixes issue #4574. As a side note, `cursor: 'not-allowed'` becomes obsolete with the presence of `pointerEvents: 'none'` but I left it in because that seems to be the convention for the package.