### PR TITLE
[@mantine/core] TagsInput: Fix disable RemoveButton when Input is `disabled`

### DIFF
--- a/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
+++ b/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
@@ -300,7 +300,7 @@ export const TagsInput = factory<TagsInputFactory>((_props, ref) => {
   const values = _value.map((item, index) => (
     <Pill
       key={`${item}-${index}`}
-      withRemoveButton={!readOnly}
+      withRemoveButton={!readOnly && !disabled}
       onRemove={() => {
         setValue(_value.filter((i) => item !== i));
         onRemove?.(item);


### PR DESCRIPTION
Fixes: https://github.com/mantinedev/mantine/issues/5959