### PR TITLE
[@mantine/dates] Fix esm mandatory file extensions bug

### DIFF
--- a/src/mantine-dates/src/utils/get-timezone-offset.ts
+++ b/src/mantine-dates/src/utils/get-timezone-offset.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
-import utcPlugin from 'dayjs/plugin/utc';
-import timezonePlugin from 'dayjs/plugin/timezone';
+import utcPlugin from 'dayjs/plugin/utc.js';
+import timezonePlugin from 'dayjs/plugin/timezone.js';
 
 dayjs.extend(utcPlugin);
 dayjs.extend(timezonePlugin);


### PR DESCRIPTION
When using @mantine/dates the following error throws:
```js
Error: Cannot find module '/Users/user/code/node_modules/.pnpm/@mantine+dates@7.0.1_@mantine+core@7.0.1_@mantine+hooks@7.0.1_dayjs@1.11.10_react-dom@18.2.0_react@18.2.0/node_modules/dayjs/plugin/utc' imported from /Users/user/code/node_modules/.pnpm/@mantine+dates@7.0.1_@mantine+core@7.0.1_@mantine+hooks@7.0.1_dayjs@1.11.10_react-dom@18.2.0_react@18.2.0/node_modules/@mantine/dates/esm/utils/get-timezone-offset.mjs
Did you mean to import dayjs@1.11.10/node_modules/dayjs/plugin/utc.js?
```

This is because of the missing .js when bare importing the plugins.

See https://nodejs.org/api/esm.html#esm_mandatory_file_extensions

and https://github.com/iamkun/dayjs/issues/1167 specifically https://github.com/iamkun/dayjs/issues/1167#issuecomment-1100752982

