### PR TITLE
[@mantine/dates] Fix: unselect date-range hover when value is changed

### DIFF
--- a/packages/@mantine/dates/src/hooks/use-dates-state/use-dates-state.ts
+++ b/packages/@mantine/dates/src/hooks/use-dates-state/use-dates-state.ts
@@ -162,10 +162,16 @@ export function useDatesState<Type extends DatePickerType = 'default'>({
   const onHoveredDateChange = type === 'range' && pickedDate ? setHoveredDate : () => {};
 
   useEffect(() => {
-    if (type === 'range' && !_value[0] && !_value[1]) {
+    if (type !== 'range') {
+      return;
+    }
+
+    const isNeitherSelected = _value[0] == null && _value[1] == null;
+    const isBothSelected = _value[0] != null && _value[1] != null;
+    if (isNeitherSelected || isBothSelected) {
       setPickedDate(null);
     }
-  }, [value]);
+  }, [_value]);
 
   return {
     onDateChange,

--- a/packages/@mantine/dates/src/hooks/use-dates-state/use-dates-state.ts
+++ b/packages/@mantine/dates/src/hooks/use-dates-state/use-dates-state.ts
@@ -170,6 +170,7 @@ export function useDatesState<Type extends DatePickerType = 'default'>({
     const isBothSelected = _value[0] != null && _value[1] != null;
     if (isNeitherSelected || isBothSelected) {
       setPickedDate(null);
+      setHoveredDate(null);
     }
   }, [_value]);
 


### PR DESCRIPTION
Fixes https://github.com/mantinedev/mantine/issues/6692 


**Notes:**
- Added `setHoveredDate` to fix the direction of the selected `Day` box when updating
- Updated the `UseEffect` dependencies to use the uncontrolled/controlled `_value` to better match the effect