### PR TITLE
[@mantine/core] TagsInput: Fix incorrect IME keyboard input handling for `Backspace` (#6010)

### DIFF
--- a/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
+++ b/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
@@ -277,7 +277,12 @@ export const TagsInput = factory<TagsInputFactory>((_props, ref) => {
       }
     }
 
-    if (event.key === 'Backspace' && length === 0 && _value.length > 0) {
+    if (
+      event.key === 'Backspace' &&
+      length === 0 &&
+      _value.length > 0 &&
+      !event.nativeEvent.isComposing
+    ) {
       onRemove?.(_value[_value.length - 1]);
       setValue(_value.slice(0, _value.length - 1));
     }


### PR DESCRIPTION
When people use IME to type in CJK words, a `Backspace` key would delete both a char in the CJK words and the previous tag before this fix.

Ref PR: https://github.com/mantinedev/mantine/pull/4947