### PR TITLE
fix: Mantine 6.x MantineThemeOther support for module augmentation for TypeScript 5.5

### DIFF
--- a/src/mantine-styles/src/theme/types/MantineTheme.ts
+++ b/src/mantine-styles/src/theme/types/MantineTheme.ts
@@ -8,7 +8,9 @@ import type { ColorScheme } from './ColorScheme';
 import type { CSSObject } from '../../tss';
 
 export type LoaderType = 'bars' | 'oval' | 'dots';
-export type MantineThemeOther = Record<string, any>;
+export interface MantineThemeOther {
+  [key: string]: any;
+}
 export type MantineThemeComponents = Record<string, ThemeComponent>;
 
 export interface HeadingStyle {


### PR DESCRIPTION
Mantine 6.0.22 introduced some fixes to support module augmentation. This is documented on the [Mantine.dev](https://v6.mantine.dev/theming/theme-object/#other) website as a way to support typing the `MantineThemeOther` object. This PR specifically address `MantineThemeOther`, which was missed.

The issue was a result of Typescript fixing a bug, see https://github.com/microsoft/TypeScript/issues/58961

See https://github.com/mantinedev/mantine/pull/6445 for previous fixes.