### PR TITLE
[@mantine/charts]: Fix LineChart Legend and Tooltip to support nested names

### DIFF
--- a/packages/@mantine/charts/src/ChartTooltip/ChartTooltip.test.tsx
+++ b/packages/@mantine/charts/src/ChartTooltip/ChartTooltip.test.tsx
@@ -1,0 +1,210 @@
+import { patchConsoleWarn, render } from '@mantine-tests/core';
+import { ChartTooltip } from './ChartTooltip';
+
+const payload = [
+  {
+    className: 'mantine-LineChart-line',
+    style: {},
+    name: 'Apples',
+    fill: 'var(--mantine-color-indigo-6)',
+    stroke: 'var(--mantine-color-indigo-6)',
+    strokeWidth: 2,
+    fillOpacity: 1,
+    strokeOpacity: 1,
+    dataKey: 'Apples',
+    color: 'var(--mantine-color-indigo-6)',
+    value: 3129,
+    payload: {
+      date: 'Mar 26',
+      Apples: 3129,
+      Oranges: 1726,
+      Tomatoes: 2290,
+    },
+  },
+  {
+    className: 'mantine-LineChart-line',
+    style: {},
+    name: 'Oranges',
+    fill: 'var(--mantine-color-blue-6)',
+    stroke: 'var(--mantine-color-blue-6)',
+    strokeWidth: 2,
+    fillOpacity: 1,
+    strokeOpacity: 1,
+    dataKey: 'Oranges',
+    color: 'var(--mantine-color-blue-6)',
+    value: 1726,
+    payload: {
+      date: 'Mar 26',
+      Apples: 3129,
+      Oranges: 1726,
+      Tomatoes: 2290,
+    },
+  },
+  {
+    className: 'mantine-LineChart-line',
+    style: {},
+    name: 'Tomatoes',
+    fill: 'var(--mantine-color-teal-6)',
+    stroke: 'var(--mantine-color-teal-6)',
+    strokeWidth: 2,
+    fillOpacity: 1,
+    strokeOpacity: 1,
+    dataKey: 'Tomatoes',
+    color: 'var(--mantine-color-teal-6)',
+    value: 2290,
+    payload: {
+      date: 'Mar 26',
+      Apples: 3129,
+      Oranges: 1726,
+      Tomatoes: 2290,
+    },
+  },
+];
+
+const series = [
+  {
+    name: 'Apples',
+    label: 'Apples sales',
+    color: 'indigo.6',
+  },
+  {
+    name: 'Oranges',
+    label: 'Oranges sales',
+    color: 'blue.6',
+  },
+  {
+    name: 'Tomatoes',
+    label: 'Tomatoes sales',
+    color: 'teal.6',
+  },
+];
+
+const nestedPayload = [
+  {
+    className: 'mantine-LineChart-line',
+    style: {},
+    name: 'salad.ApplesProp',
+    fill: 'var(--mantine-color-indigo-6)',
+    stroke: 'var(--mantine-color-indigo-6)',
+    strokeWidth: 2,
+    fillOpacity: 1,
+    strokeOpacity: 1,
+    dataKey: 'salad.ApplesProp',
+    color: 'var(--mantine-color-indigo-6)',
+    value: 3129,
+    payload: {
+      date: 'Mar 26',
+      TomatoesProp: 2290,
+      salad: {
+        ApplesProp: 3129,
+        OrangesProp: 1726,
+      },
+    },
+  },
+  {
+    className: 'mantine-LineChart-line',
+    style: {},
+    name: 'salad.OrangesProp',
+    fill: 'var(--mantine-color-blue-6)',
+    stroke: 'var(--mantine-color-blue-6)',
+    strokeWidth: 2,
+    fillOpacity: 1,
+    strokeOpacity: 1,
+    dataKey: 'salad.OrangesProp',
+    color: 'var(--mantine-color-blue-6)',
+    value: 1726,
+    payload: {
+      date: 'Mar 26',
+      TomatoesProp: 2290,
+      salad: {
+        ApplesProp: 3129,
+        OrangesProp: 1726,
+      },
+    },
+  },
+  {
+    className: 'mantine-LineChart-line',
+    style: {},
+    name: 'TomatoesProp',
+    fill: 'var(--mantine-color-teal-6)',
+    stroke: 'var(--mantine-color-teal-6)',
+    strokeWidth: 2,
+    fillOpacity: 1,
+    strokeOpacity: 1,
+    dataKey: 'TomatoesProp',
+    color: 'var(--mantine-color-teal-6)',
+    value: 2290,
+    payload: {
+      date: 'Mar 26',
+      TomatoesProp: 2290,
+      salad: {
+        ApplesProp: 3129,
+        OrangesProp: 1726,
+      },
+    },
+  },
+];
+
+const nestedSeries = [
+  {
+    name: 'salad.ApplesProp',
+    color: 'indigo.6',
+    label: 'AppleLabel',
+  },
+  {
+    name: 'salad.OrangesProp',
+    color: 'blue.6',
+    label: 'OrangesLabel',
+  },
+  {
+    name: 'TomatoesProp',
+    color: 'teal.6',
+    label: 'TomatoesLabel',
+  },
+];
+
+describe('@mantine/charts/ChartToolTip', () => {
+  beforeAll(() => {
+    patchConsoleWarn();
+  });
+
+  afterAll(() => {
+    patchConsoleWarn.release();
+  });
+
+  it('accurately renders Tooltip label and data with default shallow names', async () => {
+    const { container } = render(<ChartTooltip label="Mar 26" payload={payload} series={series} />);
+    expect(container.querySelectorAll('.mantine-ChartTooltip-tooltipItem')).toHaveLength(3);
+
+    const tooltipLabelList = container.querySelectorAll('.mantine-ChartTooltip-tooltipItemBody');
+    const tooltipDataList = container.querySelectorAll('.mantine-ChartTooltip-tooltipItemData');
+
+    expect(tooltipLabelList[0].textContent).toBe('Apples sales');
+    expect(tooltipDataList[0].textContent).toBe('3129');
+
+    expect(tooltipLabelList[1].textContent).toBe('Oranges sales');
+    expect(tooltipDataList[1].textContent).toBe('1726');
+
+    expect(tooltipLabelList[2].textContent).toBe('Tomatoes sales');
+    expect(tooltipDataList[2].textContent).toBe('2290');
+  });
+
+  it('accurately renders Tooltip label and data with nested names', async () => {
+    const { container } = render(
+      <ChartTooltip label="Mar 26" payload={nestedPayload} series={nestedSeries} />
+    );
+    expect(container.querySelectorAll('.mantine-ChartTooltip-tooltipItem')).toHaveLength(3);
+
+    const tooltipLabelList = container.querySelectorAll('.mantine-ChartTooltip-tooltipItemBody');
+    const tooltipDataList = container.querySelectorAll('.mantine-ChartTooltip-tooltipItemData');
+
+    expect(tooltipLabelList[0].textContent).toBe('AppleLabel');
+    expect(tooltipDataList[0].textContent).toBe('3129');
+
+    expect(tooltipLabelList[1].textContent).toBe('OrangesLabel');
+    expect(tooltipDataList[1].textContent).toBe('1726');
+
+    expect(tooltipLabelList[2].textContent).toBe('TomatoesLabel');
+    expect(tooltipDataList[2].textContent).toBe('2290');
+  });
+});

--- a/packages/@mantine/charts/src/ChartTooltip/ChartTooltip.tsx
+++ b/packages/@mantine/charts/src/ChartTooltip/ChartTooltip.tsx
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import {
   Box,
   BoxProps,
@@ -21,7 +20,7 @@ function updateChartTooltipPayload(payload: Record<string, any>[]): Record<strin
     const matchFound = item.name.search(/\./);
     if (matchFound >= 0) {
       const newDataKey = item.name.substring(0, matchFound);
-      const nestedPayload = _.clone(item.payload[newDataKey]);
+      const nestedPayload = { ...item.payload[newDataKey] };
       const shallowPayload = Object.entries(item.payload).reduce((acc, current) => {
         const [k, v] = current;
         return k === newDataKey ? acc : { ...acc, [k]: v };

--- a/packages/@mantine/charts/src/ChartTooltip/ChartTooltip.tsx
+++ b/packages/@mantine/charts/src/ChartTooltip/ChartTooltip.tsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {
   Box,
   BoxProps,
@@ -17,11 +18,25 @@ import classes from './ChartTooltip.module.css';
 
 function updateChartTooltipPayload(payload: Record<string, any>[]): Record<string, any>[] {
   return payload.map((item) => {
-    const newDataKey = item.name.split('.').pop();
-    return {
-      ...item,
-      name: newDataKey,
-    };
+    const matchFound = item.name.search(/\./);
+    if (matchFound >= 0) {
+      const newDataKey = item.name.substring(0, matchFound);
+      const nestedPayload = _.clone(item.payload[newDataKey]);
+      const shallowPayload = Object.entries(item.payload).reduce((acc, current) => {
+        const [k, v] = current;
+        return k === newDataKey ? acc : { ...acc, [k]: v };
+      }, {});
+
+      return {
+        ...item,
+        name: item.name.substring(matchFound + 1),
+        payload: {
+          ...shallowPayload,
+          ...nestedPayload,
+        },
+      };
+    }
+    return item;
   });
 }
 
@@ -48,7 +63,7 @@ function getData(item: Record<string, any>, type: 'area' | 'radial' | 'scatter')
   if (Array.isArray(item.payload[item.dataKey])) {
     return item.payload[item.dataKey][1] - item.payload[item.dataKey][0];
   }
-  return item.payload[item.dataKey];
+  return item.payload[item.name];
 }
 
 export type ChartTooltipStylesNames =

--- a/packages/@mantine/charts/src/LineChart/LineChart.test.tsx
+++ b/packages/@mantine/charts/src/LineChart/LineChart.test.tsx
@@ -41,30 +41,6 @@ const nestedData = [
       OrangesProp: 2103,
     },
   },
-  {
-    date: 'Mar 24',
-    TomatoesProp: 1821,
-    salad: {
-      ApplesProp: 3322,
-      OrangesProp: 986,
-    },
-  },
-  {
-    date: 'Mar 25',
-    TomatoesProp: 2809,
-    salad: {
-      ApplesProp: 3470,
-      OrangesProp: 2108,
-    },
-  },
-  {
-    date: 'Mar 26',
-    TomatoesProp: 2290,
-    salad: {
-      ApplesProp: 3129,
-      OrangesProp: 1726,
-    },
-  },
 ];
 
 const data = [
@@ -79,24 +55,6 @@ const data = [
     Apples: 2756,
     Oranges: 2103,
     Tomatoes: 2402,
-  },
-  {
-    date: 'Mar 24',
-    Apples: 3322,
-    Oranges: 986,
-    Tomatoes: 1821,
-  },
-  {
-    date: 'Mar 25',
-    Apples: 3470,
-    Oranges: 2108,
-    Tomatoes: 2809,
-  },
-  {
-    date: 'Mar 26',
-    Apples: 3129,
-    Oranges: 1726,
-    Tomatoes: 2290,
   },
 ];
 

--- a/packages/@mantine/charts/src/LineChart/LineChart.test.tsx
+++ b/packages/@mantine/charts/src/LineChart/LineChart.test.tsx
@@ -1,5 +1,18 @@
-import { patchConsoleWarn, tests } from '@mantine-tests/core';
+import React from 'react';
+import { patchConsoleWarn, render, tests } from '@mantine-tests/core';
 import { LineChart, LineChartProps, LineChartStylesNames } from './LineChart';
+
+jest.mock('recharts', () => {
+  const OriginalModule = jest.requireActual('recharts');
+  return {
+    ...OriginalModule,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <OriginalModule.ResponsiveContainer width={800} height={800}>
+        {children}
+      </OriginalModule.ResponsiveContainer>
+    ),
+  };
+});
 
 const defaultProps: LineChartProps = {
   data: [
@@ -10,6 +23,82 @@ const defaultProps: LineChartProps = {
   dataKey: 'date',
   style: { width: 200, height: 200 },
 };
+
+const nestedData = [
+  {
+    date: 'Mar 22',
+    TomatoesProp: 2452,
+    salad: {
+      ApplesProp: 2890,
+      OrangesProp: 2338,
+    },
+  },
+  {
+    date: 'Mar 23',
+    TomatoesProp: 2402,
+    salad: {
+      ApplesProp: 2756,
+      OrangesProp: 2103,
+    },
+  },
+  {
+    date: 'Mar 24',
+    TomatoesProp: 1821,
+    salad: {
+      ApplesProp: 3322,
+      OrangesProp: 986,
+    },
+  },
+  {
+    date: 'Mar 25',
+    TomatoesProp: 2809,
+    salad: {
+      ApplesProp: 3470,
+      OrangesProp: 2108,
+    },
+  },
+  {
+    date: 'Mar 26',
+    TomatoesProp: 2290,
+    salad: {
+      ApplesProp: 3129,
+      OrangesProp: 1726,
+    },
+  },
+];
+
+const data = [
+  {
+    date: 'Mar 22',
+    Apples: 2890,
+    Oranges: 2338,
+    Tomatoes: 2452,
+  },
+  {
+    date: 'Mar 23',
+    Apples: 2756,
+    Oranges: 2103,
+    Tomatoes: 2402,
+  },
+  {
+    date: 'Mar 24',
+    Apples: 3322,
+    Oranges: 986,
+    Tomatoes: 1821,
+  },
+  {
+    date: 'Mar 25',
+    Apples: 3470,
+    Oranges: 2108,
+    Tomatoes: 2809,
+  },
+  {
+    date: 'Mar 26',
+    Apples: 3129,
+    Oranges: 1726,
+    Tomatoes: 2290,
+  },
+];
 
 describe('@mantine/charts/LineChart', () => {
   beforeAll(() => {
@@ -33,5 +122,61 @@ describe('@mantine/charts/LineChart', () => {
     refType: HTMLDivElement,
     displayName: '@mantine/charts/LineChart',
     stylesApiSelectors: ['root'],
+  });
+
+  it('renders LineChart legend with nested series name', async () => {
+    const { container } = render(
+      <div style={{ padding: 40 }}>
+        <LineChart
+          h={300}
+          data={nestedData}
+          dataKey="date"
+          series={[
+            { name: 'salad.ApplesProp', color: 'indigo.6', label: 'AppleLabel' },
+            { name: 'salad.OrangesProp', color: 'blue.6', label: 'OrangesLabel' },
+            { name: 'TomatoesProp', color: 'teal.6', label: 'TomatoesLabel' },
+          ]}
+          curveType="linear"
+          withLegend
+        />
+      </div>
+    );
+
+    expect(container.querySelector('.recharts-surface')).toBeInTheDocument();
+
+    const legendElementList = container.querySelectorAll('.mantine-ChartLegend-legendItemName');
+    expect(legendElementList).toHaveLength(3);
+
+    expect(legendElementList[0].textContent).toEqual('AppleLabel');
+    expect(legendElementList[1].textContent).toEqual('OrangesLabel');
+    expect(legendElementList[2].textContent).toEqual('TomatoesLabel');
+  });
+
+  it('renders LineChart legend labels', () => {
+    const { container } = render(
+      <div style={{ padding: 40 }}>
+        <LineChart
+          h={300}
+          data={data}
+          dataKey="date"
+          withLegend
+          legendProps={{ verticalAlign: 'bottom' }}
+          series={[
+            { name: 'Apples', label: 'Apples sales', color: 'indigo.6' },
+            { name: 'Oranges', label: 'Oranges sales', color: 'blue.6' },
+            { name: 'Tomatoes', label: 'Tomatoes sales', color: 'teal.6' },
+          ]}
+        />
+      </div>
+    );
+
+    expect(container.querySelector('.recharts-surface')).toBeInTheDocument();
+
+    const legendElementList = container.querySelectorAll('.mantine-ChartLegend-legendItemName');
+    expect(legendElementList).toHaveLength(3);
+
+    expect(legendElementList[0].textContent).toEqual('Apples sales');
+    expect(legendElementList[1].textContent).toEqual('Oranges sales');
+    expect(legendElementList[2].textContent).toEqual('Tomatoes sales');
   });
 });

--- a/packages/@mantine/charts/src/utils/get-series-labels/get-series-labels.ts
+++ b/packages/@mantine/charts/src/utils/get-series-labels/get-series-labels.ts
@@ -8,6 +8,12 @@ export function getSeriesLabels(series: ChartSeries[] | undefined): ChartSeriesL
   }
 
   return series.reduce<ChartSeriesLabels>((acc, item) => {
+    const matchFound = item.name.search(/\./);
+    if (matchFound >= 0) {
+      const key = item.name.substring(matchFound + 1);
+      acc[key] = item.label;
+      return acc;
+    }
     acc[item.name] = item.label;
     return acc;
   }, {});


### PR DESCRIPTION
Fixes #6529 
Relates to #5886 

Update tooltip payload by unpacking item's not related to the nested name. Then unpack nested details into same object. 

Updates getSeriesLabels to account for nested name. 

Adds Unit Tests for displaying legend and tooltip label and data. 