### PR TITLE
[@mantine/hooks] fix infinite re-render of `useLocalStorage` hook

### DIFF
--- a/packages/@mantine/hooks/src/use-local-storage/create-storage.ts
+++ b/packages/@mantine/hooks/src/use-local-storage/create-storage.ts
@@ -77,7 +77,7 @@ export function createStorage<T>(type: StorageType, hookName: string) {
     defaultValue,
     getInitialValueInEffect = true,
     deserialize = deserializeJSON,
-    serialize = (value: T) => serializeJSON(value, hookName),
+    serialize = useCallback((value: T) => serializeJSON(value, hookName), [hookName]),
   }: StorageProperties<T>) {
     const readStorageValue = useCallback(
       (skipStorage?: boolean): T => {


### PR DESCRIPTION
as the `serialize` prop was not memorized the `setStorageValue` function was created on each re-render - resulting in an infinite re-render loop.

After this fix it is still needed to memorize the `serialize` and `deserialize` if overwriting them in your own code.

fixes https://github.com/mantinedev/mantine/issues/6017