### PR TITLE
docs: fix readme redirect links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,19 @@
 - `@mantine/hooks` – collection of 50+ hooks for state and UI management
 - [`@mantine/styles`](https://mantine.dev/styles/create-styles/) – [emotion](https://emotion.sh/) based css-in-js library that is used in all Mantine components
 - `@mantine/core` – core components library – 100+ components, exports everything from `@mantine/styles`
-- [`@mantine/form`](https://mantine.dev/form/use-form/) – forms management library
-- [`@mantine/notifications`](https://mantine.dev/others/notifications/) – a fully featured notifications system
-- [`@mantine/spotlight`](https://mantine.dev/others/spotlight/) – `Ctrl + K` command center for your application
+- [`@mantine/form`](https://mantine.dev/form/use-form) – forms management library
+- [`@mantine/notifications`](https://mantine.dev/others/notifications) – a fully featured notifications system
+- [`@mantine/spotlight`](https://mantine.dev/others/spotlight) – `Ctrl + K` command center for your application
 - [`@mantine/prism`](https://mantine.dev/others/prism/) – code highlight built with [prism-react-renderer](https://github.com/FormidableLabs/prism-react-renderer)
-- [`@mantine/tiptap`](https://mantine.dev/others/tiptap/) – a Tiptap based rich text editor
-- [`@mantine/dropzone`](https://mantine.dev/others/dropzone/) – manages files drag 'n' drop to an area or entire screen
-- [`@mantine/carousel`](https://mantine.dev/others/carousel/) – Carousel component
-- [`@mantine/nprogress`](https://mantine.dev/others/nprogress/) – navigation progress
-- [`@mantine/modals`](https://mantine.dev/others/modals/) – centralized modals manager
+- [`@mantine/tiptap`](https://mantine.dev/others/tiptap) – a Tiptap based rich text editor
+- [`@mantine/dropzone`](https://mantine.dev/others/dropzone) – manages files drag 'n' drop to an area or entire screen
+- [`@mantine/carousel`](https://mantine.dev/others/carousel) – Carousel component
+- [`@mantine/nprogress`](https://mantine.dev/others/nprogress) – navigation progress
+- [`@mantine/modals`](https://mantine.dev/others/modals) – centralized modals manager
 - [`@mantine/ssr`](https://mantine.dev/guides/ssr/) – server side rendering utilities
-- [`@mantine/next`](https://mantine.dev/guides/next/) – server side rendering utilities for Next.js
-- [`@mantine/remix`](https://mantine.dev/guides/remix/) – server side rendering utilities for Remix
-- [`gatsby-plugin-mantine`](https://mantine.dev/guides/gatsby/) – Gatsby plugin to setup server side rendering
+- [`@mantine/next`](https://mantine.dev/guides/next) – server side rendering utilities for Next.js
+- [`@mantine/remix`](https://mantine.dev/guides/remix) – server side rendering utilities for Remix
+- [`gatsby-plugin-mantine`](https://mantine.dev/guides/gatsby) – Gatsby plugin to setup server side rendering
 - [`eslint-config-mantine`](https://www.npmjs.com/package/eslint-config-mantine) – ESLint and Prettier configuration that is used in all Mantine projects
 
 ## Getting help


### PR DESCRIPTION
The redirect links on the README.md are not workingas intended due to the extra `/` in the links. The current URLs return 404.

Also: 
These pages do not exist in general: 
1. (https://mantine.dev/styles/create-styles/)
2. (https://mantine.dev/others/prism/)
3. (https://mantine.dev/guides/ssr/)

Hence, I did not change the links for the above, however, if you have a link that you would redirect to, I'll be happy to address it in the same PR.