### PR TITLE
[@mantine/core] Select: Fix search text not updating

### DIFF
--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -171,7 +171,7 @@ export const Select = factory<SelectFactory>((_props, ref) => {
     if (typeof value === 'string' && optionsLockup[value]) {
       setSearch(optionsLockup[value].label);
     }
-  }, [value]);
+  }, [value, optionsLockup]);
 
   return (
     <>


### PR DESCRIPTION
The select input isn't watching the `data` prop change after a value is already set, this will cause the underlying input to remain unchanged/blank. A simple case could be seen with something like this:

```ts
  const value = "Foo";
  const [options, setOptions] = useState([]);

  useEffect(() => {
    const optionsSetter = setTimeout(() => {
      setOptions(["Foo", "Bar"]);
    }, 1500);
    return () => clearTimeout(optionsSetter);
  });

  return (
      <Select data={options} value={value} />
  );
  ```
  
By watching the optionsLockup in the useEffect dependencies it should catch updates to that data. 