### PR TITLE
[mantine/tiptap] set align-items to center for toolbar

### DIFF
--- a/packages/@mantine/tiptap/src/RichTextEditor.module.css
+++ b/packages/@mantine/tiptap/src/RichTextEditor.module.css
@@ -279,6 +279,7 @@
 
 .toolbar {
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
   gap: var(--mantine-spacing-sm);
   top: var(--rte-sticky-offset, 0);


### PR DESCRIPTION
In mantine v6, by default Toolbar will render into a `<Group>` component and the `align-items` value is `center` by default. V7 breaks this behavior.