### PR TITLE
[Docs] Grammar fix in the bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Report an issue with @mantine/* or @mantinex/* scoped package
-description: Use this template to report issues with the library, to ask questions or to suggest new features, use GitHub discussions instead
+description: Use this template to report issues with the library. To ask questions or to suggest new features, use GitHub discussions instead
 body:
   - type: checkboxes
     id: dependencies


### PR DESCRIPTION
Fixed a minor grammar issue with the bug report issue template. I added a period instead of the comma to separate the two independent clauses.