### PR TITLE
[@mantine/dates] Fix error with timezones in Month

### DIFF
--- a/packages/@mantine/dates/src/components/Month/Month.tsx
+++ b/packages/@mantine/dates/src/components/Month/Month.tsx
@@ -175,7 +175,6 @@ export const Month = factory<MonthFactory>((_props, ref) => {
   const dates = getMonthDays({
     month,
     firstDayOfWeek: ctx.getFirstDayOfWeek(firstDayOfWeek),
-    timezone: ctx.timezone || undefined,
     consistentWeeks: ctx.consistentWeeks,
   });
 
@@ -243,6 +242,7 @@ export const Month = factory<MonthFactory>((_props, ref) => {
             }}
             onClick={(event) => {
               dayProps?.onClick?.(event);
+
               __onDayClick?.(event, date);
             }}
             onMouseDown={(event) => {

--- a/packages/@mantine/dates/src/components/Month/get-date-in-tab-order/get-date-in-tab-order.test.ts
+++ b/packages/@mantine/dates/src/components/Month/get-date-in-tab-order/get-date-in-tab-order.test.ts
@@ -6,7 +6,6 @@ const defaultDates = getMonthDays({
   month: new Date(2010, 5, 1),
   firstDayOfWeek: 1,
   consistentWeeks: false,
-  timezone: undefined,
 });
 const defaultMinDate = new Date(2000, 0);
 const defaultMaxDate = new Date(2100, 0);
@@ -40,7 +39,6 @@ describe('@mantine/dates/get-date-in-tab-order', () => {
           month: new Date(),
           firstDayOfWeek: 1,
           consistentWeeks: false,
-          timezone: undefined,
         }),
         defaultMinDate,
         defaultMaxDate,
@@ -61,7 +59,6 @@ describe('@mantine/dates/get-date-in-tab-order', () => {
           month: new Date(2010, 1, 1),
           firstDayOfWeek: 1,
           consistentWeeks: false,
-          timezone: undefined,
         }),
         defaultMinDate,
         defaultMaxDate,
@@ -91,7 +88,6 @@ describe('@mantine/dates/get-date-in-tab-order', () => {
           month: new Date(2010, 1, 1),
           firstDayOfWeek: 1,
           consistentWeeks: false,
-          timezone: undefined,
         }),
         defaultMinDate,
         defaultMaxDate,

--- a/packages/@mantine/dates/src/components/Month/get-month-days/get-month-days.test.ts
+++ b/packages/@mantine/dates/src/components/Month/get-month-days/get-month-days.test.ts
@@ -7,7 +7,6 @@ describe('@mantine/dates/get-month-days', () => {
       month: new Date(2021, 1, 2),
       firstDayOfWeek: 1,
       consistentWeeks: false,
-      timezone: undefined,
     });
     expect(monthDays).toHaveLength(4);
 
@@ -24,7 +23,6 @@ describe('@mantine/dates/get-month-days', () => {
     const monthDays = getMonthDays({
       month: new Date(2021, 1, 2),
       firstDayOfWeek: 0,
-      timezone: undefined,
       consistentWeeks: false,
     });
     expect(monthDays).toHaveLength(5);
@@ -42,7 +40,6 @@ describe('@mantine/dates/get-month-days', () => {
       month: new Date(2021, 3, 2),
       firstDayOfWeek: 1,
       consistentWeeks: false,
-      timezone: undefined,
     });
 
     expect(monthDays).toHaveLength(5);
@@ -58,7 +55,6 @@ describe('@mantine/dates/get-month-days', () => {
       month: new Date(2021, 3, 2),
       firstDayOfWeek: 0,
       consistentWeeks: false,
-      timezone: undefined,
     });
 
     expect(monthDays).toHaveLength(5);
@@ -74,7 +70,6 @@ describe('@mantine/dates/get-month-days', () => {
       month: new Date(2021, 1, 2),
       firstDayOfWeek: 1,
       consistentWeeks: true,
-      timezone: undefined,
     });
 
     expect(monthDays).toHaveLength(6);

--- a/packages/@mantine/dates/src/components/Month/get-month-days/get-month-days.ts
+++ b/packages/@mantine/dates/src/components/Month/get-month-days/get-month-days.ts
@@ -1,32 +1,21 @@
 import { DayOfWeek } from '../../../types';
-import { shiftTimezone } from '../../../utils';
 import { getEndOfWeek } from '../get-end-of-week/get-end-of-week';
 import { getStartOfWeek } from '../get-start-of-week/get-start-of-week';
 
 interface GetMonthDaysInput {
   month: Date;
   firstDayOfWeek: DayOfWeek | undefined;
-  timezone: string | undefined;
   consistentWeeks: boolean | undefined;
 }
 
 export function getMonthDays({
   month,
   firstDayOfWeek = 1,
-  timezone = undefined,
   consistentWeeks,
 }: GetMonthDaysInput): Date[][] {
   const currentMonth = month.getMonth();
-  const startOfMonth = shiftTimezone(
-    'add',
-    new Date(month.getFullYear(), currentMonth, 1),
-    timezone
-  );
-  const endOfMonth = shiftTimezone(
-    'add',
-    new Date(month.getFullYear(), month.getMonth() + 1, 0),
-    timezone
-  );
+  const startOfMonth = new Date(month.getFullYear(), currentMonth, 1);
+  const endOfMonth = new Date(month.getFullYear(), month.getMonth() + 1, 0);
   const endDate = getEndOfWeek(endOfMonth, firstDayOfWeek);
   const date = getStartOfWeek(startOfMonth, firstDayOfWeek);
   const weeks: Date[][] = [];


### PR DESCRIPTION
Fixes #5840 

The problem was that variables startOfMonth and endOfMonth shifted by timezone once and then shifted again during clicks.
At version 7.4.2 which works ok, timezone at getMonthDays was always "undefined" there for it worked good as mentioned in the Issue. With new version of Month.tsx in 7.5.0 timezone is not undefined and so there is a double shift of date.

Is this a rigth direction to solve it?
