### PR TITLE
[@mantine/core] Fix broken other theme override type

### DIFF
--- a/src/mantine-core/src/core/MantineProvider/theme.types.ts
+++ b/src/mantine-core/src/core/MantineProvider/theme.types.ts
@@ -156,7 +156,7 @@ export type MantineShadow = keyof MantineShadowsValues | (string & {});
 export type MantineLineHeight = keyof MantineLineHeightValues;
 
 export interface MantineThemeOther {
-  [key: string]: any
+  [key: string]: any;
 }
 
 export interface MantineGradient {

--- a/src/mantine-core/src/core/MantineProvider/theme.types.ts
+++ b/src/mantine-core/src/core/MantineProvider/theme.types.ts
@@ -155,7 +155,9 @@ export type MantineSpacing = keyof MantineSpacingValues | (string & {}) | number
 export type MantineShadow = keyof MantineShadowsValues | (string & {});
 export type MantineLineHeight = keyof MantineLineHeightValues;
 
-export type MantineThemeOther = Record<string, any>;
+export interface MantineThemeOther {
+  [key: string]: any
+}
 
 export interface MantineGradient {
   from: string;


### PR DESCRIPTION
Similar to the `MantineThemeColorsOverride` issue  #4816, changed `MantineThemeOther` to interface to be overwritten