### PR TITLE
[@mantine/core] Switch: fix accessibility V6

### DIFF
--- a/src/mantine-core/src/InlineInput/InlineInput.tsx
+++ b/src/mantine-core/src/InlineInput/InlineInput.tsx
@@ -18,6 +18,8 @@ export interface InlineInputProps
   error: React.ReactNode;
   size: MantineNumberSize;
   labelPosition: 'left' | 'right';
+  bodyElement?: any;
+  labelElement?: any;
 }
 
 export const InlineInput = forwardRef<HTMLDivElement, InlineInputProps>(
@@ -36,6 +38,8 @@ export const InlineInput = forwardRef<HTMLDivElement, InlineInputProps>(
       error,
       size,
       labelPosition,
+      bodyElement = 'div',
+      labelElement = 'label',
       variant,
       ...others
     },
@@ -48,14 +52,23 @@ export const InlineInput = forwardRef<HTMLDivElement, InlineInputProps>(
 
     return (
       <Box className={cx(classes.root, className)} ref={ref} {...others}>
-        <div className={cx(classes.body)}>
+        <Box
+          component={bodyElement}
+          htmlFor={bodyElement === 'label' ? id : undefined}
+          className={cx(classes.body)}
+        >
           {children}
 
           <div className={classes.labelWrapper}>
             {label != null && (
-              <label className={classes.label} data-disabled={disabled || undefined} htmlFor={id}>
+              <Box
+                component={labelElement}
+                htmlFor={labelElement === 'label' ? id : undefined}
+                className={classes.label}
+                data-disabled={disabled || undefined}
+              >
                 {label}
-              </label>
+              </Box>
             )}
 
             {description && (
@@ -66,7 +79,7 @@ export const InlineInput = forwardRef<HTMLDivElement, InlineInputProps>(
               <Input.Error className={classes.error}>{error}</Input.Error>
             )}
           </div>
-        </div>
+        </Box>
       </Box>
     );
   }

--- a/src/mantine-core/src/Switch/Switch.test.tsx
+++ b/src/mantine-core/src/Switch/Switch.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import {
   checkAccessibility,
-  itHandlesBooleanState,
+  itHandlesSwitchCheckboxState,
   itSupportsSystemProps,
   itConnectsLabelAndInput,
   itSupportsWrapperProps,
@@ -20,7 +20,7 @@ const defaultProps: SwitchProps = {
 
 describe('@mantine/core/Switch', () => {
   checkAccessibility([<Switch aria-label="Switch without label" />, <Switch label="With label" />]);
-  itHandlesBooleanState(Switch, defaultProps);
+  itHandlesSwitchCheckboxState(Switch, defaultProps);
   itConnectsLabelAndInput(Switch, defaultProps);
   itSupportsWrapperProps(Switch, defaultProps);
   itSupportsFocusEvents(Switch, defaultProps, 'input');
@@ -55,6 +55,6 @@ describe('@mantine/core/Switch', () => {
 
   it('sets disabled attribute on input based on disabled prop', () => {
     render(<Switch disabled />);
-    expect(screen.getByRole('checkbox')).toBeDisabled();
+    expect(screen.getByRole('switch')).toBeDisabled();
   });
 });

--- a/src/mantine-core/src/Switch/Switch.tsx
+++ b/src/mantine-core/src/Switch/Switch.tsx
@@ -134,6 +134,8 @@ export const Switch: SwitchComponent = forwardRef<HTMLInputElement, SwitchProps>
       description={description}
       error={error}
       disabled={disabled}
+      bodyElement="label"
+      labelElement="span"
       __staticSelector="Switch"
       classNames={classNames}
       styles={styles}
@@ -154,13 +156,14 @@ export const Switch: SwitchComponent = forwardRef<HTMLInputElement, SwitchProps>
         id={uuid}
         ref={ref}
         type="checkbox"
+        role="switch"
         className={classes.input}
       />
 
-      <label htmlFor={uuid} className={classes.track}>
+      <div className={classes.track} aria-hidden>
         <div className={classes.thumb}>{thumbIcon}</div>
         <div className={classes.trackLabel}>{_checked ? onLabel : offLabel}</div>
-      </label>
+      </div>
     </InlineInput>
   );
 }) as any;

--- a/src/mantine-core/src/Switch/SwitchGroup/SwitchGroup.test.tsx
+++ b/src/mantine-core/src/Switch/SwitchGroup/SwitchGroup.test.tsx
@@ -39,18 +39,18 @@ describe('@mantine/core/SwitchGroup', () => {
 
   it('supports uncontrolled state', async () => {
     render(<SwitchGroup {...defaultProps} defaultValue={['test-value-1']} />);
-    expect(screen.getAllByRole('checkbox')[0]).toBeChecked();
-    await userEvent.click(screen.getAllByRole('checkbox')[1]);
-    expect(screen.getAllByRole('checkbox')[1]).toBeChecked();
+    expect(screen.getAllByRole('switch')[0]).toBeChecked();
+    await userEvent.click(screen.getAllByRole('switch')[1]);
+    expect(screen.getAllByRole('switch')[1]).toBeChecked();
   });
 
   it('supports controlled state', async () => {
     const spy = jest.fn();
     render(<SwitchGroup {...defaultProps} value={['test-value-2']} onChange={spy} />);
-    expect(screen.getAllByRole('checkbox')[1]).toBeChecked();
-    await userEvent.click(screen.getAllByRole('checkbox')[0]);
-    expect(screen.getAllByRole('checkbox')[1]).toBeChecked();
-    expect(screen.getAllByRole('checkbox')[0]).not.toBeChecked();
+    expect(screen.getAllByRole('switch')[1]).toBeChecked();
+    await userEvent.click(screen.getAllByRole('switch')[0]);
+    expect(screen.getAllByRole('switch')[1]).toBeChecked();
+    expect(screen.getAllByRole('switch')[0]).not.toBeChecked();
     expect(spy).toHaveBeenCalledWith(['test-value-2', 'test-value-1']);
   });
 });

--- a/src/mantine-tests/src/index.ts
+++ b/src/mantine-tests/src/index.ts
@@ -12,6 +12,7 @@ export { itSupportsFocusEvents } from './it-supports-focus-events';
 export { itSupportsSystemProps } from './it-supports-system-props';
 export { itConnectsLabelAndInput } from './it-connects-label-and-input';
 export { itHandlesBooleanState } from './it-handles-boolean-state';
+export { itHandlesSwitchCheckboxState } from './it-handles-switch-checkbox-state';
 export { createContextContainer } from './create-context-container';
 export { itThrowsContextError } from './it-throws-context-error';
 export { itSupportsProviderDefaultProps } from './it-supports-provider-default-props';

--- a/src/mantine-tests/src/it-handles-switch-checkbox-state.tsx
+++ b/src/mantine-tests/src/it-handles-switch-checkbox-state.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+export function itHandlesSwitchCheckboxState<P>(
+  Component: React.ComponentType<P>,
+  requiredProps: P
+) {
+  it('correctly handles uncontrolled state', async () => {
+    render(<Component {...requiredProps} />);
+    expect(screen.getByRole('switch')).not.toBeChecked();
+    await userEvent.click(screen.getByRole('switch'));
+    expect(screen.getByRole('switch')).toBeChecked();
+  });
+
+  it('correctly handles controlled state', async () => {
+    const spy = jest.fn();
+    render(<Component {...requiredProps} checked={false} onChange={spy} />);
+    expect(screen.getByRole('switch')).not.toBeChecked();
+    await userEvent.click(screen.getByRole('switch'));
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('switch')).not.toBeChecked();
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/mantinedev/mantine/issues/5699.

Backport of https://github.com/mantinedev/mantine/pull/5746

Things to note:

- Due to the implementation of role="switch", some tests needed to be adjusted.
- Screen readers no longer read out the onLabel and offLabel values, however I consider this to be appropriate as the label or aria-label should be used to provide enough context that these values are not needed.
- Screen reader testing was conducted across ChromeVox and Ubuntu Orca.
- Open to suggestions on types for bodyElement and labelElement.