### PR TITLE
[@mantine/core] Select: More stable useEffect dependency for search

### DIFF
--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -181,10 +181,10 @@ export const Select = factory<SelectFactory>((_props, ref) => {
       setSearch('');
     }
 
-    if (typeof value === 'string' && optionsLockup[value]) {
-      setSearch(optionsLockup[value].label);
+    if (typeof value === 'string' && selectedOption) {
+      setSearch(selectedOption.label);
     }
-  }, [value, optionsLockup]);
+  }, [value, selectedOption]);
 
   const clearButton = clearable && !!_value && !disabled && !readOnly && (
     <Combobox.ClearButton


### PR DESCRIPTION
I was tracking down the issue mentioned in #4995 and discovered it was due to multiple renders caused by the useEffect hook.

Often times the `data` prop isn't a stable reference so using the `optionsLockup` which is derived from it in a useEffect was causing unnecessary renders. 

Instead, I have used the `selectedOption` in the dependency array which seems to be more stable even when `data` changes.  