### PR TITLE
[@mantine/core] Fix line-height resolver on style props

### DIFF
--- a/packages/@mantine/core/src/core/Box/style-props/resolvers/line-height-resolver/line-height-resolver.ts
+++ b/packages/@mantine/core/src/core/Box/style-props/resolvers/line-height-resolver/line-height-resolver.ts
@@ -1,7 +1,7 @@
 import { MantineTheme } from '../../../../MantineProvider';
 
 export function lineHeightResolver(value: unknown, theme: MantineTheme) {
-  if (typeof value === 'string' && value in theme.fontSizes) {
+  if (typeof value === 'string' && value in theme.lineHeights) {
     return `var(--mantine-line-height-${value})`;
   }
 


### PR DESCRIPTION
I think previously there was a typo referring to `theme.fontSizes`