### PR TITLE
[chore] Update clsx to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "@tiptap/extension-underline": "^2.0.0-beta.202",
     "@tiptap/react": "^2.0.0-beta.202",
     "@tiptap/starter-kit": "^2.0.0-beta.202",
-    "clsx": "1.1.1",
+    "clsx": "2.0.0",
     "csstype": "3.0.9",
     "dayjs": "^1.10.5",
     "embla-carousel-autoplay": "^7.0.0",

--- a/src/mantine-styles/package.json
+++ b/src/mantine-styles/package.json
@@ -31,7 +31,7 @@
     "@emotion/react": ">=11.9.0"
   },
   "dependencies": {
-    "clsx": "1.1.1",
+    "clsx": "2.0.0",
     "csstype": "3.0.9"
   },
   "devDependencies": {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6236,10 +6236,10 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clsx@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
-  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+clsx@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.0.0.tgz#12658f3fd98fafe62075595a5c30e43d18f3d00b"
+  integrity sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==
 
 co@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
Release notes: https://github.com/lukeed/clsx/releases/tag/v2.0.0

Benefit: If a project is using the latest clsx version, there will be no duplicates in the `node_modules` folder and the bundle.