### PR TITLE
[@mantine/core] fix: actions store of `Spotlight`

### DIFF
--- a/packages/@mantine/spotlight/src/spotlight.store.ts
+++ b/packages/@mantine/spotlight/src/spotlight.store.ts
@@ -33,7 +33,7 @@ export function updateSpotlightStateAction(
 }
 
 export function openSpotlightAction(store: SpotlightStore) {
-  updateSpotlightStateAction(() => ({ opened: true }), store);
+  updateSpotlightStateAction(() => ({ opened: true, selected: -1 }), store);
 }
 
 export function closeSpotlightAction(store: SpotlightStore) {


### PR DESCRIPTION
Fixes: https://github.com/mantinedev/mantine/issues/5992

before
[https://github.com/mantinedev/mantine/assets/79452224/a28a2920-eee8-45cc-84ea-979e8f0b6ba8](https://github.com/mantinedev/mantine/assets/79452224/a28a2920-eee8-45cc-84ea-979e8f0b6ba8)


after
[https://github.com/mantinedev/mantine/assets/79452224/a28a2920-eee8-45cc-84ea-979e8f0b6ba8](https://github.com/mantinedev/mantine/assets/79452224/74355a87-c5d5-4977-a31f-0dfc4aa6b4b7)
