### PR TITLE
[@mantine/core] Menu: Fix broken focus logic when `keepMounted` is set (`v6` backport)

### DIFF
--- a/src/mantine-core/src/Menu/Menu.story.tsx
+++ b/src/mantine-core/src/Menu/Menu.story.tsx
@@ -24,6 +24,31 @@ export function DisabledFirstItem() {
     </Menu>
   );
 }
+export function FormTab() {
+  return (
+    <div>
+      <form>
+        <input />
+        <input />
+      </form>
+
+      <Menu keepMounted>
+        <Menu.Target>
+          <Button>Hey</Button>
+        </Menu.Target>
+        <Menu.Dropdown>
+          <Menu.Item>Item 2</Menu.Item>
+          <Menu.Item>Item 3</Menu.Item>
+        </Menu.Dropdown>
+      </Menu>
+
+      <form>
+        <input />
+        <input />
+      </form>
+    </div>
+  );
+}
 
 export function Usage() {
   return (

--- a/src/mantine-core/src/Menu/Menu.tsx
+++ b/src/mantine-core/src/Menu/Menu.tsx
@@ -158,7 +158,7 @@ export function Menu(props: MenuProps) {
         opened={_opened}
         onChange={toggleDropdown}
         defaultOpened={defaultOpened}
-        trapFocus={trigger === 'click'}
+        trapFocus={trigger === 'click' && _opened}
         closeOnEscape={closeOnEscape && trigger === 'click'}
         __staticSelector="Menu"
         classNames={{ ...classNames, dropdown: cx(classes.dropdown, classNames?.dropdown) }}


### PR DESCRIPTION
**Please note**, this is a backport of https://github.com/mantinedev/mantine/commit/b2c216fac8d90fb016b30ced553a4fad760d63c7 for `v6`.

This PR is fixing the `Menu`  focus problem described in https://github.com/mantinedev/mantine/issues/4502 for `v6`.

Since `@mantine/core` version 7 requires react 18+, it would be great to backport this fix. It will be helpful for all users who experience the focus problem, but can't upgrade to react 18 yet.