### PR TITLE
pass renderOption to grouped Options

### DIFF
--- a/packages/@mantine/core/src/components/Combobox/OptionsDropdown/OptionsDropdown.tsx
+++ b/packages/@mantine/core/src/components/Combobox/OptionsDropdown/OptionsDropdown.tsx
@@ -79,6 +79,7 @@ function Option({
       unstyled={unstyled}
       withCheckIcon={withCheckIcon}
       checkIconPosition={checkIconPosition}
+      renderOption={renderOption}
     />
   ));
 


### PR DESCRIPTION
one line change to pass renderOption to the child Options when the data source is grouped.
Fixes #5966