### PR TITLE
fix: Convert the type of useHover ref to MutableRefObject.

### DIFF
--- a/packages/@mantine/hooks/src/use-hover/use-hover.ts
+++ b/packages/@mantine/hooks/src/use-hover/use-hover.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 export function useHover<T extends HTMLElement = HTMLDivElement>() {
   const [hovered, setHovered] = useState(false);
-  const ref = useRef<T>(null);
+  const ref = useRef<T | null>(null);
   const onMouseEnter = useCallback(() => setHovered(true), []);
   const onMouseLeave = useCallback(() => setHovered(false), []);
 


### PR DESCRIPTION
https://mantine.dev/hooks/use-hover/

The document describes MutableRefObject, but currently it is RefObject.
Correcting type inference by adding null to generics.
