### PR TITLE
[@mantine/hooks] use-focus-trap: shift + tab bug

### DIFF
--- a/src/mantine-core/src/FocusTrap/FocusTrap.test.tsx
+++ b/src/mantine-core/src/FocusTrap/FocusTrap.test.tsx
@@ -51,6 +51,67 @@ describe('@mantine/core/FocusTrap', () => {
     expect(document.body).toHaveFocus();
   });
 
+  it('traps focus on shift + tab', async () => {
+    render(
+      <FocusTrap>
+        <div>
+          <input />
+          <button type="button">Button</button>
+          <input type="radio" />
+        </div>
+      </FocusTrap>
+    );
+
+    await wait(10);
+    expect(screen.getByRole('textbox')).toHaveFocus();
+
+    userEvent.tab();
+    expect(screen.getByRole('button')).toHaveFocus();
+
+    userEvent.tab({ shift: true });
+    expect(screen.getByRole('textbox')).toHaveFocus();
+
+    userEvent.tab({ shift: true });
+    expect(screen.getByRole('button')).toHaveFocus();
+  });
+
+  it('traps focus on shift + tab and handles Radio Groups', async () => {
+    render(
+      <FocusTrap>
+        <div>
+          <label htmlFor="1">
+            Option One
+            <input type="radio" name="group" id="1" />
+          </label>
+
+          <label htmlFor="2">
+            Option Two
+            <input type="radio" name="group" id="2" />
+          </label>
+
+          <label htmlFor="3">
+            Option Three
+            <input type="radio" name="group" id="3" />
+          </label>
+
+          <button type="button">Button</button>
+        </div>
+      </FocusTrap>
+    );
+
+    await wait(10);
+    expect(screen.getByLabelText('Option One')).toHaveFocus();
+
+    userEvent.tab();
+    expect(screen.getByRole('button')).toHaveFocus();
+
+    userEvent.tab({ shift: true });
+    expect(screen.getByLabelText('Option Three')).toHaveFocus();
+
+    userEvent.tab({ shift: true });
+    expect(screen.getByRole('button')).toHaveFocus();
+  });
+
   it('manages aria-hidden attributes', () => {
     const adjacentDiv = document.createElement('div');
     adjacentDiv.setAttribute('data-testid', 'adjacent');

--- a/src/mantine-hooks/src/use-focus-trap/scope-tab.ts
+++ b/src/mantine-hooks/src/use-focus-trap/scope-tab.ts
@@ -8,7 +8,19 @@ export function scopeTab(node: HTMLElement, event: KeyboardEvent) {
   }
   const finalTabbable = tabbable[event.shiftKey ? 0 : tabbable.length - 1];
   const root = node.getRootNode() as unknown as DocumentOrShadowRoot;
-  const leavingFinalTabbable = finalTabbable === root.activeElement || node === root.activeElement;
+  let leavingFinalTabbable = finalTabbable === root.activeElement || node === root.activeElement;
+
+  // Handle the case of the active element being in a RadioGroup with the finalTabbable element
+  if (root.activeElement instanceof HTMLInputElement && root.activeElement.type === 'radio') {
+    const activeRadioGroup = tabbable.filter(
+      (element) =>
+        element instanceof HTMLInputElement &&
+        root.activeElement instanceof HTMLInputElement &&
+        element.type === 'radio' &&
+        element.name === root.activeElement.name
+    );
+    leavingFinalTabbable = activeRadioGroup.includes(finalTabbable);
+  }
 
   if (!leavingFinalTabbable) {
     return;


### PR DESCRIPTION
When using shift + tab to go back into a Radio Group, the last option will be selected, which doesn't line up with `finalTabbable`, and breaks out of the focus trap.

To fix, we can check to see if the active element is a radio button, find its radio group, and then check to see if the `finalTabbable` is in the same group. If so, set `leavingFinalTabbable` to `true`.

Addresses #4678