### PR TITLE
[@mantine/core] packages: fix animation of indicator

### DIFF
--- a/packages/@mantine/core/src/components/Indicator/Indicator.module.css
+++ b/packages/@mantine/core/src/components/Indicator/Indicator.module.css
@@ -6,7 +6,7 @@
 
   100% {
     opacity: 0;
-    transform: scale(2);
+    transform: scale(2.8);
   }
 }
 

--- a/packages/@mantine/core/src/components/Indicator/Indicator.module.css
+++ b/packages/@mantine/core/src/components/Indicator/Indicator.module.css
@@ -1,12 +1,12 @@
 @keyframes processing {
   0% {
     opacity: 0.6;
-    box-shadow: 0 0 0 0 var(--indicator-color);
+    transform: scale(0);
   }
 
   100% {
     opacity: 0;
-    box-shadow: 0 0 0 rem(8px) var(--indicator-color);
+    transform: scale(2);
   }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/mantinedev/mantine/issues/5887

The CSS animation with `border-shadow` may not look good on some browsers, so I used `transform` to fix it.

I have tried to make it look almost the same, but not exactly the same, so I would appreciate it if you could compare the following video to see if there are any problems!

## before
[Screencast from 2024年03月12日 21時52分18秒.webm](https://github.com/mantinedev/mantine/assets/79452224/b63ec2b9-da8d-4d34-890e-2fff6cd30b5f)


## after
[Screencast from 2024年03月12日 22時06分16秒.webm](https://github.com/mantinedev/mantine/assets/79452224/f8e52da9-1334-4b54-83b1-faa73f5da67d)
