### PR TITLE
[docs] Update CssVariableColorSwatch table regex to match `rgba` variables

### DIFF
--- a/apps/mantine.dev/src/components/CssVariablesList/CssVariableColorSwatch/CssVariableColorSwatch.tsx
+++ b/apps/mantine.dev/src/components/CssVariablesList/CssVariableColorSwatch/CssVariableColorSwatch.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ColorSwatch } from '@mantine/core';
 
-const colorVariableRegex = /^(var\(--mantine-color[\w-]+\)|#\w+|rgba?\([\w\,\. ]+\))$/gm;
+const colorVariableRegex = /^(var\(--mantine-color[\w-]+\)|#\w+|rgba?\([\w,. ]+\))$/gm;
 
 export interface CssVariableColorSwatchProps {
   variable: string;

--- a/apps/mantine.dev/src/components/CssVariablesList/CssVariableColorSwatch/CssVariableColorSwatch.tsx
+++ b/apps/mantine.dev/src/components/CssVariablesList/CssVariableColorSwatch/CssVariableColorSwatch.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ColorSwatch } from '@mantine/core';
 
-const colorVariableRegex = /^(var\(--mantine-color[\w-]+\)|#\w+|rgba?\(\w+\))$/gm;
+const colorVariableRegex = /^(var\(--mantine-color[\w-]+\)|#\w+|rgba?\([\w\,\. ]+\))$/gm;
 
 export interface CssVariableColorSwatchProps {
   variable: string;


### PR DESCRIPTION
I noticed the table did not show a color swatch for the `rgba` values.
This PR adjusts the regex so the `rgba` variables are matched.