### PR TITLE
[mantine.dev] fix: remove autofocus from searchinput at Prop tab

### DIFF
--- a/apps/mantine.dev/src/components/PropsTable/PropsTablesList.tsx
+++ b/apps/mantine.dev/src/components/PropsTable/PropsTablesList.tsx
@@ -32,7 +32,6 @@ export function PropsTablesList({ components, componentPrefix }: PropsTablesList
         placeholder="Search props"
         radius="md"
         size="lg"
-        autoFocus
       />
       {tables}
     </div>


### PR DESCRIPTION
# Not Good UX

On SmartPhones, when you arrive Prop tab, keyboard shows and I thought it was not good at UX.

https://github.com/user-attachments/assets/acc1fc42-5bb7-4dcb-bd70-1eb843056c84

