### PR TITLE
[@mantine/core] Tree: fix react warning about levelOffset

### DIFF
--- a/packages/@mantine/core/src/components/Tree/Tree.tsx
+++ b/packages/@mantine/core/src/components/Tree/Tree.tsx
@@ -133,6 +133,7 @@ export const Tree = factory<TreeFactory>((_props, ref) => {
     clearSelectionOnOutsideClick,
     allowRangeSelection,
     expandOnSpace,
+    levelOffset,
     ...others
   } = props;
 


### PR DESCRIPTION
React 19 RC complains: 

> React does not recognize the `levelOffset` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `leveloffset` instead. If you accidentally passed it from a parent component, remove it from the DOM element.  
`ul`
`_Box<@http://localhost:5173/node_modules/.vite/deps/chunk-MRL2GTIY.js?v=2e806eeb:3767:3`
`Tree<@http://localhost:5173/node_modules/.vite/deps/chunk-MRL2GTIY.js?v=2e806eeb:27494:25`
...
