### PR TITLE
Allow overwrite of default onKeyDown behaviour of the TagsInput component

### DIFF
--- a/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
+++ b/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
@@ -266,6 +266,8 @@ export const TagsInput = factory<TagsInputFactory>((_props, ref) => {
   const handleInputKeydown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     onKeyDown?.(event);
 
+    if (event.isPropagationStopped()) return;
+
     const inputValue = _searchValue.trim();
     const { length } = inputValue;
 


### PR DESCRIPTION
Fixes #6568
Allow disabling of default key down behaviour by stopping the event propagation.