### PR TITLE
[@mantine/core] AlphaSlider: Fix (#5517)

### DIFF
--- a/packages/@mantine/core/src/components/ColorPicker/AlphaSlider/AlphaSlider.tsx
+++ b/packages/@mantine/core/src/components/ColorPicker/AlphaSlider/AlphaSlider.tsx
@@ -32,7 +32,7 @@ export const AlphaSlider = forwardRef<HTMLDivElement, AlphaSliderProps>((props, 
           backgroundImage:
             'linear-gradient(45deg, var(--_slider-checkers) 25%, transparent 25%), linear-gradient(-45deg, var(--_slider-checkers) 25%, transparent 25%), linear-gradient(45deg, transparent 75%, var(--_slider-checkers) 75%), linear-gradient(-45deg, var(--mantine-color-body) 75%, var(--_slider-checkers) 75%)',
           backgroundSize: `${rem(8)} ${rem(8)}`,
-          backgroundPosition: `0 0, 0 ${rem(4)}, ${rem(4)} -${rem(4)}, -${rem(4)} 0`,
+          backgroundPosition: `0 0, 0 ${rem(4)}, ${rem(4)} ${rem(-4)}, ${rem(-4)} 0`,
         },
         {
           backgroundImage: `linear-gradient(90deg, transparent, ${color})`,


### PR DESCRIPTION
Fixed because `background-position` calc was not work.

Fixes #5517 