### PR TITLE
chore: fix a typo

### DIFF
--- a/apps/help.mantine.dev/src/pages/q/data-grid-i-need.mdx
+++ b/apps/help.mantine.dev/src/pages/q/data-grid-i-need.mdx
@@ -29,4 +29,4 @@ and [Table](https://mantine.dev/code/table/) component from Mantine.
 
 The DataGrid component is complex and requires a lot of maintenance.
 As of now (January 2024), it is not planned to add native DataGrid component
-to Mantine in the nearest future.
+to Mantine in the near future.


### PR DESCRIPTION
I think there is typo, maybe you meant `near` not `nearest`