### PR TITLE
DOC: align shown code and components

### DIFF
--- a/src/mantine-demos/src/demos/theming/Theming.demo.colorsOverride.tsx
+++ b/src/mantine-demos/src/demos/theming/Theming.demo.colorsOverride.tsx
@@ -18,6 +18,8 @@ function Demo() {
       <Group>
         <Button color="ocean-blue">Ocean blue button</Button>
         <Button color="bright-pink" variant="filled">
+          Bright pink button
+        </Button>
       </Group>
     </MantineProvider>
   );

--- a/src/mantine-demos/src/demos/theming/Theming.demo.colorsOverride.tsx
+++ b/src/mantine-demos/src/demos/theming/Theming.demo.colorsOverride.tsx
@@ -16,8 +16,8 @@ function Demo() {
       }}
     >
       <Group>
-        <Button>Primary button</Button>
-        <Button color="blue">Blue button</Button>
+        <Button color="ocean-blue">Ocean blue button</Button>
+        <Button color="bright-pink" variant="filled">
       </Group>
     </MantineProvider>
   );


### PR DESCRIPTION
In one example, the shown code in the docs did not match the corresponding components displayed in the docs. This commit fixes this problem.