### PR TITLE
Fix inline code highlight examples

### DIFF
--- a/packages/@docs/demos/src/demos/code-highlight/CodeHighlight.demo.inline.tsx
+++ b/packages/@docs/demos/src/demos/code-highlight/CodeHighlight.demo.inline.tsx
@@ -10,7 +10,8 @@ function Demo() {
   return (
     <Text>
       You can highlight code inline:{' '}
-      <InlineCodeHighlight code="" language="tsx" />. Is not that cool?
+      <InlineCodeHighlight code={'<InlineCodeHighlight code="" language="tsx" />'} language="tsx" />
+      . Is not that cool?
     </Text>
   );
 }
@@ -19,8 +20,9 @@ function Demo() {
 function Demo() {
   return (
     <Text>
-      You can highlight code inline: <InlineCodeHighlight code="" language="tsx" />. Is not that
-      cool?
+      You can highlight code inline:{' '}
+      <InlineCodeHighlight code={'<InlineCodeHighlight code="" language="tsx" />'} language="tsx" />
+      . Is not that cool?
     </Text>
   );
 }

--- a/packages/@mantine/code-highlight/src/CodeHighlight.story.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlight.story.tsx
@@ -244,10 +244,14 @@ export function Inline() {
   return (
     <div style={{ padding: 40 }}>
       <p>
-        Hello there! this is <InlineCodeHighlight code="" language="tsx" /> some code Lorem ipsum
-        dolor sit amet consectetur adipisicing elit. Aliquid reiciendis, facilis repudiandae vero
-        mollitia non dolorum cupiditate assumenda odio unde quaerat beatae explicabo veritatis nam
-        temporibus! Quibusdam quod enim voluptatibus?
+        Hello there! this is{' '}
+        <InlineCodeHighlight
+          code={'<InlineCodeHighlight code="" language="tsx" />'}
+          language="tsx"
+        />{' '}
+        some code Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid reiciendis,
+        facilis repudiandae vero mollitia non dolorum cupiditate assumenda odio unde quaerat beatae
+        explicabo veritatis nam temporibus! Quibusdam quod enim voluptatibus?
       </p>
     </div>
   );


### PR DESCRIPTION
Just fixing something I noticed when viewing the docs on inline code highlighting.

Before:

<img width="1440" alt="Screenshot 2024-05-06 at 08 26 49" src="https://github.com/mantinedev/mantine/assets/33153339/0dcebdc1-67e3-48e4-a922-5ed0bd0429da">

<img width="1440" alt="Screenshot 2024-05-06 at 08 23 09" src="https://github.com/mantinedev/mantine/assets/33153339/147a13d1-88de-4b18-961f-936f3b47e1d3">


After:

<img width="1440" alt="Screenshot 2024-05-06 at 08 26 39" src="https://github.com/mantinedev/mantine/assets/33153339/7c1b58e3-27d1-401a-b300-362e08431459">

<img width="1440" alt="Screenshot 2024-05-06 at 08 22 18" src="https://github.com/mantinedev/mantine/assets/33153339/ec3cacc8-24e1-4a2b-a672-c7d4fec99503">

