### PR TITLE
[@mantine/core] Tabs: Add `keepMounted` prop to TabsPanel

### DIFF
--- a/src/mantine-core/src/components/Tabs/TabsPanel/TabsPanel.tsx
+++ b/src/mantine-core/src/components/Tabs/TabsPanel/TabsPanel.tsx
@@ -19,7 +19,8 @@ export interface TabsPanelProps
     ElementProps<'div'> {
   /** Panel content */
   children: React.ReactNode;
-
+  /** If set to `true`, the content will be kept mounted, even if `keepMounted` is set `false` in the parent `Tabs` component */
+  keepMounted?: boolean;
   /** Value of associated control */
   value: string;
 }
@@ -40,7 +41,7 @@ export const TabsPanel = factory<TabsPanelFactory>((_props, ref) => {
   const ctx = useTabsContext();
 
   const active = ctx.value === value;
-  const content = ctx.keepMounted ? children : active ? children : null;
+  const content = ctx.keepMounted || props.keepMounted ? children : active ? children : null;
 
   return (
     <Box


### PR DESCRIPTION
When `keepMounted` prop is passed to Tabs component, it is applied to all the panels. This change allows to set `keepMounted` property to specific panels.

**A scenario I faced:**
I have 3 panels, a normal, a lazy loaded, and one with iframe. I want to keep the normal and iframe panels mounted but want the lazy loaded to only mount when opened. If `keepMounted` is set to false, the iframe keeps refreshing and if it is set to true, the component is not lazy loaded.