### PR TITLE
[@mantine/core] Rating: Prevent emulated mouse events in touch devices

### DIFF
--- a/src/mantine-core/src/components/Rating/Rating.tsx
+++ b/src/mantine-core/src/components/Rating/Rating.tsx
@@ -128,6 +128,8 @@ export const Rating = factory<RatingFactory>((_props, ref) => {
     onMouseMove,
     onHover,
     onMouseLeave,
+    onTouchStart,
+    onTouchEnd,
     size,
     variant,
     getSymbolLabel,
@@ -174,6 +176,16 @@ export const Rating = factory<RatingFactory>((_props, ref) => {
   const stableValueRounded = roundValueTo(_value, decimalUnit);
   const finalValue = hovered !== -1 ? hovered : stableValueRounded;
 
+  const getRatingFromCoordinates = (x: number) => {
+    const { left, right, width } = rootRef.current!.getBoundingClientRect();
+    const symbolWidth = width / _count;
+
+    const hoverPosition = dir === 'rtl' ? right - x : x - left;
+    const hoverValue = hoverPosition / symbolWidth;
+
+    return clamp(roundValueTo(hoverValue + decimalUnit / 2, decimalUnit), decimalUnit, _count);
+  };
+
   const handleMouseEnter = (event: React.MouseEvent<HTMLDivElement>) => {
     onMouseEnter?.(event);
     !readOnly && setOutside(false);
@@ -186,17 +198,7 @@ export const Rating = factory<RatingFactory>((_props, ref) => {
       return;
     }
 
-    const { left, right, width } = rootRef.current!.getBoundingClientRect();
-    const symbolWidth = width / _count;
-
-    const hoverPosition = dir === 'rtl' ? right - event.clientX : event.clientX - left;
-    const hoverValue = hoverPosition / symbolWidth;
-
-    const rounded = clamp(
-      roundValueTo(hoverValue + decimalUnit / 2, decimalUnit),
-      decimalUnit,
-      _count
-    );
+    const rounded = getRatingFromCoordinates(event.clientX);
 
     setHovered(rounded);
     rounded !== hovered && onHover?.(rounded);
@@ -214,7 +216,37 @@ export const Rating = factory<RatingFactory>((_props, ref) => {
     hovered !== -1 && onHover?.(-1);
   };
 
+  const handleTouchStart = (event: React.TouchEvent<HTMLDivElement>) => {
+    event.preventDefault();
+
+    const { touches } = event;
+    if (touches.length !== 1) {
+      return;
+    }
+
+    const touch = touches[0];
+    setValue(getRatingFromCoordinates(touch.clientX));
+
+    onTouchStart?.(event);
+  };
+
+  const handleTouchEnd = (event: React.TouchEvent<HTMLDivElement>) => {
+    event.preventDefault();
+
+    onTouchEnd?.(event);
+  };
+
   const handleItemBlur = () => isOutside && setHovered(-1);
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement> | number) => {
+    if (!readOnly) {
+      if (typeof event === 'number') {
+        setHovered(event);
+      } else {
+        setHovered(parseFloat(event.target.value));
+      }
+    }
+  };
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement> | number) => {
     if (!readOnly) {
@@ -261,6 +293,7 @@ export const Rating = factory<RatingFactory>((_props, ref) => {
                 name={_name}
                 onChange={handleChange}
                 onBlur={handleItemBlur}
+                onInputChange={handleInputChange}
                 id={`${_id}-${index}-${fractionIndex}`}
               />
             );
@@ -277,6 +310,8 @@ export const Rating = factory<RatingFactory>((_props, ref) => {
         onMouseMove={handleMouseMove}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
         variant={variant}
         size={size}
         id={_id}

--- a/src/mantine-core/src/components/Rating/RatingItem/RatingItem.tsx
+++ b/src/mantine-core/src/components/Rating/RatingItem/RatingItem.tsx
@@ -14,6 +14,7 @@ export interface RatingItemProps extends BoxProps, ElementProps<'input', 'value'
   value: number;
   id: string;
   onChange(event: React.ChangeEvent<HTMLInputElement> | number): void;
+  onInputChange(event: React.ChangeEvent<HTMLInputElement> | number): void;
 }
 
 export function RatingItem({
@@ -28,7 +29,9 @@ export function RatingItem({
   fractionValue,
   color,
   id,
+  onBlur,
   onChange,
+  onInputChange,
   style,
   ...others
 }: RatingItemProps) {
@@ -48,7 +51,8 @@ export function RatingItem({
           data-active={active || undefined}
           aria-label={getSymbolLabel?.(value)}
           value={value}
-          onChange={onChange}
+          onBlur={onBlur}
+          onChange={onInputChange}
           {...others}
         />
       )}


### PR DESCRIPTION
Fixes #4399 

When using a touch device browsers will dispatch emulated mouse events which, in this case, will cause the `handleMouseLeave` callback to be called as soon as we click elsewhere. One of the ways to fix this is to prevent emulated events by preventing this behaviour in `onTouchStart` and `onTouchEnd`.
Read more about emulated events [here](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Using_Touch_Events).

Issue fixed:

https://github.com/mantinedev/mantine/assets/7091198/0c2b8566-b162-4d60-a09b-c1e291dd7966

I also noticed that when using the keyboard we are changing the rating when using arrow navigation and not waiting for the spacebar which IMO is not right, because we might just be passing by 🤷 ? I added this fix here but I can remove it if it doesn't fit.

Issue fixed:

https://github.com/mantinedev/mantine/assets/7091198/cdf8cf43-fafd-47a7-8679-cfe628cd7a5b
