### PR TITLE
[@mantine/core]: update global.css

### DIFF
--- a/packages/@mantine/core/src/core/MantineProvider/global.css
+++ b/packages/@mantine/core/src/core/MantineProvider/global.css
@@ -1,8 +1,9 @@
 /* ----- CSS reset ----- */
-*,
-*::before,
-*::after {
+html {
   box-sizing: border-box;
+}
+*, *:before, *:after {
+  box-sizing: inherit;
 }
 
 input,


### PR DESCRIPTION
Modify universal box sizing to use inheritance which is considered a better practice.

reasons why you would need the inheritance version:
[https://css-tricks.com/box-sizing/](https://css-tricks.com/box-sizing/)
[https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/](https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/)