### PR TITLE
[core] Fix typo on the esm folder exclude for the `@docs` package

### DIFF
--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -14,7 +14,7 @@
     "./packages/@mantine-tests/*/esm/**/*",
     "./packages/@mantine-tests/*/cjs/**/*",
     "./packages/@mantine-tests/*/lib/**/*",
-    "./packages/@docs/*/ems/**/*",
+    "./packages/@docs/*/esm/**/*",
     "./packages/@docs/*/cjs/**/*",
     "./packages/@docs/*/lib/**/*",
     "./packages/@mantine/*/lib/**/*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "./packages/@mantine-tests/*/esm/**/*",
     "./packages/@mantine-tests/*/cjs/**/*",
     "./packages/@mantine-tests/*/lib/**/*",
-    "./packages/@docs/*/ems/**/*",
+    "./packages/@docs/*/esm/**/*",
     "./packages/@docs/*/cjs/**/*",
     "./packages/@docs/*/lib/**/*",
     "./packages/@mantine/*/lib/**/*",


### PR DESCRIPTION
I was looking around and spotted what appears to be a typo on an exclude for the "esm" folder (it doesn't seem to produce any errors, though).