### PR TITLE
[@mantine/core] ScrollAreaAutosize: fix overflow

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -206,7 +206,7 @@ export const ScrollAreaAutosize = factory<ScrollAreaFactory>((props, ref) => {
   } = useProps('ScrollAreaAutosize', defaultProps, props);
 
   return (
-    <Box {...others} ref={ref} style={[{ display: 'flex' }, style]}>
+    <Box {...others} ref={ref} style={[{ display: 'flex', overflow: 'auto' }, style]}>
       <Box style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
         <ScrollArea
           classNames={classNames}


### PR DESCRIPTION
While using the `ScrollAreaAutosize` component I noticed that when used in conjunction with the `Table` component the data would overflow out of the viewport, particularly on smaller screen widths and mobile devices (screenshot 1 and 2).

**Screenshot 1 (Issue)**
<img width="1440" alt="Screenshot 2023-12-26 at 14 08 01" src="https://github.com/mantinedev/mantine/assets/10277014/5cf6ff64-4caa-413e-835e-fa70483f15ca">

**Screenshot 2 (Issue)**
<img width="1440" alt="Screenshot 2023-12-26 at 14 08 13" src="https://github.com/mantinedev/mantine/assets/10277014/ee851178-e39f-48b9-a871-c196cee67615">

I was able to fix this by adding `overflow: auto` to the `style` prop of the `ScrollAreaAutosize` component which renders it in the outermost parent `div` of the `ScrollArea` component (screenshot 3 and 4). I don't think this is an issue specific to my project so I'm making this update in hopes that it helps the library as a whole.

**Screenshot 3 (Fix)**
<img width="1440" alt="Screenshot 2023-12-26 at 14 12 11" src="https://github.com/mantinedev/mantine/assets/10277014/3a8b9467-aad3-4c4a-bb5d-1702aeca25ea">

**Screenshot 4 (Fix)**
<img width="1440" alt="Screenshot 2023-12-26 at 14 16 27" src="https://github.com/mantinedev/mantine/assets/10277014/4935f467-9ffe-45c0-bbd9-c1c009b76b8e">