### PR TITLE
[@mantine/core] fix: ensure TagsInput dropdown reopens after clearing

### DIFF
--- a/packages/@mantine/core/src/components/PillsInput/PillsInput.tsx
+++ b/packages/@mantine/core/src/components/PillsInput/PillsInput.tsx
@@ -4,6 +4,7 @@ import { __BaseInputProps, __InputStylesNames } from '../Input';
 import { InputBase } from '../InputBase';
 import { PillsInputProvider } from './PillsInput.context';
 import { PillsInputField } from './PillsInputField/PillsInputField';
+import { ComboboxParsedItem } from '../Combobox';
 
 export interface PillsInputProps
   extends BoxProps,
@@ -13,6 +14,9 @@ export interface PillsInputProps
   __stylesApiProps?: Record<string, any>;
   __staticSelector?: string;
   multiline?: boolean;
+  openDropdown: () => void;
+  dropdownOpened: boolean;
+  parsedData: ComboboxParsedItem[];
 }
 
 export type PillsInputFactory = Factory<{
@@ -32,8 +36,11 @@ export const PillsInput = factory<PillsInputFactory>((_props, ref) => {
     children,
     onMouseDown,
     onClick,
+    openDropdown,
     size,
     disabled,
+    dropdownOpened,
+    parsedData,
     __staticSelector,
     error,
     variant,
@@ -59,6 +66,9 @@ export const PillsInput = factory<PillsInputFactory>((_props, ref) => {
           event.preventDefault();
           onClick?.(event);
           fieldRef.current?.focus();
+          if(!dropdownOpened && parsedData.length > 0) {
+            openDropdown();
+          }
         }}
         {...others}
         multiline

--- a/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
+++ b/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
@@ -388,6 +388,9 @@ export const TagsInput = factory<TagsInputFactory>((_props, ref) => {
             __stylesApiProps={{ ...props, multiline: true }}
             id={_id}
             mod={mod}
+            openDropdown={combobox.openDropdown}
+            dropdownOpened={combobox.dropdownOpened}
+            parsedData={parsedData}
           >
             <Pill.Group disabled={disabled} unstyled={unstyled} {...getStyles('pillsList')}>
               {values}


### PR DESCRIPTION
Fix: Resolve the issue where the TagsInput dropdown would not reopen after clearing tags.

---
This PR addresses the issue where the dropdown of the TagsInput component fails to reopen after the user clicks the clear button and subsequently attempts to interact with the input again.

**Problem:**
The dropdown, after tags are cleared via the clear button, remains closed upon subsequent interactions unless clicked outside and back again. This behavior was consistent across all browsers and was problematic from a UX perspective.

**Solution:**
A modification was made to the `PillsInput` component's click event logic. Now, the dropdown checks if there are any items in the `parsedData` array (ensuring there are actionable items) before deciding to open. This change ensures that the dropdown reopens as expected when there are items available to display, thus improving the component's usability.

fixes #6115
commit: [3a43d08](https://github.com/mantinedev/mantine/pull/6207/commits/3a43d08f034ea5c0c0cc447555e6e3d4c7905d83)
