### PR TITLE
Fix: Combobox onClose does not work #5427

### DIFF
--- a/packages/@mantine/core/src/components/Combobox/Combobox.tsx
+++ b/packages/@mantine/core/src/components/Combobox/Combobox.tsx
@@ -156,12 +156,7 @@ export function Combobox(_props: ComboboxProps) {
         readOnly,
       }}
     >
-      <Popover
-        opened={store.dropdownOpened}
-        {...others}
-        withRoles={false}
-        unstyled={unstyled}
-      >
+      <Popover opened={store.dropdownOpened} {...others} withRoles={false} unstyled={unstyled}>
         {children}
       </Popover>
     </ComboboxProvider>

--- a/packages/@mantine/core/src/components/Combobox/Combobox.tsx
+++ b/packages/@mantine/core/src/components/Combobox/Combobox.tsx
@@ -159,7 +159,6 @@ export function Combobox(_props: ComboboxProps) {
       <Popover
         opened={store.dropdownOpened}
         {...others}
-        onClose={store.closeDropdown}
         withRoles={false}
         unstyled={unstyled}
       >


### PR DESCRIPTION
[https://github.com/mantinedev/mantine/issues/5427](url)

onClose function was getting called directly without going through the onChange events. So, onClose was removed directly and now the dropdown is closing through onChange. Because of which events are passing and alerts are working fine,