### PR TITLE
[@mantine/core] NumberInput: Fix double border between controls

### DIFF
--- a/packages/@mantine/core/src/components/NumberInput/NumberInput.module.css
+++ b/packages/@mantine/core/src/components/NumberInput/NumberInput.module.css
@@ -78,7 +78,7 @@
   }
 
   &:where(:first-of-type) {
-    border-bottom: rem(0.5px) solid var(--_input-bd);
+    border-bottom: rem(1px) solid var(--_input-bd);
     border-radius: 0 var(--control-radius) 0 0;
 
     @mixin where-rtl {
@@ -87,7 +87,6 @@
   }
 
   &:last-of-type {
-    border-top: rem(0.5px) solid var(--_input-bd);
     border-radius: 0 0 var(--control-radius) 0;
 
     @mixin rtl {


### PR DESCRIPTION
**Before:**

![image](https://github.com/mantinedev/mantine/assets/34271675/51229e60-81b5-445d-be0a-d3cccc1f8d49)

**After:**

![image](https://github.com/mantinedev/mantine/assets/34271675/44680ee0-ac24-4764-b61f-7e254038a252)