### PR TITLE
Update react-textarea-autosize to 8.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "react-imask": "^6.4.3",
     "react-number-format": "^5.2.2",
     "react-remove-scroll": "^2.5.6",
-    "react-textarea-autosize": "8.5.2",
+    "react-textarea-autosize": "8.5.3",
     "react-transition-group": "4.4.5",
     "type-fest": "^3.13.1",
     "zod": "^3.21.4"

--- a/src/mantine-core/package.json
+++ b/src/mantine-core/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.24.8",
     "clsx": "2.0.0",
-    "react-textarea-autosize": "8.5.2",
+    "react-textarea-autosize": "8.5.3",
     "react-remove-scroll": "^2.5.6",
     "type-fest": "^3.13.1",
     "react-number-format": "^5.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13907,10 +13907,10 @@ react-style-singleton@^2.2.1:
     invariant "^2.2.4"
     tslib "^2.0.0"
 
-react-textarea-autosize@8.5.2:
-  version "8.5.2"
-  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.5.2.tgz#6421df2b5b50b9ca8c5e96fd31be688ea7fa2f9d"
-  integrity sha512-uOkyjkEl0ByEK21eCJMHDGBAAd/BoFQBawYK5XItjAmCTeSbjxghd8qnt7nzsLYzidjnoObu6M26xts0YGKsGg==
+react-textarea-autosize@8.5.3:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz#d1e9fe760178413891484847d3378706052dd409"
+  integrity sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==
   dependencies:
     "@babel/runtime" "^7.20.13"
     use-composed-ref "^1.3.0"


### PR DESCRIPTION
Fixes `Textarea` component when using Next.js edge runtime. 

The `Textarea` component was experiencing server-side rendering (SSR) failure when used with Next.js edge runtime. The error message returned was:

```
ReferenceError: document is not defined
    at (../../node_modules/react-textarea-autosize/dist/react-textarea-autosize.browser.esm.js:100:0)
    at (webpack/bootstrap:21:0)
    at (../../node_modules/@mantine/core/cjs/components/Textarea/Textarea.js:6:23)
    at (webpack/bootstrap:21:0)
    at (../../node_modules/@mantine/core/cjs/components/JsonInput/JsonInput.js:8:15)
    at (webpack/bootstrap:21:0)
    at (../../node_modules/@mantine/core/cjs/index.js?4f1e:199:16)
    at (webpack/bootstrap:21:0)
    at (../../node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.production.min.js:26:18)
    at (../../node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.e
```

This specific issue was addressed and resolved in the latest version of `react-textarea-autosize`, which can be found here: [v8.5.3](https://github.com/Andarist/react-textarea-autosize/releases/tag/v8.5.3).