### PR TITLE
[@mantine/core] fix: corrected typos in TagsInput documentation

### DIFF
--- a/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
+++ b/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
@@ -54,13 +54,13 @@ export interface TagsInputProps
   /** Default value for uncontrolled component */
   defaultValue?: string[];
 
-  /** Called whe value changes */
+  /** Called when value changes */
   onChange?: (value: string[]) => void;
 
   /** Called when tag is removed */
   onRemove?: (value: string) => void;
 
-  /** Called whe the clear button is clicked */
+  /** Called when the clear button is clicked */
   onClear?: () => void;
 
   /** Controlled search value */


### PR DESCRIPTION
Simple correction to a couple of typos I noticed while in the Mantine documentation for the `TagsInput` component.