### PR TITLE
fix: avoid re throwing use-fetch error

### DIFF
--- a/packages/@mantine/hooks/src/use-fetch/use-fetch.ts
+++ b/packages/@mantine/hooks/src/use-fetch/use-fetch.ts
@@ -37,7 +37,7 @@ export function useFetch<T>(url: string, { autoInvoke = true, ...options }: UseF
           setError(err);
         }
 
-        throw err;
+        return err;
       });
   }, [url]);
 


### PR DESCRIPTION
Based on the https://github.com/mantinedev/mantine/issues/6215, that use-fetch hook throws error and crash whole application. Proposal is just not re-throwing again the error to component level, since in React catching an error of a hook is not that easy as doing a try-catch.