### PR TITLE
[@mantine/core] Fixed Pagination autoContrast given by MantineProvider

### DIFF
--- a/packages/@mantine/core/src/components/Pagination/Pagination.story.tsx
+++ b/packages/@mantine/core/src/components/Pagination/Pagination.story.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { MantineProvider } from '../../core';
 import { Button } from '../Button';
 import { Group } from '../Group';
 import { Pagination } from './Pagination';
@@ -20,6 +21,17 @@ export function DynamicTotal() {
 
 export function AutoContrast() {
   return <Pagination total={45} color="lime.3" autoContrast />;
+}
+
+export function AutoContrastFromProvider() {
+  return (
+    <>
+      <MantineProvider theme={{ autoContrast: true }}>
+        <Button color="lime.3">test</Button>
+        <Pagination total={45} color="lime.3" />
+      </MantineProvider>
+    </>
+  );
 }
 
 export function Controlled() {

--- a/packages/@mantine/core/src/components/Pagination/PaginationRoot/PaginationRoot.tsx
+++ b/packages/@mantine/core/src/components/Pagination/PaginationRoot/PaginationRoot.tsx
@@ -99,15 +99,24 @@ const defaultProps: Partial<PaginationRootProps> = {
 };
 
 const varsResolver = createVarsResolver<PaginationRootFactory>(
-  (theme, { size, radius, color, autoContrast }) => ({
-    root: {
-      '--pagination-control-radius': radius === undefined ? undefined : getRadius(radius),
-      '--pagination-control-size': getSize(size, 'pagination-control-size'),
-      '--pagination-control-fz': getFontSize(size),
-      '--pagination-active-bg': color ? getThemeColor(color, theme) : undefined,
-      '--pagination-active-color': autoContrast ? getContrastColor({ color, theme }) : undefined,
-    },
-  })
+  (theme, { size, radius, color, autoContrast }) => {
+    const colors = theme.variantColorResolver({
+      color: color || theme.primaryColor,
+      theme,
+      variant: 'filled',
+      autoContrast,
+    });
+
+    return {
+      root: {
+        '--pagination-control-radius': radius === undefined ? undefined : getRadius(radius),
+        '--pagination-control-size': getSize(size, 'pagination-control-size'),
+        '--pagination-control-fz': getFontSize(size),
+        '--pagination-active-bg': color ? getThemeColor(color, theme) : undefined,
+        '--pagination-active-color': colors.color,
+      },
+    };
+  }
 );
 
 export const PaginationRoot = factory<PaginationRootFactory>((_props, ref) => {


### PR DESCRIPTION
The `Pagination` component's `autoContrast` worked when property is added to the component. But if the global `autoContrast` from theme object was given, it was ignored.

Worked:
```jsx
<Pagination total={45} autoContrast />
```

Didn't work:
```jsx
<MantineProvider theme={{ autoContrast: true }}>
  <Pagination total={45} />
</MantineProvider>
```

Also added a pagination story to show the case along with a button (which can be removed of course). 