### PR TITLE
[@mantine/form] Add resetField function

### DIFF
--- a/packages/@docs/demos/src/demos/form/Form.demo.resetField.tsx
+++ b/packages/@docs/demos/src/demos/form/Form.demo.resetField.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Box, Button, Group, TextInput } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { useForm } from '@mantine/form';
+import { TextInput, Button, Group, Box } from '@mantine/core';
+
+function Demo() {
+  const form = useForm({
+    initialValues: {
+      name: '',
+      email: '',
+    },
+  });
+
+  return (
+    <Box maw={340} mx="auto">
+      <TextInput label="Name" placeholder="Name" {...form.getInputProps('name')} />
+      <TextInput mt="md" label="Email" placeholder="Email" {...form.getInputProps('email')} />
+
+      <Group justify="center" mt="xl">
+        <Button onClick={() => form.resetField('name')}>
+          Reset name field to initial value
+        </Button>
+      </Group>
+    </Box>
+  );
+}
+`;
+
+function Demo() {
+  const form = useForm({
+    initialValues: {
+      name: '',
+      email: '',
+    },
+  });
+
+  return (
+    <Box maw={340} mx="auto">
+      <TextInput label="Name" placeholder="Name" {...form.getInputProps('name')} />
+      <TextInput mt="md" label="Email" placeholder="Email" {...form.getInputProps('email')} />
+
+      <Group justify="center" mt="xl">
+        <Button onClick={() => form.resetField('name')}>Reset name field to initial value</Button>
+      </Group>
+    </Box>
+  );
+}
+
+export const resetField: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+};

--- a/packages/@docs/demos/src/demos/form/Form.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/form/Form.demos.story.tsx
@@ -88,6 +88,11 @@ export const Demo_reset = {
   render: renderDemo(demos.reset),
 };
 
+export const Demo_resetField = {
+  name: '⭐ Demo: resetField',
+  render: renderDemo(demos.resetField),
+};
+
 export const Demo_status = {
   name: '⭐ Demo: status',
   render: renderDemo(demos.status),

--- a/packages/@docs/demos/src/demos/form/index.ts
+++ b/packages/@docs/demos/src/demos/form/index.ts
@@ -15,6 +15,7 @@ export { stepper } from './Form.demo.stepper';
 export { setFieldValue } from './Form.demo.setFieldValue';
 export { setValues } from './Form.demo.setValues';
 export { reset } from './Form.demo.reset';
+export { resetField } from './Form.demo.resetField';
 export { status } from './Form.demo.status';
 export { blurValidation } from './Form.demo.blurValidation';
 export { blurFieldValidation } from './Form.demo.blurFieldValidation';

--- a/packages/@mantine/form/src/tests/resetField.test.ts
+++ b/packages/@mantine/form/src/tests/resetField.test.ts
@@ -1,0 +1,63 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useForm } from '../use-form';
+
+describe('@mantine/form/resetField', () => {
+  it('resets error and value with resetField handler', () => {
+    const hook = renderHook(() =>
+      useForm({ initialErrors: { a: 'too short', b: 'too long' }, initialValues: { a: 1, b: 2 } })
+    );
+    expect(hook.result.current.errors).toStrictEqual({ a: 'too short', b: 'too long' });
+    expect(hook.result.current.values).toStrictEqual({ a: 1, b: 2 });
+
+    act(() => hook.result.current.setValues({ a: 3, b: 4 }));
+    act(() => hook.result.current.setErrors({ a: 'error 1', b: 'error 2' }));
+
+    expect(hook.result.current.values).toStrictEqual({ a: 3, b: 4 });
+    expect(hook.result.current.errors).toStrictEqual({ a: 'error 1', b: 'error 2' });
+
+    act(() => hook.result.current.resetField('a'));
+
+    expect(hook.result.current.errors).toStrictEqual({ b: 'error 2' });
+    expect(hook.result.current.values).toStrictEqual({ a: 1, b: 4 });
+  });
+
+  it('resets touched and dirty state', async () => {
+    const hook = renderHook(() =>
+      useForm({ initialValues: { a: 1 }, initialDirty: { a: true }, initialTouched: { a: true } })
+    );
+
+    expect(hook.result.current.isDirty()).toBe(true);
+    expect(hook.result.current.isTouched()).toBe(true);
+
+    await waitFor(() => {
+      act(() => hook.result.current.resetField('a'));
+      expect(hook.result.current.isDirty()).toBe(false);
+      expect(hook.result.current.isTouched()).toBe(false);
+    });
+  });
+
+  it('resets value without keeping added value', () => {
+    const hook = renderHook(() =>
+      useForm<{ a: number; b?: number; c?: number }>({ initialValues: { a: 1, b: 2 } })
+    );
+
+    act(() => hook.result.current.setFieldValue('c', 3));
+    expect(hook.result.current.isDirty()).toBe(true);
+    expect(hook.result.current.values).toStrictEqual({ a: 1, b: 2, c: 3 });
+
+    act(() => hook.result.current.resetField('c'));
+    expect(hook.result.current.isDirty()).toBe(false);
+    expect(hook.result.current.values).toStrictEqual({ a: 1, b: 2 });
+  });
+
+  it('resets value correctly after updating initial values', () => {
+    const hook = renderHook(() => useForm({ initialValues: { a: 1, b: 2 } }));
+    const newInitialState = { a: 3, b: 4 };
+
+    act(() => hook.result.current.setValues({ a: 100, b: 200 }));
+    act(() => hook.result.current.setInitialValues(newInitialState));
+    act(() => hook.result.current.resetField('a'));
+
+    expect(hook.result.current.values).toStrictEqual({ a: 3, b: 200 });
+  });
+});

--- a/packages/@mantine/form/src/types.ts
+++ b/packages/@mantine/form/src/types.ts
@@ -105,6 +105,7 @@ export type ClearFieldError = (path: unknown) => void;
 export type ClearFieldDirty = (path: unknown) => void;
 export type ClearErrors = () => void;
 export type Reset = () => void;
+export type ResetField<Values> = <Field extends LooseKeys<Values>>(path: Field) => void;
 export type Validate = () => FormValidationResult;
 export type ValidateField<Values> = <Field extends LooseKeys<Values>>(
   path: Field
@@ -179,6 +180,7 @@ export interface UseFormReturnType<
   clearFieldError: ClearFieldError;
   clearErrors: ClearErrors;
   reset: Reset;
+  resetField: ResetField<Values>;
   validate: Validate;
   validateField: ValidateField<Values>;
   reorderListItem: ReorderListItem<Values>;

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -24,6 +24,7 @@ import {
   ReorderListItem,
   Reset,
   ResetDirty,
+  ResetField,
   SetErrors,
   SetFieldError,
   SetFieldValue,
@@ -93,6 +94,20 @@ export function useForm<
     clearErrors();
     setDirty({});
     resetTouched();
+  }, []);
+
+  const resetField: ResetField<Values> = useCallback((path) => {
+    _setValues((current) => {
+      const initialValue = getPath(path, valuesSnapshot.current) as PathValue<Values, typeof path>;
+      const result = setPath(path, initialValue, current);
+
+      onValuesChange?.(result, current);
+
+      return result;
+    });
+    clearFieldError(path);
+    clearFieldDirty(path);
+    setTouched((currentTouched) => ({ ...currentTouched, [path]: false }));
   }, []);
 
   const setFieldError: SetFieldError<Values> = useCallback(
@@ -323,6 +338,7 @@ export function useForm<
     clearFieldError,
     clearErrors,
     reset,
+    resetField,
     validate,
     validateField,
     reorderListItem,


### PR DESCRIPTION
fix https://github.com/orgs/mantinedev/discussions/5023

It'd be super useful to be able to reset only one field, especially since we don't have any access to the `initialValues` snapshot of mantine form.

Currently we need to wrap a Mantine form with a custom context that keeps track of the `initialValues` to be able to reset the value for a specific field. 

Introducing a `resetField` function makes this a lot easier.

There is one test that fails, the reason is that I'm not sure how to handle dynamically added fields. Should it reset to an empty value, or remove the field entirely? I want some input on that.

Small related comment regarding the tests, we shouldn't need to wrap all the `renderHook` actions in an act. It's already done at the testing library level.

cc @dedalusium