### PR TITLE
[@mantine/hooks] use-timeout: Memoize returned callbacks

### DIFF
--- a/src/mantine-hooks/src/use-timeout/use-timeout.ts
+++ b/src/mantine-hooks/src/use-timeout/use-timeout.ts
@@ -32,7 +32,7 @@ export function useTimeout(
     }
 
     return clear;
-  }, [clear, delay, options.autoInvoke, start]);
+  }, [clear, options.autoInvoke, start]);
 
   return { start, clear };
 }

--- a/src/mantine-hooks/src/use-timeout/use-timeout.ts
+++ b/src/mantine-hooks/src/use-timeout/use-timeout.ts
@@ -16,7 +16,7 @@ export function useTimeout(
         }, delay);
       }
     },
-    [callback, delay],
+    [callback, delay]
   );
 
   const clear = useCallback(() => {
@@ -32,7 +32,7 @@ export function useTimeout(
     }
 
     return clear;
-  }, [clear, options.autoInvoke, start]);
+  }, [clear, start]);
 
   return { start, clear };
 }

--- a/src/mantine-hooks/src/use-timeout/use-timeout.ts
+++ b/src/mantine-hooks/src/use-timeout/use-timeout.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useCallback } from 'react';
 
 export function useTimeout(
   callback: (...callbackParams: any[]) => void,
@@ -7,21 +7,24 @@ export function useTimeout(
 ) {
   const timeoutRef = useRef<number | null>(null);
 
-  const start = (...callbackParams: any[]) => {
-    if (!timeoutRef.current) {
-      timeoutRef.current = window.setTimeout(() => {
-        callback(callbackParams);
-        timeoutRef.current = null;
-      }, delay);
-    }
-  };
+  const start = useCallback(
+    (...callbackParams: any[]) => {
+      if (!timeoutRef.current) {
+        timeoutRef.current = window.setTimeout(() => {
+          callback(callbackParams);
+          timeoutRef.current = null;
+        }, delay);
+      }
+    },
+    [callback, delay],
+  );
 
-  const clear = () => {
+  const clear = useCallback(() => {
     if (timeoutRef.current) {
       window.clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
     }
-  };
+  }, []);
 
   useEffect(() => {
     if (options.autoInvoke) {
@@ -29,7 +32,7 @@ export function useTimeout(
     }
 
     return clear;
-  }, [delay]);
+  }, [clear, delay, options.autoInvoke, start]);
 
   return { start, clear };
 }


### PR DESCRIPTION
Currently, `start` and `clear` have unstable references, so they change every render. This makes them hard to use in effects, and cause unnecessary rerenders. This PR fixes that with `useCallback`.