### PR TITLE
[@mantine/core] Select: reset search value empty #5211

### DIFF
--- a/src/mantine-core/src/components/Select/Select.tsx
+++ b/src/mantine-core/src/components/Select/Select.tsx
@@ -184,6 +184,10 @@ export const Select = factory<SelectFactory>((_props, ref) => {
     if (typeof value === 'string' && selectedOption) {
       setSearch(selectedOption.label);
     }
+
+    if (value === '') {
+      setSearch('');
+    }
   }, [value, selectedOption]);
 
   const clearButton = clearable && !!_value && !disabled && !readOnly && (


### PR DESCRIPTION
another fix for reseting the value of the select when it's empty

this is much simpler as it resets the search value when the original value is set back to ""

