### PR TITLE
[@mantine/core] PinInput: Fix changing of "length" prop not rerendering Component

### DIFF
--- a/packages/@mantine/core/src/components/PinInput/PinInput.tsx
+++ b/packages/@mantine/core/src/components/PinInput/PinInput.tsx
@@ -211,6 +211,7 @@ export const PinInput = factory<PinInputFactory>((props, ref) => {
           }
         : undefined,
   });
+
   const _valueToString = _value.join('').trim();
 
   const inputsRef = useRef<Array<HTMLInputElement>>([]);
@@ -325,6 +326,10 @@ export const PinInput = factory<PinInputFactory>((props, ref) => {
       focusInputField('next', copyValueToPinArray.length - 1);
     }
   };
+
+  useEffect(() => {
+    setValues(createPinArray(length ?? 0, _valueToString));
+  }, [length]);
 
   useEffect(() => {
     if (_valueToString.length !== length) return;


### PR DESCRIPTION
Should only rarely affect production deployments, but at least it affects the docs. PinInput is not rerendered when you change the length prop after the initial rendering.

@rtivital tell me if you also want a test, then I'll create one. Didn't cause I think it's very rare that the length change dynamically in prod. Did this fix mainly for the docs (and because I dont find peace when I know it should update but it doesn't :D).