### PR TITLE
use `leftSection` in NavLink.demo.active.tsx

### DIFF
--- a/packages/@docs/demos/src/demos/core/NavLink/NavLink.demo.active.tsx
+++ b/packages/@docs/demos/src/demos/core/NavLink/NavLink.demo.active.tsx
@@ -29,7 +29,7 @@ function Demo() {
       label={item.label}
       description={item.description}
       rightSection={item.rightSection}
-      icon={<item.icon size="1rem" stroke={1.5} />}
+      leftSection={<item.icon size="1rem" stroke={1.5} />}
       onClick={() => setActive(index)}
       {{props}}
     />
@@ -60,7 +60,7 @@ function Demo(props: any) {
       label={item.label}
       description={item.description}
       rightSection={item.rightSection}
-      icon={<item.icon size="1rem" stroke={1.5} />}
+      leftSection={<item.icon size="1rem" stroke={1.5} />}
       onClick={() => setActive(index)}
       {...props}
     />


### PR DESCRIPTION
With mantine version 7, [components that previously had an `icon` prop now use `leftSection` instead of `icon`](https://mantine.dev/changelog/7-0-0/#left-and-right-section).

This PR updates a demo example that still uses `icon`.

Thanks for all your work on Mantine!