### PR TITLE
Add overlay blur support for Safari

### DIFF
--- a/src/mantine-core/src/components/Overlay/Overlay.module.css
+++ b/src/mantine-core/src/components/Overlay/Overlay.module.css
@@ -3,6 +3,7 @@
   position: var(--_overlay-position, absolute);
   background: var(--overlay-bg, rgba(0, 0, 0, 0.6));
   backdrop-filter: var(--overlay-filter);
+  -webkit-backdrop-filter: var(--overlay-filter);
   border-radius: var(--overlay-radius, 0);
   z-index: var(--overlay-z-index);
 


### PR DESCRIPTION
`backdrop-filter` is only supported on Safari by using the `-webkit-` prefix.
Related to: #5245 

Chrome:
![Screenshot 2023-11-30 at 5 22 08 PM](https://github.com/mantinedev/mantine/assets/24587702/4af1ca53-54a4-4f47-8652-626a19460ca0)

Safari:
![Screenshot 2023-11-30 at 5 22 02 PM](https://github.com/mantinedev/mantine/assets/24587702/262b0452-ee87-47a8-9344-68bd71496db3)
