### PR TITLE
[@mantine/core]: Remove invalid and redundant parentheses in Slider

### DIFF
--- a/packages/@mantine/core/src/components/Slider/Slider.module.css
+++ b/packages/@mantine/core/src/components/Slider/Slider.module.css
@@ -178,7 +178,7 @@
   height: var(--slider-size);
   width: var(--slider-size);
   border-radius: 1000px;
-  transform: translateX((calc(var(--slider-size) / -2)));
+  transform: translateX(calc(var(--slider-size) / -2));
   background-color: var(--mantine-color-white);
   pointer-events: none;
 


### PR DESCRIPTION
This PR removes unnecessary parentheses in the `Slider.module.css` that can lead to an error when imported.