### PR TITLE
Update getting-started.mdx

### DIFF
--- a/docs/src/pages/getting-started.mdx
+++ b/docs/src/pages/getting-started.mdx
@@ -159,7 +159,7 @@ Then create `.vscode/settings.json` file in the root folder of your project with
     "**/*.scss",
     "**/*.sass",
     "**/*.less",
-    "node_modules/@mantine/core/esm/index.css"
+    "node_modules/@mantine/core/styles.css"
   ]
 }
 ```


### PR DESCRIPTION
In v7.3, the CSS file location changed. This PR adjusts CSS Variable Autocompletion VSCode extension accordingly.