### PR TITLE
[@mantine/spotlight] Search for the action item in the document or in ShadowDOMs

### DIFF
--- a/packages/@mantine/spotlight/src/spotlight.store.ts
+++ b/packages/@mantine/spotlight/src/spotlight.store.ts
@@ -53,8 +53,8 @@ export function setListId(id: string, store: SpotlightStore) {
 }
 
 function findElementByQuerySelector<T extends HTMLElement>(
-  root: Document | Element | ShadowRoot,
-  selector: string
+  selector: string,
+  root: Document | Element | ShadowRoot = document
 ): T | null {
   // Directly try to find the element in the current root.
   const element = root.querySelector<T>(selector);
@@ -82,7 +82,7 @@ function findElementByQuerySelector<T extends HTMLElement>(
 
 export function selectAction(index: number, store: SpotlightStore): number {
   const state = store.getState();
-  const actionsList = findElementByQuerySelector(document, `#${state.listId}`);
+  const actionsList = findElementByQuerySelector(`#${state.listId}`);
   const selected = actionsList?.querySelector<HTMLButtonElement>('[data-selected]');
   const actions = actionsList?.querySelectorAll<HTMLButtonElement>('[data-action]') ?? [];
   const nextIndex = index === -1 ? actions.length - 1 : index === actions.length ? 0 : index;
@@ -107,7 +107,6 @@ export function selectPreviousAction(store: SpotlightStore) {
 export function triggerSelectedAction(store: SpotlightStore) {
   const state = store.getState();
   const selected = findElementByQuerySelector<HTMLButtonElement>(
-    document,
     `#${state.listId} [data-selected]`
   );
   selected?.click();

--- a/packages/@mantine/spotlight/src/spotlight.store.ts
+++ b/packages/@mantine/spotlight/src/spotlight.store.ts
@@ -82,7 +82,7 @@ function findElementByQuerySelector<T extends HTMLElement>(
 
 export function selectAction(index: number, store: SpotlightStore): number {
   const state = store.getState();
-  const actionsList = findElementByQuerySelector(`#${state.listId}`);
+  const actionsList = state.listId ? findElementByQuerySelector(`#${state.listId}`) : null;
   const selected = actionsList?.querySelector<HTMLButtonElement>('[data-selected]');
   const actions = actionsList?.querySelectorAll<HTMLButtonElement>('[data-action]') ?? [];
   const nextIndex = index === -1 ? actions.length - 1 : index === actions.length ? 0 : index;

--- a/packages/@mantine/spotlight/src/spotlight.store.ts
+++ b/packages/@mantine/spotlight/src/spotlight.store.ts
@@ -62,7 +62,7 @@ function findElementByQuerySelector<T extends HTMLElement>(
 
   // Iterate through all children of the current root.
   const children = root instanceof ShadowRoot ? root.host.children : root.children;
-  for (let i = 0; i < children.length; i++) {
+  for (let i = 0; i < children.length; i += 1) {
     const child = children[i];
 
     // Recursively search in the child's shadow root if it exists.

--- a/packages/@mantine/spotlight/src/spotlight.store.ts
+++ b/packages/@mantine/spotlight/src/spotlight.store.ts
@@ -57,8 +57,8 @@ function findElementByQuerySelector<T extends HTMLElement>(
   selector: string
 ): T | null {
   // Directly try to find the element in the current root.
-  const element = root.querySelector(selector);
-  if (element) return element as T;
+  const element = root.querySelector<T>(selector);
+  if (element) return element;
 
   // Iterate through all children of the current root.
   const children = root instanceof ShadowRoot ? root.host.children : root.children;
@@ -67,13 +67,13 @@ function findElementByQuerySelector<T extends HTMLElement>(
 
     // Recursively search in the child's shadow root if it exists.
     if (child.shadowRoot) {
-      const shadowElement = findElementByQuerySelector(child.shadowRoot, selector);
-      if (shadowElement) return shadowElement as T;
+      const shadowElement = findElementByQuerySelector<T>(child.shadowRoot, selector);
+      if (shadowElement) return shadowElement;
     }
 
     // Also, search recursively in the child itself if it does not have a shadow root or the element wasn't found in its shadow root.
-    const nestedElement = findElementByQuerySelector(child, selector);
-    if (nestedElement) return nestedElement as T;
+    const nestedElement = findElementByQuerySelector<T>(child, selector);
+    if (nestedElement) return nestedElement;
   }
 
   // Return null if the element isn't found in the current root or any of its shadow DOMs.

--- a/packages/@mantine/spotlight/src/spotlight.store.ts
+++ b/packages/@mantine/spotlight/src/spotlight.store.ts
@@ -52,9 +52,37 @@ export function setListId(id: string, store: SpotlightStore) {
   store.updateState((state) => ({ ...state, listId: id }));
 }
 
+function findElementByQuerySelector<T extends HTMLElement>(
+  root: Document | Element | ShadowRoot,
+  selector: string
+): T | null {
+  // Directly try to find the element in the current root.
+  const element = root.querySelector(selector);
+  if (element) return element as T;
+
+  // Iterate through all children of the current root.
+  const children = root instanceof ShadowRoot ? root.host.children : root.children;
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+
+    // Recursively search in the child's shadow root if it exists.
+    if (child.shadowRoot) {
+      const shadowElement = findElementByQuerySelector(child.shadowRoot, selector);
+      if (shadowElement) return shadowElement as T;
+    }
+
+    // Also, search recursively in the child itself if it does not have a shadow root or the element wasn't found in its shadow root.
+    const nestedElement = findElementByQuerySelector(child, selector);
+    if (nestedElement) return nestedElement as T;
+  }
+
+  // Return null if the element isn't found in the current root or any of its shadow DOMs.
+  return null;
+}
+
 export function selectAction(index: number, store: SpotlightStore): number {
   const state = store.getState();
-  const actionsList = document.getElementById(state.listId);
+  const actionsList = findElementByQuerySelector(document, `#${state.listId}`);
   const selected = actionsList?.querySelector<HTMLButtonElement>('[data-selected]');
   const actions = actionsList?.querySelectorAll<HTMLButtonElement>('[data-action]') ?? [];
   const nextIndex = index === -1 ? actions.length - 1 : index === actions.length ? 0 : index;
@@ -78,7 +106,10 @@ export function selectPreviousAction(store: SpotlightStore) {
 
 export function triggerSelectedAction(store: SpotlightStore) {
   const state = store.getState();
-  const selected = document.querySelector<HTMLButtonElement>(`#${state.listId} [data-selected]`);
+  const selected = findElementByQuerySelector<HTMLButtonElement>(
+    document,
+    `#${state.listId} [data-selected]`
+  );
   selected?.click();
 }
 

--- a/packages/@mantine/spotlight/src/spotlight.store.ts
+++ b/packages/@mantine/spotlight/src/spotlight.store.ts
@@ -67,12 +67,12 @@ function findElementByQuerySelector<T extends HTMLElement>(
 
     // Recursively search in the child's shadow root if it exists.
     if (child.shadowRoot) {
-      const shadowElement = findElementByQuerySelector<T>(child.shadowRoot, selector);
+      const shadowElement = findElementByQuerySelector<T>(selector, child.shadowRoot);
       if (shadowElement) return shadowElement;
     }
 
     // Also, search recursively in the child itself if it does not have a shadow root or the element wasn't found in its shadow root.
-    const nestedElement = findElementByQuerySelector<T>(child, selector);
+    const nestedElement = findElementByQuerySelector<T>(selector, child);
     if (nestedElement) return nestedElement;
   }
 


### PR DESCRIPTION
Following up on [my proposed fix on Discord](https://discord.com/channels/854810300876062770/1198385031287156826/1207000915345809498), here's finally the PR.
The added method tries to find the Spotlight's action element in the document and in any potential ShadowDOM.