### PR TITLE
[@mantine/core] add `withScrollArea` to `ModalContext` #6360

### DIFF
--- a/packages/@mantine/core/src/components/Modal/Modal.context.ts
+++ b/packages/@mantine/core/src/components/Modal/Modal.context.ts
@@ -6,6 +6,7 @@ export type ScrollAreaComponent = React.FC<any>;
 interface ModalContext {
   fullScreen: boolean | undefined;
   yOffset: string | number | undefined;
+  withScrollArea: boolean | undefined;
   scrollAreaComponent: ScrollAreaComponent | undefined;
   getStyles: GetStylesApi<ModalRootFactory>;
 }

--- a/packages/@mantine/core/src/components/Modal/ModalContent.tsx
+++ b/packages/@mantine/core/src/components/Modal/ModalContent.tsx
@@ -24,6 +24,7 @@ export const ModalContent = factory<ModalContentFactory>((_props, ref) => {
 
   const ctx = useModalContext();
   const Scroll: React.FC<any> = ctx.scrollAreaComponent || NativeScrollArea;
+  const withScrollArea = ctx.withScrollArea !== false;
 
   return (
     <ModalBaseContent
@@ -34,13 +35,15 @@ export const ModalContent = factory<ModalContentFactory>((_props, ref) => {
       ref={ref}
       {...others}
     >
-      <Scroll
-        style={{
-          maxHeight: ctx.fullScreen ? '100dvh' : `calc(100dvh - (${rem(ctx.yOffset)} * 2))`,
-        }}
-      >
-        {children}
-      </Scroll>
+      {withScrollArea ? (
+        <Scroll
+          style={{
+            maxHeight: ctx.fullScreen ? '100dvh' : `calc(100dvh - (${rem(ctx.yOffset)} * 2))`,
+          }}
+        >
+          {children}
+        </Scroll>
+      ) : children}
     </ModalBaseContent>
   );
 });

--- a/packages/@mantine/core/src/components/Modal/ModalContent.tsx
+++ b/packages/@mantine/core/src/components/Modal/ModalContent.tsx
@@ -43,7 +43,9 @@ export const ModalContent = factory<ModalContentFactory>((_props, ref) => {
         >
           {children}
         </Scroll>
-      ) : children}
+      ) : (
+        children
+      )}
     </ModalBaseContent>
   );
 });

--- a/packages/@mantine/core/src/components/Modal/ModalRoot.tsx
+++ b/packages/@mantine/core/src/components/Modal/ModalRoot.tsx
@@ -29,11 +29,11 @@ export interface ModalRootProps extends StylesApiProps<ModalRootFactory>, ModalB
   /** Left/right modal offset, `5vw` by default */
   xOffset?: React.CSSProperties['marginLeft'];
 
-  /** Scroll area component, native `div` element by default */
-  scrollAreaComponent?: ScrollAreaComponent;
-
   /** Determines whether the modal should have scroll area, `true` by default */
   withScrollArea?: boolean;
+
+  /** Scroll area component, native `div` element by default */
+  scrollAreaComponent?: ScrollAreaComponent;
 
   /** Key of `theme.radius` or any valid CSS value to set `border-radius`, `theme.defaultRadius` by default */
   radius?: MantineRadius;

--- a/packages/@mantine/core/src/components/Modal/ModalRoot.tsx
+++ b/packages/@mantine/core/src/components/Modal/ModalRoot.tsx
@@ -32,6 +32,9 @@ export interface ModalRootProps extends StylesApiProps<ModalRootFactory>, ModalB
   /** Scroll area component, native `div` element by default */
   scrollAreaComponent?: ScrollAreaComponent;
 
+  /** Determines whether the modal should have scroll area, `true` by default */
+  withScrollArea?: boolean;
+
   /** Key of `theme.radius` or any valid CSS value to set `border-radius`, `theme.defaultRadius` by default */
   radius?: MantineRadius;
 
@@ -59,6 +62,7 @@ const defaultProps: Partial<ModalRootProps> = {
   returnFocus: true,
   closeOnEscape: true,
   keepMounted: false,
+  withScrollArea: true,
   zIndex: getDefaultZIndex('modal'),
   transitionProps: { duration: 200, transition: 'pop' },
   yOffset: '5dvh',
@@ -85,6 +89,7 @@ export const ModalRoot = factory<ModalRootFactory>((_props, ref) => {
     unstyled,
     vars,
     yOffset,
+    withScrollArea,
     scrollAreaComponent,
     radius,
     fullScreen,
@@ -108,7 +113,7 @@ export const ModalRoot = factory<ModalRootFactory>((_props, ref) => {
   });
 
   return (
-    <ModalProvider value={{ yOffset, scrollAreaComponent, getStyles, fullScreen }}>
+    <ModalProvider value={{ yOffset, scrollAreaComponent, withScrollArea, getStyles, fullScreen }}>
       <ModalBase
         ref={ref}
         {...getStyles('root')}


### PR DESCRIPTION
TL;DR:

Allows users to bypass the `Scroll` component to provide more flexibility for handling complex layouts.

Related feature request: https://github.com/orgs/mantinedev/discussions/6360