### PR TITLE
[@mantine/hook]: fix use-os returns `macos` when ipad

### DIFF
--- a/packages/@mantine/hooks/src/use-os/use-os.ts
+++ b/packages/@mantine/hooks/src/use-os/use-os.ts
@@ -40,7 +40,7 @@ function getOS(): OS {
 
   const { userAgent } = window.navigator;
 
-  if (isIOS(userAgent)) {
+  if (isIOS(userAgent) || (isMacOS(userAgent) && 'ontouchend' in document)) {
     return 'ios';
   }
   if (isMacOS(userAgent)) {


### PR DESCRIPTION
fixes: https://github.com/mantinedev/mantine/issues/6508

added `ontouchend` to determine ipad air and pro.