### PR TITLE
Fix Jumbotron Padding in HomePage Documentation

### DIFF
--- a/docs/src/components/HomePage/Jumbotron/Jumbotron.module.css
+++ b/docs/src/components/HomePage/Jumbotron/Jumbotron.module.css
@@ -7,8 +7,8 @@ $jumbotron-breakpoint: em(960px);
 
 .inner {
   position: relative;
-  padding-top: rem(220px);
-  padding-bottom: rem(180px);
+  padding-top: rem(80px);
+  padding-bottom: rem(120px);
 
   @media (max-width: $jumbotron-breakpoint) {
     padding-top: rem(60px);


### PR DESCRIPTION
### Description:

This pull request addresses a minor styling issue in the documentation for the HomePage component. The changes are confined to the `Jumbotron.module.css` file, specifically adjusting the padding values for improved visual appeal. The original values seemed excessive, so I have updated them to create a more balanced and aesthetically pleasing layout. This modification enhances the overall user experience without affecting the functionality.

### Changes Made:

- Updated padding-top from rem(220px) to rem(80px)
- Updated padding-bottom from rem(180px) to rem(120px)

### Before vs After

#### Before
<img width="1459" alt="image" src="https://github.com/mantinedev/mantine/assets/18473317/74b6fe39-d926-4ab9-8eab-d38891cb0634">

#### After
<img width="1457" alt="image" src="https://github.com/mantinedev/mantine/assets/18473317/4dee6d12-87b3-4aab-a791-2012631631e7">

<br />

This change has been tested locally and ensures a more visually appealing appearance of the Jumbotron component on the homepage.

Thank you 😃 