### PR TITLE
[@mantine/core] conver-css-variables for host selector

### DIFF
--- a/packages/@mantine/core/src/core/MantineProvider/convert-css-variables/convert-css-variables.ts
+++ b/packages/@mantine/core/src/core/MantineProvider/convert-css-variables/convert-css-variables.ts
@@ -15,15 +15,19 @@ export interface ConvertCSSVariablesInput {
 export function convertCssVariables(input: ConvertCSSVariablesInput, selector: string) {
   const sharedVariables = cssVariablesObjectToString(input.variables);
   const shared = sharedVariables ? wrapWithSelector(selector, sharedVariables) : '';
-
   const dark = cssVariablesObjectToString(input.dark);
+  const light = cssVariablesObjectToString(input.light);
+
   const darkForced = dark
-    ? wrapWithSelector(`${selector}[data-mantine-color-scheme="dark"]`, dark)
+    ? selector === ':host'
+      ? wrapWithSelector(`${selector}([data-mantine-color-scheme="dark"])`, dark)
+      : wrapWithSelector(`${selector}[data-mantine-color-scheme="dark"]`, dark)
     : '';
 
-  const light = cssVariablesObjectToString(input.light);
   const lightForced = light
-    ? wrapWithSelector(`${selector}[data-mantine-color-scheme="light"]`, light)
+    ? selector === ':host'
+      ? wrapWithSelector(`${selector}([data-mantine-color-scheme="light"])`, light)
+      : wrapWithSelector(`${selector}[data-mantine-color-scheme="light"]`, light)
     : '';
 
   return `${shared}${darkForced}${lightForced}`;


### PR DESCRIPTION
[:host() mdn](https://developer.mozilla.org/en-US/docs/Web/CSS/:host_function)
css variables doesn't work in shadow dom even though set `cssVariablesSelector` to `:host` on `MantineProvider`
cause `:host` has another convention unlike `:root`

add ternary operator when `cssVariablesSelector` is `:host`


