### PR TITLE
Ensure fallback image has ref

### DIFF
--- a/packages/@mantine/core/src/components/Image/Image.tsx
+++ b/packages/@mantine/core/src/components/Image/Image.tsx
@@ -91,6 +91,7 @@ export const Image = polymorphicFactory<ImageFactory>((_props, ref) => {
     return (
       <Box
         component="img"
+        ref={ref}
         src={fallbackSrc}
         {...getStyles('root')}
         onError={onError}


### PR DESCRIPTION
The ref is not set on the Image when there is an error or no src

this PR fixes that issue