### PR TITLE
[@mantine/core] TagsInput: Fix required prop behavior

### DIFF
--- a/src/mantine-core/src/components/TagsInput/TagsInput.tsx
+++ b/src/mantine-core/src/components/TagsInput/TagsInput.tsx
@@ -144,6 +144,7 @@ export const TagsInput = factory<TagsInputFactory>((_props, ref) => {
     inputContainer,
     inputWrapperOrder,
     withAsterisk,
+    required,
     labelProps,
     descriptionProps,
     errorProps,
@@ -335,6 +336,7 @@ export const TagsInput = factory<TagsInputFactory>((_props, ref) => {
             inputContainer={inputContainer}
             inputWrapperOrder={inputWrapperOrder}
             withAsterisk={withAsterisk}
+            required={required}
             labelProps={labelProps}
             descriptionProps={descriptionProps}
             errorProps={errorProps}
@@ -367,6 +369,7 @@ export const TagsInput = factory<TagsInputFactory>((_props, ref) => {
                   onPaste={handlePaste}
                   value={_searchValue}
                   onChange={(event) => setSearchValue(event.currentTarget.value)}
+                  required={required && _value.length === 0}
                   disabled={disabled}
                   readOnly={readOnly}
                   id={_id}


### PR DESCRIPTION
Fixes #5016 

## 1. display asterisk when `required` prop is passed
Pass `required` prop to `PillInput` component so that an asterisk is displayed when `required` prop is passed to `TagsInput`.

## 2. fix form validation behavior when `required` prop is passed
The `value` prop of `PillsInput.Field` is `_searchValue`, which is empty immediately after splitting.
Therefore, setting `required` will enable form validation even if tag (`_value`) is present.

To fix this, the condition of `required` in `PillsInput.Field` is set to `required && _value.length === 0`.