### PR TITLE
[@mantine/docs] fix: replace `form.touched()` by `form.isTouched()`

### DIFF
--- a/docs/pages/form/status.mdx
+++ b/docs/pages/form/status.mdx
@@ -27,7 +27,7 @@ form.isDirty('nested.field'); // -> nested fields are also supported
 
 // If field path is not provided,
 // then functions will return form state instead
-form.touched(); // -> was any field in form focused or changed?
+form.isTouched(); // -> was any field in form focused or changed?
 form.isDirty(); // -> was any field in form modified?
 ```
 


### PR DESCRIPTION
I fixed a typo in the documentation that referenced the `touched()` function, which has been removed in the latest version. Updated it to `isTouched()` to reflect the current function name.
