### PR TITLE
fix(docs): update footer styles

### DIFF
--- a/docs/components/Footer/Footer.module.css
+++ b/docs/components/Footer/Footer.module.css
@@ -4,12 +4,12 @@ $footer-breakpoint-mobile: 40em;
 .root {
   --docs-footer-height: rem(400px);
 
-  @media (max-width: 50em) {
-    --docs-footer-height: rem(460px);
+  @media (max-width: $footer-breakpoint-tablet) {
+    --docs-footer-height: rem(520px);
   }
 
   @media (max-width: $footer-breakpoint-mobile) {
-    --docs-footer-height: rem(320px);
+    --docs-footer-height: rem(380px);
   }
 }
 


### PR DESCRIPTION
This PR updates styles for the docs footer so that the buttons at the bottom are not disappearing because of the reduced height

> Currently I have increased height by 60 pixels, but if that's not enough, it can be increased some more

Mobile breakpoint:
![mobile-before](https://github.com/mantinedev/mantine/assets/36604233/2aad4aad-1545-4cde-a863-e6eb1f0aefb6)
![mobile-after](https://github.com/mantinedev/mantine/assets/36604233/13f4aebb-11cb-4472-bfb9-afacf06872d1)

Tablet breakpoint:
![tablet-before](https://github.com/mantinedev/mantine/assets/36604233/3baa3efc-2800-480b-90e1-9790f7c4fc1c)
![tablet-after](https://github.com/mantinedev/mantine/assets/36604233/a676d75b-9c1c-4e99-9bf5-42e1caf6913f)