### PR TITLE
[@mantine/core] Grid: Pass `id` prop to dom element

### DIFF
--- a/src/mantine-core/src/Grid/Col/Col.tsx
+++ b/src/mantine-core/src/Grid/Col/Col.tsx
@@ -93,7 +93,6 @@ export const Col = forwardRef<HTMLDivElement, ColProps>((props: ColProps, ref) =
     orderLg,
     orderXl,
     className,
-    id,
     unstyled,
     variant,
     ...others

--- a/src/mantine-core/src/Grid/Grid.tsx
+++ b/src/mantine-core/src/Grid/Grid.tsx
@@ -66,7 +66,6 @@ export const Grid: GridComponent = forwardRef<HTMLDivElement, GridProps>((props,
     align,
     columns,
     className,
-    id,
     unstyled,
     variant,
     ...others


### PR DESCRIPTION
This PR will allow users to pass the `id` prop to the `Grid` and `Grid.Col` components, as mantine is already doing for other components.

I couldn't find a good reason why the `id` prop was removed from the props that are passed to the DOM element. If there is, feel free to disregard this PR, although in that case the TS types should probably reflect that.