### PR TITLE
[@mantine/core] Menu: fix keboard Esc from closing menu and modal when in a modal

### DIFF
--- a/packages/@mantine/core/src/components/Menu/MenuDropdown/MenuDropdown.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuDropdown/MenuDropdown.tsx
@@ -84,7 +84,13 @@ export const MenuDropdown = factory<MenuDropdownFactory>((props, ref) => {
       data-menu-dropdown
       onKeyDown={handleKeyDown}
     >
-      <div tabIndex={-1} data-autofocus aria-hidden style={{ outline: 0 }} />
+      <div
+        tabIndex={-1}
+        data-autofocus
+        data-mantine-stop-propagation
+        aria-hidden
+        style={{ outline: 0 }}
+      />
       {children}
     </Popover.Dropdown>
   );

--- a/packages/@mantine/core/src/components/Menu/MenuItem/MenuItem.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuItem/MenuItem.tsx
@@ -105,6 +105,7 @@ export const MenuItem = polymorphicFactory<MenuItemFactory>((props, ref) => {
       data-menu-item
       data-disabled={disabled || undefined}
       data-hovered={ctx.hovered === itemIndex ? true : undefined}
+      data-mantine-stop-propagation
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onClick={handleClick}

--- a/packages/@mantine/core/src/components/Modal/Modal.story.tsx
+++ b/packages/@mantine/core/src/components/Modal/Modal.story.tsx
@@ -1,5 +1,6 @@
 import { useDisclosure } from '@mantine/hooks';
 import { Button } from '../Button';
+import { Menu } from '../Menu';
 import { ScrollArea } from '../ScrollArea';
 import { Select } from '../Select';
 import { Tabs } from '../Tabs';
@@ -43,6 +44,27 @@ export function WithSelect() {
       <Button onClick={open}>Open modal</Button>
       <Modal opened={opened} onClose={close} title="Just a Modal">
         <Select data={['React', 'Angular']} searchable />
+      </Modal>
+    </div>
+  );
+}
+
+export function WithMenu() {
+  const [opened, { open, close }] = useDisclosure(true);
+  return (
+    <div style={{ padding: 40 }}>
+      <Button onClick={open}>Open modal</Button>
+      <Modal opened={opened} onClose={close} title="Just a Modal">
+        <Menu>
+          <Menu.Target>
+            <Button>Toggle menu</Button>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item>One</Menu.Item>
+            <Menu.Item>Two</Menu.Item>
+            <Menu.Item>Three</Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
       </Modal>
     </div>
   );


### PR DESCRIPTION
Fixes https://github.com/mantinedev/mantine/issues/6528

Things to note:

- Added storybook page with Menu in Modal
- Adds data-mantine-stop-propagation to interactive menu items to stop keyboard events from bubbling up
- Code Formatting changes provided by prettier
