### PR TITLE
Allow SegmentedControlProps to accept custom string literals as gener…

### DIFF
--- a/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.tsx
@@ -32,13 +32,13 @@ export type SegmentedControlStylesNames =
   | 'innerLabel';
 export type SegmentedControlCssVariables = {
   root:
-    | '--sc-radius'
-    | '--sc-color'
-    | '--sc-font-size'
-    | '--sc-padding'
-    | '--sc-shadow'
-    | '--sc-transition-duration'
-    | '--sc-transition-timing-function';
+  | '--sc-radius'
+  | '--sc-color'
+  | '--sc-font-size'
+  | '--sc-padding'
+  | '--sc-shadow'
+  | '--sc-transition-duration'
+  | '--sc-transition-timing-function';
 };
 
 export interface SegmentedControlItem {
@@ -47,21 +47,21 @@ export interface SegmentedControlItem {
   disabled?: boolean;
 }
 
-export interface SegmentedControlProps
+export interface SegmentedControlProps<T extends string = string>
   extends BoxProps,
-    StylesApiProps<SegmentedControlFactory>,
-    ElementProps<'div', 'onChange'> {
+  StylesApiProps<SegmentedControlFactory>,
+  ElementProps<'div', 'onChange'> {
   /** Data based on which controls are rendered */
-  data: (string | SegmentedControlItem)[];
+  data: (T | SegmentedControlItem)[];
 
   /** Controlled component value */
-  value?: string;
+  value?: T;
 
   /** Uncontrolled component default value */
-  defaultValue?: string;
+  defaultValue?: T;
 
   /** Called when value changes */
-  onChange?: (value: string) => void;
+  onChange?: (value: T) => void;
 
   /** Determines whether the component is disabled */
   disabled?: boolean;


### PR DESCRIPTION
Allow SegmentedControlProps to accept custom string literals as generic type for data, value, defaultValue and onChange prop.

- Updated `SegmentedControlProps` to support a customizable `onChange` handler that can accept specific string literal types.
- Introduced a generic type `T extends string = string` to constrain the value prop while allowing users to define their own set of valid string options.
- The change maintains backward compatibility by defaulting to the general `string` type if no specific literals are provided.