### PR TITLE
fix: Unknown event handler property `onTopReached`. It will be ignored.

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -213,6 +213,7 @@ export const ScrollAreaAutosize = factory<ScrollAreaFactory>((props, ref) => {
     style,
     vars,
     onBottomReached,
+    onTopReached,
     ...others
   } = useProps('ScrollAreaAutosize', defaultProps, props);
 
@@ -235,6 +236,7 @@ export const ScrollAreaAutosize = factory<ScrollAreaFactory>((props, ref) => {
           vars={vars}
           scrollbars={scrollbars}
           onBottomReached={onBottomReached}
+          onTopReached={onTopReached}
         >
           {children}
         </ScrollArea>


### PR DESCRIPTION
`onBottomReached` has been fixed in 7.12.2, but `onTopReached` has not been fixed until now.