### PR TITLE
Widen `description` type to include JSX nodes

### DIFF
--- a/packages/@mantine/spotlight/src/SpotlightAction.tsx
+++ b/packages/@mantine/spotlight/src/SpotlightAction.tsx
@@ -29,7 +29,7 @@ export interface SpotlightActionProps
   label?: string;
 
   /** Action description, pass string to use in default filter */
-  description?: string;
+  description?: React.ReactNode;
 
   /** Section displayed on the left side of the label, for example, icon */
   leftSection?: React.ReactNode;


### PR DESCRIPTION
Is there any reason this can't be a JSX component?

Have tested locally and it appears to render fine but there may be some more wide reaching concerns.