### PR TITLE
`form.setFieldValue` based on previous value

### DIFF
--- a/packages/@mantine/form/src/tests/setFieldValue.test.ts
+++ b/packages/@mantine/form/src/tests/setFieldValue.test.ts
@@ -43,4 +43,11 @@ describe('@mantine/form/setFieldValue', () => {
     act(() => hook.result.current.setFieldValue('a.0.b.c', 10));
     expect(hook.result.current.values).toStrictEqual({ a: [{ b: { c: 10 } }, { b: { c: 20 } }] });
   });
+
+  it('sets value at path based on previous value', () => {
+    const hook = renderHook(() => useForm({ initialValues: { a: { d: 2, b: { c: 1 } } } }));
+
+    act(() => hook.result.current.setFieldValue('a.b.c', (prev) => prev + 1));
+    expect(hook.result.current.values).toStrictEqual({ a: { d: 2, b: { c: 2 } } });
+  });
 });

--- a/packages/@mantine/form/src/types.ts
+++ b/packages/@mantine/form/src/types.ts
@@ -87,7 +87,7 @@ export type GetInputProps<Values> = <Field extends LooseKeys<Values>>(
 
 export type SetFieldValue<Values> = <Field extends LooseKeys<Values>>(
   path: Field,
-  value: Field extends keyof Values ? Values[Field] : unknown
+  value: Field extends keyof Values ? Values[Field] | ((prev: Values[Field]) => Values[Field]) : unknown
 ) => void;
 
 export type ClearFieldError = (path: unknown) => void;

--- a/packages/@mantine/form/src/types.ts
+++ b/packages/@mantine/form/src/types.ts
@@ -87,7 +87,9 @@ export type GetInputProps<Values> = <Field extends LooseKeys<Values>>(
 
 export type SetFieldValue<Values> = <Field extends LooseKeys<Values>>(
   path: Field,
-  value: Field extends keyof Values ? Values[Field] | ((prev: Values[Field]) => Values[Field]) : unknown
+  value: Field extends keyof Values
+    ? Values[Field] | ((prev: Values[Field]) => Values[Field])
+    : unknown
 ) => void;
 
 export type ClearFieldError = (path: unknown) => void;

--- a/packages/@mantine/form/src/types.ts
+++ b/packages/@mantine/form/src/types.ts
@@ -85,11 +85,19 @@ export type GetInputProps<Values> = <Field extends LooseKeys<Values>>(
   options?: GetInputPropsOptions
 ) => GetInputPropsReturnType;
 
+export type PathValue<T, P extends LooseKeys<T>> = P extends `${infer K}.${infer Rest}`
+  ? K extends keyof T
+    ? PathValue<T[K], Rest>
+    : unknown
+  : P extends keyof T
+    ? T[P]
+    : unknown;
+
 export type SetFieldValue<Values> = <Field extends LooseKeys<Values>>(
   path: Field,
-  value: Field extends keyof Values
-    ? Values[Field] | ((prev: Values[Field]) => Values[Field])
-    : unknown
+  value:
+    | PathValue<Values, Field>
+    | ((prevValue: PathValue<Values, Field>) => PathValue<Values, Field>)
 ) => void;
 
 export type ClearFieldError = (path: unknown) => void;

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -132,7 +132,11 @@ export function useForm<
     clearFieldDirty(path);
     setTouched((currentTouched) => ({ ...currentTouched, [path]: true }));
     _setValues((current) => {
-      const result = setPath(path, payload instanceof Function ? payload(current) : payload, current);
+      const result = setPath(
+        path,
+        payload instanceof Function ? payload(current) : payload,
+        current
+      );
 
       if (shouldValidate) {
         const validationResults = validateFieldValue(path, rules, result);

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -127,12 +127,12 @@ export function useForm<
     []
   );
 
-  const setFieldValue: SetFieldValue<Values> = useCallback((path, value) => {
+  const setFieldValue: SetFieldValue<Values> = useCallback((path, payload) => {
     const shouldValidate = shouldValidateOnChange(path, validateInputOnChange);
     clearFieldDirty(path);
     setTouched((currentTouched) => ({ ...currentTouched, [path]: true }));
     _setValues((current) => {
-      const result = setPath(path, value, current);
+      const result = setPath(path, payload instanceof Function ? payload(current) : payload, current);
 
       if (shouldValidate) {
         const validationResults = validateFieldValue(path, rules, result);
@@ -151,7 +151,7 @@ export function useForm<
 
   const setValues: SetValues<Values> = useCallback((payload) => {
     _setValues((currentValues) => {
-      const valuesPartial = typeof payload === 'function' ? payload(currentValues) : payload;
+      const valuesPartial = payload instanceof Function ? payload(currentValues) : payload;
       const result = { ...currentValues, ...valuesPartial };
       onValuesChange?.(result, currentValues);
       return result;

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -19,6 +19,7 @@ import {
   IsValid,
   OnReset,
   OnSubmit,
+  PathValue,
   RemoveListItem,
   ReorderListItem,
   Reset,
@@ -132,9 +133,10 @@ export function useForm<
     clearFieldDirty(path);
     setTouched((currentTouched) => ({ ...currentTouched, [path]: true }));
     _setValues((current) => {
+      const currentValue = getPath(path, current) as PathValue<Values, typeof path>;
       const result = setPath(
         path,
-        payload instanceof Function ? payload(current) : payload,
+        payload instanceof Function ? payload(currentValue) : payload,
         current
       );
 


### PR DESCRIPTION
Hey everyone! :wave: 

I would like to set the value of a field `foo` based on the value it currently has. This is currently possible by using 

```ts
form.setValues(prev => ({ foo: prev.foo + 1 }))
```

but (to the best of my knowledge) not by something like

```ts
form.setFieldValue("foo", prev => prev + 1)
```

I thought I'd give it a shot to make this a proper pull request, but I am facing type issues in the test I added:

> Parameter 'prev' implicitly has an 'any' type. ts(7006)

I would really appreciate if someone could take it from here. Thanks! :pray: 