### PR TITLE
[@mantine/hooks] Resolved defaultValue not set in session storage

### DIFF
--- a/packages/@mantine/hooks/src/use-local-storage/create-storage.ts
+++ b/packages/@mantine/hooks/src/use-local-storage/create-storage.ts
@@ -150,7 +150,7 @@ export function createStorage<T>(type: StorageType, hookName: string) {
 
     useEffect(() => {
       if (getInitialValueInEffect) {
-        setValue(readStorageValue());
+        setStorageValue(readStorageValue());
       }
     }, []);
 


### PR DESCRIPTION
Fixes https://github.com/mantinedev/mantine/issues/5230.

This PR resolves the defaultValue not being set on load in session storage.