### PR TITLE
[@mantine/core] Button: Fix disabled outline button style

### DIFF
--- a/src/mantine-core/src/components/Button/Button.module.css
+++ b/src/mantine-core/src/components/Button/Button.module.css
@@ -74,6 +74,7 @@
     --_button-bg: var(--_disabled-bg);
     --_button-color: var(--_disabled-color);
     transform: none;
+    border-color: transparent;
   }
 
   &[data-loading] {


### PR DESCRIPTION
I referred to the implementation in v6.
https://github.com/mantinedev/mantine/blob/cdf1179358c6d4591f5de76a2a41935ff4c91ec6/src/mantine-core/src/Button/Button.styles.ts#L138

Current:
![スクリーンショット 2023-09-20 21 19 17](https://github.com/mantinedev/mantine/assets/62416191/0a3eed05-614e-4fd8-8567-d99fadcd52a2)

This Pull Request:
![スクリーンショット 2023-09-20 21 19 35](https://github.com/mantinedev/mantine/assets/62416191/74f86742-dca5-452d-8230-6c6282e48d5a)

If this was an intentional change from v6, please close this PR.
And thank you for the hard work on v7!
