### PR TITLE
[build] `npm run setup` didn't run on windows

### DIFF
--- a/scripts/utils/get-path.ts
+++ b/scripts/utils/get-path.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 
 export function getPath(filePath: string) {
-  return path.join(process.cwd(), filePath);
+  return path.posix.resolve(filePath);
 }
 
 export function getPaths(filePaths: string[]) {


### PR DESCRIPTION
When running `npm run setup` on windows (without WSL) it fails with the following message:
```
node:internal/validators:162
    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
          ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at validateString (node:internal/validators:162:11)
    at Object.basename (node:path:756:5)
    at transformFileName (scripts\build\generate-css.ts:13:15)
    at generateCoreCSS (\scripts\build\generate-css.ts:57:56) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

This is because of the glob path containing back slashes but `fast-glob` not supporting these:
https://www.npmjs.com/package/fast-glob#pattern-syntax
> Always use forward-slashes in glob expressions (patterns and [ignore](https://www.npmjs.com/package/fast-glob#ignore) option).