### PR TITLE
fixed typo in the docs

### DIFF
--- a/docs/pages/theming/mantine-provider.mdx
+++ b/docs/pages/theming/mantine-provider.mdx
@@ -6,9 +6,9 @@ export default Layout(MDX_DATA.MantineProvider);
 
 # MantineProvider
 
-`MantineProvider` provides [theme object](/theming/theme-object) context value, manages color scheme
+`MantineProvider` provides a [theme object](/theming/theme-object) context value, manages color scheme
 changes and injects [CSS variables](/styles/css-variables/). It must be rendered at the root of your
-application and should be user only once.
+application and should be used only once.
 
 ## Usage
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -133,10 +133,10 @@
   version "0.0.0"
   uid ""
 
-"@mantine/store@7.0.0-beta.5":
-  version "7.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@mantine/store/-/store-7.0.0-beta.5.tgz#24d55bf2dc45e33e9005e131b2944bbf3d19c263"
-  integrity sha512-smKxfat+Gne95qaMivjUJbifIxp4/ptxVnSkyw6RD580aspexRQOIGRtX/OeMmS6Yz9D5beLkl6Q1C/8/RHNhg==
+"@mantine/store@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@mantine/store/-/store-7.0.0.tgz#5e57b8ec98531446a4afb2afdc02dd411bd8d379"
+  integrity sha512-MliHi9TUe7fTLIzj3LWYEoQPkm3TbkmCUNBdynFrx0Ls+WoyNjW73RhxbiZB2KfHXs/tsYySA6mjMoSgUhkQDw==
 
 "@mantine/store@link:../src/mantine-store":
   version "0.0.0"


### PR DESCRIPTION
Fixed typo in the  theming section for the MantineProvider. Added "a" before 'theme object' for better clarity and changed user to used to make it grammatically correct 