### PR TITLE
[@mantine/core] Allow value reset in SegmentedControl

### DIFF
--- a/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.story.tsx
+++ b/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.story.tsx
@@ -111,3 +111,19 @@ export function SelectedItemRemoved() {
     </div>
   );
 }
+
+export function Unselect() {
+  const [value, setValue] = useState('');
+
+  const dataList = ['1', '2', '3'];
+
+  return (
+    <div style={{ padding: 40 }}>
+      <SegmentedControl value={value} onChange={setValue} data={dataList} mr={10} />
+
+      <button type="button" onClick={() => setValue('')}>
+        Unselect
+      </button>
+    </div>
+  );
+}

--- a/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.tsx
@@ -201,7 +201,7 @@ export const SegmentedControl = factory<SegmentedControlFactory>((_props, ref) =
   const [observerRef, containerRect] = useResizeObserver();
 
   useEffect(() => {
-    if (_value in refs.current && observerRef.current) {
+    if (observerRef.current) {
       const element = refs.current[_value];
       if (element) {
         const rootPadding = getRootPadding(rootRef.current!, WRAPPER_PADDING);


### PR DESCRIPTION
Currently it's not possible to deselect/reset the value of the `SegmentedControl`. You can start out with an empty value, if you take for instance the empty string as value and make sure that in the `data` property it doesn't map to anything. If however you then select a value, and then change the value state back to the empty string, the `SegmentedControl` will still visually show your last selected value to be selected (however `data-selected=true` will no longer be present).

My PR here fixes this behavior and allows you, with a controlled value, to make the component unselected / without anything selected.