### PR TITLE
[@mantine/core] Fix: correct a small typo referencing colorsTuple in border-resolver

### DIFF
--- a/packages/@mantine/core/src/core/Box/style-props/resolvers/border-resolver/border-resolver.ts
+++ b/packages/@mantine/core/src/core/Box/style-props/resolvers/border-resolver/border-resolver.ts
@@ -1,4 +1,4 @@
-import { colorsTuple, MantineTheme } from '../../../../MantineProvider';
+import { MantineTheme } from '../../../../MantineProvider';
 import { rem } from '../../../../utils';
 import { colorResolver } from '../color-resolver/color-resolver';
 
@@ -11,7 +11,7 @@ export function borderResolver(value: unknown, theme: MantineTheme) {
     const [size, style, ...colorTuple] = value.split(' ').filter((val) => val.trim() !== '');
     let result = `${rem(size)}`;
     style && (result += ` ${style}`);
-    colorsTuple.length > 0 && (result += ` ${colorResolver(colorTuple.join(' '), theme)}`);
+    colorTuple.length > 0 && (result += ` ${colorResolver(colorTuple.join(' '), theme)}`);
     return result.trim();
   }
 


### PR DESCRIPTION
This is not a reported issue, I just found what I believe to be a small typo when reading through the code base.

It seems this may have been an auto-complete mistake that also automatically imported the colorsTuple function from MantineProvider. Calling `length` on a function returns the number of arguments in the function definition, in this case colorsTuple takes a parameter, so its length is `> 0`.

It just so happens there's no bug or failing test case, as colorResolver will ultimately return an empty string for an empty string input, so this typo doesn't appear to really matter.