### PR TITLE
[core] Add children to CardSectionProps

### DIFF
--- a/src/mantine-core/src/components/Card/CardSection/CardSection.tsx
+++ b/src/mantine-core/src/components/Card/CardSection/CardSection.tsx
@@ -18,6 +18,9 @@ export interface CardSectionProps extends BoxProps, CompoundStylesApiProps<CardS
 
   /** Determines whether the section should inherit padding from the parent `Card`, `false` by default */
   inheritPadding?: boolean;
+
+  /** Section content */
+  children?: React.ReactNode;
 }
 
 export type CardSectionFactory = PolymorphicFactory<{


### PR DESCRIPTION
From the document, it looks like that `CardSectionProps` should have children.

https://mantine.dev/core/card/