### PR TITLE
[@mantine/core] make MantineThemeColorsOverride an interface instead of type

### DIFF
--- a/docs/pages/theming/colors.mdx
+++ b/docs/pages/theming/colors.mdx
@@ -202,3 +202,19 @@ function Demo() {
 ## Default colors
 
 <ThemeColors />
+
+## Add custom colors types
+
+TypeScript will only autocomplete Mantine's default colors when accessing the theme. To add your custom colors to the MantineColor type, you can use TypeScript module declaration.
+
+```ts
+import { DefaultMantineColor, MantineColorsTuple } from '@mantine/core';
+
+type ExtendedCustomColors = 'primaryColorName' | 'secondaryColorName' | DefaultMantineColor;
+
+declare module '@mantine/core' {
+  export interface MantineThemeColorsOverride {
+    colors: Record<ExtendedCustomColors, MantineColorsTuple>;
+  }
+}
+```

--- a/src/mantine-core/src/core/MantineProvider/theme.types.ts
+++ b/src/mantine-core/src/core/MantineProvider/theme.types.ts
@@ -201,7 +201,7 @@ export type DefaultMantineColor =
   | 'teal'
   | (string & {});
 
-export type MantineThemeColorsOverride = {};
+export interface MantineThemeColorsOverride {}
 
 export type MantineThemeColors = MantineThemeColorsOverride extends {
   colors: Record<infer CustomColors, MantineColorsTuple>;


### PR DESCRIPTION
This is needed to allow `MantineThemeColorsOverride` to be overwritten 