### PR TITLE
Update use-window-event.ts

### DIFF
--- a/src/mantine-hooks/src/use-window-event/use-window-event.ts
+++ b/src/mantine-hooks/src/use-window-event/use-window-event.ts
@@ -2,7 +2,9 @@ import { useEffect } from 'react';
 
 export function useWindowEvent<K extends string = keyof Exclude<WindowEventMap, string>>(
   type: K,
-  listener: K extends keyof WindowEventMap ? (this: Window, ev: WindowEventMap[K]) => void : EventListener,
+  listener: K extends keyof WindowEventMap
+    ? (this: Window, ev: WindowEventMap[K]) => void
+    : EventListener,
   options?: boolean | AddEventListenerOptions
 ) {
   useEffect(() => {

--- a/src/mantine-hooks/src/use-window-event/use-window-event.ts
+++ b/src/mantine-hooks/src/use-window-event/use-window-event.ts
@@ -1,10 +1,8 @@
 import { useEffect } from 'react';
 
-export function useWindowEvent<K extends string = keyof WindowEventMap>(
+export function useWindowEvent<K extends string = keyof Exclude<WindowEventMap, string>>(
   type: K,
-  listener: K extends keyof WindowEventMap
-    ? (this: Window, ev: WindowEventMap[K]) => void
-    : (this: Window, ev: CustomEvent) => void,
+  listener: K extends keyof WindowEventMap ? (this: Window, ev: WindowEventMap[K]) => void : EventListener,
   options?: boolean | AddEventListenerOptions
 ) {
   useEffect(() => {


### PR DESCRIPTION
Typed custom event. Previously, when passing a custom event, the type was any, but now it is considered as Event.

Listner typing bug fixed