### PR TITLE
[@mantine/core] Add tests for <FocusTrap /> using shift + tab

### DIFF
--- a/src/mantine-core/src/components/FocusTrap/FocusTrap.test.tsx
+++ b/src/mantine-core/src/components/FocusTrap/FocusTrap.test.tsx
@@ -49,6 +49,71 @@ describe('@mantine/core/FocusTrap', () => {
     expect(document.body).toHaveFocus();
   });
 
+  it('traps focus on shift + tab', async () => {
+    render(
+      <FocusTrap>
+        <div>
+          <input />
+          <button type="button">Button</button>
+          <input type="radio" />
+        </div>
+      </FocusTrap>
+    );
+
+    await wait(10);
+    expect(screen.getByRole('textbox')).toHaveFocus();
+
+    userEvent.tab();
+    expect(screen.getByRole('button')).toHaveFocus();
+
+    userEvent.tab({ shift: true });
+    await wait(10);
+    expect(screen.getByRole('textbox')).toHaveFocus();
+
+    userEvent.tab({ shift: true });
+    await wait(10);
+    expect(screen.getByRole('radio')).toHaveFocus();
+  });
+
+  it('traps focus on shift + tab and handles Radio Groups', async () => {
+    render(
+      <FocusTrap>
+        <div>
+          <label htmlFor="1">
+            Option One
+            <input type="radio" name="group" id="1" />
+          </label>
+
+          <label htmlFor="2">
+            Option Two
+            <input type="radio" name="group" id="2" />
+          </label>
+
+          <label htmlFor="3">
+            Option Three
+            <input type="radio" name="group" id="3" />
+          </label>
+
+          <button type="button">Button</button>
+        </div>
+      </FocusTrap>
+    );
+
+    await wait(10);
+    expect(screen.getByLabelText('Option One')).toHaveFocus();
+
+    userEvent.tab();
+    expect(screen.getByRole('button')).toHaveFocus();
+
+    userEvent.tab({ shift: true });
+    await wait(10);
+    expect(screen.getByLabelText('Option Three')).toHaveFocus();
+
+    userEvent.tab({ shift: true });
+    await wait(10);
+    expect(screen.getByRole('button')).toHaveFocus();
+  });
+
   it('manages aria-hidden attributes', () => {
     const adjacentDiv = document.createElement('div');
     adjacentDiv.setAttribute('data-testid', 'adjacent');


### PR DESCRIPTION
Fixes the tests that blocked #4679, and #4856 was merged without. Ended up being a silly thing that blocked my PR for weeks 🙄 .

Unfortunately, `useFocusTrap` has a `setTimeout` before actually focusing on an element, so we need to add a `wait()` before each of these assertions. These two test cases will add about 60ms to the total run time of the test suite, so I'll leave it up to @rtivital to decide on their worth.