### PR TITLE
[@mantine/core] ScrollArea: Fix incorrect inset of the horizontal scrollbar

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.module.css
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.module.css
@@ -81,8 +81,8 @@
     height: var(--scrollarea-scrollbar-size);
     flex-direction: column;
     bottom: 0;
-    inset-inline-end: 0;
-    inset-inline-start: var(--sa-corner-height);
+    inset-inline-start: 0;
+    inset-inline-end: var(--sa-corner-width);
   }
 }
 


### PR DESCRIPTION
Fix incorrect inset position of the horizontal scrollbar in the `ScrollArea` component ([Discord discussion](https://discord.com/channels/854810300876062770/1227466423048081438)).
