### PR TITLE
[@mantine/core] Expose useTabsContext to enable reusability

### DIFF
--- a/packages/@mantine/core/src/components/Tabs/index.ts
+++ b/packages/@mantine/core/src/components/Tabs/index.ts
@@ -2,6 +2,7 @@ export { Tabs } from './Tabs';
 export { TabsList } from './TabsList/TabsList';
 export { TabsTab } from './TabsTab/TabsTab';
 export { TabsPanel } from './TabsPanel/TabsPanel';
+export { useTabsContext } from './Tabs.context';
 
 export type {
   TabsProps,
@@ -13,3 +14,4 @@ export type {
 export type { TabsTabProps, TabsTabStylesNames } from './TabsTab/TabsTab';
 export type { TabsPanelProps, TabsPanelStylesNames } from './TabsPanel/TabsPanel';
 export type { TabsListProps, TabsListStylesNames } from './TabsList/TabsList';
+export type { TabsContextValue } from './Tabs.context';


### PR DESCRIPTION
Not sure if this lives in the spirit of the library, but it would allow more customization of the Tabs component, allowing users to have full control over the component being used, allowing for better reusability.

eg

```
import { useTabsContext, SegmentedControl, SegmentedControlItem } from "@mantine/core";

type Props = {
  items: SegmentedControlItem[];
};

const TabSegmentedControl = ({ items }: Props) => {
  const ctx = useTabsContext();

  return (
    <SegmentedControl
      value={ctx.value}
      onChange={(value) => ctx.onChange(value)}
      data={items}
    />
  );
};

export default TabSegmentedControl;
```