### PR TITLE
[@mantine/core] Anchor: fix span prop #4695

### DIFF
--- a/src/mantine-core/src/Anchor/Anchor.tsx
+++ b/src/mantine-core/src/Anchor/Anchor.tsx
@@ -15,7 +15,7 @@ const defaultProps: Partial<AnchorProps> = {
 
 export const _Anchor = forwardRef<HTMLAnchorElement, AnchorProps & { component: any }>(
   (props, ref) => {
-    const { component, className, unstyled, variant, size, color, underline, ...others } =
+    const { component, className, unstyled, variant, size, color, underline, span, ...others } =
       useComponentDefaultProps('Anchor', defaultProps as AnchorProps & { component: any }, props);
 
     const { classes, cx } = useStyles(
@@ -26,7 +26,7 @@ export const _Anchor = forwardRef<HTMLAnchorElement, AnchorProps & { component: 
 
     return (
       <Text
-        component={component || 'a'}
+        component={span ? 'span' : component || 'a'}
         ref={ref}
         className={cx(classes.root, className)}
         size={size}


### PR DESCRIPTION
Using the span prop on an Anchor as in <Anchor span> has no effect. Now its work