### PR TITLE
[@mantine/core] NumberInput: Fix ignored allowNegative prop (#6162)

### DIFF
--- a/packages/@mantine/core/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/@mantine/core/src/components/NumberInput/NumberInput.test.tsx
@@ -18,6 +18,9 @@ const defaultProps: NumberInputProps = {
 const clickIncrement = (container: HTMLElement) =>
   userEvent.click(container.querySelector('.mantine-NumberInput-control[data-direction="up"]')!);
 
+const clickDecrement = (container: HTMLElement) =>
+  userEvent.click(container.querySelector('.mantine-NumberInput-control[data-direction="down"]')!);
+
 const getInput = () => screen.getByRole('textbox');
 const enterText = (text: string) => userEvent.type(getInput(), text);
 const expectValue = (value: string) => expect(getInput()).toHaveValue(value);
@@ -174,6 +177,16 @@ describe('@mantine/core/NumberInput', () => {
     await enterText('{backspace}');
     await enterText('{backspace}');
 
+    expect(spy).toHaveBeenLastCalledWith(0);
+  });
+
+  it('does not allow negative numbers if the allowNegative prop is false', async () => {
+    const spy = jest.fn();
+    const { container } = render(<NumberInput onChange={spy} value={0} allowNegative={false} />);
+
+    await clickDecrement(container);
+
+    expectValue('0');
     expect(spy).toHaveBeenLastCalledWith(0);
   });
 });

--- a/packages/@mantine/core/src/components/NumberInput/NumberInput.tsx
+++ b/packages/@mantine/core/src/components/NumberInput/NumberInput.tsx
@@ -290,16 +290,17 @@ export const NumberInput = factory<NumberInputFactory>((_props, ref) => {
   const decrementRef = useRef<() => void>();
   decrementRef.current = () => {
     let val: number;
+    const minValue = min !== undefined ? min : !allowNegative ? 0 : Number.MIN_SAFE_INTEGER;
     const currentValuePrecision = getDecimalPlaces(_value);
     const stepPrecision = getDecimalPlaces(step!);
     const maxPrecision = Math.max(currentValuePrecision, stepPrecision);
     const factor = 10 ** maxPrecision;
 
     if (typeof _value !== 'number' || Number.isNaN(_value)) {
-      val = clamp(startValue!, min, max);
+      val = clamp(startValue!, minValue, max);
     } else {
       const decrementedValue = (Math.round(_value * factor) - Math.round(step! * factor)) / factor;
-      val = min !== undefined && decrementedValue < min ? min : decrementedValue;
+      val = minValue !== undefined && decrementedValue < minValue ? minValue : decrementedValue;
     }
 
     const formattedValue = val.toFixed(maxPrecision);


### PR DESCRIPTION
After looking into #6162, I found that commit 081a47a removed the `allowNegative` prop. This PR brings back support for it and fixes the bug where the `NumberInput` could go negative.