### PR TITLE
[@mantine/tiptap] ColorPickerControl: fix incorrect color displayed

### DIFF
--- a/src/mantine-tiptap/src/controls/ColorPickerControl/ColorPickerControl.tsx
+++ b/src/mantine-tiptap/src/controls/ColorPickerControl/ColorPickerControl.tsx
@@ -46,9 +46,12 @@ export const ColorPickerControl = forwardRef<HTMLButtonElement, ColorPickerContr
     const [state, setState] = useState<'palette' | 'colorPicker'>('palette');
     const theme = useMantineTheme();
     const currentColor =
-      editor?.getAttributes('textStyle').color || theme.colorScheme === 'dark'
-        ? theme.colors.dark[1]
-        : theme.black;
+      editor?.getAttributes('textStyle').color
+      || (
+        theme.colorScheme === 'dark'
+          ? theme.colors.dark[1]
+          : theme.black
+      );
 
     const handleChange = (value: string, shouldClose = true) => {
       (editor.chain() as any).focus().setColor(value).run();

--- a/src/mantine-tiptap/src/controls/ColorPickerControl/ColorPickerControl.tsx
+++ b/src/mantine-tiptap/src/controls/ColorPickerControl/ColorPickerControl.tsx
@@ -46,12 +46,8 @@ export const ColorPickerControl = forwardRef<HTMLButtonElement, ColorPickerContr
     const [state, setState] = useState<'palette' | 'colorPicker'>('palette');
     const theme = useMantineTheme();
     const currentColor =
-      editor?.getAttributes('textStyle').color
-      || (
-        theme.colorScheme === 'dark'
-          ? theme.colors.dark[1]
-          : theme.black
-      );
+      editor?.getAttributes('textStyle').color ||
+      (theme.colorScheme === 'dark' ? theme.colors.dark[1] : theme.black);
 
     const handleChange = (value: string, shouldClose = true) => {
       (editor.chain() as any).focus().setColor(value).run();


### PR DESCRIPTION
I added parentheses to fix the incorrect expression for `currentColor`. In the previous code, the expression will always returns `theme.colors.dark[1]` in dark mode and `theme.black` in light mode.