### PR TITLE
[@mantine/core]: Text: Fix inline prop in css (mantinedev#5190)

### DIFF
--- a/src/mantine-core/src/components/Text/Text.module.css
+++ b/src/mantine-core/src/components/Text/Text.module.css
@@ -2,7 +2,7 @@
   -webkit-tap-highlight-color: transparent;
   text-decoration: none;
   font-size: var(--text-fz, var(--mantine-font-size-md));
-  line-height: var(--text-lh, var(--mantine-line-height-md));
+  line-height: var(--_text-line-height, var(--text-lh, var(--mantine-line-height-md)));
   font-weight: normal;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Fixes mantinedev#5190.

I compared with other components and it seems var `--_text-line-height` is missed in core text css configuration. 