### PR TITLE
[@mantine/dropzone] Added 7z & rar mime types

### DIFF
--- a/packages/@mantine/dropzone/src/mime-types.ts
+++ b/packages/@mantine/dropzone/src/mime-types.ts
@@ -11,6 +11,8 @@ export const MIME_TYPES = {
   // Documents
   mp4: 'video/mp4',
   zip: 'application/zip',
+  rar: 'application/x-rar',
+  '7z': 'application/x-7z-compressed',
   csv: 'text/csv',
   pdf: 'application/pdf',
   doc: 'application/msword',


### PR DESCRIPTION
Added 7z & rar mime types for simpler usage in Dropzone and more aesthetically pleasing usage.

Note: rar can supposedly also be represented as [application/vnd.rar](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types), [application/x-rar-compressed](https://en.wikipedia.org/wiki/RAR_(file_format)) and [application/octet-stream](https://simple.wikipedia.org/wiki/RAR_(file_format))
*Source: Mozilla & Wikipedia