### PR TITLE
[@mantine/hooks] use-local-storage Update document to specify the getInitialValueInEffect default value

### DIFF
--- a/apps/mantine.dev/src/pages/hooks/use-local-storage.mdx
+++ b/apps/mantine.dev/src/pages/hooks/use-local-storage.mdx
@@ -141,7 +141,7 @@ interface UseLocalStorage<T> {
   /** Default value that will be set if value is not found in local storage */
   defaultValue?: T;
 
-  /** If set to true, value will be updated in useEffect after mount */
+  /** If set to true, value will be updated in useEffect after mount. Default value is true. */
   getInitialValueInEffect: boolean;
 
   /** Function to serialize value into a string to be saved in local storage */

--- a/apps/mantine.dev/src/pages/hooks/use-local-storage.mdx
+++ b/apps/mantine.dev/src/pages/hooks/use-local-storage.mdx
@@ -142,7 +142,7 @@ interface UseLocalStorage<T> {
   defaultValue?: T;
 
   /** If set to true, value will be updated in useEffect after mount. Default value is true. */
-  getInitialValueInEffect: boolean;
+  getInitialValueInEffect?: boolean;
 
   /** Function to serialize value into a string to be saved in local storage */
   serialize?: (value: T) => string;

--- a/packages/@mantine/hooks/src/use-local-storage/create-storage.ts
+++ b/packages/@mantine/hooks/src/use-local-storage/create-storage.ts
@@ -11,7 +11,7 @@ export interface StorageProperties<T> {
   /** Default value that will be set if value is not found in storage */
   defaultValue?: T;
 
-  /** If set to true, value will be update is useEffect after mount */
+  /** If set to true, value will be updated in useEffect after mount. Default value is true. */
   getInitialValueInEffect?: boolean;
 
   /** Function to serialize value into string to be save in storage */


### PR DESCRIPTION
The code is specifying this property as optional.
https://github.com/mantinedev/mantine/blob/29f24e31d9c33316395b317cd152648d55c65ef9/packages/%40mantine/hooks/src/use-local-storage/create-storage.ts#L15C3-L15C37

The document didn't specify it as optional:
https://github.com/mantinedev/mantine/blob/master/apps/mantine.dev/src/pages/hooks/use-local-storage.mdx#definition

The code also assign default value as "true" when not specified.
https://github.com/mantinedev/mantine/blob/29f24e31d9c33316395b317cd152648d55c65ef9/packages/%40mantine/hooks/src/use-local-storage/create-storage.ts#L78

It created a confusing when I was working with this hook at the 1st time and caused unexpected behavior.