### PR TITLE
Fix useHash not updating

### DIFF
--- a/packages/@mantine/hooks/src/use-hash/use-hash.ts
+++ b/packages/@mantine/hooks/src/use-hash/use-hash.ts
@@ -19,7 +19,7 @@ export function useHash({ getInitialValueInEffect = true }: UseHashOptions = {})
   useWindowEvent('hashchange', () => {
     const newHash = window.location.hash;
     if (hash !== newHash) {
-      setHashValue(hash);
+      setHashValue(newHash);
     }
   });
 


### PR DESCRIPTION
`setHashValue` used wrong value and was not updating beyond refresh.
This was actually fixed in #3773, but maybe a bad rebase or something re-introduced this for v7 in https://github.com/mantinedev/mantine/commit/588383b1dfae7a7f4fc3b664837dc5cab12b6ec1.
Please let me know if you'd like me to write some tests for this, any help with that would be appreciated.