### PR TITLE
[@mantine/core] Set correct accessible name on date picker input components

### DIFF
--- a/src/mantine-dates/src/components/PickerInputBase/PickerInputBase.tsx
+++ b/src/mantine-dates/src/components/PickerInputBase/PickerInputBase.tsx
@@ -164,6 +164,7 @@ export const PickerInputBase = forwardRef<HTMLButtonElement, PickerInputBaseProp
         >
           <Popover.Target shouldOverrideDefaultTargetId={!hasLabel}>
             <Input
+              aria-label={formattedValue}
               data-dates-input
               data-read-only={readOnly || undefined}
               disabled={disabled}


### PR DESCRIPTION
Fixes https://github.com/mantinedev/mantine/issues/4730.

Sets useful accessible name on all date picker input components.