### PR TITLE
[@mantine/dropzone] Add image HEIC to IMAGE_MIME_TYPE in @mantine/dropzone

### DIFF
--- a/packages/@mantine/dropzone/src/mime-types.ts
+++ b/packages/@mantine/dropzone/src/mime-types.ts
@@ -6,6 +6,7 @@ export const MIME_TYPES = {
   svg: 'image/svg+xml',
   webp: 'image/webp',
   avif: 'image/avif',
+  heic: 'image/heic',
 
   // Documents
   mp4: 'video/mp4',
@@ -28,6 +29,7 @@ export const IMAGE_MIME_TYPE = [
   MIME_TYPES.svg,
   MIME_TYPES.webp,
   MIME_TYPES.avif,
+  MIME_TYPES.heic,
 ];
 
 export const PDF_MIME_TYPE = [MIME_TYPES.pdf];


### PR DESCRIPTION
Fixes https://github.com/mantinedev/mantine/issues/5866.

HEIC is used by Apple devices after iOS 11. It can be very useful.