### PR TITLE
[@mantine/form] call onValuesChange with previous form values

### DIFF
--- a/packages/@mantine/form/src/tests/insertListItem.test.ts
+++ b/packages/@mantine/form/src/tests/insertListItem.test.ts
@@ -82,6 +82,11 @@ describe('@mantine/form/insertListItem', () => {
     );
 
     act(() => hook.result.current.insertListItem('a', { b: 3 }, 1));
-    expect(spy).toHaveBeenCalledWith({ a: [{ b: 1 }, { b: 3 }, { b: 2 }] });
+    expect(spy).toHaveBeenCalledWith(
+      { a: [{ b: 1 }, { b: 3 }, { b: 2 }] },
+      {
+        a: [{ b: 1 }, { b: 2 }],
+      }
+    );
   });
 });

--- a/packages/@mantine/form/src/tests/removeListItem.test.ts
+++ b/packages/@mantine/form/src/tests/removeListItem.test.ts
@@ -80,6 +80,9 @@ describe('@mantine/form/removeListItem', () => {
     );
 
     act(() => hook.result.current.removeListItem('a', 1));
-    expect(spy).toHaveBeenCalledWith({ a: [{ b: 1 }, { b: 3 }] });
+    expect(spy).toHaveBeenCalledWith(
+      { a: [{ b: 1 }, { b: 3 }] },
+      { a: [{ b: 1 }, { b: 2 }, { b: 3 }] }
+    );
   });
 });

--- a/packages/@mantine/form/src/tests/reorderListItem.test.ts
+++ b/packages/@mantine/form/src/tests/reorderListItem.test.ts
@@ -50,12 +50,21 @@ describe('@mantine/form/reorderListItem', () => {
     );
 
     act(() => hook.result.current.reorderListItem('a.1.b', { from: 1, to: 0 }));
-    expect(spy).toHaveBeenCalledWith({
-      a: [
-        { b: [{ c: 1 }, { c: 2 }, { c: 3 }] },
-        { b: [{ c: 5 }, { c: 4 }, { c: 6 }] },
-        { b: [{ c: 7 }, { c: 8 }, { c: 9 }] },
-      ],
-    });
+    expect(spy).toHaveBeenCalledWith(
+      {
+        a: [
+          { b: [{ c: 1 }, { c: 2 }, { c: 3 }] },
+          { b: [{ c: 5 }, { c: 4 }, { c: 6 }] },
+          { b: [{ c: 7 }, { c: 8 }, { c: 9 }] },
+        ],
+      },
+      {
+        a: [
+          { b: [{ c: 1 }, { c: 2 }, { c: 3 }] },
+          { b: [{ c: 4 }, { c: 5 }, { c: 6 }] },
+          { b: [{ c: 7 }, { c: 8 }, { c: 9 }] },
+        ],
+      }
+    );
   });
 });

--- a/packages/@mantine/form/src/tests/values.test.ts
+++ b/packages/@mantine/form/src/tests/values.test.ts
@@ -28,27 +28,27 @@ describe('@mantine/form/values', () => {
     const spy = jest.fn();
     const hook = renderHook(() => useForm({ initialValues: { a: 1, b: 2 }, onValuesChange: spy }));
     act(() => hook.result.current.setValues({ a: 3, b: 4 }));
-    expect(spy).toHaveBeenCalledWith({ a: 3, b: 4 });
+    expect(spy).toHaveBeenCalledWith({ a: 3, b: 4 }, { a: 1, b: 2 });
   });
 
   it('calls onValuesChange when setValues is called with function', () => {
     const spy = jest.fn();
     const hook = renderHook(() => useForm({ initialValues: { a: 1, b: 2 }, onValuesChange: spy }));
     act(() => hook.result.current.setValues((current) => ({ ...current, a: 3 })));
-    expect(spy).toHaveBeenCalledWith({ a: 3, b: 2 });
+    expect(spy).toHaveBeenCalledWith({ a: 3, b: 2 }, { a: 1, b: 2 });
   });
 
   it('calls onValuesChange when setValues is called with values partial', () => {
     const spy = jest.fn();
     const hook = renderHook(() => useForm({ initialValues: { a: 1, b: 2 }, onValuesChange: spy }));
     act(() => hook.result.current.setValues({ a: 3 }));
-    expect(spy).toHaveBeenCalledWith({ a: 3, b: 2 });
+    expect(spy).toHaveBeenCalledWith({ a: 3, b: 2 }, { a: 1, b: 2 });
   });
 
   it('calls onValuesChange when setFieldValue is called', () => {
     const spy = jest.fn();
     const hook = renderHook(() => useForm({ initialValues: { a: 1, b: 2 }, onValuesChange: spy }));
     act(() => hook.result.current.setFieldValue('a', 3));
-    expect(spy).toHaveBeenCalledWith({ a: 3, b: 2 });
+    expect(spy).toHaveBeenCalledWith({ a: 3, b: 2 }, { a: 1, b: 2 });
   });
 });

--- a/packages/@mantine/form/src/types.ts
+++ b/packages/@mantine/form/src/types.ts
@@ -143,7 +143,7 @@ export interface UseFormInput<
   clearInputErrorOnChange?: boolean;
   validateInputOnChange?: boolean | LooseKeys<Values>[];
   validateInputOnBlur?: boolean | LooseKeys<Values>[];
-  onValuesChange?: (values: Values) => void;
+  onValuesChange?: (values: Values, previous: Values) => void;
   enhanceGetInputProps?: (payload: {
     inputProps: GetInputPropsReturnType;
     field: LooseKeys<Values>;

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -140,7 +140,7 @@ export function useForm<
           : clearFieldError(path);
       }
 
-      onValuesChange?.(result);
+      onValuesChange?.(result, current);
 
       return result;
     });
@@ -152,7 +152,7 @@ export function useForm<
     _setValues((currentValues) => {
       const valuesPartial = typeof payload === 'function' ? payload(currentValues) : payload;
       const result = { ...currentValues, ...valuesPartial };
-      onValuesChange?.(result);
+      onValuesChange?.(result, currentValues);
       return result;
     });
     clearInputErrorOnChange && clearErrors();
@@ -162,7 +162,7 @@ export function useForm<
     clearFieldDirty(path);
     _setValues((current) => {
       const result = reorderPath(path, payload, current);
-      onValuesChange?.(result);
+      onValuesChange?.(result, current);
       return result;
     });
     _setErrors((errs) => reorderErrors(path, payload, errs));
@@ -172,7 +172,7 @@ export function useForm<
     clearFieldDirty(path);
     _setValues((current) => {
       const result = removePath(path, index, current);
-      onValuesChange?.(result);
+      onValuesChange?.(result, current);
       return result;
     });
     _setErrors((errs) => changeErrorIndices(path, index, errs, -1));
@@ -182,7 +182,7 @@ export function useForm<
     clearFieldDirty(path);
     _setValues((current) => {
       const result = insertPath(path, item, index, current);
-      onValuesChange?.(result);
+      onValuesChange?.(result, current);
       return result;
     });
     _setErrors((errs) => changeErrorIndices(path, index, errs, 1));


### PR DESCRIPTION
Hi,
based on #5644, I tried to implement that. 
I think it is convenient to have the previous values in that callback function. You can then check which values changed and how.
