### PR TITLE
FIX - Small glitch when using a confirm modal without children #6324

### DIFF
--- a/packages/@mantine/modals/src/ConfirmModal.tsx
+++ b/packages/@mantine/modals/src/ConfirmModal.tsx
@@ -46,7 +46,7 @@ export function ConfirmModal({
     <>
       {children && <Box mb="md">{children}</Box>}
 
-      <Group justify="flex-end" {...groupProps}>
+      <Group mt={children ? 0 : "md"} justify="flex-end" {...groupProps}>
         <Button variant="default" {...cancelProps} onClick={handleCancel}>
           {cancelProps?.children || cancelLabel}
         </Button>


### PR DESCRIPTION
Fixes #6324

Implement a condition within the **Group** inside **ConfirmModal.tsx** that dynamically sets the marginTop style property to 'md' if the component contains children, otherwise set it to '0'.

Before: 
![image](https://github.com/mantinedev/mantine/assets/54320725/aef73447-978e-4d3d-ac92-6defee274030)

After
<img width="492" alt="image" src="https://github.com/mantinedev/mantine/assets/54320725/e3133c62-8162-4b43-b63c-3ad3bbd5b47e">
