### PR TITLE
[@mantine/core] Button: fix loading overlay default border radius

### DIFF
--- a/src/mantine-core/src/components/Button/Button.module.css
+++ b/src/mantine-core/src/components/Button/Button.module.css
@@ -85,7 +85,7 @@
       content: '';
       position: absolute;
       inset: rem(-1px);
-      border-radius: var(--button-radius);
+      border-radius: var(--button-radius, var(--mantine-radius-default));
       background-color: var(--_button-loading-overlay-bg);
     }
   }


### PR DESCRIPTION
Fixes a problem you can see easily in the Mantine docs in dark mode, where the border radius of the overlay doesn't match the button's: https://mantine.dev/core/button/#loading-state

![image](https://github.com/mantinedev/mantine/assets/3955124/3f988e6c-233f-4a83-a8a0-017b75eb4d1d)

