### PR TITLE
[@mantine/core] InlineInput: Fix InlineInput component does not receive padding when a value of 0 is passed into the label prop. 

### DIFF
--- a/src/mantine-core/src/InlineInput/InlineInput.tsx
+++ b/src/mantine-core/src/InlineInput/InlineInput.tsx
@@ -52,7 +52,7 @@ export const InlineInput = forwardRef<HTMLDivElement, InlineInputProps>(
           {children}
 
           <div className={classes.labelWrapper}>
-            {label && (
+            {label != null && (
               <label className={classes.label} data-disabled={disabled || undefined} htmlFor={id}>
                 {label}
               </label>


### PR DESCRIPTION
#4746 