### PR TITLE
[docs] Progress: Fix animated prop in Storybook demo

### DIFF
--- a/src/mantine-demos/src/demos/core/Progress/Progress.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/core/Progress/Progress.demo.usage.tsx
@@ -34,6 +34,6 @@ export const usage: MantineDemo = {
       libraryValue: '__',
     },
     { prop: 'striped', type: 'boolean', initialValue: false, libraryValue: false },
-    { prop: 'animate', type: 'boolean', initialValue: false, libraryValue: false },
+    { prop: 'animated', type: 'boolean', initialValue: false, libraryValue: false },
   ],
 };


### PR DESCRIPTION
Update the Progress component's Storybook to use the `animated` prop instead of `animate` from v6 which is [currently broken in the docs](https://mantine.dev/core/progress/).

![progress-animated](https://github.com/mantinedev/mantine/assets/9349865/1ddb3f75-6390-4e9a-b26f-c7f4ef216a5c)
