### PR TITLE
[@mantine/core] fix: multiselect disabled functionality for pills

### DIFF
--- a/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
@@ -239,7 +239,7 @@ export const MultiSelect = factory<MultiSelectFactory>((_props, ref) => {
   const values = _value.map((item, index) => (
     <Pill
       key={`${item}-${index}`}
-      withRemoveButton={!readOnly}
+      withRemoveButton={!readOnly && !optionsLockup[item]?.disabled}
       onRemove={() => setValue(_value.filter((i) => item !== i))}
       unstyled={unstyled}
       {...getStyles('pill')}


### PR DESCRIPTION
Description:
Makes it so that pills in the input field are not removable if its respective option is disabled.

Issues addressed:
#5621 

Video of implementation:

https://github.com/mantinedev/mantine/assets/39493240/295c6c73-e772-44cd-8df5-c1f88f9a4fee

