### PR TITLE
Checkbox, Switch, Radio layout is broken in 7.5.0 #5652

### DIFF
--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.module.css
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.module.css
@@ -15,7 +15,7 @@
   width: var(--checkbox-size);
   height: var(--checkbox-size);
   order: var(--_checkbox-inner-order, 1);
-
+  margin-left: rem(7px);
   &[data-label-position='left'] {
     --_checkbox-inner-order: 2;
   }

--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.module.css
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.module.css
@@ -15,7 +15,7 @@
   width: var(--checkbox-size);
   height: var(--checkbox-size);
   order: var(--_checkbox-inner-order, 1);
-  margin-left: rem(7px);
+
   &[data-label-position='left'] {
     --_checkbox-inner-order: 2;
   }

--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
@@ -198,7 +198,7 @@ export const Checkbox = factory<CheckboxFactory>((_props, ref) => {
       data-checked={contextProps.checked || checked || undefined}
       variant={variant}
       ref={rootRef}
-      mod={mod}
+      mod={[mod, { 'data-label-position': labelPosition }]}
       {...styleProps}
       {...wrapperProps}
     >

--- a/packages/@mantine/core/src/components/Radio/Radio.tsx
+++ b/packages/@mantine/core/src/components/Radio/Radio.tsx
@@ -195,7 +195,7 @@ export const Radio = factory<RadioFactory>((_props, ref) => {
       data-checked={contextProps.checked || undefined}
       variant={variant}
       ref={rootRef}
-      mod={mod}
+      mod={[mod, { 'data-label-position': labelPosition }]}
       {...styleProps}
       {...wrapperProps}
     >

--- a/packages/@mantine/core/src/components/Switch/Switch.tsx
+++ b/packages/@mantine/core/src/components/Switch/Switch.tsx
@@ -193,7 +193,7 @@ export const Switch = factory<SwitchFactory>((_props, ref) => {
       data-checked={contextProps.checked || undefined}
       variant={variant}
       ref={rootRef}
-      mod={mod}
+      mod={[mod, { 'data-label-position': labelPosition }]}
       {...styleProps}
       {...wrapperProps}
     >


### PR DESCRIPTION
Label position and space error between label and element has been fixed.
![image](https://github.com/mantinedev/mantine/assets/78801738/327a99dd-f9ec-4fc8-a27a-72ab369d8681)
![image](https://github.com/mantinedev/mantine/assets/78801738/7e65679f-3ec7-4b24-88d5-a771f5a5e44f)
