### PR TITLE
fix: Typescript 5.5 compatibility for Mantine v6

### DIFF
--- a/src/mantine-modals/src/context.ts
+++ b/src/mantine-modals/src/context.ts
@@ -36,7 +36,7 @@ export interface ModalsContextProps {
   closeAll: () => void;
 }
 
-export type MantineModalsOverride = {};
+export interface MantineModalsOverride {};
 
 export type MantineModalsOverwritten = MantineModalsOverride extends {
   modals: Record<string, React.FC<ContextModalProps<any>>>;

--- a/src/mantine-styles/src/theme/types/MantineColor.ts
+++ b/src/mantine-styles/src/theme/types/MantineColor.ts
@@ -17,7 +17,7 @@ export type DefaultMantineColor =
   | 'teal'
   | (string & {});
 
-export type MantineThemeColorsOverride = {};
+export interface MantineThemeColorsOverride {};
 
 export type MantineThemeColors = MantineThemeColorsOverride extends {
   colors: Record<infer CustomColors, Tuple<string, 10>>;


### PR DESCRIPTION
TypeScript type augmentation does work with TypeScript 5.5

Fixes https://github.com/mantinedev/mantine/issues/6438 for Mantine v6

Same as https://github.com/mantinedev/mantine/pull/6443 for Mantine v7
