### PR TITLE
[bugfix]: reorder onChange and onChangeEnd events for Slider arrow keys

### DIFF
--- a/packages/@mantine/core/src/components/Slider/Slider/Slider.test.tsx
+++ b/packages/@mantine/core/src/components/Slider/Slider/Slider.test.tsx
@@ -129,4 +129,27 @@ describe('@mantine/core/Slider', () => {
     const { container } = render(<Slider defaultValue={120} max={100} />);
     expectInputValue('100', container);
   });
+
+  it('will call onChange before onChangeEvent', async () => {
+    const changeSpy = jest.fn();
+    const endSpy = jest.fn();
+    render(
+      <Slider
+        value={50}
+        step={10}
+        onChange={() => changeSpy(performance.now())}
+        onChangeEnd={() => endSpy(performance.now())}
+      />
+    );
+
+    await pressArrow('right');
+    expect(changeSpy.mock.calls[0][0]).toBeLessThan(
+      endSpy.mock.calls[endSpy.mock.calls.length - 1][0]
+    );
+
+    await pressArrow('left');
+    expect(changeSpy.mock.calls[1][0]).toBeLessThan(
+      endSpy.mock.calls[endSpy.mock.calls.length - 1][0]
+    );
+  });
 });

--- a/packages/@mantine/core/src/components/Slider/Slider/Slider.tsx
+++ b/packages/@mantine/core/src/components/Slider/Slider/Slider.tsx
@@ -236,8 +236,8 @@ export const Slider = factory<SliderFactory>((_props, ref) => {
             Math.min(Math.max(_value + step!, min!), max!),
             precision
           );
-          onChangeEnd?.(nextValue);
           setValue(nextValue);
+          onChangeEnd?.(nextValue);
           break;
         }
 
@@ -248,8 +248,8 @@ export const Slider = factory<SliderFactory>((_props, ref) => {
             Math.min(Math.max(dir === 'rtl' ? _value - step! : _value + step!, min!), max!),
             precision
           );
-          onChangeEnd?.(nextValue);
           setValue(nextValue);
+          onChangeEnd?.(nextValue);
           break;
         }
 
@@ -260,8 +260,8 @@ export const Slider = factory<SliderFactory>((_props, ref) => {
             Math.min(Math.max(_value - step!, min!), max!),
             precision
           );
-          onChangeEnd?.(nextValue);
           setValue(nextValue);
+          onChangeEnd?.(nextValue);
           break;
         }
 
@@ -272,24 +272,24 @@ export const Slider = factory<SliderFactory>((_props, ref) => {
             Math.min(Math.max(dir === 'rtl' ? _value + step! : _value - step!, min!), max!),
             precision
           );
-          onChangeEnd?.(nextValue);
           setValue(nextValue);
+          onChangeEnd?.(nextValue);
           break;
         }
 
         case 'Home': {
           event.preventDefault();
           thumb.current?.focus();
-          onChangeEnd?.(min!);
           setValue(min!);
+          onChangeEnd?.(min!);
           break;
         }
 
         case 'End': {
           event.preventDefault();
           thumb.current?.focus();
-          onChangeEnd?.(max!);
           setValue(max!);
+          onChangeEnd?.(max!);
           break;
         }
 


### PR DESCRIPTION
Resolves #6063 by changing the function call order, and adds a test to verify the timing.

It's unclear to me why `onChangeEnd` is called twice (this behavior was there previously), but importantly the second `onChangeEnd` happens *after* `onChange`.