### PR TITLE
[@mantine/form] Call `form.watch` subscribers on `form.initialize`

### DIFF
--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -61,23 +61,33 @@ export function useForm<
     mode === 'uncontrolled' && setFormKey((key) => key + 1);
   }, []);
 
-  const initialize: Initialize<Values> = useCallback((values) => {
-    const previousValues = $values.refValues.current;
-    $values.initialize(values, () => mode === 'uncontrolled' && setFormKey((key) => key + 1));
-    clearInputErrorOnChange && $errors.clearErrors();
-    mode === 'uncontrolled' && setFormKey((key) => key + 1);
+  const handleValuesChanges = useCallback(
+    (previousValues: Values) => {
+      clearInputErrorOnChange && $errors.clearErrors();
+      mode === 'uncontrolled' && setFormKey((key) => key + 1);
 
-    Object.keys($watch.subscribers.current).forEach((path) => {
-      const value = getPath(path, $values.refValues.current);
-      const previousValue = getPath(path, previousValues);
+      Object.keys($watch.subscribers.current).forEach((path) => {
+        const value = getPath(path, $values.refValues.current);
+        const previousValue = getPath(path, previousValues);
 
-      if (value !== previousValue) {
-        $watch
-          .getFieldSubscribers(path)
-          .forEach((cb) => cb({ previousValues, updatedValues: $values.refValues.current }));
-      }
-    });
-  }, [clearInputErrorOnChange]);
+        if (value !== previousValue) {
+          $watch
+            .getFieldSubscribers(path)
+            .forEach((cb) => cb({ previousValues, updatedValues: $values.refValues.current }));
+        }
+      });
+    },
+    [clearInputErrorOnChange]
+  );
+
+  const initialize: Initialize<Values> = useCallback(
+    (values) => {
+      const previousValues = $values.refValues.current;
+      $values.initialize(values, () => mode === 'uncontrolled' && setFormKey((key) => key + 1));
+      handleValuesChanges(previousValues);
+    },
+    [handleValuesChanges]
+  );
 
   const setFieldValue: SetFieldValue<Values> = useCallback(
     (path, value, options) => {
@@ -120,21 +130,9 @@ export function useForm<
     (values) => {
       const previousValues = $values.refValues.current;
       $values.setValues({ values, updateState: mode === 'controlled' });
-      clearInputErrorOnChange && $errors.clearErrors();
-      mode === 'uncontrolled' && setFormKey((key) => key + 1);
-
-      Object.keys($watch.subscribers.current).forEach((path) => {
-        const value = getPath(path, $values.refValues.current);
-        const previousValue = getPath(path, previousValues);
-
-        if (value !== previousValue) {
-          $watch
-            .getFieldSubscribers(path)
-            .forEach((cb) => cb({ previousValues, updatedValues: $values.refValues.current }));
-        }
-      });
+      handleValuesChanges(previousValues);
     },
-    [onValuesChange, clearInputErrorOnChange]
+    [onValuesChange, handleValuesChanges]
   );
 
   const validate: Validate = useCallback(() => {


### PR DESCRIPTION
Fixes #6638

This PR adds tests covering the problem of `form.watch` subscribers not being called when the value changes because of `form.initialize()` as described in #6638 and fixes it.

The way it fixes it is by notifying the subscribers the same way `setValues` does it.

Let me know if this is not the right way to fix this.