### PR TITLE
Update changelog link

### DIFF
--- a/docs/components/Footer/data.ts
+++ b/docs/components/Footer/data.ts
@@ -7,7 +7,7 @@ export const FOOTER_LINKS_DATA: LinksGroupProps[] = [
     data: [
       { type: 'next', label: 'Contribute', link: '/pages/contributing/' },
       { type: 'next', label: 'About Mantine', link: '/pages/about/' },
-      { type: 'next', label: 'Changelog', link: '/pages/changelog/' },
+      { type: 'next', label: 'Changelog', link: '/changelog/previous-versions/' },
       { type: 'link', label: 'Releases', link: meta.gitHubLinks.releases },
     ],
   },


### PR DESCRIPTION
I don't know if there is an internal link to @latest anywhere, perhaps could use that instead of `previous-versions`. Feels wrong to hardcode `/changelog/7-0-0` somewhere

Changelog link in footer currently `404`s
![Screenshot 2023-09-18 at 11 57 27 AM](https://github.com/mantinedev/mantine/assets/8879108/86ac9d25-511d-4203-843f-c944355c58a4)
