### PR TITLE
[@mantine/core] Tooltip floatingStrategy=fixed updates position to fixed

### DIFF
--- a/packages/@mantine/core/src/components/Tooltip/Tooltip.module.css
+++ b/packages/@mantine/core/src/components/Tooltip/Tooltip.module.css
@@ -21,6 +21,10 @@
   &:where([data-multiline]) {
     white-space: normal;
   }
+
+  &:where([data-fixed]) {
+    position: fixed;
+  }
 }
 
 .arrow {

--- a/packages/@mantine/core/src/components/Tooltip/Tooltip.story.tsx
+++ b/packages/@mantine/core/src/components/Tooltip/Tooltip.story.tsx
@@ -223,3 +223,20 @@ export function DefaultOpened() {
     </div>
   );
 }
+
+export function Fixed() {
+  return (
+    <div style={{ padding: 40 }}>
+      <Tooltip
+        position="right"
+        label="Tooltip has fixed position"
+        withArrow
+        transitionProps={{ duration: 0 }}
+        opened
+        floatingStrategy="fixed"
+      >
+        <button type="button">target</button>
+      </Tooltip>
+    </div>
+  );
+}

--- a/packages/@mantine/core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/@mantine/core/src/components/Tooltip/Tooltip.tsx
@@ -217,6 +217,7 @@ export const Tooltip = factory<TooltipFactory>((_props, ref) => {
           {(transitionStyles) => (
             <Box
               {...others}
+              data-fixed={floatingStrategy === 'fixed' || undefined}
               variant={variant}
               mod={[{ multiline }, mod]}
               {...tooltip.getFloatingProps({


### PR DESCRIPTION
Fixes issue raised here: https://github.com/mantinedev/mantine/issues/6497 

I followed what was done in https://github.com/mantinedev/mantine/issues/6419, which fixes the same issue for the Popover component. 