### PR TITLE
[@mantine/core] add non-empty check for portal className

### DIFF
--- a/packages/@mantine/core/src/components/Portal/Portal.test.tsx
+++ b/packages/@mantine/core/src/components/Portal/Portal.test.tsx
@@ -25,4 +25,16 @@ describe('@mantine/core/Portal', () => {
   it('has correct displayName', () => {
     expect(Portal.displayName).toStrictEqual('@mantine/core/Portal');
   });
+
+  it('syncs its className to the generated Portal node', () => {
+    render(<Portal className="test-portal">test-portal</Portal>);
+    const portal = document.querySelector('[data-portal]')!;
+    expect(portal.classList).toContain('test-portal');
+  });
+
+  it('does not crash when className is empty or contains extra spaces', () => {
+    render(<Portal className="">empty-className</Portal>);
+    render(<Portal className="hello  world">className-with-spaces</Portal>);
+    expect(document.querySelectorAll('[data-portal]')).toHaveLength(2);
+  });
 });

--- a/packages/@mantine/core/src/components/Portal/Portal.tsx
+++ b/packages/@mantine/core/src/components/Portal/Portal.tsx
@@ -6,7 +6,8 @@ import { useProps } from '../../core';
 function createPortalNode(props: React.ComponentPropsWithoutRef<'div'>) {
   const node = document.createElement('div');
   node.setAttribute('data-portal', 'true');
-  typeof props.className === 'string' && node.classList.add(...props.className.split(' '));
+  typeof props.className === 'string' &&
+    node.classList.add(...props.className.split(' ').filter(Boolean));
   typeof props.style === 'object' && Object.assign(node.style, props.style);
   typeof props.id === 'string' && node.setAttribute('id', props.id);
   return node;


### PR DESCRIPTION
As discussed on Discord, filter out the tokens passed to `classList.add` in modal to avoid the following DOM exception:

```
Uncaught DOMException: Failed to execute 'add' on 'DOMTokenList': The token provided must not be empty.
```

I added two non-regression tests regarding this.