### PR TITLE
Fix: Modal doesn't close when pressing escape #2827

### DIFF
--- a/packages/@mantine/core/src/components/ModalBase/use-modal.ts
+++ b/packages/@mantine/core/src/components/ModalBase/use-modal.ts
@@ -32,7 +32,7 @@ export function useModal({
   const shouldLockScroll = useLockScroll({ opened, transitionDuration });
 
   useWindowEvent('keydown', (event) => {
-    if (!trapFocus && event.key === 'Escape' && closeOnEscape) {
+    if (event.key === 'Escape' && (!trapFocus || closeOnEscape)) {
       onClose();
     }
   });


### PR DESCRIPTION
Issue: https://github.com/mantinedev/mantine/issues/2827,
When the user to except the closing behaviour for modal in the `criteria [closeOnEscape = true and closeOnClickOutside = false]`, the Event Listener traps with `trapFocus`, hence modified the condition that so that closing a modal won't depend on `trapFocus`.