### PR TITLE
feat(core/button): +disabled bg and color css variable

### DIFF
--- a/packages/@docs/styles-api/src/data/Button.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/Button.styles-api.ts
@@ -22,6 +22,8 @@ export const ButtonStylesApi: StylesApiData<ButtonFactory> = {
       '--button-padding-x': 'Controls horizontal `padding` of the button',
       '--button-fz': 'Controls `font-size` of the button',
       '--button-justify': 'Controls `justify-content` of `inner` element',
+      '--button-disabled-color': 'Control text `color` when disabled',
+      '--button-disabled-bg': 'Controls `background` when disabled',
     },
   },
 

--- a/packages/@mantine/core/src/components/Button/Button.module.css
+++ b/packages/@mantine/core/src/components/Button/Button.module.css
@@ -65,13 +65,12 @@
     transform: none;
 
     @mixin where-light {
-      color: var(--mantine-color-gray-5);
-      background: var(--mantine-color-gray-1);
+      color: var(--button-disabled-color, var(--mantine-color-gray-5));
+      background: var(--button-disabled-bg, var(--mantine-color-gray-1));
     }
-
     @mixin where-dark {
-      color: var(--mantine-color-dark-3);
-      background: var(--mantine-color-dark-6);
+      color: var(--button-disabled-color, --mantine-color-dark-3);
+      background: var(--button-disabled-bg, --mantine-color-dark-6);
     }
   }
 

--- a/packages/@mantine/core/src/components/Button/Button.tsx
+++ b/packages/@mantine/core/src/components/Button/Button.tsx
@@ -19,8 +19,8 @@ import {
 import { Loader, LoaderProps } from '../Loader';
 import { MantineTransition, Transition } from '../Transition';
 import { UnstyledButton } from '../UnstyledButton';
-import { ButtonGroup } from './ButtonGroup/ButtonGroup';
 import classes from './Button.module.css';
+import { ButtonGroup } from './ButtonGroup/ButtonGroup';
 
 export type ButtonStylesNames = 'root' | 'inner' | 'loader' | 'section' | 'label';
 export type ButtonVariant =
@@ -44,7 +44,9 @@ export type ButtonCssVariables = {
     | '--button-hover'
     | '--button-hover-color'
     | '--button-color'
-    | '--button-bd';
+    | '--button-bd'
+    | '--button-disabled-color'
+    | '--button-disabled-bg';
 };
 
 export interface ButtonProps extends BoxProps, StylesApiProps<ButtonFactory> {
@@ -135,6 +137,8 @@ const varsResolver = createVarsResolver<ButtonFactory>(
         '--button-color': colors.color,
         '--button-bd': color || variant ? colors.border : undefined,
         '--button-hover-color': color || variant ? colors.hoverColor : undefined,
+        '--button-disabled-color': undefined,
+        '--button-disabled-bg': undefined,
       },
     };
   }


### PR DESCRIPTION
To add a bit more customization of the button (and ultimately other components, this is just a touch base with you to know if it's something we could add to our wonderful library!), this PR add:

'--button-disabled-bg'
'--button-disabled-color'

css variables to button component. If they are not defined, it falls back to the current mantine values.