### PR TITLE
Add "size" popover middleware to fix overflow issues in Popover.Dropdown

### DIFF
--- a/src/mantine-core/src/components/Popover/Popover.story.tsx
+++ b/src/mantine-core/src/components/Popover/Popover.story.tsx
@@ -227,7 +227,8 @@ export function Size() {
       <Popover
         opened={opened}
         middlewares={{ shift: true, flip: true, size: true }}
-        onChange={setState}>
+        onChange={setState}
+      >
         <Popover.Target>
           <button type="button" onClick={() => setState((c) => !c)}>
             Toggle popover

--- a/src/mantine-core/src/components/Popover/Popover.story.tsx
+++ b/src/mantine-core/src/components/Popover/Popover.story.tsx
@@ -219,6 +219,29 @@ export function Inline() {
   );
 }
 
+export function Size() {
+  const [opened, setState] = useState(false);
+
+  return (
+    <div style={{ padding: 40 }}>
+      <Popover
+        opened={opened}
+        middlewares={{ shift: true, flip: true, size: true }}
+        onChange={setState}>
+        <Popover.Target>
+          <button type="button" onClick={() => setState((c) => !c)}>
+            Toggle popover
+          </button>
+        </Popover.Target>
+
+        <Popover.Dropdown style={{ overflow: 'auto' }}>
+          <div style={{ width: 100, height: 2000, background: 'pink' }} />
+        </Popover.Dropdown>
+      </Popover>
+    </div>
+  );
+}
+
 export function PopoverEvents() {
   const [opened, setState] = useState(false);
   const [toggle1, setToggle1] = useState(false);

--- a/src/mantine-core/src/components/Popover/Popover.types.ts
+++ b/src/mantine-core/src/components/Popover/Popover.types.ts
@@ -4,4 +4,5 @@ export interface PopoverMiddlewares {
   shift: boolean;
   flip: boolean;
   inline?: boolean;
+  size?: boolean;
 }

--- a/src/mantine-core/src/components/Popover/use-popover.ts
+++ b/src/mantine-core/src/components/Popover/use-popover.ts
@@ -9,6 +9,7 @@ import {
   Middleware,
   inline,
   limitShift,
+  UseFloatingReturn,
 } from '@floating-ui/react';
 import { FloatingAxesOffsets, FloatingPosition, useFloatingAutoUpdate } from '../Floating';
 import { PopoverWidth, PopoverMiddlewares } from './Popover.types';
@@ -29,7 +30,7 @@ interface UsePopoverOptions {
   arrowOffset: number;
 }
 
-function getPopoverMiddlewares(options: UsePopoverOptions) {
+function getPopoverMiddlewares(options: UsePopoverOptions, getFloating: () => UseFloatingReturn) {
   const middlewares: Middleware[] = [offset(options.offset)];
 
   if (options.middlewares?.shift) {
@@ -45,6 +46,28 @@ function getPopoverMiddlewares(options: UsePopoverOptions) {
   }
 
   middlewares.push(arrow({ element: options.arrowRef, padding: options.arrowOffset }));
+
+  if (options.middlewares?.size || options.width === 'target') {
+    middlewares.push(size({
+      apply({ rects, availableWidth, availableHeight }) {
+        const floating = getFloating();
+        const styles = floating.refs.floating.current?.style ?? {};
+
+        if (options.middlewares?.size) {
+          Object.assign(styles, {
+            maxWidth: `${availableWidth}px`,
+            maxHeight: `${availableHeight}px`,
+          });
+        }
+
+        if (options.width === 'target') {
+          Object.assign(styles, {
+            width: `${rects.reference.width}px`,
+          });
+        }
+      },
+    }));
+  }
 
   return middlewares;
 }
@@ -76,20 +99,7 @@ export function usePopover(options: UsePopoverOptions) {
 
   const floating = useFloating({
     placement: options.position,
-    middleware: [
-      ...getPopoverMiddlewares(options),
-      ...(options.width === 'target'
-        ? [
-            size({
-              apply({ rects }) {
-                Object.assign(floating.refs.floating.current?.style ?? {}, {
-                  width: `${rects.reference.width}px`,
-                });
-              },
-            }),
-          ]
-        : []),
-    ],
+    middleware: getPopoverMiddlewares(options, () => floating),
   });
 
   useFloatingAutoUpdate({

--- a/src/mantine-core/src/components/Popover/use-popover.ts
+++ b/src/mantine-core/src/components/Popover/use-popover.ts
@@ -30,7 +30,10 @@ interface UsePopoverOptions {
   arrowOffset: number;
 }
 
-function getPopoverMiddlewares(options: UsePopoverOptions, getFloating: () => UseFloatingReturn) {
+function getPopoverMiddlewares(
+  options: UsePopoverOptions,
+  getFloating: () => UseFloatingReturn<Element>
+) {
   const middlewares: Middleware[] = [offset(options.offset)];
 
   if (options.middlewares?.shift) {
@@ -48,25 +51,27 @@ function getPopoverMiddlewares(options: UsePopoverOptions, getFloating: () => Us
   middlewares.push(arrow({ element: options.arrowRef, padding: options.arrowOffset }));
 
   if (options.middlewares?.size || options.width === 'target') {
-    middlewares.push(size({
-      apply({ rects, availableWidth, availableHeight }) {
-        const floating = getFloating();
-        const styles = floating.refs.floating.current?.style ?? {};
+    middlewares.push(
+      size({
+        apply({ rects, availableWidth, availableHeight }) {
+          const floating = getFloating();
+          const styles = floating.refs.floating.current?.style ?? {};
 
-        if (options.middlewares?.size) {
-          Object.assign(styles, {
-            maxWidth: `${availableWidth}px`,
-            maxHeight: `${availableHeight}px`,
-          });
-        }
+          if (options.middlewares?.size) {
+            Object.assign(styles, {
+              maxWidth: `${availableWidth}px`,
+              maxHeight: `${availableHeight}px`,
+            });
+          }
 
-        if (options.width === 'target') {
-          Object.assign(styles, {
-            width: `${rects.reference.width}px`,
-          });
-        }
-      },
-    }));
+          if (options.width === 'target') {
+            Object.assign(styles, {
+              width: `${rects.reference.width}px`,
+            });
+          }
+        },
+      })
+    );
   }
 
   return middlewares;
@@ -97,7 +102,7 @@ export function usePopover(options: UsePopoverOptions) {
     }
   };
 
-  const floating = useFloating({
+  const floating: UseFloatingReturn<Element> = useFloating({
     placement: options.position,
     middleware: getPopoverMiddlewares(options, () => floating),
   });


### PR DESCRIPTION
Currently, if the `Popover.Dropdown` content is tall, there is no way to add scrollbars (overflow) properly as the dropdown overflows the page. Reproduction https://codesandbox.io/s/amazing-nobel-s6zqy8

This issue is supposed to be fixed by [size](https://floating-ui.com/docs/size) middleware in `floating-ui`. This PR fixes the issue by adding `size` option in `PopoverMiddlewares` which enables the `size` middleware, which in turn uses `availableWidth` and `availableHeight` per `floating-ui` docs.

I decided not to set `overflow: auto` automatically in `Popover.Dropdown` because in some places there might be a requirement to shrink the content and not to add scrollbars.

How to verify:
- `yarn storybook`
- Open http://localhost:6006/?path=/story/popover--size
- Click on the button and verify that it's possible to scroll the dropdown content properly

Issue (codesandbox):
<img width="317" alt="Screenshot 2023-11-07 at 12 43 33" src="https://github.com/mantinedev/mantine/assets/8542534/be97dfb9-0c01-4f1d-9858-7fdeb015c248">

Fix (storybook):
<img width="658" alt="Screenshot 2023-11-07 at 12 32 46" src="https://github.com/mantinedev/mantine/assets/8542534/0161c8b7-b556-4b08-b089-0ae71c5b928b">
