### PR TITLE
fix(@mantine/core): Add z-index to sticky header in Table component

### DIFF
--- a/packages/@mantine/core/src/components/Table/Table.module.css
+++ b/packages/@mantine/core/src/components/Table/Table.module.css
@@ -92,6 +92,7 @@
   position: var(--_thead-position, static);
   top: var(--table-sticky-header-offset, 0);
   background-color: var(--_thead-bg, transparent);
+  z-index: 1;
 
   &[data-sticky] {
     --_thead-position: sticky;


### PR DESCRIPTION
**Description:**

Resolves an issue where the sticky header in the Table component was not behaving correctly due to missing z-index. The change ensures that the sticky header is displayed correctly on top of other elements.

**Issue Details:**
- fixes: #5384 


**Changes:**
- Added `z-index: 1;` to the `.thead` class in `mantine/packages/@mantine/core/src/components/Table/Table.module.css`.


**Checklist:**
- [x] Code follows the project's coding guidelines.

**Screen-record:**

https://github.com/mantinedev/mantine/assets/134603758/918dbee4-749d-4dd4-852f-c26ce67aca94