### PR TITLE
Fix checked chip padding at XL size

### DIFF
--- a/packages/@mantine/core/src/components/Chip/Chip.module.css
+++ b/packages/@mantine/core/src/components/Chip/Chip.module.css
@@ -21,7 +21,7 @@
   --chip-checked-padding-sm: 10px;
   --chip-checked-padding-md: 11.7px;
   --chip-checked-padding-lg: 13.5px;
-  --chip-checked-padding-xl: 12.5px;
+  --chip-checked-padding-xl: 15.7px;
 
   --chip-spacing-xs: 10px;
   --chip-spacing-sm: 12px;


### PR DESCRIPTION
Fixes the incorrect padding for checked Chip at XL size.

![image](https://github.com/user-attachments/assets/91512342-e9ec-40ec-93c5-245dc42eda29)

Formula: 32-(18+(22/1.5))/2