### PR TITLE
[@mantine/core] Timeline: Fix `autoContrast` being passed to the dom node as attribute (#5846)

### DIFF
--- a/packages/@mantine/core/src/components/Timeline/Timeline.tsx
+++ b/packages/@mantine/core/src/components/Timeline/Timeline.tsx
@@ -106,6 +106,7 @@ export const Timeline = factory<TimelineFactory>((_props, ref) => {
     lineWidth,
     reverseActive,
     mod,
+    autoContrast,
     ...others
   } = props;
 


### PR DESCRIPTION
Fixes #5846 