### PR TITLE
[@mantine/core] SegmentedControl: Add hover color (only color applied component)

### DIFF
--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.module.css
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.module.css
@@ -225,3 +225,17 @@
     }
   }
 }
+
+.control:not([data-disabled]):not([data-active]) {
+  background-color: var(--_bg);
+
+  @mixin hover {
+    @mixin light {
+      --_bg: var(--sc-hover);
+    }
+
+    @mixin dark {
+      --_bg: var(--sc-hover);
+    }
+  }
+}

--- a/src/mantine-core/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/mantine-core/src/components/SegmentedControl/SegmentedControl.tsx
@@ -28,6 +28,7 @@ export type SegmentedControlStylesNames = 'root' | 'input' | 'label' | 'control'
 export type SegmentedControlCssVariables = {
   root:
     | '--sc-radius'
+    | '--sc-hover'
     | '--sc-color'
     | '--sc-font-size'
     | '--sc-padding'
@@ -102,6 +103,7 @@ const varsResolver = createVarsResolver<SegmentedControlFactory>(
   (theme, { radius, color, transitionDuration, size, transitionTimingFunction }) => ({
     root: {
       '--sc-radius': radius === undefined ? undefined : getRadius(radius),
+      '--sc-hover': color ? `var(--mantine-color-${color}-outline-hover)` : undefined,
       '--sc-color': color ? getThemeColor(color, theme) : undefined,
       '--sc-shadow': color ? undefined : 'var(--mantine-shadow-xs)',
       '--sc-transition-duration':

--- a/src/mantine-styles-api/src/data/SegmentedControl.styles-api.ts
+++ b/src/mantine-styles-api/src/data/SegmentedControl.styles-api.ts
@@ -12,6 +12,7 @@ export const SegmentedControlStylesApi: StylesApiData<SegmentedControlFactory> =
 
   vars: {
     root: {
+      '--sc-hover': 'Controls `background-color` of `indicator` when hovered',
       '--sc-color': 'Control `background-color` of `indicator`',
       '--sc-font-size': 'Controls `font-size` of labels',
       '--sc-padding': 'Controls `padding` of control',


### PR DESCRIPTION
I thought it would be better to have a color on hover for a SegmentedControl with color, so I added it.

![mQDfxkr - Imgur](https://github.com/mantinedev/mantine/assets/1396267/41dd5793-bf5d-4870-90cb-501ff16fef50)

Pass test
https://app.warp.dev/block/C79nYUsYK7bMvBeoUMH0lm

If you don't want hover, please close it.