### PR TITLE
[docs] Fix typos for "GitHub"

### DIFF
--- a/docs/src/components/Footer/data.ts
+++ b/docs/src/components/Footer/data.ts
@@ -17,7 +17,7 @@ export const FOOTER_LINKS_DATA: LinksGroupProps[] = [
     data: [
       { type: 'link', label: 'Chat on Discord', link: meta.discordLink },
       { type: 'link', label: 'Follow on Twitter', link: meta.twitterLink },
-      { type: 'link', label: 'Follow on Github', link: 'https://github.com/rtivital' },
+      { type: 'link', label: 'Follow on GitHub', link: 'https://github.com/rtivital' },
       {
         type: 'link',
         label: 'GitHub discussions',
@@ -30,7 +30,7 @@ export const FOOTER_LINKS_DATA: LinksGroupProps[] = [
     data: [
       { type: 'link', label: 'Mantine UI', link: meta.uiLink },
       { type: 'link', label: 'Documentation', link: meta.docsLink },
-      { type: 'link', label: 'Github organization', link: meta.gitHubLinks.organization },
+      { type: 'link', label: 'GitHub organization', link: meta.gitHubLinks.organization },
       { type: 'link', label: 'npm organization', link: meta.npmLink },
     ],
   },


### PR DESCRIPTION
Fixed typos for the word "GitHub" in the footer of the docs. The spelling used was "Github" (with a lower-case "h") instead of the correct spelling "GitHub" (with an upper-case "H").