### PR TITLE
[@mantine/hooks] use-eye-dropper.ts Fix: #6306

### DIFF
--- a/packages/@mantine/hooks/src/use-eye-dropper/use-eye-dropper.ts
+++ b/packages/@mantine/hooks/src/use-eye-dropper/use-eye-dropper.ts
@@ -10,7 +10,7 @@ export interface EyeDropperOpenReturnType {
 }
 
 function isOpera() {
-    return navigator.userAgent.includes('OPR');
+  return navigator.userAgent.includes('OPR');
 }
 
 export function useEyeDropper() {

--- a/packages/@mantine/hooks/src/use-eye-dropper/use-eye-dropper.ts
+++ b/packages/@mantine/hooks/src/use-eye-dropper/use-eye-dropper.ts
@@ -9,11 +9,15 @@ export interface EyeDropperOpenReturnType {
   sRGBHex: string;
 }
 
+function isOpera() {
+    return navigator.userAgent.includes('OPR');
+}
+
 export function useEyeDropper() {
   const [supported, setSupported] = useState(false);
 
   useIsomorphicEffect(() => {
-    setSupported(typeof window !== 'undefined' && 'EyeDropper' in window);
+    setSupported(typeof window !== 'undefined' && !isOpera() && 'EyeDropper' in window);
   }, []);
 
   const open = useCallback(


### PR DESCRIPTION
Added additional check for Opera browser, if it is Opera browser then do not show EyeDropper.

Fixes #6306

![image](https://github.com/mantinedev/mantine/assets/73124371/07e51b36-ce84-41aa-a972-9cd221e14176)

