### PR TITLE
[mantine.dev] fix formatting typo on title styles api page

### DIFF
--- a/packages/@docs/styles-api/src/data/Title.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/Title.styles-api.ts
@@ -10,7 +10,7 @@ export const TitleStylesApi: StylesApiData<TitleFactory> = {
     root: {
       '--title-fw': 'Title `font-weight`, by default value from `theme.headings`',
       '--title-fz': 'Title `font-size`, by default value from `theme.headings`',
-      '--title-lh': 'Title `line-heigh`t, by default value from `theme.headings`',
+      '--title-lh': 'Title `line-height`, by default value from `theme.headings`',
       '--title-line-clamp': 'Controls `-webkit-line-clamp` css property',
       '--title-text-wrap': 'Controls `text-wrap` css property',
     },


### PR DESCRIPTION
Simple fix to formatting typo I noticed while in the Mantine documentation for the `Title` component.