### PR TITLE
[@mantine/charts] fix overflow of chart

### DIFF
--- a/packages/@mantine/charts/src/grid-chart.module.css
+++ b/packages/@mantine/charts/src/grid-chart.module.css
@@ -34,3 +34,7 @@
 .axisLabel {
   color: var(--chart-text-color, var(--mantine-color-dimmed));
 }
+
+svg {
+  overflow: visible;
+}


### PR DESCRIPTION
Related discussion: https://discord.com/channels/854810300876062770/1225096473130041374/1225096473130041374

after:
![Screenshot from 2024-04-04 22-58-21](https://github.com/mantinedev/mantine/assets/79452224/02d45da1-e49e-4e1c-9774-20e144d512c4)
 