### PR TITLE
[@mantine/dates] Fix: minimum-date is not in current month and value is not provided

### DIFF
--- a/packages/@mantine/dates/src/components/DateInput/DateInput.story.tsx
+++ b/packages/@mantine/dates/src/components/DateInput/DateInput.story.tsx
@@ -241,3 +241,17 @@ export function Size() {
     </div>
   );
 }
+
+export function MinimumDateOnly() {
+  const [value, setValue] = useState<Date | null>(null);
+  return (
+    <div style={{ padding: 40, maxWidth: 400 }}>
+      <DateInput
+        placeholder="Enter date"
+        value={value}
+        onChange={setValue}
+        minDate={new Date('2024-05-01')}
+      />
+    </div>
+  );
+}

--- a/packages/@mantine/dates/src/components/DateInput/DateInput.tsx
+++ b/packages/@mantine/dates/src/components/DateInput/DateInput.tsx
@@ -167,7 +167,7 @@ export const DateInput = factory<DateInputFactory>((_props, ref) => {
 
   useEffect(() => {
     if (controlled) {
-      setDate(value!);
+      setDate(value ? value! : minDate!);
     }
   }, [controlled, value]);
 


### PR DESCRIPTION
Fixes #5695.

This PR solves:
* When the `value` is null and `minDate` is in past or future, then this fix will take `minDate` as default and show the calendar.