### PR TITLE
Backport "Add size popover middleware to fix overflow issues in Popover.Dropdown" to v6

### DIFF
--- a/src/mantine-core/src/Popover/Popover.story.tsx
+++ b/src/mantine-core/src/Popover/Popover.story.tsx
@@ -199,6 +199,30 @@ export function Inline() {
   );
 }
 
+export function Size() {
+  const [opened, setState] = useState(false);
+
+  return (
+    <div style={{ padding: 40 }}>
+      <Popover
+        opened={opened}
+        middlewares={{ shift: true, flip: true, size: true }}
+        onChange={setState}
+      >
+        <Popover.Target>
+          <button type="button" onClick={() => setState((c) => !c)}>
+            Toggle popover
+          </button>
+        </Popover.Target>
+
+        <Popover.Dropdown style={{ overflow: 'auto' }}>
+          <div style={{ width: 100, height: 2000, background: 'pink' }} />
+        </Popover.Dropdown>
+      </Popover>
+    </div>
+  );
+}
+
 export function PopoverEvents() {
   const [opened, setState] = useState(false);
   const [toggle1, setToggle1] = useState(false);

--- a/src/mantine-core/src/Popover/Popover.types.ts
+++ b/src/mantine-core/src/Popover/Popover.types.ts
@@ -11,4 +11,5 @@ export interface PopoverMiddlewares {
   shift: boolean;
   flip: boolean;
   inline?: boolean;
+  size?: boolean;
 }


### PR DESCRIPTION
Backports https://github.com/mantinedev/mantine/pull/5213

This PR backports the fix above to handle tall content in `Popover.Dropdown`. Reproduction https://codesandbox.io/s/amazing-nobel-s6zqy8

How to verify:
- `yarn storybook`
- Open http://localhost:7520/?path=/story/popover--size
- Click on the button and verify that it's possible to scroll the dropdown content properly

Issue (codesandbox):
<img width="317" alt="Screenshot 2023-11-07 at 12 43 33" src="https://github.com/mantinedev/mantine/assets/8542534/be97dfb9-0c01-4f1d-9858-7fdeb015c248">

Fix (storybook):
<img width="658" alt="Screenshot 2023-11-07 at 12 32 46" src="https://github.com/mantinedev/mantine/assets/8542534/0161c8b7-b556-4b08-b089-0ae71c5b928b">