### PR TITLE
feat: use-promise hook

### DIFF
--- a/packages/@mantine/hooks/src/use-promise/use-promise.ts
+++ b/packages/@mantine/hooks/src/use-promise/use-promise.ts
@@ -1,0 +1,39 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+export const usePromise = <T>(fn: (abortController: AbortController) => Promise<T>) => {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const controller = useRef<AbortController | null>(null);
+
+  const fetch = useCallback(async () => {
+    if (!fn) throw new Error('Missing function parameter');
+
+    if (controller.current) controller.current.abort();
+
+    setError(null);
+    setLoading(true);
+
+    const newController = new AbortController();
+    controller.current = newController;
+    fn(newController)
+      .then(setData)
+      .catch((err) => {
+        setError(err);
+      })
+      .finally(() => {
+        setLoading(false);
+        controller.current = null;
+      });
+  }, [fn]);
+
+  const abort = useCallback(() => {
+    if (controller.current) {
+      controller.current.abort('aborted');
+      controller.current = null;
+    }
+  }, []);
+
+  return useMemo(() => ({ loading, error, data, fetch, abort }), [loading]);
+};


### PR DESCRIPTION
Proposal is to not depend the flow in the fetch function as occurs in the use-fetch hook, leaving developer to use whatever promise handler he wants. Example of use:

- Component level:
```javascript
const { data, error, loading, fetch, abort } = usePromise(getInstallmentsList);

useEffect(() => {
    fetch();
}, []);
```

Service level:
```javascript
const getInstallmentsList: (abortController: AbortController) => Promise<InstallmentListEntity[]> = async () => {
    await new Promise((resolve) => {
      setTimeout(resolve, 300);
    });
    return payments;
};
```

The function passed to the hook can receive the abort controller so you continue having the control to abort the request whenever needed.