### PR TITLE
Extract "key" from removeScrollProps

### DIFF
--- a/packages/@mantine/core/src/components/ModalBase/ModalBase.tsx
+++ b/packages/@mantine/core/src/components/ModalBase/ModalBase.tsx
@@ -105,6 +105,8 @@ export const ModalBase = forwardRef<HTMLDivElement, ModalBaseProps>(
     const { _id, titleMounted, bodyMounted, shouldLockScroll, setTitleMounted, setBodyMounted } =
       useModal({ id, transitionProps, opened, trapFocus, closeOnEscape, onClose, returnFocus });
 
+    const { key: removeScrollKey, ...otherRemoveScrollProps } = removeScrollProps || {};
+
     return (
       <OptionalPortal {...portalProps} withinPortal={withinPortal}>
         <ModalBaseProvider
@@ -125,7 +127,11 @@ export const ModalBase = forwardRef<HTMLDivElement, ModalBaseProps>(
             unstyled,
           }}
         >
-          <RemoveScroll enabled={shouldLockScroll && lockScroll} {...removeScrollProps}>
+          <RemoveScroll
+            enabled={shouldLockScroll && lockScroll}
+            key={removeScrollKey}
+            {...otherRemoveScrollProps}
+          >
             <Box
               ref={ref}
               {...others}


### PR DESCRIPTION
When trying to pass a `key` to the `removeScrollProps` on a modal, react logs an error in the console.  
This PR is to resolve that error.

Error Message in console:

```console
app-index.tsx:25 Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, enabled: ..., forwardProps: ..., children: ...};
  <ForwardRef {...props} />
React keys must be passed directly to JSX without using spread:
  let props = {enabled: ..., forwardProps: ..., children: ...};
  <ForwardRef key={someKey} {...props} />
    at http://localhost:3000/_next/static/chunks/node_modules_%40mantine_core_esm_components_e3257d._.js:491:199
    at Provider (http://localhost:3000/_next/static/chunks/node_modules_%40mantine_core_esm_core_831b37._.js:3121:25)
    at http://localhost:3000/_next/static/chunks/node_modules_%40mantine_core_esm_components_e3257d._.js:1056:235
    at http://localhost:3000/_next/static/chunks/node_modules_%40mantine_core_esm_components_e3257d._.js:1214:330
    at ModalsProvider (http://localhost:3000/_next/static/chunks/node_modules_dc1e9c._.js:2924:27)
    at MantineThemeProvider (http://localhost:3000/_next/static/chunks/node_modules_%40mantine_core_esm_core_831b37._.js:1206:33)
    at MantineProvider (http://localhost:3000/_next/static/chunks/node_modules_%40mantine_core_esm_core_831b37._.js:1930:28)
    at PublicStoreProvider (http://localhost:3000/_next/static/chunks/src_app_(public)_139e11._.js:119:32)
    at Form (Server)
    at InnerLayoutRouter (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:289:11)
    at RedirectErrorBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:4922:9)
    at RedirectBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:4930:11)
    at NotFoundBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:5175:11)
    at LoadingBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:393:11)
    at ErrorBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:4636:11)
    at InnerScrollAndFocusHandler (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:200:9)
    at ScrollAndFocusHandler (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:275:11)
    at RenderFromTemplateContext (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:519:44)
    at OuterLayoutRouter (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:413:11)
    at InnerLayoutRouter (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:289:11)
    at RedirectErrorBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:4922:9)
    at RedirectBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:4930:11)
    at NotFoundErrorBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:5167:9)
    at NotFoundBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:5175:11)
    at LoadingBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:393:11)
    at ErrorBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:4636:11)
    at InnerScrollAndFocusHandler (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:200:9)
    at ScrollAndFocusHandler (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:275:11)
    at RenderFromTemplateContext (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:519:44)
    at OuterLayoutRouter (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:413:11)
    at TRPCProvider (http://localhost:3000/_next/static/chunks/node_modules_26271d._.js:7681:17)
    at QueryClientProvider (http://localhost:3000/_next/static/chunks/node_modules_26271d._.js:3805:32)
    at TRPCReactProvider (http://localhost:3000/_next/static/chunks/src_aa89a8._.js:55:201)
    at body
    at html
    at PublicLayout (Server)
    at InnerLayoutRouter (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:289:11)
    at RedirectErrorBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:4922:9)
    at RedirectBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:4930:11)
    at NotFoundErrorBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:5167:9)
    at NotFoundBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:5175:11)
    at LoadingBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:393:11)
    at ErrorBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:4636:11)
    at InnerScrollAndFocusHandler (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:200:9)
    at ScrollAndFocusHandler (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:275:11)
    at RenderFromTemplateContext (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:519:44)
    at OuterLayoutRouter (http://localhost:3000/_next/static/chunks/node_modules_next_dist_0219ee._.js:413:11)
    at RedirectErrorBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:4922:9)
    at RedirectBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:4930:11)
    at NotFoundErrorBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:5167:9)
    at NotFoundBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:5175:11)
    at DevRootNotFoundBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:5235:11)
    at ReactDevOverlay (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:11751:9)
    at HotReload (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:12522:11)
    at Router (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:12839:11)
    at ErrorBoundaryHandler (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:4590:9)
    at ErrorBoundary (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:4636:11)
    at AppRouter (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:13203:13)
    at ServerRoot (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:13452:27)
    at Root (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_8bb71d._.js:13456:11)