### PR TITLE
[@mantine/core] Spoiler: Avoid leaving a gap when label is null

### DIFF
--- a/src/mantine-core/src/components/Spoiler/Spoiler.tsx
+++ b/src/mantine-core/src/components/Spoiler/Spoiler.tsx
@@ -99,8 +99,8 @@ export const Spoiler = factory<SpoilerFactory>((_props, ref) => {
   const regionId = `${_id}-region`;
   const [show, setShowState] = useState(initialState);
   const { ref: contentRef, height } = useElementSize();
-  const spoiler = maxHeight! < height;
   const spoilerMoreContent = show ? hideLabel : showLabel;
+  const spoiler = spoilerMoreContent !== null && maxHeight! < height;
 
   return (
     <Box


### PR DESCRIPTION
I'd like to use Spoiler _just_ to reveal, not to hide again. However, passing `hideLabel={null}` leaves an unsightly gap below the Spoiler.

https://codesandbox.io/s/epic-waterfall-xkkzmv?file=/src/App.tsx

![Spoiler leaves a gap when label is null](https://github.com/mantinedev/mantine/assets/45430/a2e5f9c0-d7af-4d07-9bdb-49e001a91713)

This PR fixes this issue by checking whether `spoilerMoreContent` is `null`.