### PR TITLE
[@mantine/dates] fix proper label assignment on DatePickerInput

### DIFF
--- a/packages/@mantine/dates/src/components/PickerInputBase/PickerInputBase.tsx
+++ b/packages/@mantine/dates/src/components/PickerInputBase/PickerInputBase.tsx
@@ -172,7 +172,6 @@ export const PickerInputBase = factory<PickerInputBaseFactory>((_props, ref) => 
         >
           <Popover.Target>
             <Input
-              aria-label={formattedValue || placeholder}
               data-dates-input
               data-read-only={readOnly || undefined}
               disabled={disabled}


### PR DESCRIPTION
according to [accessibility part](https://mantine.dev/dates/date-picker-input/#accessibility) of `DatePickerInput` docs it is said that if `label` prop is set, input will be accessible it is not required to set `aria-label`.

But since there was assignment of `aria-label` inside `PickerInputBase` on `Input` it essentially overrode the label from `InputWrapper` connected with `htmlFor` attribute.

It made component harder to use inside e2e tests that rely on labels for element locators, since component locator should be dynamic or `aria-label` attribute must be set alongside with `label` attribute

if this behavior of dynamically changing label based on value or placeholder is intended I'll be glad to adjust `DatePickerInput` docs instead of code change 