### PR TITLE
[@mantine/core] SegmentedControl: Add missing disabled data-attribute

### DIFF
--- a/packages/@docs/styles-api/src/data/SegmentedControl.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/SegmentedControl.styles-api.ts
@@ -32,6 +32,7 @@ export const SegmentedControlStylesApi: StylesApiData<SegmentedControlFactory> =
       selector: 'root',
       condition: '`withItemsBorder` prop is not `false`',
     },
+    { modifier: 'data-disabled', selector: 'root', condition: 'Value of `disabled` prop' },
     { modifier: 'data-orientation', selector: 'control', value: 'Value of `orientation` prop' },
     {
       modifier: 'data-active',

--- a/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.tsx
@@ -257,6 +257,7 @@ export const SegmentedControl = factory<SegmentedControlFactory>((_props, ref) =
       ]}
       {...others}
       role="radiogroup"
+      data-disabled={disabled}
     >
       {typeof _value === 'string' && (
         <FloatingIndicator


### PR DESCRIPTION
Hello. I want to customize the `root` styles of segmented control in `disabled` state, but it's not possible without `data-disabled` attribute on `root`, because the only thing you can use in CSS in that case is `:disabled` pseudo-class on nested inputs, but there are no parent selectors implemented in CSS right now, so basically it's just not possible to change `root` styles without JS when it's child inputs are disabled. But JS logic doesn't allow to customize this behavior once and for all (I mean in theme), and I have to create my own wrapper-component.

I suggest adding this attribute to make customization easier