### PR TITLE
[@mantine/hooks] change useDebouncedState setter to accept set function

### DIFF
--- a/packages/@mantine/hooks/src/use-debounced-state/use-debounced-state.test.ts
+++ b/packages/@mantine/hooks/src/use-debounced-state/use-debounced-state.test.ts
@@ -40,6 +40,12 @@ describe('use-debounced-state', () => {
     act(() => timeoutCallback());
     expect(hook.result.current[0]).toEqual('test3');
 
+    act(() => hook.result.current[1]((prev) => `${prev}0`));
+    expect(hook.result.current[0]).toEqual('test3');
+
+    act(() => timeoutCallback());
+    expect(hook.result.current[0]).toEqual('test30');
+
     clearTimeout.mockReset();
     expect(clearTimeout).toHaveBeenCalledTimes(0);
     act(() => hook.unmount());

--- a/packages/@mantine/hooks/src/use-debounced-state/use-debounced-state.ts
+++ b/packages/@mantine/hooks/src/use-debounced-state/use-debounced-state.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
 
 export function useDebouncedState<T = any>(
   defaultValue: T,
@@ -13,7 +13,7 @@ export function useDebouncedState<T = any>(
   useEffect(() => clearTimeout, []);
 
   const debouncedSetValue = useCallback(
-    (newValue: T) => {
+    (newValue: SetStateAction<T>) => {
       clearTimeout();
       if (leadingRef.current && options.leading) {
         setValue(newValue);


### PR DESCRIPTION
doesn't change current behavior - it enables the option to set the state via a SetStateAction that gives you access to its previous state value