### PR TITLE
[@mantine/core] OptionsDropdown: Remove redundant styles

### DIFF
--- a/packages/@mantine/core/src/components/Combobox/Combobox.module.css
+++ b/packages/@mantine/core/src/components/Combobox/Combobox.module.css
@@ -189,15 +189,6 @@
 }
 
 /* ------- OptionsDropdown ------- */
-.optionsDropdownScrollArea {
-  margin-right: calc(var(--_combobox-padding) * -1);
-
-  @mixin rtl {
-    margin-left: calc(var(--_combobox-padding) * -1);
-    margin-right: 0;
-  }
-}
-
 .optionsDropdownOption {
   display: flex;
   align-items: center;

--- a/packages/@mantine/core/src/components/Combobox/OptionsDropdown/OptionsDropdown.tsx
+++ b/packages/@mantine/core/src/components/Combobox/OptionsDropdown/OptionsDropdown.tsx
@@ -134,7 +134,6 @@ export function OptionsDropdown({
             type="scroll"
             scrollbarSize="var(--_combobox-padding)"
             offsetScrollbars="y"
-            className={classes.optionsDropdownScrollArea}
           >
             {options}
           </ScrollArea.Autosize>


### PR DESCRIPTION
Fixes #5676

#### Before:
<img width="450" alt="dropdown-before" src="https://github.com/mantinedev/mantine/assets/51407533/0d561b24-e06b-4a33-b648-5c75a716119f">

#### After:
<img width="450" alt="dropdown-after" src="https://github.com/mantinedev/mantine/assets/51407533/2317763e-d9b5-4b55-895f-ef60f47e9bfd">

