### PR TITLE
Hide MS Edge visibility icon

### DIFF
--- a/packages/@mantine/core/src/components/PasswordInput/PasswordInput.module.css
+++ b/packages/@mantine/core/src/components/PasswordInput/PasswordInput.module.css
@@ -44,6 +44,10 @@
     color: var(--input-placeholder-color);
     opacity: 1;
   }
+
+  &::-ms-reveal {
+    display: none;
+  }
 }
 
 .visibilityToggle {


### PR DESCRIPTION
Fixes mantinedev/mantine#6100

As noted [here](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/password-reveal#visibility-of-the-control), the icon only shows up when you start typing.