### PR TITLE
Increase scrollbar zIndex to overlap sticky elements

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollAreaScrollbar/Scrollbar.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollAreaScrollbar/Scrollbar.tsx
@@ -83,7 +83,7 @@ export const Scrollbar = forwardRef<HTMLDivElement, ScrollbarProps>((props, forw
       <div
         {...scrollbarProps}
         ref={composeRefs}
-        style={{ position: 'absolute', ...scrollbarProps.style }}
+        style={{ position: 'absolute', zIndex: 1001, ...scrollbarProps.style }}
         onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
           const mainPointer = 0;
           if (event.button === mainPointer) {


### PR DESCRIPTION
This fixes [6175](https://github.com/mantinedev/mantine/issues/6175).

Increase scrollbar zIndex to 1001 to overlap sticky elements