### PR TITLE
Fix: PinInput length property set to null causes infinite render cycle

### DIFF
--- a/packages/@mantine/core/src/components/PinInput/PinInput.tsx
+++ b/packages/@mantine/core/src/components/PinInput/PinInput.tsx
@@ -337,12 +337,12 @@ export const PinInput = factory<PinInputFactory>((props, ref) => {
   };
 
   useEffect(() => {
-    if (_valueToString.length !== length) return;
+    if (_valueToString.length !== (length ?? 0)) return;
     onComplete?.(_valueToString);
   }, [length, _valueToString]);
 
   useEffect(() => {
-    if (length !== _value.length) {
+    if ((length ?? 0) !== _value.length) {
       setValues(createPinArray(length ?? 0, _value.join('')));
     }
   }, [length, _value]);


### PR DESCRIPTION
length probably won't be undefined because it has a default value of 4
but if it is `null` then the PinInput finds itself in an infinite render loop
(I had the misfortune of doing this in a demo 🙃)

See the second use effect in the PR diff
if length is null we call setValues with an empty array
which changes the `_value` which causes the effect to re run



