### PR TITLE
fixed jittery animation on lower-res monitors

### DIFF
--- a/packages/@mantine/core/src/components/Indicator/Indicator.module.css
+++ b/packages/@mantine/core/src/components/Indicator/Indicator.module.css
@@ -1,12 +1,12 @@
 @keyframes processing {
   0% {
     opacity: 0.6;
-    box-shadow: 0 0 rem(0.5px) 0 var(--indicator-color);
+    box-shadow: 0 0 0 0 var(--indicator-color);
   }
 
   100% {
     opacity: 0;
-    box-shadow: 0 0 rem(0.5px) rem(4.4px) var(--indicator-color);
+    box-shadow: 0 0 0 rem(8px) var(--indicator-color);
   }
 }
 


### PR DESCRIPTION
As reported in isssue #5680, this PR changed the Indicator component's "processing" animation to be smoother on monitors with a 96dpi resolution.
This is done by removing the blurring of the shadow and expanding the radius of the shadow slightly. It looks a little different (larger) than before on high-res monitors (Macbooks etc) but now also works on older screens.