### PR TITLE
[@mantine/core] PinInput: Fix paste on Mac, Tab behavior

### DIFF
--- a/packages/@mantine/core/src/components/PinInput/PinInput.story.tsx
+++ b/packages/@mantine/core/src/components/PinInput/PinInput.story.tsx
@@ -96,15 +96,15 @@ export function Sizes() {
   return <div style={{ padding: 40 }}>{sizes}</div>;
 }
 
-export function InputModeNumeric() {
+export function Number() {
   return (
     <div style={{ padding: 40 }}>
-      <PinInput inputMode="numeric" />
+      <PinInput type="number" />
     </div>
   );
 }
 
-export function InputModeTab() {
+export function Tab() {
   return (
     <div style={{ padding: 40 }}>
       <PinInput />

--- a/packages/@mantine/core/src/components/PinInput/PinInput.story.tsx
+++ b/packages/@mantine/core/src/components/PinInput/PinInput.story.tsx
@@ -95,3 +95,20 @@ export function Sizes() {
   ));
   return <div style={{ padding: 40 }}>{sizes}</div>;
 }
+
+export function InputModeNumeric() {
+  return (
+    <div style={{ padding: 40 }}>
+      <PinInput inputMode="numeric" />
+    </div>
+  );
+}
+
+export function InputModeTab() {
+  return (
+    <div style={{ padding: 40 }}>
+      <PinInput />
+      <PinInput mt="md" />
+    </div>
+  );
+}

--- a/packages/@mantine/core/src/components/PinInput/PinInput.tsx
+++ b/packages/@mantine/core/src/components/PinInput/PinInput.tsx
@@ -221,18 +221,32 @@ export const PinInput = factory<PinInputFactory>((props, ref) => {
     return re?.test(code);
   };
 
-  const focusInputField = (dir: 'next' | 'prev', index: number) => {
-    if (!manageFocus) return;
+  const focusInputField = (
+    dir: 'next' | 'prev',
+    index: number,
+    event?: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (!manageFocus) {
+      event?.preventDefault();
+      return;
+    }
 
     if (dir === 'next') {
       const nextIndex = index + 1;
-      inputsRef.current[nextIndex < (length ?? 0) ? nextIndex : index].focus();
+      const canFocusNext = nextIndex < (length ?? 0);
+      if (canFocusNext) {
+        event?.preventDefault();
+        inputsRef.current[nextIndex].focus();
+      }
     }
 
     if (dir === 'prev') {
       const nextIndex = index - 1;
-
-      inputsRef.current[nextIndex > -1 ? nextIndex : index].focus();
+      const canFocusNext = nextIndex > -1;
+      if (canFocusNext) {
+        event?.preventDefault();
+        inputsRef.current[nextIndex].focus();
+      }
     }
   };
 
@@ -262,7 +276,7 @@ export const PinInput = factory<PinInputFactory>((props, ref) => {
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>, index: number) => {
-    const { ctrlKey, key, shiftKey, target } = event;
+    const { ctrlKey, metaKey, key, shiftKey, target } = event;
     const inputValue = (target as HTMLInputElement).value;
 
     if (inputMode === 'numeric') {
@@ -271,7 +285,8 @@ export const PinInput = factory<PinInputFactory>((props, ref) => {
         key === 'Tab' ||
         key === 'Control' ||
         key === 'Delete' ||
-        (ctrlKey && key === 'v')
+        (ctrlKey && key === 'v') ||
+        (metaKey && key === 'v')
           ? true
           : !Number.isNaN(Number(key));
 
@@ -281,27 +296,22 @@ export const PinInput = factory<PinInputFactory>((props, ref) => {
     }
 
     if (key === 'ArrowLeft' || (shiftKey && key === 'Tab')) {
-      event.preventDefault();
-      focusInputField('prev', index);
+      focusInputField('prev', index, event);
     } else if (key === 'ArrowRight' || key === 'Tab' || key === ' ') {
-      event.preventDefault();
-      focusInputField('next', index);
+      focusInputField('next', index, event);
     } else if (key === 'Delete') {
-      event.preventDefault();
       setFieldValue('', index);
     } else if (key === 'Backspace') {
-      event.preventDefault();
       setFieldValue('', index);
       if (length === index + 1) {
         if ((event.target as HTMLInputElement).value === '') {
-          focusInputField('prev', index);
+          focusInputField('prev', index, event);
         }
       } else {
-        focusInputField('prev', index);
+        focusInputField('prev', index, event);
       }
     } else if (inputValue.length > 0 && key === _value[index]) {
-      event.preventDefault();
-      focusInputField('next', index);
+      focusInputField('next', index, event);
     }
   };
 
@@ -322,7 +332,7 @@ export const PinInput = factory<PinInputFactory>((props, ref) => {
     if (isValid) {
       const copyValueToPinArray = createPinArray(length ?? 0, copyValue);
       setValues(copyValueToPinArray);
-      focusInputField('next', copyValueToPinArray.length - 1);
+      focusInputField('next', copyValueToPinArray.length - 2);
     }
   };
 


### PR DESCRIPTION
This PR fixes two issues with the PinInput component I noticed.
1. Pasting on MacOS was not working, as the default paste shortcut is `Command + V` instead of `Ctrl + V`.
2. Default browser tab navigation was prevented, which caused problems when a PinInput component appeared in the middle of a form. Now, if you press `tab` while in the last input segment, focus will move to the next focusable element. If you press `shift + tab` on the first input segment, focus will move to the previous focusable element.