### PR TITLE
Fix docs

### DIFF
--- a/docs/src/pages/theming/color-schemes.mdx
+++ b/docs/src/pages/theming/color-schemes.mdx
@@ -87,7 +87,7 @@ function Demo() {
 ## Transitions during color scheme change
 
 By default, transitions on all elements are disabled when color scheme changes to avoid
-inconsistent animations. To enable transitions during color scheme change, set `keepTransition: true`
+inconsistent animations. To enable transitions during color scheme change, set `keepTransitions: true`
 option on `useMantineColorScheme` hook:
 
 ```tsx
@@ -95,7 +95,7 @@ import { useMantineColorScheme } from '@mantine/core';
 
 function Demo() {
   const { colorScheme, setColorScheme } = useMantineColorScheme({
-    keepTransition: true,
+    keepTransitions: true,
   });
 }
 ```


### PR DESCRIPTION
Fixed incorrect spelling of keepTransition**s** in the [documentation](https://mantine.dev/theming/color-schemes/#transitions-during-color-scheme-change)