### PR TITLE
fix: set <Combobox /> set keepMounted should be false by default

### DIFF
--- a/packages/@mantine/core/src/components/Combobox/Combobox.tsx
+++ b/packages/@mantine/core/src/components/Combobox/Combobox.tsx
@@ -93,7 +93,7 @@ export type ComboboxFactory = Factory<{
 }>;
 
 const defaultProps: Partial<ComboboxProps> = {
-  keepMounted: true,
+  keepMounted: false,
   withinPortal: true,
   resetSelectionOnOptionHover: false,
   width: 'target',


### PR DESCRIPTION
**Description:**

fix: set <Combobox /> set keepMounted should be false by default 

**Issue Details:**
fixes: #5727


**Changes:**
-  Set keepMounted should be false by default


**Checklist:**
- [x] Code follows the project's coding guidelines.