### PR TITLE
fix: date input `defaultDate` displace `value`

### DIFF
--- a/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.tsx
+++ b/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.tsx
@@ -77,11 +77,7 @@ export const DatePickerInput: DatePickerInputComponent = forwardRef((props, ref)
     sortDates,
   });
 
-  const defaultDate =
-    _defaultDate ||
-    (Array.isArray(_value)
-      ? _value[0] || getDefaultClampedDate({ maxDate, minDate })
-      : _value || getDefaultClampedDate({ maxDate, minDate }));
+  const defaultDate = _defaultDate || getDefaultClampedDate({ maxDate, minDate });
 
   return (
     <PickerInputBase
@@ -108,7 +104,11 @@ export const DatePickerInput: DatePickerInputComponent = forwardRef((props, ref)
         variant={variant}
         type={type}
         value={_value}
-        defaultDate={defaultDate}
+        defaultDate={
+          Array.isArray(_value)
+            ? _value[0] || defaultDate
+            : _value || defaultDate
+        }
         onChange={setValue}
         locale={locale}
         classNames={classNames}

--- a/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.tsx
+++ b/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.tsx
@@ -104,11 +104,7 @@ export const DatePickerInput: DatePickerInputComponent = forwardRef((props, ref)
         variant={variant}
         type={type}
         value={_value}
-        defaultDate={
-          Array.isArray(_value)
-            ? _value[0] || defaultDate
-            : _value || defaultDate
-        }
+        defaultDate={Array.isArray(_value) ? _value[0] || defaultDate : _value || defaultDate}
         onChange={setValue}
         locale={locale}
         classNames={classNames}


### PR DESCRIPTION
fix https://github.com/mantinedev/mantine/pull/4532
Sorry for submitting a pr with an error. 
props `defaultDate` should have a lower priority than `value`.