### PR TITLE
[@mantine/core] fix: prevent onClose trigger on escape when modal is not open

### DIFF
--- a/packages/@mantine/core/src/components/ModalBase/use-modal.ts
+++ b/packages/@mantine/core/src/components/ModalBase/use-modal.ts
@@ -34,7 +34,7 @@ export function useModal({
   useWindowEvent(
     'keydown',
     (event) => {
-      if (event.key === 'Escape' && closeOnEscape) {
+      if (event.key === 'Escape' && closeOnEscape && opened) {
         const shouldTrigger =
           (event.target as HTMLElement)?.getAttribute('data-mantine-stop-propagation') !== 'true';
         shouldTrigger && onClose();


### PR DESCRIPTION
Fix: Ensure onClose is not triggered by escape key when Modal is not open
---
This PR addresses a specific issue where the `onClose` function of the Modal component was incorrectly triggered by pressing the Escape key, even when the Modal was not actively open.

**Problem:**
When the Escape key was pressed, the `onClose` handler was executed regardless of the Modal's open state. This could unintentionally disrupt the user experience and application state if the `onClose` logic was not meant to be executed at that time.

**Solution:**
The fix involves a simple, yet effective modification in the `useModal` hook. By adding a conditional check that ensures the Modal is open (`opened` state is `true`) before invoking the `onClose` function, we prevent unwanted side effects

fixes #6148 
commit: b6ea042f2f9f487a9b6e15fbf8746b01506713c5