### PR TITLE
Fix SegmentedControl FloatingIndicator Bug

### DIFF
--- a/packages/@mantine/core/src/components/FloatingIndicator/use-floating-indicator.ts
+++ b/packages/@mantine/core/src/components/FloatingIndicator/use-floating-indicator.ts
@@ -108,9 +108,9 @@ export function useFloatingIndicator({
         }
       };
 
-      document.addEventListener('transitionend', handleTransitionEnd);
+      parent.addEventListener('transitionend', handleTransitionEnd);
       return () => {
-        document.removeEventListener('transitionend', handleTransitionEnd);
+        parent.removeEventListener('transitionend', handleTransitionEnd);
       };
     }
 


### PR DESCRIPTION
Fixes #6527 

The problem was that the transitionend event listener was added to the entire document, so it was picking up transitions from any element. 

When the user clicked the burger, it opened the Navbar which changed the offsetLeft of the FloatingIndicator parent. This triggered the useEffect and called isParent with the transition event from the Navbar burger. This made isParent return true and then call updatePositionWithoutAnimation() which caused the bug.

By attaching the event listener directly to the parent element, the handler only responds to transitions within the parent and its children, resulting in correct behavior.

Please let me know if this good. Happy to revise based on your feedback.

Thanks,
Michael