### PR TITLE
[@mantine/dates] Altering prop order of `DateTimePicker`'s `TimeInput`

### DIFF
--- a/packages/@mantine/dates/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/packages/@mantine/dates/src/components/DateTimePicker/DateTimePicker.tsx
@@ -248,13 +248,6 @@ export const DateTimePicker = factory<DateTimePickerFactory>((_props, ref) => {
             withSeconds={withSeconds}
             ref={timeInputRefMerged}
             unstyled={unstyled}
-            {...timeInputProps}
-            {...getStyles('timeInput', {
-              className: timeInputProps?.className,
-              style: timeInputProps?.style,
-            })}
-            onChange={handleTimeChange}
-            onKeyDown={handleTimeInputKeyDown}
             minTime={
               _value && minDate && _value.toDateString() === minDate.toDateString()
                 ? minTime != null
@@ -269,6 +262,13 @@ export const DateTimePicker = factory<DateTimePickerFactory>((_props, ref) => {
                   : undefined
                 : undefined
             }
+            {...timeInputProps}
+            {...getStyles('timeInput', {
+              className: timeInputProps?.className,
+              style: timeInputProps?.style,
+            })}
+            onChange={handleTimeChange}
+            onKeyDown={handleTimeInputKeyDown}
             size={size}
             data-mantine-stop-propagation={__stopPropagation || undefined}
           />


### PR DESCRIPTION
After [this](https://github.com/mantinedev/mantine/issues/4596) issue, [this](https://github.com/mantinedev/mantine/pull/5819/files#diff-b9a3ca038d146815161e22ea83320e438f51ac7cb489978a20cd583f2b3b0d6cR258-R271) code was merged which replaces the passed in `minTime` and `maxTime` prop in `timeInputProps` within the `DateTimePicker` component.

This PR alters the prop order such that a consumer can override `minTime` and `maxTime` if they desire.

This could help with certain functionality where a caller wants to prevent any time before e.g. 9AM on any day to be selected.