### PR TITLE
[docs] fix ColorInput fixOnBlur demo code

### DIFF
--- a/packages/@docs/demos/src/demos/core/ColorInput/ColorInput.demo.fixOnBlur.tsx
+++ b/packages/@docs/demos/src/demos/core/ColorInput/ColorInput.demo.fixOnBlur.tsx
@@ -5,7 +5,7 @@ const code = `
 import { ColorInput } from '@mantine/core';
 
 function Demo() {
-  return <ColorInput withEyeDropper={false} label="Without eye dropper" placeholder="Not fun" />;
+  return <ColorInput fixOnBlur={false} label="Value is not fixed on blur" placeholder="May contain invalid value" />;
 }
 `;
 


### PR DESCRIPTION
The demo code for the `ColorInput` `fixOnBlur` example currently shows the code for the no eyedropper example, so small fix :)