### PR TITLE
Remove obsolete prop from example in Pagination.demo.icons.tsx

### DIFF
--- a/src/mantine-demos/src/demos/core/Pagination/Pagination.demo.icons.tsx
+++ b/src/mantine-demos/src/demos/core/Pagination/Pagination.demo.icons.tsx
@@ -25,7 +25,6 @@ function Demo() {
       {/* Regular pagination */}
       <Pagination
         total={10}
-        position="center"
         withEdges
         nextIcon={IconArrowRight}
         previousIcon={IconArrowLeft}


### PR DESCRIPTION
The docs still contain a reference to the `position` prop on the `Pagination` component (in the [`change-icons`](https://mantine.dev/core/pagination/#change-icons) example), but apparently it's been removed. I updated the text to match the actual code.