### PR TITLE
[docs] Fix: updated the proper link in changelog

### DIFF
--- a/docs/src/pages/changelog/7-5-0.mdx
+++ b/docs/src/pages/changelog/7-5-0.mdx
@@ -144,4 +144,4 @@ New articles added to the [help center](https://help.mantine.dev):
 - [SegmentedControl](/core/segmented-control) now supports `withItemsBorder` prop which allows removing border between items
 - [Progress](/core/progress) now supports `transitionDuration` prop which controls section width animation duration
 - [Textarea](/core/textarea) and [JsonInput](/core/json-input) components now support `resize` prop, which allows setting `resize` CSS property on the input
-- `@mantine/hooks` package now exports [readLocalStorageValue and readSessionStorageValue](hooks/use-local-storage/#read-storage-value) function to get value from storage outside of React components
+- `@mantine/hooks` package now exports [readLocalStorageValue and readSessionStorageValue](/hooks/use-local-storage/#read-storage-value) function to get value from storage outside of React components


### PR DESCRIPTION
Fixes 404 error while navigating from releases changelog in the docs.

![image](https://github.com/mantinedev/mantine/assets/84406070/051f5422-e4c5-4be7-a428-5aae9b8ad950)
