### PR TITLE
[@mantine/hooks] use-idle: Start timer immediately instead of waiting for an event (#6682)

### DIFF
--- a/packages/@mantine/hooks/src/use-idle/use-idle.test.tsx
+++ b/packages/@mantine/hooks/src/use-idle/use-idle.test.tsx
@@ -11,6 +11,20 @@ describe('@mantine/hooks/use-idle', () => {
     expect(hook.result.current).toBe(true);
   });
 
+  it('Starts the timer immediately instead of waiting for the first event to happen', () => {
+    const spy = jest.spyOn(window, 'setTimeout');
+    expect(spy).not.toHaveBeenCalled();
+
+    const hook = renderHook(() => useIdle(1000, { initialState: false, events: ['click', 'keypress'] }));
+
+    expect(hook.result.current).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+    setTimeout(() => {
+      expect(hook.result.current).toBe(true);
+      expect(spy).toHaveBeenCalledTimes(2);
+    }, 1001);
+  });
+
   it('Returns correct value on firing keypress event', () => {
     const hook = renderHook(() => useIdle(1000));
 

--- a/packages/@mantine/hooks/src/use-idle/use-idle.test.tsx
+++ b/packages/@mantine/hooks/src/use-idle/use-idle.test.tsx
@@ -15,7 +15,9 @@ describe('@mantine/hooks/use-idle', () => {
     const spy = jest.spyOn(window, 'setTimeout');
     expect(spy).not.toHaveBeenCalled();
 
-    const hook = renderHook(() => useIdle(1000, { initialState: false, events: ['click', 'keypress'] }));
+    const hook = renderHook(() =>
+      useIdle(1000, { initialState: false, events: ['click', 'keypress'] })
+    );
 
     expect(hook.result.current).toBe(false);
     expect(spy).toHaveBeenCalledTimes(1);

--- a/packages/@mantine/hooks/src/use-idle/use-idle.ts
+++ b/packages/@mantine/hooks/src/use-idle/use-idle.ts
@@ -35,6 +35,11 @@ export function useIdle(
 
     events.forEach((event) => document.addEventListener(event, handleEvents));
 
+    // Start the timer immediately instead of waiting for the first event to happen
+    timer.current = window.setTimeout(() => {
+      setIdle(true);
+    }, timeout);
+
     return () => {
       events.forEach((event) => document.removeEventListener(event, handleEvents));
     };


### PR DESCRIPTION
This came up when I was implementing automatic logout in our application. If a given event _never_ fires, the current implementation of `useIdle` will never return `true`.

This PR starts the timer immediately after setting up the event listeners.

Fixes #6682 