### PR TITLE
[@mantine/core] ScrollArea: Fix viewport `onScroll` prop not working

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -134,15 +134,10 @@ export const ScrollArea = factory<ScrollAreaFactory>((_props, ref) => {
         ref={viewportRef}
         data-offset-scrollbars={offsetScrollbars === true ? 'xy' : offsetScrollbars || undefined}
         data-scrollbars={scrollbars || undefined}
-        onScroll={
-          typeof onScrollPositionChange === 'function'
-            ? ({ currentTarget }) =>
-                onScrollPositionChange({
-                  x: currentTarget.scrollLeft,
-                  y: currentTarget.scrollTop,
-                })
-            : undefined
-        }
+        onScroll={(e) => {
+          viewportProps?.onScroll?.(e);
+          onScrollPositionChange?.({ x: e.currentTarget.scrollLeft, y: e.currentTarget.scrollTop });
+        }}
       >
         {children}
       </ScrollAreaViewport>


### PR DESCRIPTION
ScrollArea `viewportProps.onScroll` prop not working