### PR TITLE
[@mantine/core] Fix searchable select with controlled value

### DIFF
--- a/src/mantine-core/src/components/Select/Select.story.tsx
+++ b/src/mantine-core/src/components/Select/Select.story.tsx
@@ -86,6 +86,19 @@ export function ControlledSearch() {
   );
 }
 
+export function SearchControlledValue() {
+  return (
+    <div style={{ padding: 40 }}>
+      <Select
+        value="React"
+        data={['React', 'Angular', 'Svelte']}
+        placeholder="Select something"
+        searchable
+      />
+    </div>
+  );
+}
+
 export function AllowDeselectFalse() {
   return (
     <div style={{ padding: 40 }}>

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useId, useUncontrolled } from '@mantine/hooks';
 import {
   BoxProps,
@@ -135,8 +135,8 @@ export const Select = factory<SelectFactory>((_props, ref) => {
     ...others
   } = props;
 
-  const parsedData = getParsedComboboxData(data);
-  const optionsLockup = getOptionsLockup(parsedData);
+  const parsedData = useMemo(() => getParsedComboboxData(data), [data]);
+  const optionsLockup = useMemo(() => getOptionsLockup(parsedData), [parsedData]);
   const _id = useId(id);
 
   const [_value, setValue] = useUncontrolled({


### PR DESCRIPTION
fixes #4909

`optionsLockup` needs to be memorized as they are used in a effect further down. otherwise the effect will be triggered each render - preventing search changes to take effect.

https://github.com/mantinedev/mantine/blob/7dc4a72ece31650761c8aae96756c10e628dc9c7/src/mantine-core/src/components/Select/Select.tsx#L179-L187