### PR TITLE
[@mantine/hooks]: fix unstable pinning of item by `useHeadroom` on mobile devices

### DIFF
--- a/packages/@mantine/hooks/src/use-headroom/use-headroom.ts
+++ b/packages/@mantine/hooks/src/use-headroom/use-headroom.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useIsomorphicEffect } from '../use-isomorphic-effect/use-isomorphic-effect';
 import { useWindowScroll } from '../use-window-scroll/use-window-scroll';
 
@@ -11,6 +11,7 @@ export const isPinnedOrReleased = (
   current: number,
   fixedAt: number,
   isCurrentlyPinnedRef: React.MutableRefObject<boolean>,
+  isScrollingUp: boolean,
   onPin?: () => void,
   onRelease?: () => void
 ) => {
@@ -18,10 +19,50 @@ export const isPinnedOrReleased = (
   if (isInFixedPosition && !isCurrentlyPinnedRef.current) {
     isCurrentlyPinnedRef.current = true;
     onPin?.();
+  } else if (!isInFixedPosition && isScrollingUp && !isCurrentlyPinnedRef.current) {
+    isCurrentlyPinnedRef.current = true;
+    onPin?.();
   } else if (!isInFixedPosition && isCurrentlyPinnedRef.current) {
     isCurrentlyPinnedRef.current = false;
     onRelease?.();
   }
+};
+
+export const useScrollDirection = () => {
+  const [lastScrollTop, setLastScrollTop] = useState(0);
+  const [isScrollingUp, setIsScrollingUp] = useState(false);
+  const [isResizing, setIsResizing] = useState(false);
+
+  useEffect(() => {
+    let resizeTimer: NodeJS.Timeout | undefined;
+
+    const onResize = () => {
+      setIsResizing(true);
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => {
+        setIsResizing(false);
+      }, 300); // Reset the resizing flag after a timeout
+    };
+
+    const onScroll = () => {
+      if (isResizing) {
+        return; // Skip scroll events if resizing is in progress
+      }
+      const currentScrollTop = window.pageYOffset || document.documentElement.scrollTop;
+      setIsScrollingUp(currentScrollTop < lastScrollTop);
+      setLastScrollTop(currentScrollTop);
+    };
+
+    window.addEventListener('scroll', onScroll);
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onResize);
+    };
+  }, [lastScrollTop, isResizing]);
+
+  return isScrollingUp;
 };
 
 interface UseHeadroomInput {
@@ -40,10 +81,18 @@ interface UseHeadroomInput {
 
 export function useHeadroom({ fixedAt = 0, onPin, onFix, onRelease }: UseHeadroomInput = {}) {
   const isCurrentlyPinnedRef = useRef(false);
+  const isScrollingUp = useScrollDirection();
   const [{ y: scrollPosition }] = useWindowScroll();
 
   useIsomorphicEffect(() => {
-    isPinnedOrReleased(scrollPosition, fixedAt, isCurrentlyPinnedRef, onPin, onRelease);
+    isPinnedOrReleased(
+      scrollPosition,
+      fixedAt,
+      isCurrentlyPinnedRef,
+      isScrollingUp,
+      onPin,
+      onRelease
+    );
   }, [scrollPosition]);
 
   useIsomorphicEffect(() => {
@@ -52,7 +101,7 @@ export function useHeadroom({ fixedAt = 0, onPin, onFix, onRelease }: UseHeadroo
     }
   }, [scrollPosition, fixedAt, onFix]);
 
-  if (isFixed(scrollPosition, fixedAt)) {
+  if (isFixed(scrollPosition, fixedAt) || isScrollingUp) {
     return true;
   }
 


### PR DESCRIPTION
fixes #4563 

In order to fix the issue, I actually had to change the code logic for checking pin status. The `isPinned` function was previously used every time the `scrollPosition` returned by `useWindowScroll` changed. This is useless as causes the issue as when an address bar hides on scroll in mobile browser, a `resize` event is fired by the browser, but the `scrollPosition` hasn't actually changed.
```js
if (isPinned(scrollPosition, scrollRef.current)) {
    return true;
  }
```
In the above code, both `scrollRef.current` and `scrollPosition` hold the same value and don't offer a clear comparison.
This line of code is useless because the next condition call after it which calls `isFixed` with `scrollPosition` and the `fixedAt` value is the only true logic for this hook's implementation. 
```js
if (isFixed(scrollPosition, fixedAt)) {
    return true;
  }
```

I also changed the logic for calling `onPin` and `onRelease` callbacks. The ref which was previously used to hold the `scrollPosition` was actually used for wrong comparison. The `onPin` callback in my opinion should get called only when the pinning element has switched state from pinned to unpinned or vice versa, when the scrollPosition changes. In the current code, `onPin` is getting called so many times as user scrolls, this doesn't make sense. So, I have merged the logic of two past `useEffects` into a single one. I store the pinning status in a ref to prevent extra re-render.

I have marked this PR as a draft to make sure you inspect those changes and I hope this explanation clarifies them for you.