### PR TITLE
FIX: badge dot width fix without breaking rounded badge styles

### DIFF
--- a/packages/@mantine/core/src/components/Badge/Badge.module.css
+++ b/packages/@mantine/core/src/components/Badge/Badge.module.css
@@ -33,7 +33,8 @@
   line-height: var(--badge-lh);
   text-decoration: none;
   padding: 0 var(--badge-padding-x);
-  display: inline-flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
   justify-content: center;
   width: fit-content;
@@ -54,6 +55,7 @@
 
   &:where([data-circle]) {
     padding-inline: 2px;
+    display: flex;
     width: var(--badge-height);
   }
 }


### PR DESCRIPTION
I encountered an issue with text overflow in badges inside tables at my company. The dot variant was particularly problematic, with the dot's width shrinking when the overflow was too extensive. I have fixed this issue and will post before and after images to illustrate the changes.

Note: The new styles added to the badge root caused a problem with rounded badges. I also addressed this issue and ensured all tests passed. I checked all badge formats, and everything is now working correctly.

### Before:
![WhatsApp Image 2024-08-03 at 17 56 10](https://github.com/user-attachments/assets/e445a8b7-d9c0-4904-9bd4-5d12eb388c6c)
![WhatsApp Image 2024-08-03 at 17 56 31](https://github.com/user-attachments/assets/18ca93aa-8d1d-41c3-a591-897041755b95)

### After:
![WhatsApp Image 2024-08-03 at 17 56 45](https://github.com/user-attachments/assets/a9f3ad60-dbe2-49c5-ad9a-e6e11805edb8)

#### Also you can see rounded badges are working correctly:
![WhatsApp Image 2024-08-03 at 17 59 39(1)](https://github.com/user-attachments/assets/a36d0903-d7a8-4493-b1a9-7b301eb1cad8)
