### PR TITLE
Don't modify head tag in next app router example

### DIFF
--- a/docs/src/pages/guides/next.mdx
+++ b/docs/src/pages/guides/next.mdx
@@ -126,10 +126,8 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <head>
-        <ColorSchemeScript />
-      </head>
       <body>
+        <ColorSchemeScript />
         <MantineProvider>{children}</MantineProvider>
       </body>
     </html>


### PR DESCRIPTION
The [Next docs for app router](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#metadata) say that the `<head>` tag shouldn't be modified manually.

One repercussion of ignoring this advice is that Cypress e2e tests don't work anymore when testing an app router based Next app where the `<head>` tag was modified manually.

So I think the Mantine docs shouldn't propose doing this.

As far as I can tell, the `<ColorSchemeScript />` works fine when put in the `<body>`.