### PR TITLE
[@mantine/core] feat: adding some default variants to notification

### DIFF
--- a/apps/mantine.dev/src/pages/core/notification.mdx
+++ b/apps/mantine.dev/src/pages/core/notification.mdx
@@ -11,6 +11,10 @@ Build your own or use [@mantine/notifications](/x/notifications/) package.
 
 <Demo data={NotificationDemos.configurator} />
 
+## Variants
+
+<Demo data={NotificationDemos.variants} />
+
 ## With icon
 
 <Demo data={NotificationDemos.icon} />
@@ -27,10 +31,6 @@ To support screen readers, set close button aria-label or title with `closeButto
 import { Notification } from '@mantine/core';
 
 function Demo() {
-  return (
-    <Notification
-      closeButtonProps={{ 'aria-label': 'Hide notification' }}
-    />
-  );
+  return <Notification closeButtonProps={{ 'aria-label': 'Hide notification' }} />;
 }
 ```

--- a/packages/@docs/demos/src/demos/core/Notification/Notification.demo.configurator.tsx
+++ b/packages/@docs/demos/src/demos/core/Notification/Notification.demo.configurator.tsx
@@ -29,6 +29,13 @@ export const configurator: MantineDemo = {
   code,
   dimmed: true,
   controls: [
+    {
+      prop: 'variant',
+      type: 'select',
+      initialValue: 'outline',
+      libraryValue: 'outline',
+      data: ['outline', 'filled', 'light'],
+    },
     { prop: 'loading', type: 'boolean', initialValue: false, libraryValue: false },
     { prop: 'withCloseButton', type: 'boolean', initialValue: true, libraryValue: true },
     { prop: 'withBorder', type: 'boolean', initialValue: false, libraryValue: false },

--- a/packages/@docs/demos/src/demos/core/Notification/Notification.demo.variants.tsx
+++ b/packages/@docs/demos/src/demos/core/Notification/Notification.demo.variants.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Notification } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { Notification } from '@mantine/core';
+
+function Demo() {
+  return (
+    <>
+      <Notification variant="filled" color="red" title="Did something go wrong?">
+        Yes
+      </Notification>
+      <Notification variant="outline" color="yellow" title="A word of warning" mt="md">
+      Something might not be fine
+    </Notification>
+      <Notification variant="light" color="green" title="Better now!" mt="md">
+        Everything is fine
+      </Notification>
+    </>
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <>
+      <Notification variant="filled" color="red" title="Did something go wrong?">
+        Yes
+      </Notification>
+      <Notification variant="outline" color="yellow" title="A word of warning" mt="md">
+        Something might not be fine
+      </Notification>
+      <Notification variant="light" color="green" title="Better now!" mt="md">
+        Everything is fine
+      </Notification>
+    </>
+  );
+}
+
+export const variants: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  dimmed: true,
+  maxWidth: 400,
+  centered: true,
+  code,
+};

--- a/packages/@docs/demos/src/demos/core/Notification/index.ts
+++ b/packages/@docs/demos/src/demos/core/Notification/index.ts
@@ -1,3 +1,4 @@
 export { icon } from './Notification.demo.icon';
 export { configurator } from './Notification.demo.configurator';
 export { stylesApi } from './Notification.demo.stylesApi';
+export { variants } from "./Notification.demo.variants"

--- a/packages/@docs/styles-api/src/data/Notification.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/Notification.styles-api.ts
@@ -15,7 +15,8 @@ export const NotificationStylesApi: StylesApiData<NotificationFactory> = {
   vars: {
     root: {
       '--notification-radius': 'Controls `border-radius`',
-      '--notification-color': 'Controls icon color or notification line color',
+      '--notification-color': 'Controls `color`',
+      '--notification-bg': 'Controls `background`',
     },
   },
 

--- a/packages/@mantine/core/src/components/Alert/Alert.story.tsx
+++ b/packages/@mantine/core/src/components/Alert/Alert.story.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconPhoto } from '@tabler/icons-react';
+import { IconMoodSmile, IconPhoto } from '@tabler/icons-react';
 import { MantineThemeProvider } from '../../core';
 import { Alert } from './Alert';
 
@@ -85,9 +85,10 @@ export function AutoContrast() {
     .fill(0)
     .map((_, index) => (
       <Alert
+        icon={<IconMoodSmile stroke={1.5} />}
         withCloseButton
         title="Bummer!"
-        color={`yellow.${index}`}
+        color={`blue.${index}`}
         variant="filled"
         mt="xl"
         autoContrast

--- a/packages/@mantine/core/src/components/Notification/Notification.module.css
+++ b/packages/@mantine/core/src/components/Notification/Notification.module.css
@@ -1,5 +1,6 @@
 .root {
   --notification-radius: var(--mantine-radius-default);
+  --notification-bg: var(--mantine-color-default);
   --notification-color: var(--mantine-primary-color-filled);
 
   overflow: hidden;
@@ -13,6 +14,8 @@
   padding-bottom: var(--mantine-spacing-xs);
   border-radius: var(--notification-radius);
   box-shadow: var(--mantine-shadow-lg);
+  background-color: var(--notification-bg);
+  color: var(--notification-color);
 
   &::before {
     content: '';
@@ -24,14 +27,6 @@
     inset-inline-start: 4px;
     border-radius: var(--notification-radius);
     background-color: var(--notification-color);
-  }
-
-  @mixin where-light {
-    background-color: var(--mantine-color-white);
-  }
-
-  @mixin where-dark {
-    background-color: var(--mantine-color-dark-6);
   }
 
   &:where([data-with-icon]) {
@@ -49,6 +44,27 @@
 
     @mixin where-dark {
       border: 1px solid var(--mantine-color-dark-4);
+    }
+  }
+
+  &:where([data-variant='filled']),
+  &:where([data-variant='light']) {
+    .title {
+      color: var(--notification-color);
+    }
+
+    .closeButton {
+      color: var(--notification-color);
+    }
+  }
+
+  &:where([data-variant='filled']) {
+    .icon {
+      background-color: transparent;
+    }
+
+    .description {
+      color: var(--notification-color);
     }
   }
 }
@@ -83,14 +99,7 @@
   font-size: var(--mantine-font-size-sm);
   line-height: var(--mantine-line-height-sm);
   font-weight: 500;
-
-  @mixin where-light {
-    color: var(--mantine-color-gray-9);
-  }
-
-  @mixin where-dark {
-    color: var(--mantine-color-white);
-  }
+  color: var(--mantine-color-text);
 }
 
 .description {
@@ -119,13 +128,5 @@
 }
 
 .closeButton {
-  @mixin hover {
-    @mixin where-light {
-      background-color: var(--mantine-color-gray-0);
-    }
-
-    @mixin where-dark {
-      background-color: var(--mantine-color-dark-8);
-    }
-  }
+  color: var(--mantine-color-text);
 }

--- a/packages/@mantine/core/src/components/Notification/Notification.story.tsx
+++ b/packages/@mantine/core/src/components/Notification/Notification.story.tsx
@@ -6,7 +6,7 @@ import {
   IconMoodSmile,
   IconX,
 } from '@tabler/icons-react';
-import { Notification } from './Notification';
+import { Notification, NotificationProps } from './Notification';
 
 export default { title: 'Notification' };
 
@@ -20,11 +20,21 @@ export function SingleNotification() {
   );
 }
 
+function NotificationVariants(props: NotificationProps) {
+  return (
+    <div style={{ display: 'flex', gap: 20, justifyContent: 'space-between' }}>
+      <Notification variant="outline" {...props}></Notification>
+      <Notification variant="filled" {...props}></Notification>
+      <Notification variant="light" {...props}></Notification>
+    </div>
+  );
+}
+
 export function Usage() {
   return (
     <div style={{ padding: 60 }}>
-      <div style={{ maxWidth: 400, marginLeft: 'auto', marginRight: 'auto' }}>
-        <Notification
+      <div style={{ maxWidth: 1200, marginLeft: 'auto', marginRight: 'auto' }}>
+        <NotificationVariants
           loading
           withCloseButton={false}
           color="indigo"
@@ -32,25 +42,25 @@ export function Usage() {
           title="You will not close this notification"
         >
           It is loading you have to wait
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           onClose={() => {}}
           mt="xl"
           title="NotificationTitleSoLargeThatItWillUseOverflowEllipsisOption"
         >
           NotificationDescriptionSoLargeThatItShouldUseOverflowEllipsis
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           onClose={() => {}}
           mt="xl"
           title="Too large title Lorem ipsum dolor, sit amet consectetur adipisicing elit. Delectus, facilis eveniet. Voluptas quo voluptate laudantium in nesciunt modi accusamus ipsam, iusto pariatur excepturi et porro minima expedita vitae mollitia quae!"
         >
           Title seems to be too large, you better put this content in description
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           color="gray"
           onClose={() => {}}
           mt="xl"
@@ -58,9 +68,9 @@ export function Usage() {
           icon={<IconMoodSmile size={18} />}
         >
           Something generic happened but with icon
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           color="teal"
           onClose={() => {}}
           mt="xl"
@@ -68,9 +78,9 @@ export function Usage() {
           icon={<IconCheck size={18} />}
         >
           Your action was a complete success!
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           color="red"
           onClose={() => {}}
           mt="xl"
@@ -78,9 +88,9 @@ export function Usage() {
           icon={<IconX size={18} />}
         >
           You have done something wrong, too bad
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           color="yellow"
           onClose={() => {}}
           mt="xl"
@@ -88,9 +98,9 @@ export function Usage() {
           icon={<IconExclamationMark size={18} />}
         >
           This action will not work very soon
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           color="blue"
           onClose={() => {}}
           mt="xl"
@@ -98,49 +108,49 @@ export function Usage() {
           icon={<IconBookmark size={18} />}
         >
           You have achieved something important
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           color="gray"
           onClose={() => {}}
           title="Muted notification without icon"
           mt="xl"
         >
           Something generic happened
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           color="green"
           onClose={() => {}}
           mt="xl"
           title="Success notification without icon"
         >
           Your action was a complete success!
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           color="orange"
           onClose={() => {}}
           mt="xl"
           title="Danger notification without icon"
         >
           You have done something wrong, too bad
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           color="grape"
           onClose={() => {}}
           mt="xl"
           title="Grape notification without icon"
         >
           This action will not work very soon
-        </Notification>
+        </NotificationVariants>
 
-        <Notification color="cyan" onClose={() => {}} mt="xl" title="Primary notification">
+        <NotificationVariants color="cyan" onClose={() => {}} mt="xl" title="Primary notification">
           You have achieved something important
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           color="gray"
           onClose={() => {}}
           mt="xl"
@@ -149,9 +159,9 @@ export function Usage() {
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Dicta nam cumque natus ea aliquid
           quo illo enim totam sunt voluptatum, dolorum blanditiis sint, porro aut asperiores ut
           maxime doloremque. Cumque.
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           color="indigo"
           onClose={() => {}}
           mt="xl"
@@ -161,9 +171,9 @@ export function Usage() {
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Dicta nam cumque natus ea aliquid
           quo illo enim totam sunt voluptatum, dolorum blanditiis sint, porro aut asperiores ut
           maxime doloremque. Cumque.
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           color="orange"
           onClose={() => {}}
           mt="xl"
@@ -171,9 +181,9 @@ export function Usage() {
           title="NotificationWithIconAndTitleSoLargeThatItWillUseOverflowEllipsisOption"
         >
           NotificationWithIconAndDescriptionSoLargeThatItShouldUseOverflowEllipsis
-        </Notification>
+        </NotificationVariants>
 
-        <Notification
+        <NotificationVariants
           color="pink"
           onClose={() => {}}
           withCloseButton={false}
@@ -182,24 +192,69 @@ export function Usage() {
           title="NotificationWithIconDisallowCloseAndTitleSoLargeThatItWillUseOverflowEllipsisOption"
         >
           NotificationWithIconDisallowCloseAndDescriptionSoLargeThatItShouldUseOverflowEllipsis
-        </Notification>
+        </NotificationVariants>
 
-        <Notification color="grape" onClose={() => {}} mt="xl">
+        <NotificationVariants color="grape" onClose={() => {}} mt="xl">
           Notification without title
-        </Notification>
+        </NotificationVariants>
 
-        <Notification color="grape" onClose={() => {}} mt="xl">
+        <NotificationVariants color="grape" onClose={() => {}} mt="xl">
           NotificationWithoutTitleAndTheDescriptionSoLargeThatItShouldUseOverflowEllipsis
-        </Notification>
+        </NotificationVariants>
 
-        <Notification color="pink" onClose={() => {}} mt="xl" icon={<IconCheck size={18} />}>
+        <NotificationVariants
+          color="pink"
+          onClose={() => {}}
+          mt="xl"
+          icon={<IconCheck size={18} />}
+        >
           Notification without title but with icon
-        </Notification>
+        </NotificationVariants>
 
-        <Notification withBorder color="gray" onClose={() => {}} mt="xl">
+        <NotificationVariants withBorder color="gray" onClose={() => {}} mt="xl">
           Notification with border
-        </Notification>
+        </NotificationVariants>
       </div>
+    </div>
+  );
+}
+
+function NotificationWithStates(props: NotificationProps) {
+  return (
+    <div style={{ display: 'flex', gap: 20, justifyContent: 'space-between' }}>
+      <Notification {...props}></Notification>
+      <Notification icon={<IconMoodSmile size={18} />} {...props}></Notification>
+      <Notification loading {...props}></Notification>
+    </div>
+  );
+}
+
+export function AutoContrast() {
+  const buttons = Array(10)
+    .fill(0)
+    .map((_, index) => (
+      <NotificationWithStates
+        key={index}
+        color={`blue.${index}`}
+        variant="filled"
+        autoContrast
+        title="This is a notification!"
+      >
+        This is notification information
+      </NotificationWithStates>
+    ));
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        gap: 10,
+        padding: 40,
+      }}
+    >
+      {buttons}
     </div>
   );
 }


### PR DESCRIPTION
Hello,

First time contributor, but long time user of the mantine library.

I wanted to get some familiarity with the mantine codebase, and add something of value at the same time, so I took a look at adding some of the standard variants in the color-variants-resolver to the Notification component.

I looked at Alert for inspiration, and have tried not to introduce any breaking changes. Updated storybook and documentation highlighting the three variants:

Outline - same as Notification base component
Filled - proposal for filled version with autocontrast support
Light - proposal for light version similar to Alert

Let me know what you think and if any changes are required