### PR TITLE
Fix links in README and Footer in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 ## Links
 
 - [Documentation](https://mantine.dev/)
-- [Contributing](https://mantine.dev/pages/contributing/)
+- [Contribute](https://mantine.dev/contribute)
 - [Ask question or give feedback](https://github.com/mantinedev/mantine/discussions)
-- [Changelog](https://mantine.dev/pages/changelog/)
+- [Changelog](https://mantine.dev/changelog/7-0-0)
 - [Follow on Twitter](https://twitter.com/mantinedev)
 - [Join Discord community](https://discord.gg/wbH82zuWMN)
 
@@ -50,7 +50,7 @@ Mantine has a very friendly community, we are always happy to help you get start
   <img src="https://contrib.rocks/image?repo=mantinedev/mantine" />
 </a>
 
-[Become a contributor](https://mantine.dev/pages/contributing/)
+[Become a contributor](https://mantine.dev/contribute)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - [Documentation](https://mantine.dev/)
 - [Contribute](https://mantine.dev/contribute)
 - [Ask question or give feedback](https://github.com/mantinedev/mantine/discussions)
-- [Changelog](https://mantine.dev/changelog/7-0-0)
+- [Changelog](https://mantine.dev/changelog/previous-versions)
 - [Follow on Twitter](https://twitter.com/mantinedev)
 - [Join Discord community](https://discord.gg/wbH82zuWMN)
 

--- a/docs/components/Footer/data.ts
+++ b/docs/components/Footer/data.ts
@@ -5,9 +5,9 @@ export const FOOTER_LINKS_DATA: LinksGroupProps[] = [
   {
     title: 'About',
     data: [
-      { type: 'next', label: 'Contribute', link: '/pages/contributing/' },
-      { type: 'next', label: 'About Mantine', link: '/pages/about/' },
-      { type: 'next', label: 'Changelog', link: '/pages/changelog/' },
+      { type: 'next', label: 'Contribute', link: '/contribute' },
+      { type: 'next', label: 'About Mantine', link: '/about' },
+      { type: 'next', label: 'Changelog', link: '/changelog/previous-versions' },
       { type: 'link', label: 'Releases', link: meta.gitHubLinks.releases },
     ],
   },


### PR DESCRIPTION
It appears the `href` for many pages on the Mantine docs have changed with Mantine v7. Ex:

- `/pages/contributing` --> `/contribute`
- `/pages/about` --> `/about`
- ...

These haven't been updated in the README or footer in the Mantine documentation, so users clicking on these links would navigate to the 404 page. These are now updated in this PR.

It appears the root `/changelog` page does not exist anymore with Mantine v7, so the Previous Versions page `/changelog/previous-versions` is now used in place of that.