### PR TITLE
Fix: RGBA calculations && issue 5540

### DIFF
--- a/packages/@mantine/core/src/components/NumberInput/NumberInput.tsx
+++ b/packages/@mantine/core/src/components/NumberInput/NumberInput.tsx
@@ -401,7 +401,7 @@ export const NumberInput = factory<NumberInputFactory>((_props, ref) => {
       __staticSelector="NumberInput"
       decimalScale={allowDecimal ? decimalScale : 0}
       onKeyDown={handleKeyDown}
-      rightSectionPointerEvents={rightSectionPointerEvents ?? disabled ? 'none' : undefined}
+      rightSectionPointerEvents={rightSectionPointerEvents ?? (disabled ? 'none' : undefined)}
       rightSectionWidth={rightSectionWidth ?? `var(--ni-right-section-width-${size || 'sm'})`}
       allowLeadingZeros={allowLeadingZeros}
       onBlur={(event) => {

--- a/packages/@mantine/core/src/core/MantineProvider/color-functions/to-rgba/to-rgba.test.ts
+++ b/packages/@mantine/core/src/core/MantineProvider/color-functions/to-rgba/to-rgba.test.ts
@@ -23,6 +23,9 @@ describe('@mantine/core/to-rgba', () => {
     expect(toRgba('rgb(240, 62, 62, 0.8)')).toStrictEqual({ r: 240, g: 62, b: 62, a: 0.8 });
     expect(toRgba('rgb(214, 51, 108, 1)')).toStrictEqual({ r: 214, g: 51, b: 108, a: 1 });
     expect(toRgba('rgb(112, 72, 232, .2)')).toStrictEqual({ r: 112, g: 72, b: 232, a: 0.2 });
+    expect(toRgba('rgb(240, 62, 62 / 0.8)')).toStrictEqual({ r: 240, g: 62, b: 62, a: 0.8 });
+    expect(toRgba('rgb(214, 51, 108 / 1)')).toStrictEqual({ r: 214, g: 51, b: 108, a: 1 });
+    expect(toRgba('rgb(112, 72, 232 / .2)')).toStrictEqual({ r: 112, g: 72, b: 232, a: 0.2 });
   });
 
   it('returns the correct rgba values when given an hsl string', () => {

--- a/packages/@mantine/core/src/core/MantineProvider/color-functions/to-rgba/to-rgba.ts
+++ b/packages/@mantine/core/src/core/MantineProvider/color-functions/to-rgba/to-rgba.ts
@@ -52,8 +52,8 @@ function hexToRgba(color: string): RGBA {
 
 function rgbStringToRgba(color: string): RGBA {
   const [r, g, b, a] = color
-    .replace(/[^0-9,.]/g, '')
-    .split(',')
+    .replace(/[^0-9,./]/g, '')
+    .split(/[/,]/)
     .map(Number);
 
   return { r, g, b, a: a || 1 };


### PR DESCRIPTION
## Fix 1 : add "/" to RGBA calculations

When calculating RGBA, errors occur in the following cases:

Success: rgb(255, 0, 255, 1)
Failure: rgb(255, 0, 255 / 1)

Upon executing 'rgb(255, 0, 255/ 1),' the expected result is {r: 255, g: 0, b: 255, a: 1}, but the actual result is {r: 255, g: 0, b: 2551, a: 1}.

commit :  https://github.com/mantinedev/mantine/pull/5544/commits/3caefc4768fb62924ac90d078333a9a7365502b1

## Fix 2 : error in the expression caused by missing parentheses

Resolved the issue: https://github.com/mantinedev/mantine/issues/5540

commit : https://github.com/mantinedev/mantine/pull/5544/commits/b941c67c3c5f1cde17dd917a280841112d13e90c

