### PR TITLE
[@mantine/core] Remove incompatible use of replaceAll

### DIFF
--- a/src/mantine-core/src/Highlight/highlighter/highlighter.ts
+++ b/src/mantine-core/src/Highlight/highlighter/highlighter.ts
@@ -1,6 +1,4 @@
-function escapeRegex(value: string) {
-  return value.replace(/[-[\]{}()*+?.,\\^$|#]/g, '\\$&');
-}
+import { escapeRegex } from '@mantine/utils';
 
 export function highlighter(value: string, _highlight: string | string[]) {
   if (_highlight == null) {

--- a/src/mantine-core/src/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/NumberInput/NumberInput.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, forwardRef } from 'react';
 import { useMergedRef, assignRef, useOs, clamp } from '@mantine/hooks';
 import { DefaultProps, Selectors, useComponentDefaultProps, rem, getSize } from '@mantine/styles';
+import { escapeRegex } from '@mantine/utils';
 import { TextInput } from '../TextInput';
 import { InputStylesNames, InputWrapperStylesNames } from '../Input';
 import { getInputMode } from './get-input-mode/get-input-mode';
@@ -199,7 +200,9 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>((props
     let num = val;
 
     if (decimalSeparator) {
-      num = num.replaceAll(thousandsSeparator, '').replace(decimalSeparator, '.');
+      num = num
+        .replace(new RegExp(escapeRegex(thousandsSeparator), 'g'), '')
+        .replace(decimalSeparator, '.');
     }
 
     return parser(num);

--- a/src/mantine-form/src/resolvers/yup-resolver/yup-resolver.ts
+++ b/src/mantine-form/src/resolvers/yup-resolver/yup-resolver.ts
@@ -25,7 +25,7 @@ export function yupResolver(schema: any) {
       const results = {};
 
       yupError.inner.forEach((error) => {
-        results[error.path.replaceAll('[', '.').replaceAll(']', '')] = error.message;
+        results[error.path.replace(/\[/g, '.').replace(/\]/g, '')] = error.message;
       });
 
       return results;

--- a/src/mantine-utils/src/escape-regex/escape-regex.ts
+++ b/src/mantine-utils/src/escape-regex/escape-regex.ts
@@ -1,0 +1,3 @@
+export function escapeRegex(value: string) {
+  return value.replace(/[-[\]{}()*+?.,\\^$|#]/g, '\\$&');
+}

--- a/src/mantine-utils/src/index.ts
+++ b/src/mantine-utils/src/index.ts
@@ -13,6 +13,7 @@ export { useHovered } from './use-hovered/use-hovered';
 export { groupOptions, getGroupedOptions } from './group-options/group-options';
 export { createUseExternalEvents } from './create-use-external-events/create-use-external-events';
 export { isElement } from './is-element/is-element';
+export { escapeRegex } from './escape-regex/escape-regex';
 
 export type { PolymorphicComponentProps } from './create-polymorphic-component/create-polymorphic-component';
 export type { ForwardRefWithStaticComponents } from './ForwardRefWithStaticComponents';


### PR DESCRIPTION
Fixes #4759.

This removes `replaceAll()` that is not supported by all of the browsers that Mantine intends to support.

Instead, `replace` is called with a global regex.

Note that it's necessary to escape the potential regex string (e.g., in the case that `thousandsSeparator` is a special character like `.`). Fortunately, this escape function was already written.