### PR TITLE
[@mantine/core] Select: fix on reset ui issue

### DIFF
--- a/src/mantine-core/src/components/Input/Input.tsx
+++ b/src/mantine-core/src/components/Input/Input.tsx
@@ -101,6 +101,9 @@ export interface __InputProps {
 
   /** Determines whether the input should have red border and text color when `error` prop is set, `true` by default */
   withErrorStyles?: boolean;
+
+  /** Determines whether form has been reset or not `false` by default */
+  isreset?: string;
 }
 
 export interface InputProps extends BoxProps, __InputProps, StylesApiProps<InputFactory> {

--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -132,6 +132,7 @@ export const Select = factory<SelectFactory>((_props, ref) => {
     clearable,
     clearButtonProps,
     hiddenInputProps,
+    isreset,
     ...others
   } = props;
 
@@ -185,6 +186,13 @@ export const Select = factory<SelectFactory>((_props, ref) => {
       setSearch(selectedOption.label);
     }
   }, [value, selectedOption]);
+
+  useEffect(() => {
+    if (isreset === 'true') {
+      setSearch('');
+      setValue('');
+    }
+  }, [isreset]);
 
   const clearButton = clearable && !!_value && !disabled && !readOnly && (
     <Combobox.ClearButton

--- a/src/mantine-form/src/use-form.ts
+++ b/src/mantine-form/src/use-form.ts
@@ -53,6 +53,7 @@ export function useForm<
   const [dirty, setDirty] = useState(initialDirty);
   const [values, _setValues] = useState(initialValues);
   const [errors, _setErrors] = useState(filterErrors(initialErrors));
+  const [isReset, setIsReset] = useState(false);
 
   const valuesSnapshot = useRef<Values>(initialValues);
   const setValuesSnapshot = (_values: Values) => {
@@ -75,9 +76,11 @@ export function useForm<
   const clearErrors: ClearErrors = useCallback(() => _setErrors({}), []);
   const reset: Reset = useCallback(() => {
     _setValues(valuesSnapshot.current);
+    setIsReset(true);
     clearErrors();
     setDirty({});
     resetTouched();
+    setTimeout(() => setIsReset(false), 100);
   }, []);
 
   const setFieldError: SetFieldError<Values> = useCallback(
@@ -219,6 +222,8 @@ export function useForm<
         }
       };
     }
+
+    payload.isreset = `${isReset}`;
 
     return payload;
   };


### PR DESCRIPTION
#5211

I've add a prop to the use form called "isreset" which will indicate when a form has been reset and can be used to do other side effects while reseting as well