### PR TITLE
[mantine.dev] fix: dependency of `@mantine/tiptap` was wrong

### DIFF
--- a/apps/mantine.dev/src/components/MdxProvider/MdxPackagesInstallation/data.ts
+++ b/apps/mantine.dev/src/components/MdxProvider/MdxPackagesInstallation/data.ts
@@ -41,7 +41,7 @@ export const PACKAGES_DATA = [
       '@mantine/hooks',
       '@mantine/core',
       '@mantine/tiptap',
-      '@tabler/icons-react',
+      '@tiptap/pm',
       '@tiptap/react',
       '@tiptap/extension-link',
       '@tiptap/starter-kit',


### PR DESCRIPTION
SEE: https://mantine.dev/getting-started/#get-started-without-framework

## describe BUG
when you check `@mantine/tiptap` , tabler-icons will be imported instead of `@tiptap/pm`