### PR TITLE
[core] Fix entrypoints for CJS and ESM modules

### DIFF
--- a/configuration/rollup/create-package-config.ts
+++ b/configuration/rollup/create-package-config.ts
@@ -97,6 +97,8 @@ export default async function createPackageConfig(config: PkgConfigInput): Promi
   if (config.format === 'es') {
     output.dir = path.resolve(config.basePath, 'esm');
     output.preserveModules = true;
+    // Output ESM as .mjs files
+    output.entryFileNames = '[name].mjs';
   }
 
   if (config.format === 'cjs') {

--- a/scripts/utils/generate-dts.ts
+++ b/scripts/utils/generate-dts.ts
@@ -10,5 +10,11 @@ export default async function generateDts(packagePath: string) {
 
   const files = await fg(['lib/**/*.js'], { cwd: packagePath });
 
+  // Duplicate the type definitions for ESM
+  await fs.copy(
+    path.join(packagePath, 'lib/index.d.ts'),
+    path.join(packagePath, 'lib/index.d.mts')
+  );
+
   return Promise.all(files.map((file) => fs.remove(path.join(packagePath, file))));
 }

--- a/src/mantine-carousel/package.json
+++ b/src/mantine-carousel/package.json
@@ -2,13 +2,19 @@
   "name": "@mantine/carousel",
   "description": "Embla based carousel",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     },
     "./styles.css": "./esm/index.css",
     "./styles/*": "./esm/styles/*"

--- a/src/mantine-code-highlight/package.json
+++ b/src/mantine-code-highlight/package.json
@@ -2,13 +2,19 @@
   "name": "@mantine/code-highlight",
   "description": "Code highlight with Mantine theme",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     },
     "./styles.css": "./esm/index.css"
   },

--- a/src/mantine-colors-generator/package.json
+++ b/src/mantine-colors-generator/package.json
@@ -1,13 +1,19 @@
 {
   "name": "@mantine/colors-generator",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     }
   },
   "license": "MIT",

--- a/src/mantine-core/package.json
+++ b/src/mantine-core/package.json
@@ -2,13 +2,19 @@
   "name": "@mantine/core",
   "description": "React components library focused on usability, accessibility and developer experience",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     },
     "./styles.css": "./esm/index.css",
     "./styles/*": "./esm/styles/*"

--- a/src/mantine-dates-tests/package.json
+++ b/src/mantine-dates-tests/package.json
@@ -2,12 +2,19 @@
   "name": "@mantine/dates-tests",
   "private": true,
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     }
   },
   "license": "MIT",

--- a/src/mantine-dates/package.json
+++ b/src/mantine-dates/package.json
@@ -2,13 +2,19 @@
   "name": "@mantine/dates",
   "description": "Calendars, date and time pickers based on Mantine components",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     },
     "./styles.css": "./esm/index.css"
   },

--- a/src/mantine-demos/package.json
+++ b/src/mantine-demos/package.json
@@ -3,13 +3,19 @@
   "description": "Demos used in documentation",
   "private": true,
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     },
     "./styles.css": "./esm/index.css"
   },

--- a/src/mantine-dropzone/package.json
+++ b/src/mantine-dropzone/package.json
@@ -2,13 +2,19 @@
   "name": "@mantine/dropzone",
   "description": "Dropzone component built with Mantine theme and components",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     },
     "./styles.css": "./esm/index.css"
   },

--- a/src/mantine-ds/package.json
+++ b/src/mantine-ds/package.json
@@ -2,13 +2,19 @@
   "name": "@mantine/ds",
   "description": "Internal Mantine components used on *.mantine.dev websites",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     },
     "./styles.css": "./esm/index.css"
   },

--- a/src/mantine-form/package.json
+++ b/src/mantine-form/package.json
@@ -2,13 +2,19 @@
   "name": "@mantine/form",
   "description": "Mantine form management library",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     }
   },
   "license": "MIT",

--- a/src/mantine-hooks/package.json
+++ b/src/mantine-hooks/package.json
@@ -1,13 +1,19 @@
 {
   "name": "@mantine/hooks",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     }
   },
   "license": "MIT",

--- a/src/mantine-modals/package.json
+++ b/src/mantine-modals/package.json
@@ -2,13 +2,19 @@
   "name": "@mantine/modals",
   "description": "Modals manager based on Mantine components",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     },
     "./styles.css": "./esm/index.css"
   },

--- a/src/mantine-notifications/package.json
+++ b/src/mantine-notifications/package.json
@@ -1,13 +1,19 @@
 {
   "name": "@mantine/notifications",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     },
     "./styles.css": "./esm/index.css"
   },

--- a/src/mantine-nprogress/package.json
+++ b/src/mantine-nprogress/package.json
@@ -2,13 +2,19 @@
   "name": "@mantine/nprogress",
   "description": "Navigation progress bar",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     },
     "./styles.css": "./esm/index.css"
   },

--- a/src/mantine-spotlight/package.json
+++ b/src/mantine-spotlight/package.json
@@ -1,13 +1,19 @@
 {
   "name": "@mantine/spotlight",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     },
     "./styles.css": "./esm/index.css"
   },

--- a/src/mantine-store/package.json
+++ b/src/mantine-store/package.json
@@ -1,13 +1,19 @@
 {
   "name": "@mantine/store",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     }
   },
   "license": "MIT",

--- a/src/mantine-styles-api/package.json
+++ b/src/mantine-styles-api/package.json
@@ -3,13 +3,19 @@
   "description": "Mantine components styles api descriptions",
   "private": true,
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     }
   },
   "license": "MIT",

--- a/src/mantine-tests/package.json
+++ b/src/mantine-tests/package.json
@@ -2,12 +2,19 @@
   "name": "@mantine/tests",
   "private": true,
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     }
   },
   "license": "MIT",

--- a/src/mantine-tiptap/package.json
+++ b/src/mantine-tiptap/package.json
@@ -2,13 +2,19 @@
   "name": "@mantine/tiptap",
   "description": "Rich text editor based on tiptap",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     },
     "./styles.css": "./esm/index.css"
   },

--- a/src/mantine-vanilla-extract/package.json
+++ b/src/mantine-vanilla-extract/package.json
@@ -1,13 +1,19 @@
 {
   "name": "@mantine/vanilla-extract",
   "version": "7.0.0",
+  "main": "./cjs/index.js",
   "types": "./lib/index.d.ts",
-  "module": "./esm/index.js",
+  "module": "./esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     }
   },
   "license": "MIT",


### PR DESCRIPTION
I have been experiencing issues with the v2 release of Remix and Mantine v7 (see https://discord.com/channels/854810300876062770/1066443903080869889/1153294961324851220). Since Remix v2 is now ESM-only by default, it apparently changed the interaction with the `@mantine/*` packages:

```
import { ColorSchemeScript, MantineProvider } from "@mantine/core";
         ^^^^^^^^^^^^^^^^^
SyntaxError: Named export 'ColorSchemeScript' not found. The requested module '@mantine/core' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from '@mantine/core';
const { ColorSchemeScript, MantineProvider } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
    at ModuleJob.run (node:internal/modules/esm/module_job:190:5)
```

As far as I can tell and by testing the issue with a local modified `mantine` build, it seems that Remix imports the Mantine packages as CommonJS – even though there are ESM files provided. 

Jacob Parris from the Remix community pointed me to this test: https://arethetypeswrong.github.io/?p=%40mantine%2Fcore%407.0.0

It led me to this problem description: https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FallbackCondition.md in combination with this one https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md

Digging deeper and testing it on my machine, the problem projected on Mantine appears as follows: since Mantine is no ESM-native package (missing type: "module" in package.json), some bundlers (or just native Node.js?) treat it as a CommonJS package, hence the `index.d.ts` type declarations defined early in the `package.json`. To solve this, one would have to declare different type AND module entrypoints for both ESM and CJS to separate them consequently – like in this example :

```json
{
  "name": "pkg",
  "exports": {
    ".": {
      "import": {
        "types": "./lib/index.d.mts",
        "default": "./esm/index.mjs"
      },
      "require": {
        "types": "./lib/index.d.ts",
        "default": "./cjs/index.js"
      }
    }
  }
}
```
After changing the ESM output to `.mjs`, creating a duplicate `index.d.mts` file and updating the `package.json`as shown above, the packages work with Remix v2 (tested @mantine/core and /hooks) 

It also still works with the `remix-min-template` using >v1 of Remix.

**Disclaimer**: I am not expert in package distribution and this whole CJS/ESM rabbit hole. Hence, I do not declare final wisdom here – just some uneducated afternoon troubleshooting.