### PR TITLE
fix: Version select menu is hidden

### DIFF
--- a/docs/src/components/Shell/Navbar/Navbar.module.css
+++ b/docs/src/components/Shell/Navbar/Navbar.module.css
@@ -4,7 +4,7 @@
   top: var(--docs-header-height);
   bottom: 0;
   left: 0;
-  z-index: 100;
+  z-index: 1;
   width: var(--docs-navbar-width);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
**Description:**

fix: Version select menu is hidden 

**Issue Details:**
- fixes: #5607


**Changes:**
- Added `z-index: 1;` to the `.navbar` class


**Checklist:**
- [x] Code follows the project's coding guidelines.

**Screen-record:**

https://github.com/mantinedev/mantine/assets/134603758/d7545add-047e-4dd0-9126-6cf397374fb9

