### PR TITLE
[@mantine/core] Spread mod attribute in InlineInput to fix label alignment

### DIFF
--- a/packages/@mantine/core/src/components/InlineInput/InlineInput.tsx
+++ b/packages/@mantine/core/src/components/InlineInput/InlineInput.tsx
@@ -63,6 +63,7 @@ export const InlineInput = forwardRef<HTMLDivElement, InlineInputProps>(
       variant,
       style,
       vars,
+      mod,
       ...others
     },
     ref
@@ -86,7 +87,7 @@ export const InlineInput = forwardRef<HTMLDivElement, InlineInputProps>(
           '--label-fz': getFontSize(size),
           '--label-lh': getSize(size, 'label-lh'),
         }}
-        mod={{ 'label-position': labelPosition }}
+        mod={[{ 'label-position': labelPosition }, mod]}
         variant={variant}
         size={size}
         {...others}


### PR DESCRIPTION
Since https://github.com/mantinedev/mantine/commit/58d10fe87feaf836e3bfc1bf180aff3854f5ee68, the label positioning is broken.

This makes sure that the `mod` prop that `InlineInput` sets on the Box doesn't get overwritten by the `{...others}`.

Fixes: 

https://mantine.dev/core/switch/

![image](https://github.com/mantinedev/mantine/assets/1634993/aeb6cddc-9c3f-49c7-ae19-da08785a99d9)

https://mantine.dev/core/radio/

![image](https://github.com/mantinedev/mantine/assets/1634993/8b502f93-f4a7-4d54-8186-69d976f98e7f)


https://mantine.dev/core/checkbox/

![image](https://github.com/mantinedev/mantine/assets/1634993/d9aeb605-c3d7-4f70-81d9-d3353216c6ec)
