### PR TITLE
[docs] Add prepend option to Emotion Cache example

### DIFF
--- a/docs/src/docs/theming/emotion-cache.mdx
+++ b/docs/src/docs/theming/emotion-cache.mdx
@@ -26,7 +26,7 @@ a configuration object with the following properties:
 ```tsx
 import { MantineProvider, createEmotionCache } from '@mantine/core';
 
-const myCache = createEmotionCache({ key: 'mantine' });
+const myCache = createEmotionCache({ key: 'mantine', prepend: true });
 
 function Demo() {
   return (


### PR DESCRIPTION
When implementing Emotion Cache in our project, the `prepend` option caused some confusion and some missed visual bugs. The docs don't mention that you need to set `prepend: true`, if you need the custom cache to behave like the cache automatically generated by Mantine. This behavior only made sense when reading between the lines of the docs, this change aims to make it a little more obvious by adjusting the example code provided.