### PR TITLE
[docs] Add CssVariableColorSwatch column to CSS variables list

### DIFF
--- a/docs/src/components/CssVariablesList/CssVariableColorSwatch/CssVariableColorSwatch.tsx
+++ b/docs/src/components/CssVariablesList/CssVariableColorSwatch/CssVariableColorSwatch.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { ColorSwatch } from '@mantine/core';
+
+const colorVariableRegex = /^(var\(--mantine-color[\w-]+\)|#\w+|rgba?\(\w+\))$/gm;
+
+export interface CssVariableColorSwatchProps {
+  variable: string;
+}
+
+export function CssVariableColorSwatch({ variable }: CssVariableColorSwatchProps) {
+  if (!variable || !variable.match(colorVariableRegex)) {
+    return null;
+  }
+
+  return <ColorSwatch size={20} color={variable} />;
+}

--- a/docs/src/components/CssVariablesList/CssVariablesList.tsx
+++ b/docs/src/components/CssVariablesList/CssVariablesList.tsx
@@ -1,22 +1,26 @@
 import React from 'react';
 import { Code, DEFAULT_THEME, defaultCssVariablesResolver, keys } from '@mantine/core';
 import { MdxDataTable, MdxTitle } from '../MdxProvider';
+import { CssVariableColorSwatch } from './CssVariableColorSwatch/CssVariableColorSwatch';
 
 export function CssVariablesList() {
   const resolvedVariables = defaultCssVariablesResolver(DEFAULT_THEME);
   const variables = keys(resolvedVariables.variables).map((key) => [
     <Code style={{ whiteSpace: 'nowrap' }}>{key}</Code>,
     resolvedVariables.variables[key],
+    <CssVariableColorSwatch variable={resolvedVariables.variables[key]} />,
   ]);
 
   const lightVariables = keys(resolvedVariables.light).map((key) => [
     <Code style={{ whiteSpace: 'nowrap' }}>{key}</Code>,
     resolvedVariables.light[key],
+    <CssVariableColorSwatch variable={resolvedVariables.light[key]} />,
   ]);
 
   const darkVariables = keys(resolvedVariables.dark).map((key) => [
     <Code style={{ whiteSpace: 'nowrap' }}>{key}</Code>,
     resolvedVariables.dark[key],
+    <CssVariableColorSwatch variable={resolvedVariables.dark[key]} />,
   ]);
 
   return (


### PR DESCRIPTION
I was going through the documentation to find some CSS variables to use for some default theme colors, and noticed that it was a bit difficult to figure out.

This PR adds a `ColorSwatch` column to the docs with the corresponding color if the CSS variable value matches a regex.

### Screenshots
| Before | After |
| -------|------|
|![color-variables-1-before](https://github.com/mantinedev/mantine/assets/531798/701bdded-ecdd-4d40-8b5e-d186d77584c8)|![color-variables-1-after](https://github.com/mantinedev/mantine/assets/531798/028145d5-4b61-44bd-ad2a-b9a3fc847c8e)
|![color-variables-2-before](https://github.com/mantinedev/mantine/assets/531798/c05f8bdb-3ebe-40c7-8366-b0c2563cd2bb)|![color-variables-2-after](https://github.com/mantinedev/mantine/assets/531798/2eb5a13d-7a84-4b37-9fee-9666bf61a4e5)

