### PR TITLE
fix: slider View source code link is broken 

### DIFF
--- a/docs/src/mdx/data/mdx-core-data.ts
+++ b/docs/src/mdx/data/mdx-core-data.ts
@@ -377,7 +377,7 @@ export const MDX_CORE_DATA: Record<string, Frontmatter> = {
     styles: ['Slider'],
     description: 'Slider and RangeSlider components',
     import: "import { Slider } from '@mantine/core';",
-    source: '@mantine/core/src/components/Slider/Slider.tsx',
+    source: '@mantine/core/src/components/Slider/Slider/Slider.tsx',
     docs: 'core/slider.mdx',
   },
   Stack: {


### PR DESCRIPTION
**Description:**

fix: slider View source code link is broken 

**Issue Details:**
fix: slider View source code link is broken 


**Changes:**
- Updated Slider Source link


**Checklist:**
- [x] Code follows the project's coding guidelines.

**Screen-record:**

https://github.com/mantinedev/mantine/assets/134603758/c9786d6a-4fdd-43c0-88b4-4abf71ba0e85


