### PR TITLE
[@mantine/spotlight] Fix input bug with Japanese IME

### DIFF
--- a/src/mantine-spotlight/src/SpotlightSearch.tsx
+++ b/src/mantine-spotlight/src/SpotlightSearch.tsx
@@ -41,9 +41,11 @@ export const SpotlightSearch = factory<SpotlightSearchFactory>((props, ref) => {
   );
   const ctx = useSpotlightContext();
   const inputStyles = ctx.getStyles('search');
+  const [isComposing, setIsComposing] = React.useState(false); // IME
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     onKeyDown?.(event);
+    if (isComposing) return;
 
     if (event.nativeEvent.code === 'ArrowDown') {
       event.preventDefault();
@@ -73,6 +75,8 @@ export const SpotlightSearch = factory<SpotlightSearchFactory>((props, ref) => {
         onChange?.(event);
       }}
       onKeyDown={handleKeyDown}
+      onCompositionStart={() => setIsComposing(true)}
+      onCompositionEnd={() => setIsComposing(false)}
     />
   );
 });


### PR DESCRIPTION
related: https://discord.com/channels/854810300876062770/887408088800448553/1176006456332529714

---

Spotlight is not submitted when the enter key is pressed during IME input.
Tested on macOS 14.0.