### PR TITLE
MANTINE-6336: Fix DateInput to setInputValue to _value which has time zone applied

### DIFF
--- a/packages/@mantine/dates/src/components/DateInput/DateInput.tsx
+++ b/packages/@mantine/dates/src/components/DateInput/DateInput.tsx
@@ -245,8 +245,8 @@ export const DateInput = factory<DateInputFactory>((_props, ref) => {
     ) : null);
 
   useDidUpdate(() => {
-    value !== undefined && !dropdownOpened && setInputValue(formatValue(value!));
-  }, [value]);
+    _value !== undefined && !dropdownOpened && setInputValue(formatValue(_value!));
+  }, [_value]);
 
   return (
     <>


### PR DESCRIPTION
Fixes #6336 

Reviewed code and discovered that the useDidUpdate hook was not setting the state value with timezone when applicable. 

Before: It was running and setting the inputValue to the initial onChange Value without applying the updates from the useUncontrolledDates Hook. 

After: _value is the source of truth to display in input and will display with updates applied by useUncontrolledDates Hook. 