### PR TITLE
[@mantine/core] Add createable back into to MultiSelect and Select components

### DIFF
--- a/src/mantine-core/src/components/MultiSelect/MutliSelect.story.tsx
+++ b/src/mantine-core/src/components/MultiSelect/MutliSelect.story.tsx
@@ -155,3 +155,33 @@ export function SearchableHidePicked() {
     </div>
   );
 }
+
+export function Createable() {
+  const [options, setOptions] = useState([
+    { value: '1', label: 'React' },
+    { value: '2', label: 'Angular' },
+    { value: '3', label: 'Svelte' },
+  ]);
+
+  const [selectedValues, setSelectedValues] = useState<string[]>([]);
+
+  const handleCreate = (value: string) => {
+    const newOption = { value, label: value };
+    setOptions(prevOptions => [...prevOptions, newOption]);
+    return newOption;
+  };
+
+  return (
+    <div style={{ padding: 40 }}>
+      <MultiSelect
+        createable
+        data={options}
+        onChange={setSelectedValues}
+        onCreate={handleCreate}
+        placeholder="Type to create new options"
+        searchable
+        value={selectedValues}
+      />
+    </div>
+  );
+}

--- a/src/mantine-core/src/components/MultiSelect/createable.ts
+++ b/src/mantine-core/src/components/MultiSelect/createable.ts
@@ -1,0 +1,61 @@
+import { ComboboxItem, ComboboxItemGroup, ComboboxData, ComboboxParsedItem } from '../Combobox';
+
+function isComboboxItem(item: string | ComboboxItem | ComboboxItemGroup): item is ComboboxItem {
+  return (item as ComboboxItem).value !== undefined && (item as ComboboxItem).label !== undefined;
+}
+
+function isComboboxItemGroup(
+  item: string | ComboboxItem | ComboboxItemGroup,
+): item is ComboboxItemGroup {
+  return (
+    (item as ComboboxItemGroup).group !== undefined &&
+    Array.isArray((item as ComboboxItemGroup).items)
+  );
+}
+
+export function convertToComboboxParsedItem(_data: ComboboxData): ComboboxParsedItem[] {
+  const convertedData: ComboboxParsedItem[] = [];
+
+  for (const item of _data) {
+    if (isComboboxItem(item)) {
+      convertedData.push(item);
+    } else if (isComboboxItemGroup(item)) {
+      const items = item.items.filter(isComboboxItem);
+
+      convertedData.push({
+        group: item.group,
+        items,
+      });
+    }
+  }
+
+  return convertedData;
+}
+
+interface IGetCreateModifiedData {
+  _searchValue: string,
+  createable: boolean | undefined,
+  data: ComboboxData | undefined,
+}
+
+export const createLabel = (_searchValue: string) => `+ Create ${_searchValue}`;
+
+export const addNewOptionToData = ({
+  _searchValue,
+  createable,
+  data,
+}: IGetCreateModifiedData) => {
+  const parsedValue: ComboboxParsedItem[] = _searchValue
+    ? convertToComboboxParsedItem([
+        { label: createLabel(_searchValue), value: _searchValue },
+      ])
+    : [];
+
+  const shouldAddNewItem =
+    createable && _searchValue && _searchValue.trim() !== '';
+  return shouldAddNewItem
+    ? [...(data ? convertToComboboxParsedItem(data) : []), ...parsedValue]
+    : data
+    ? convertToComboboxParsedItem(data)
+    : [];
+};

--- a/src/mantine-core/src/components/Select/Select.story.tsx
+++ b/src/mantine-core/src/components/Select/Select.story.tsx
@@ -182,3 +182,34 @@ export function HiddenDropdown() {
     </div>
   );
 }
+
+export function Createable() {
+  const [options, setOptions] = useState([
+    { value: '1', label: 'React' },
+    { value: '2', label: 'Angular' },
+    { value: '3', label: 'Svelte' },
+  ]);
+
+  const [selectedValue, setSelectedValue] = useState<string | null>(null);
+
+  const handleCreate = (value: string) => {
+    const newOption = { value, label: value };
+    setOptions(prevOptions => [...prevOptions, newOption]);
+    setSelectedValue(value);
+    return newOption;
+  };
+
+  return (
+    <div style={{ padding: 40 }}>
+      <Select
+        createable
+        data={options}
+        onChange={setSelectedValue}
+        onCreate={handleCreate}
+        placeholder="Type to create new options"
+        searchable
+        value={selectedValue}
+      />
+    </div>
+  );
+}

--- a/src/mantine-core/src/components/Select/createable.ts
+++ b/src/mantine-core/src/components/Select/createable.ts
@@ -1,0 +1,109 @@
+import { ComboboxItem, ComboboxItemGroup, ComboboxData, ComboboxParsedItem } from '../Combobox';
+
+function isComboboxItem(item: string | ComboboxItem | ComboboxItemGroup): item is ComboboxItem {
+  return (item as ComboboxItem).value !== undefined && (item as ComboboxItem).label !== undefined;
+}
+
+function isComboboxItemGroup(
+  item: string | ComboboxItem | ComboboxItemGroup,
+): item is ComboboxItemGroup {
+  return (
+    (item as ComboboxItemGroup).group !== undefined &&
+    Array.isArray((item as ComboboxItemGroup).items)
+  );
+}
+
+export function convertToComboboxParsedItem(_data: ComboboxData): ComboboxParsedItem[] {
+  const convertedData: ComboboxParsedItem[] = [];
+
+  for (const item of _data) {
+    if (isComboboxItem(item)) {
+      convertedData.push(item);
+    } else if (isComboboxItemGroup(item)) {
+      const items = item.items.filter(isComboboxItem);
+
+      convertedData.push({
+        group: item.group,
+        items,
+      });
+    }
+  }
+
+  return convertedData;
+}
+
+interface IGetCreateModifiedData {
+  search: string,
+  createable: boolean | undefined,
+  parsedData: ComboboxParsedItem[],
+  optionsLockup: Record<string, ComboboxItem>,
+  _value: string | null,
+}
+
+export const createLabel = (search: string) => `+ Create ${search}`;
+
+export function getOptionExists(
+  parsedData: ComboboxParsedItem[],
+  search: string,
+) {
+  const lowerSearch = search.toLowerCase();
+
+  const optionExists = parsedData?.some((item) => {
+    if (typeof item === 'object' && 'group' in item) {
+      return item.items.some(
+        (groupItem) =>
+          groupItem.label.toLowerCase() === lowerSearch ||
+          groupItem.value.toLowerCase() === lowerSearch,
+      );
+    }
+    return (
+      typeof item === 'object' &&
+      (item.label.toLowerCase() === lowerSearch ||
+        item.value.toLowerCase() === lowerSearch)
+    );
+  });
+
+  return optionExists ?? false;
+}
+
+export const addNewOptionToData = ({
+  search,
+  createable,
+  parsedData,
+  optionsLockup,
+  _value,
+}: IGetCreateModifiedData) => {
+  const seenValues = new Set();
+  const uniqueData = parsedData.filter((item) => {
+    if ('value' in item && seenValues.has(item.value)) {
+      return false;
+    }
+    'value' in item && seenValues.add(item.value);
+    return true;
+  });
+  const parsedValue: ComboboxParsedItem[] = search
+    ? convertToComboboxParsedItem([
+      { label: createLabel(search), value: search },
+    ])
+    : [];
+
+  const isOptionSelected =
+    _value && optionsLockup[_value] && optionsLockup[_value].label === search;
+
+  const shouldAddNewItem =
+    createable &&
+    search &&
+    search.trim() !== '' && !isOptionSelected;
+
+  if (shouldAddNewItem) {
+    return [...uniqueData, ...parsedValue];
+  }
+
+  const valueIsNullAndNotInData = _value === null && !uniqueData.some((item) => 'value' in item && item.value === _value);
+
+  if (valueIsNullAndNotInData) {
+    return uniqueData.filter((item) => 'value' in item && item.value !== _value);
+  }
+
+  return uniqueData;
+};


### PR DESCRIPTION
I updated @mantine/core from 6 to 7 and noticed `createable` didn't exist anymore and I was using it in my project. I studied the old version and tried to add it back to function as close to the old version as I could. I split off a chunk of my code into a 	`createable.ts` file to keep it separate. No ts errors.

I'm not sure why it was removed from 7, maybe there is a reason other than the feature just didn't make it in? If it just didn't make it in, here it is.  Otherwise I'm curious to know why it was removed. I'd rather not use a fork, so hoping this is useful. 

Happy to make any requested modifications. Love this library.

![image](https://github.com/mantinedev/mantine/assets/18486434/8e80d024-f827-4c8f-8276-308b026c4a65)

![image](https://github.com/mantinedev/mantine/assets/18486434/322156bb-c75d-4115-9c7a-233f0a377c7b)

UPDATED: MultiSelect Component 
`createable` prop to determine if new values can be created by the user
- Added `onCreate` callback when a new value is created
- Added `handleCreate` function to handle the creation of new values
- Modified `handleOptionsSubmit` function to handle the submission of options, including the handling of createable options
- Added `dataWithPotentialNewItem` to include the potential new createable item
- Modified `noOptionsFound` to consider whether picked options should be hidden or not
- Added `displayCreateOption` to check if createable and search value are present
- Modified `optionsData` to include the createable item if present
- Added `handleCreate` function to handle the creation of new options
- Added MultiSelect storybook story to include `Createable` component

Did the same for Select.  Added a storybook story, no TS errors. Tried to follow a similar format.

![image](https://github.com/mantinedev/mantine/assets/18486434/70185380-fdc4-4c6d-88be-841cfa838ad5)

![image](https://github.com/mantinedev/mantine/assets/18486434/e574eed9-f13c-45e2-96d4-457330cbe50e)

UPDATED: Select component now supports creating new options
- Added a new prop `createable` to the `Select` component which determines if new values can be created by the user. It is set to `false` by default.
- Added a new prop `onCreate` to the `Select` component which is a callback function that is called when a new value is created by the user.
- Added a new function `handleCreate` which adds a new option to the list of options and sets it as the selected value.
- Added a new function `addNewOptionToData` which appends the new option to the list of data if `createable` is `true`.
- Added a new function `getOptionExists` which checks if the new option already exists in the list of data.
- Updated the `getParsedComboboxData` function to return the parsed data along with the new option if it exists.
- Updated the `handleOptionSubmit` function to handle creating a new option if `createable` is `true`.
- Updated the `OptionsDropdown` component to use the new parsed data.
- Added a new file `createable.ts` which contains the helper functions used for creating new options.