### PR TITLE
[@mantine/core] NumberInput value type fix

### DIFF
--- a/src/mantine-core/src/components/NumberInput/NumberInput.test.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.test.tsx
@@ -73,7 +73,7 @@ describe('@mantine/core/NumberInput', () => {
     const spy = jest.fn();
     render(<NumberInput max={10} min={0} step={6} onChange={spy} />);
     await enterText('5');
-    expect(spy).toHaveBeenLastCalledWith(5);
+    expect(spy).toHaveBeenLastCalledWith('5');
     await enterText('{backspace}');
     expect(spy).toHaveBeenLastCalledWith('');
     expectValue('');
@@ -85,15 +85,15 @@ describe('@mantine/core/NumberInput', () => {
 
     focusInput();
     await enterText('3');
-    expect(spy).toHaveBeenLastCalledWith(3);
+    expect(spy).toHaveBeenLastCalledWith('3');
     expect(spy).toHaveBeenCalledTimes(1);
 
     await enterText('2');
-    expect(spy).toHaveBeenLastCalledWith(32);
+    expect(spy).toHaveBeenLastCalledWith('32');
     expect(spy).toHaveBeenCalledTimes(2);
 
     await enterText('a');
-    expect(spy).toHaveBeenLastCalledWith(32);
+    expect(spy).toHaveBeenLastCalledWith('32');
     expect(spy).toHaveBeenCalledTimes(2);
   });
 

--- a/src/mantine-core/src/components/NumberInput/NumberInput.tsx
+++ b/src/mantine-core/src/components/NumberInput/NumberInput.tsx
@@ -227,7 +227,11 @@ export const NumberInput = factory<NumberInputFactory>((_props, ref) => {
   });
 
   const handleValueChange: OnValueChange = (payload, event) => {
-    setValue(isValidNumber(payload.floatValue) ? payload.floatValue : payload.value);
+    setValue(
+      typeof _value === 'number' && isValidNumber(payload.floatValue)
+        ? payload.floatValue
+        : payload.value
+    );
     onValueChange?.(payload, event);
   };
 


### PR DESCRIPTION
`NumberInput` value type will be based on initial value type. 

Fixes: #4912
Fixes: #4901 