### PR TITLE
[@mantine/core] Fix table highlight doesn't work on striped dark rows

### DIFF
--- a/src/mantine-core/src/components/Table/Table.module.css
+++ b/src/mantine-core/src/components/Table/Table.module.css
@@ -37,7 +37,7 @@
   background-color: var(--_tr-bg, transparent);
 
   @mixin hover {
-    --_tr-bg: var(--_tr-hover-bg, transparent);
+    --_tr-bg: var(--_tr-hover-bg, transparent) !important;
   }
 
   &[data-with-row-border] {


### PR DESCRIPTION
Problem was on specificity, darker rows have styles that override the hover background change. Adding `!important` rule solved the problem by prioritizing hover.