### PR TITLE
Update get-input-props.mdx

### DIFF
--- a/docs/src/pages/form/get-input-props.mdx
+++ b/docs/src/pages/form/get-input-props.mdx
@@ -151,7 +151,7 @@ export function CustomInput({
 Then use it with `form.getInputProps`:
 
 ```tsx
-import { useForm } from '@mantine/core';
+import { useForm } from '@mantine/form';
 import { CustomInput } from './CustomInput';
 
 function Demo() {


### PR DESCRIPTION
corrected the import statement for `useForm`. 

Current : `import { useForm } from '@mantine/core';`

Expected : `import { useForm } from '@mantine/form';`