### PR TITLE
[@mantine/core] fix parse color option props

### DIFF
--- a/packages/@mantine/core/src/core/MantineProvider/color-functions/parse-theme-color/parse-theme-color.ts
+++ b/packages/@mantine/core/src/core/MantineProvider/color-functions/parse-theme-color/parse-theme-color.ts
@@ -4,7 +4,7 @@ import { getPrimaryShade } from '../get-primary-shade/get-primary-shade';
 import { isLightColor } from '../luminance/luminance';
 
 interface ParseThemeColorOptions {
-  color: unknown;
+  color: string;
   theme: MantineTheme;
   colorScheme?: MantineColorScheme;
 }


### PR DESCRIPTION
fixes: https://github.com/mantinedev/mantine/issues/6764

Sorry if you had any reasons to make `color` unknown. 