### PR TITLE
Show warnings on unload when dirty

### DIFF
--- a/packages/@docs/demos/src/demos/form/Form.demo.showWarningOnUnloadWhenDirty.tsx
+++ b/packages/@docs/demos/src/demos/form/Form.demo.showWarningOnUnloadWhenDirty.tsx
@@ -1,0 +1,73 @@
+/* eslint-disable no-console */
+
+import { Button, TextInput } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { useForm } from '@mantine/form';
+import { TextInput, Button } from '@mantine/core';
+
+function Demo() {
+  const form = useForm({
+    mode: 'uncontrolled',
+    initialValues: { text: 'initial value' },
+    showWarningOnUnloadWhenDirty: true,
+  });
+
+  return (
+    <div>
+      <TextInput
+        {...form.getInputProps('text')}
+        key={form.key('text')}
+        label="Touched/dirty demo"
+        placeholder="Touched/dirty demo"
+      />
+
+      <Button
+        onClick={() =>
+          console.log({ touched: form.isTouched('text'), dirty: form.isDirty('text') })
+        }
+      >
+        Log status to console
+      </Button>
+    </div>
+  );
+}
+`;
+
+function Demo() {
+  const form = useForm({
+    mode: 'uncontrolled',
+    initialValues: { text: 'initial value' },
+    showWarningOnUnloadWhenDirty: true,
+  });
+
+  return (
+    <div>
+      <TextInput
+        {...form.getInputProps('text')}
+        key={form.key('text')}
+        label="Touched/dirty demo"
+        placeholder="Touched/dirty demo"
+      />
+
+      <Button
+        mt="md"
+        onClick={() =>
+          console.log({ touched: form.isTouched('text'), dirty: form.isDirty('text') })
+        }
+      >
+        Log status to console
+      </Button>
+    </div>
+  );
+}
+
+export const showWarningOnUnloadWhenDirty: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+  centered: true,
+  maxWidth: 340,
+};

--- a/packages/@docs/demos/src/demos/form/Form.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/form/Form.demos.story.tsx
@@ -162,3 +162,8 @@ export const Demo_focusError = {
   name: '⭐ Demo: focusError',
   render: renderDemo(demos.focusError),
 };
+
+export const Demo_showWarningOnUnloadWhenDirty = {
+  name: '⭐ Demo: showWarningOnUnloadWhenDirty',
+  render: renderDemo(demos.showWarningOnUnloadWhenDirty),
+};

--- a/packages/@docs/demos/src/demos/form/index.ts
+++ b/packages/@docs/demos/src/demos/form/index.ts
@@ -30,3 +30,4 @@ export { uncontrolled } from './Form.demo.uncontrolled';
 export { onValuesChange } from './Form.demo.onValuesChange';
 export { watch } from './Form.demo.watch';
 export { focusError } from './Form.demo.focusError';
+export { showWarningOnUnloadWhenDirty } from './Form.demo.showWarningOnUnloadWhenDirty';

--- a/packages/@mantine/form/src/types.ts
+++ b/packages/@mantine/form/src/types.ts
@@ -187,6 +187,7 @@ export interface UseFormInput<
   clearInputErrorOnChange?: boolean;
   validateInputOnChange?: boolean | LooseKeys<Values>[];
   validateInputOnBlur?: boolean | LooseKeys<Values>[];
+  showWarningOnUnloadWhenDirty?: boolean;
   onValuesChange?: (values: Values, previous: Values) => void;
   enhanceGetInputProps?: (payload: {
     inputProps: GetInputPropsReturnType;

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useFormActions } from './actions';
 import { getInputOnChange } from './get-input-on-change';
 import { useFormErrors } from './hooks/use-form-errors/use-form-errors';
@@ -44,6 +44,7 @@ export function useForm<
   transformValues = ((values: Values) => values) as any,
   enhanceGetInputProps,
   validate: rules,
+  showWarningOnUnloadWhenDirty = false,
 }: UseFormInput<Values, TransformValues> = {}): UseFormReturnType<Values, TransformValues> {
   const $errors = useFormErrors<Values>(initialErrors);
   const $values = useFormValues<Values>({ initialValues, onValuesChange, mode });
@@ -221,6 +222,24 @@ export function useForm<
     (path) => document.querySelector(`[data-path="${getDataPath(name, path)}"]`),
     []
   );
+
+
+  useEffect(() => {
+    if (showWarningOnUnloadWhenDirty) {
+      const handler = (event: BeforeUnloadEvent) => {
+        if ($status.isDirty()) {
+          event.preventDefault();
+          event.returnValue = true;
+        }
+      };
+
+      window.addEventListener("beforeunload", handler);
+
+      return () => {
+        window.removeEventListener("beforeunload", handler);
+      };
+    }
+  }, [$status, showWarningOnUnloadWhenDirty]);
 
   const form: UseFormReturnType<Values, TransformValues> = {
     watch: $watch.watch,


### PR DESCRIPTION
Checks if the form is dirty when the user unloads the window and shows a warning.

I've build this several times when using form to ensure the user doesn't loose changes when the form is dirty. 

This dirty check is reset after using setDirty or resetting the form.

Steps to reproduce:
- Start storybook
- Go to /?path=/story/form--demo-show-warning-on-unload-when-dirty
- Edit the field
- Close the window
- Alert is shown for unsaved changes