### PR TITLE
Progress Demo | Changed Animated -> Animate

### DIFF
--- a/src/mantine-demos/src/demos/core/Progress/Progress.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/core/Progress/Progress.demo.usage.tsx
@@ -34,6 +34,6 @@ export const usage: MantineDemo = {
       libraryValue: '__',
     },
     { prop: 'striped', type: 'boolean', initialValue: false, libraryValue: false },
-    { prop: 'animated', type: 'boolean', initialValue: false, libraryValue: false },
+    { prop: 'animate', type: 'boolean', initialValue: false, libraryValue: false },
   ],
 };


### PR DESCRIPTION
# Changes Made
In the [Mantine Documentation](https://mantine.dev/core/progress/), the code block says `animated` which has been changed to `animate`.

# References
## [Mantine Progress Bar Documentation](https://mantine.dev/core/progress/)
![image](https://github.com/mantinedev/mantine/assets/98240335/9f49600b-875d-4e04-8178-096834d5502c)
## Code Editor
![image](https://github.com/mantinedev/mantine/assets/98240335/85b32dcd-9c5e-4f79-a80c-a9b1dae5ac15)
