### PR TITLE
[docs: Group component] Mention default gap and vertical centering to show it's a higher level abstraction and more opinonated than `Flex`

### DIFF
--- a/docs/pages/core/group.mdx
+++ b/docs/pages/core/group.mdx
@@ -7,7 +7,7 @@ export default Layout(MDX_DATA.Group);
 ## Usage
 
 `Group` is a horizontal flex container. If you need a vertical flex container, use [Stack](/core/stack)
-component instead. If you need to have full control over flex container properties, use [Flex](/core/flex) component.
+component instead. If you need to have full control over flex container properties, use [Flex](/core/flex) component. By default, `Group` sets a small gap between elements and centers them vertically.
 
 <Demo data={GroupDemos.usage} />
 


### PR DESCRIPTION
I'm not sure if talking about the default values in the `Usage` section is something desirable or not.

Having a slight glance of the gap and vertical centering is useful here, but also increases verbosity.

I considered also talking about the wrap behaviour that is activated by default, as opposed to a `Flex` where it is does not wrap by default.