### PR TITLE
[@mantine/core] Fix conbobox keyDown handling during IME input conversion

### DIFF
--- a/packages/@mantine/core/src/components/Combobox/use-combobox-target-props/use-combobox-target-props.ts
+++ b/packages/@mantine/core/src/components/Combobox/use-combobox-target-props/use-combobox-target-props.ts
@@ -29,6 +29,9 @@ export function useComboboxTargetProps({
     }
 
     if (withKeyboardNavigation) {
+      // Ignore during composition in IME
+      if (event.nativeEvent.isComposing) return;
+
       if (event.nativeEvent.code === 'ArrowDown') {
         event.preventDefault();
 
@@ -52,6 +55,10 @@ export function useComboboxTargetProps({
       }
 
       if (event.nativeEvent.code === 'Enter' || event.nativeEvent.code === 'NumpadEnter') {
+        // This is a workaround for handling differences in behavior of isComposing property in Safari
+        // See: https://dninomiya.github.io/form-guide/stop-enter-submit
+        if (event.nativeEvent.keyCode === 229) return;
+
         const selectedOptionIndex = ctx.store.getSelectedOptionIndex();
 
         if (ctx.store.dropdownOpened && selectedOptionIndex !== -1) {


### PR DESCRIPTION
Fixes #5934.

Fixes an issue in the Combobox where confirming an IME conversion incorrectly submits the focused option.

I confirmed to work as expected in Safari.
