### PR TITLE
[@mantine/core] Checkbox: Fix `indeterminate` styles when `disabled` for `outlined` variant

### DIFF
--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.module.css
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.module.css
@@ -94,7 +94,7 @@
     --_checkbox-icon-color: var(--checkbox-color);
   }
 
-  &[data-indeterminate],
+  &[data-indeterminate]:not(:disabled),
   &:checked:not(:disabled) {
     [data-mantine-color-scheme] & {
       --_checkbox-bg: transparent;


### PR DESCRIPTION
Fixes #5805

Reproduction:

- Go to http://localhost:7545/core/checkbox/#usage
- Change variant from `filled` to `outline`
- Turn on `indeterminate`
- Turn on `disabled`
- **Note that checkbox style is now gray-ish**

Screenshots _(taken from localhost)_:

![image](https://github.com/mantinedev/mantine/assets/20128985/86b508d0-452b-4854-915b-a2195c149e5f)
