### PR TITLE
Allow useComputedColorScheme defaultValue to be undefined

### DIFF
--- a/packages/@mantine/core/src/core/MantineProvider/use-mantine-color-scheme/use-computed-color-scheme.ts
+++ b/packages/@mantine/core/src/core/MantineProvider/use-mantine-color-scheme/use-computed-color-scheme.ts
@@ -2,7 +2,7 @@ import { useColorScheme, UseMediaQueryOptions } from '@mantine/hooks';
 import { useMantineColorScheme } from './use-mantine-color-scheme';
 
 export function useComputedColorScheme(
-  defaultValue: 'light' | 'dark',
+  defaultValue?: 'light' | 'dark',
   options: UseMediaQueryOptions = { getInitialValueInEffect: true }
 ) {
   const osColorScheme = useColorScheme(defaultValue, options);


### PR DESCRIPTION
If we have getInitialValueInEffect, we might as well be able to set defaultValue to undefined. Preferably I'd like to completely omit the parameter...