### PR TITLE
Add @mantine/ds to docs

### DIFF
--- a/docs/pages/contribute.mdx
+++ b/docs/pages/contribute.mdx
@@ -31,7 +31,7 @@ First of all, thank you for showing interest in contributing to Mantine! All you
 - Fork the [repository](https://github.com/mantinedev/mantine), then clone or download your fork.
 - Install dependencies with yarn – `yarn`
 - Build local version of all packages – `npm run build:all`
-- Build local version of specific packages – `npm run build @mantine/core @mantine/demos @mantine/hooks`
+- Build local version of specific packages – `npm run build @mantine/core @mantine/demos @mantine/hooks @mantine/ds`
 - To start storybook – `npm run storybook`
 - To start docs – `npm run docs`
 - To rebuild props descriptions – `npm run docs:docgen`


### PR DESCRIPTION
Docs is missing @mantine/ds in local install instructions. This was causing me issues starting the local server.