### PR TITLE
[@mantine/core] Adjust the hover property for phones and desktop.

### DIFF
--- a/src/mantine-styles/src/theme/functions/fns/hover/hover.test.ts
+++ b/src/mantine-styles/src/theme/functions/fns/hover/hover.test.ts
@@ -6,10 +6,10 @@ const testHoverStyle = {
 
 const testReturnStyle = {
   backgroundColor: 'blue',
-  '@media (hover: hover)': {
+  '@media (pointer: fine)': {
     '&:hover': testHoverStyle,
   },
-  '@media (hover: none)': {
+  '@media (pointer: coarse)': {
     '&:active': testHoverStyle,
   },
 };

--- a/src/mantine-styles/src/theme/functions/fns/hover/hover.ts
+++ b/src/mantine-styles/src/theme/functions/fns/hover/hover.ts
@@ -2,10 +2,10 @@ import type { CSSObject } from '../../../../tss';
 
 export function hover(hoverStyle: CSSObject) {
   return {
-    '@media (hover: hover)': {
+    '@media (pointer: fine)': {
       '&:hover': hoverStyle,
     },
-    '@media (hover: none)': {
+    '@media (pointer: coarse)': {
       '&:active': hoverStyle,
     },
   };


### PR DESCRIPTION
Solved the hover issue Using the pointer media query:
(pointer:fine) (targets the mouse hover)
show the hover color when hovering with the mouse.
(pointer:coarse) (targets the finger press)
show the hover color on active instead since there is no hover on mobile devices.