### PR TITLE
fix(@mantine/hooks): useOS returns macos when ipad

### DIFF
--- a/packages/@mantine/hooks/src/use-os/use-os.ts
+++ b/packages/@mantine/hooks/src/use-os/use-os.ts
@@ -40,11 +40,11 @@ function getOS(): OS {
 
   const { userAgent } = window.navigator;
 
-  if (isMacOS(userAgent)) {
-    return 'macos';
-  }
   if (isIOS(userAgent)) {
     return 'ios';
+  }
+  if (isMacOS(userAgent)) {
+    return 'macos';
   }
   if (isWindows(userAgent)) {
     return 'windows';


### PR DESCRIPTION
fixes: https://github.com/mantinedev/mantine/issues/6508
 

reason of bug  this is that ipad also contains "Machintosh".
So that I've changed to check for IOS first!
