### PR TITLE
[docs] fix style api overview example

### DIFF
--- a/docs/pages/overview.mdx
+++ b/docs/pages/overview.mdx
@@ -208,7 +208,7 @@ Example of [TextInput](/core/text-input) component selectors:
 
 <SelectorsTable
   data={TextInputStylesApi}
-  component="Button"
+  component="TextInput"
   withTableBorder={false}
   fixedLayout={false}
 />


### PR DESCRIPTION
The leading text says:

```mdx
Example of [TextInput](/core/text-input) component selectors:
```

But the example shows button style prop api

```mdx
<SelectorsTable
  data={TextInputStylesApi}
  component="Button"
  withTableBorder={false}
  fixedLayout={false}
/>
```

This change the example to `TextInput`.

Result:

![image](https://github.com/mantinedev/mantine/assets/17731302/9a38bade-bfae-464b-a395-52d1cc3661a7)
