### PR TITLE
fix: badge content is not centered with custom width

### DIFF
--- a/packages/@mantine/core/src/components/Badge/Badge.module.css
+++ b/packages/@mantine/core/src/components/Badge/Badge.module.css
@@ -34,8 +34,7 @@
   line-height: var(--badge-lh);
   text-decoration: none;
   padding: 0 var(--badge-padding-x);
-  display: grid;
-  grid-template-columns: auto 1fr auto;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   width: fit-content;
@@ -56,7 +55,6 @@
 
   &:where([data-circle]) {
     padding-inline: 2px;
-    display: flex;
     width: var(--badge-height);
   }
 }
@@ -79,7 +77,7 @@
   &::before {
     content: '';
     display: block;
-    width: var(--badge-dot-size);
+    min-width: var(--badge-dot-size);
     height: var(--badge-dot-size);
     border-radius: var(--badge-dot-size);
     background-color: var(--badge-dot-color);


### PR DESCRIPTION
Hey this morning I came across the following badges in our application:

![image](https://github.com/user-attachments/assets/f5d1127d-49d2-47c8-a0e2-13774d107d61)

As you can see they are no longer centered. I took a look in the history and found the pull request #6629 from last week. The changes I made allow the content to still be centered, but also allow the dot to be it's full size when having it small:

![image](https://github.com/user-attachments/assets/fd6769e2-eedf-4471-b96e-74b8a3500bde)
![image](https://github.com/user-attachments/assets/681ba419-e755-474f-b309-1af930c99e9f)
![image](https://github.com/user-attachments/assets/810fe16e-209b-4922-9797-3a588f62b876)
![image](https://github.com/user-attachments/assets/d1ee38e6-5b30-403b-85cb-c9a0759efcca)
![image](https://github.com/user-attachments/assets/90b92a90-d9f6-46b2-9b3c-f24fc98ac6e6)
![image](https://github.com/user-attachments/assets/befbaa4f-5afc-43cd-91bd-86a259b2ec95)
![image](https://github.com/user-attachments/assets/2b3e8d68-f102-4ab1-bf08-304af2d86c84)

