### PR TITLE
[@mantine/core] Alert: Fix padding without title

### DIFF
--- a/src/mantine-core/src/components/Alert/Alert.module.css
+++ b/src/mantine-core/src/components/Alert/Alert.module.css
@@ -22,6 +22,9 @@
 
 .body {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mantine-spacing-xs);
 }
 
 .title {
@@ -68,7 +71,6 @@
   overflow: hidden;
   font-size: var(--mantine-font-size-sm);
   color: var(--_message-color, var(--__message-color));
-  margin-top: var(--mantine-spacing-xs);
 
   @mixin light {
     --__message-color: var(--mantine-color-black);


### PR DESCRIPTION
This PR resolves #5305: The children of an `<Alert>` are offset from the alert's icon when the (optional) title is omitted. 

Fix: The `margin-top` on the `<Alert>` `.message` is replaced with a flex gap.

Before:
<img width="813" alt="Screenshot 2023-12-01 at 14 56 34" src="https://github.com/mantinedev/mantine/assets/19669022/d07dbe45-9820-4aa5-a7be-31f37009d352">

After:
<img width="806" alt="Screenshot 2023-12-01 at 14 44 49" src="https://github.com/mantinedev/mantine/assets/19669022/13e142c2-aeaf-4b52-a411-5ea2b94c17ba">
