### PR TITLE
Update docs with description on how to use with PostCSS plugins as an…

### DIFF
--- a/apps/mantine.dev/src/pages/styles/postcss-preset.mdx
+++ b/apps/mantine.dev/src/pages/styles/postcss-preset.mdx
@@ -35,6 +35,25 @@ module.exports = {
 };
 ```
 
+It is also possible that you are working in a project that uses a PostCSS config style where the plugins are defined as an Array.
+If this is the case, then you may add `postcss-preset-mantine` in the following manner:
+
+```js
+// Creating a function to maintain consistency with other plugins
+function mantineCSS() {
+  return {
+    postcssPlugin: 'postcss-preset-mantine',
+    plugins: {},
+  };
+}
+
+module.exports = {
+  plugins: [
+    mantineCSS()
+  ],
+};
+```
+
 All done! You can now use all the features of the preset.
 
 ## rem/em functions


### PR DESCRIPTION
… Array

This PR add a small update to the docs to help describe how to update a PostCSS config file if the plugins are declared as an Array instead of an Object.

This is not a difficult change to understand, but it was a bit of a foot-gun in a current project that does use an Array for plugins.