### PR TITLE
Allow using colorScheme in MantineProvider's theme

### DIFF
--- a/packages/@mantine/core/src/core/MantineProvider/MantineProvider.tsx
+++ b/packages/@mantine/core/src/core/MantineProvider/MantineProvider.tsx
@@ -15,7 +15,7 @@ suppressNextjsWarning();
 
 export interface MantineProviderProps {
   /** Theme override object */
-  theme?: MantineThemeOverride;
+  theme?: MantineThemeOverride | ((colorScheme: MantineColorScheme) => MantineThemeOverride);
 
   /** Used to retrieve/set color scheme value in external storage, by default uses `window.localStorage` */
   colorSchemeManager?: MantineColorSchemeManager;
@@ -58,27 +58,32 @@ export interface MantineProviderProps {
 }
 
 export function MantineProvider({
-  theme,
-  children,
-  getStyleNonce,
-  withStaticClasses = true,
-  withGlobalClasses = true,
-  deduplicateCssVariables = true,
-  withCssVariables = true,
-  cssVariablesSelector = ':root',
-  classNamesPrefix = 'mantine',
-  colorSchemeManager = localStorageColorSchemeManager(),
-  defaultColorScheme = 'light',
-  getRootElement = () => document.documentElement,
-  cssVariablesResolver,
-  forceColorScheme,
-}: MantineProviderProps) {
-  const { colorScheme, setColorScheme, clearColorScheme } = useProviderColorScheme({
+                                  theme: initialTheme,
+                                  children,
+                                  getStyleNonce,
+                                  withStaticClasses = true,
+                                  withGlobalClasses = true,
+                                  deduplicateCssVariables = true,
+                                  withCssVariables = true,
+                                  cssVariablesSelector = ':root',
+                                  classNamesPrefix = 'mantine',
+                                  colorSchemeManager = localStorageColorSchemeManager(),
+                                  defaultColorScheme = 'light',
+                                  getRootElement = () => document.documentElement,
+                                  cssVariablesResolver,
+                                  forceColorScheme,
+                                }: MantineProviderProps) {
+  const {
+    colorScheme,
+    setColorScheme,
+    clearColorScheme,
+  } = useProviderColorScheme({
     defaultColorScheme,
     forceColorScheme,
     manager: colorSchemeManager,
     getRootElement,
   });
+  const theme = typeof initialTheme === 'function' ? initialTheme(colorScheme) : initialTheme;
 
   useRespectReduceMotion({
     respectReducedMotion: theme?.respectReducedMotion || false,
@@ -123,13 +128,18 @@ export interface HeadlessMantineProviderProps {
   children: React.ReactNode;
 }
 
-export function HeadlessMantineProvider({ children, theme }: HeadlessMantineProviderProps) {
+export function HeadlessMantineProvider({
+                                          children,
+                                          theme,
+                                        }: HeadlessMantineProviderProps) {
   return (
     <MantineContext.Provider
       value={{
         colorScheme: 'auto',
-        setColorScheme: () => {},
-        clearColorScheme: () => {},
+        setColorScheme: () => {
+        },
+        clearColorScheme: () => {
+        },
         getRootElement: () => document.documentElement,
         classNamesPrefix: 'mantine',
         cssVariablesSelector: ':root',

--- a/packages/@mantine/core/src/core/MantineProvider/MantineProvider.tsx
+++ b/packages/@mantine/core/src/core/MantineProvider/MantineProvider.tsx
@@ -58,26 +58,22 @@ export interface MantineProviderProps {
 }
 
 export function MantineProvider({
-                                  theme: initialTheme,
-                                  children,
-                                  getStyleNonce,
-                                  withStaticClasses = true,
-                                  withGlobalClasses = true,
-                                  deduplicateCssVariables = true,
-                                  withCssVariables = true,
-                                  cssVariablesSelector = ':root',
-                                  classNamesPrefix = 'mantine',
-                                  colorSchemeManager = localStorageColorSchemeManager(),
-                                  defaultColorScheme = 'light',
-                                  getRootElement = () => document.documentElement,
-                                  cssVariablesResolver,
-                                  forceColorScheme,
-                                }: MantineProviderProps) {
-  const {
-    colorScheme,
-    setColorScheme,
-    clearColorScheme,
-  } = useProviderColorScheme({
+  theme: initialTheme,
+  children,
+  getStyleNonce,
+  withStaticClasses = true,
+  withGlobalClasses = true,
+  deduplicateCssVariables = true,
+  withCssVariables = true,
+  cssVariablesSelector = ':root',
+  classNamesPrefix = 'mantine',
+  colorSchemeManager = localStorageColorSchemeManager(),
+  defaultColorScheme = 'light',
+  getRootElement = () => document.documentElement,
+  cssVariablesResolver,
+  forceColorScheme,
+}: MantineProviderProps) {
+  const { colorScheme, setColorScheme, clearColorScheme } = useProviderColorScheme({
     defaultColorScheme,
     forceColorScheme,
     manager: colorSchemeManager,
@@ -128,18 +124,13 @@ export interface HeadlessMantineProviderProps {
   children: React.ReactNode;
 }
 
-export function HeadlessMantineProvider({
-                                          children,
-                                          theme,
-                                        }: HeadlessMantineProviderProps) {
+export function HeadlessMantineProvider({ children, theme }: HeadlessMantineProviderProps) {
   return (
     <MantineContext.Provider
       value={{
         colorScheme: 'auto',
-        setColorScheme: () => {
-        },
-        clearColorScheme: () => {
-        },
+        setColorScheme: () => {},
+        clearColorScheme: () => {},
         getRootElement: () => document.documentElement,
         classNamesPrefix: 'mantine',
         cssVariablesSelector: ':root',


### PR DESCRIPTION
This PR allows you to pass a function to MantineProvider's theme, which takes as an argument the current `colorScheme`. This allows for easier customization of components based on the color scheme.