### PR TITLE
Update Table/index.ts to export components

### DIFF
--- a/packages/@mantine/core/src/components/Table/index.ts
+++ b/packages/@mantine/core/src/components/Table/index.ts
@@ -32,4 +32,3 @@ export type {
   TableScrollContainerCssVariables,
   TableScrollContainerFactory,
 } from './TableScrollContainer';
-export type { TableDataRendererProps } from './TableDataRenderer';

--- a/packages/@mantine/core/src/components/Table/index.ts
+++ b/packages/@mantine/core/src/components/Table/index.ts
@@ -28,7 +28,7 @@ export type {
 } from './Table.components';
 export type { 
   TableScrollContainerProps,
-  TableScrollContainerStyleNames,
+  TableScrollContainerStylesNames,
   TableScrollContainerCssVariables,
   TableScrollContainerFactory,
 } from './TableScrollContainer';

--- a/packages/@mantine/core/src/components/Table/index.ts
+++ b/packages/@mantine/core/src/components/Table/index.ts
@@ -9,6 +9,7 @@ export {
   TableThead,
 } from './Table.components';
 export { TableScrollContainer } from './TableScrollContainer';
+export { TableDataRenderer } from './TableDataRenderer';
 export type {
   TableProps,
   TableStylesNames,
@@ -26,3 +27,10 @@ export type {
   TableTfootProps,
   TableTheadProps,
 } from './Table.components';
+export type { 
+  TableScrollContainerProps,
+  TableScrollContainerStyleNames,
+  TableScrollContainerCssVariables,
+  TableScrollContainerFactory,
+} from './TableScrollContainer';
+export type { TableDataRendererProps } from './TableDataRenderer';

--- a/packages/@mantine/core/src/components/Table/index.ts
+++ b/packages/@mantine/core/src/components/Table/index.ts
@@ -9,7 +9,6 @@ export {
   TableThead,
 } from './Table.components';
 export { TableScrollContainer } from './TableScrollContainer';
-export { TableDataRenderer } from './TableDataRenderer';
 export type {
   TableProps,
   TableStylesNames,


### PR DESCRIPTION
The TableScrollContainer props and the TableDataRenderer were not being exported from the Table package.