### PR TITLE
Issue Fix: use-focus-trap doesn't handle Radio Groups well

### DIFF
--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -133,10 +133,10 @@
   version "0.0.0"
   uid ""
 
-"@mantine/store@7.0.0-beta.5":
-  version "7.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@mantine/store/-/store-7.0.0-beta.5.tgz#24d55bf2dc45e33e9005e131b2944bbf3d19c263"
-  integrity sha512-smKxfat+Gne95qaMivjUJbifIxp4/ptxVnSkyw6RD580aspexRQOIGRtX/OeMmS6Yz9D5beLkl6Q1C/8/RHNhg==
+"@mantine/store@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@mantine/store/-/store-7.0.0.tgz#5e57b8ec98531446a4afb2afdc02dd411bd8d379"
+  integrity sha512-MliHi9TUe7fTLIzj3LWYEoQPkm3TbkmCUNBdynFrx0Ls+WoyNjW73RhxbiZB2KfHXs/tsYySA6mjMoSgUhkQDw==
 
 "@mantine/store@link:../src/mantine-store":
   version "0.0.0"

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -133,10 +133,10 @@
   version "0.0.0"
   uid ""
 
-"@mantine/store@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@mantine/store/-/store-7.0.2.tgz#cb3288829c75c5d6b96555cab33c58c72cc32c3d"
-  integrity sha512-0OAca3r/IQ6c7Pb6YvmL+5hyCo31vA3SfZKTwb1KquX4SjFfjpdhPuTR/tzjmxqwIw4zkzXH/7ckNZ/AHHwm8A==
+"@mantine/store@7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@mantine/store/-/store-7.1.1.tgz#859071535c97fc54862ffe946f58d95cb0455777"
+  integrity sha512-gCF59GbcRdAOqhrjWQczCAL3Hg+gMaiuATkXFCgbjkwIYXy22zlFAnSKckKHxWuRu7d51dJkPrGelnc7HtZQzA==
 
 "@mantine/store@link:../src/mantine-store":
   version "0.0.0"
@@ -655,11 +655,6 @@ astring@^1.8.0:
   resolved "https://registry.yarnpkg.com/astring/-/astring-1.8.4.tgz#6d4c5d8de7be2ead9e4a3cc0e2efb8d759378904"
   integrity sha512-97a+l2LBU3Op3bBQEff79i/E4jMD2ZLFD8rHx9B6mXyB2uQwhJQYfiDqUwtfjF4QA1F2qs//N6Cw8LetMbQjcw==
 
-attr-accept@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
-  integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
-
 bail@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
@@ -872,13 +867,6 @@ fault@^2.0.0:
   integrity sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==
   dependencies:
     format "^0.2.0"
-
-file-selector@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.6.0.tgz#fa0a8d9007b829504db4d07dd4de0310b65287dc"
-  integrity sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==
-  dependencies:
-    tslib "^2.4.0"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -1635,13 +1623,11 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-dropzone@14.2.3:
-  version "14.2.3"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-14.2.3.tgz#0acab68308fda2d54d1273a1e626264e13d4e84b"
-  integrity sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==
+react-dropzone-esm@15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/react-dropzone-esm/-/react-dropzone-esm-15.0.1.tgz#8c689638aaa9feb5b2a429dd565acfa6792263e5"
+  integrity sha512-RdeGpqwHnoV/IlDFpQji7t7pTtlC2O1i/Br0LWkRZ9hYtLyce814S71h5NolnCZXsIN5wrZId6+8eQj2EBnEzg==
   dependencies:
-    attr-accept "^2.2.2"
-    file-selector "^0.6.0"
     prop-types "^15.8.1"
 
 react-is@^16.13.1, react-is@^16.7.0:
@@ -1701,10 +1687,10 @@ react-style-singleton@^2.2.1:
     invariant "^2.2.4"
     tslib "^2.0.0"
 
-react-textarea-autosize@8.5.2:
-  version "8.5.2"
-  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.5.2.tgz#6421df2b5b50b9ca8c5e96fd31be688ea7fa2f9d"
-  integrity sha512-uOkyjkEl0ByEK21eCJMHDGBAAd/BoFQBawYK5XItjAmCTeSbjxghd8qnt7nzsLYzidjnoObu6M26xts0YGKsGg==
+react-textarea-autosize@8.5.3:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz#d1e9fe760178413891484847d3378706052dd409"
+  integrity sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==
   dependencies:
     "@babel/runtime" "^7.20.13"
     use-composed-ref "^1.3.0"

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -133,10 +133,10 @@
   version "0.0.0"
   uid ""
 
-"@mantine/store@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@mantine/store/-/store-7.0.0.tgz#5e57b8ec98531446a4afb2afdc02dd411bd8d379"
-  integrity sha512-MliHi9TUe7fTLIzj3LWYEoQPkm3TbkmCUNBdynFrx0Ls+WoyNjW73RhxbiZB2KfHXs/tsYySA6mjMoSgUhkQDw==
+"@mantine/store@7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@mantine/store/-/store-7.0.2.tgz#cb3288829c75c5d6b96555cab33c58c72cc32c3d"
+  integrity sha512-0OAca3r/IQ6c7Pb6YvmL+5hyCo31vA3SfZKTwb1KquX4SjFfjpdhPuTR/tzjmxqwIw4zkzXH/7ckNZ/AHHwm8A==
 
 "@mantine/store@link:../src/mantine-store":
   version "0.0.0"

--- a/src/mantine-dates/src/components/DateInput/DateInput.tsx
+++ b/src/mantine-dates/src/components/DateInput/DateInput.tsx
@@ -137,18 +137,18 @@ export const DateInput = factory<DateInputFactory>((_props, ref) => {
 
   const { calendarProps, others } = pickCalendarProps(rest);
   const ctx = useDatesContext();
-  const defaultDateParser = (val: string) => {
-    const parsedDate = dayjs(val, valueFormat, ctx.getLocale(locale)).toDate();
+  const defaultDateParser = (DateVal: string) => {
+    const parsedDate = dayjs(DateVal, valueFormat, ctx.getLocale(locale)).toDate();
     return Number.isNaN(parsedDate.getTime())
-      ? dateStringParser(val, ctx.getTimezone())
+      ? dateStringParser(DateVal, ctx.getTimezone())
       : parsedDate;
   };
 
   const _dateParser = dateParser || defaultDateParser;
   const _allowDeselect = allowDeselect !== undefined ? allowDeselect : clearable;
 
-  const formatValue = (val: Date) =>
-    val ? dayjs(val).locale(ctx.getLocale(locale)).format(valueFormat) : '';
+  const formatValue = (dateVal: Date) =>
+    dateVal ? dayjs(dateVal).locale(ctx.getLocale(locale)).format(valueFormat) : '';
 
   const [_value, setValue, controlled] = useUncontrolledDates({
     type: 'default',

--- a/src/mantine-dates/src/components/DateInput/DateInput.tsx
+++ b/src/mantine-dates/src/components/DateInput/DateInput.tsx
@@ -137,10 +137,10 @@ export const DateInput = factory<DateInputFactory>((_props, ref) => {
 
   const { calendarProps, others } = pickCalendarProps(rest);
   const ctx = useDatesContext();
-  const defaultDateParser = (dateVal: string) => {
-    const parsedDate = dayjs(dateVal, valueFormat, ctx.getLocale(locale)).toDate();
+  const defaultDateParser = (val: string) => {
+    const parsedDate = dayjs(val, valueFormat, ctx.getLocale(locale)).toDate();
     return Number.isNaN(parsedDate.getTime())
-      ? dateStringParser(dateVal, ctx.getTimezone())
+      ? dateStringParser(val, ctx.getTimezone())
       : parsedDate;
   };
 

--- a/src/mantine-dates/src/components/DateInput/DateInput.tsx
+++ b/src/mantine-dates/src/components/DateInput/DateInput.tsx
@@ -137,10 +137,10 @@ export const DateInput = factory<DateInputFactory>((_props, ref) => {
 
   const { calendarProps, others } = pickCalendarProps(rest);
   const ctx = useDatesContext();
-  const defaultDateParser = (DateVal: string) => {
-    const parsedDate = dayjs(DateVal, valueFormat, ctx.getLocale(locale)).toDate();
+  const defaultDateParser = (dateVal: string) => {
+    const parsedDate = dayjs(dateVal, valueFormat, ctx.getLocale(locale)).toDate();
     return Number.isNaN(parsedDate.getTime())
-      ? dateStringParser(DateVal, ctx.getTimezone())
+      ? dateStringParser(dateVal, ctx.getTimezone())
       : parsedDate;
   };
 

--- a/src/mantine-dates/src/components/DateInput/DateInput.tsx
+++ b/src/mantine-dates/src/components/DateInput/DateInput.tsx
@@ -147,8 +147,8 @@ export const DateInput = factory<DateInputFactory>((_props, ref) => {
   const _dateParser = dateParser || defaultDateParser;
   const _allowDeselect = allowDeselect !== undefined ? allowDeselect : clearable;
 
-  const formatValue = (dateVal: Date) =>
-    dateVal ? dayjs(dateVal).locale(ctx.getLocale(locale)).format(valueFormat) : '';
+  const formatValue = (val: Date) =>
+    val ? dayjs(val).locale(ctx.getLocale(locale)).format(valueFormat) : '';
 
   const [_value, setValue, controlled] = useUncontrolledDates({
     type: 'default',

--- a/src/mantine-hooks/src/use-focus-trap/scope-tab.ts
+++ b/src/mantine-hooks/src/use-focus-trap/scope-tab.ts
@@ -10,7 +10,6 @@ export function scopeTab(node: HTMLElement, event: KeyboardEvent) {
   const root = node.getRootNode() as unknown as DocumentOrShadowRoot;
   let leavingFinalTabbable = finalTabbable === root.activeElement || node === root.activeElement;
 
-  // Handle the case of the active element being in a RadioGroup with the finalTabbable element
   const activeElement = root.activeElement as Element;
   const activeElementIsRadio =
     activeElement.tagName === 'INPUT' && activeElement.getAttribute('type') === 'radio';

--- a/src/mantine-hooks/src/use-focus-trap/scope-tab.ts
+++ b/src/mantine-hooks/src/use-focus-trap/scope-tab.ts
@@ -8,7 +8,20 @@ export function scopeTab(node: HTMLElement, event: KeyboardEvent) {
   }
   const finalTabbable = tabbable[event.shiftKey ? 0 : tabbable.length - 1];
   const root = node.getRootNode() as unknown as DocumentOrShadowRoot;
-  const leavingFinalTabbable = finalTabbable === root.activeElement || node === root.activeElement;
+  let leavingFinalTabbable = finalTabbable === root.activeElement || node === root.activeElement;
+
+  // Handle the case of the active element being in a RadioGroup with the finalTabbable element
+  const activeElement = root.activeElement as Element;
+  const activeElementIsRadio =
+    activeElement.tagName === 'INPUT' && activeElement.getAttribute('type') === 'radio';
+  if (activeElementIsRadio) {
+    const activeRadioGroup = tabbable.filter(
+      (element) =>
+        element.getAttribute('type') === 'radio' &&
+        element.getAttribute('name') === activeElement.getAttribute('name')
+    );
+    leavingFinalTabbable = activeRadioGroup.includes(finalTabbable);
+  }
 
   if (!leavingFinalTabbable) {
     return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6048,30 +6048,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001449:
-  version "1.0.30001457"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001457.tgz#6af34bb5d720074e2099432aa522c21555a18301"
-  integrity sha512-SDIV6bgE1aVbK6XyxdURbUE89zY7+k1BBBaOwYwkNCglXlel/E7mELiHC64HQ+W0xSKlqWhV9Wh7iHxUjMs4fA==
-
-caniuse-lite@^1.0.30001109:
-  version "1.0.30001458"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001458.tgz#871e35866b4654a7d25eccca86864f411825540c"
-  integrity sha512-lQ1VlUUq5q9ro9X+5gOEyH7i3vm+AYVT1WDCVB69XOZ17KZRhnZ9J0Sqz7wTHQaLBJccNCHq8/Ww5LlOIZbB0w==
-
-caniuse-lite@^1.0.30001219:
-  version "1.0.30001232"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001232.tgz#2ebc8b6a77656fd772ab44a82a332a26a17e9527"
-  integrity sha512-e4Gyp7P8vqC2qV2iHA+cJNf/yqUKOShXQOJHQt81OHxlIZl/j/j3soEA0adAQi8CPUQgvOdDENyQ5kd6a6mNSg==
-
-caniuse-lite@^1.0.30001332:
-  version "1.0.30001341"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz#59590c8ffa8b5939cf4161f00827b8873ad72498"
-  integrity sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==
-
-caniuse-lite@^1.0.30001503:
-  version "1.0.30001517"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz#90fabae294215c3495807eb24fc809e11dc2f0a8"
-  integrity sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001503:
+  version "1.0.30001540"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001540.tgz"
+  integrity sha512-9JL38jscuTJBTcuETxm8QLsFr/F6v0CYYTEU6r5+qSM98P2Q0Hmu0eG1dTG5GBUmywU3UlcVOUSIJYY47rdFSw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #4678

```js
import { findTabbableDescendants } from './tabbable';

export function scopeTab(node: HTMLElement, event: KeyboardEvent) {
  const tabbable = findTabbableDescendants(node);
  if (!tabbable.length) {
    event.preventDefault();
    return;
  }
  const finalTabbable = tabbable[event.shiftKey ? 0 : tabbable.length - 1];
  const root = node.getRootNode() as unknown as DocumentOrShadowRoot;
  let leavingFinalTabbable = finalTabbable === root.activeElement || node === root.activeElement;

  // Handle the case of the active element being in a RadioGroup with the finalTabbable element
  const activeElement = root.activeElement as Element;
  const activeElementIsRadio =
    activeElement.tagName === 'INPUT' && activeElement.getAttribute('type') === 'radio';
  if (activeElementIsRadio) {
    const activeRadioGroup = tabbable.filter(
      (element) =>
        element.getAttribute('type') === 'radio' &&
        element.getAttribute('name') === activeElement.getAttribute('name')
    );
    leavingFinalTabbable = activeRadioGroup.includes(finalTabbable);
  }

  if (!leavingFinalTabbable) {
    return;
  }

  event.preventDefault();

  const target = tabbable[event.shiftKey ? tabbable.length - 1 : 0];

  if (target) {
    target.focus();
  }
}
```