### PR TITLE
[@mantine/date] fix: add missing aria-label props to `Calender`

### DIFF
--- a/packages/@mantine/dates/src/components/Calendar/Calendar.tsx
+++ b/packages/@mantine/dates/src/components/Calendar/Calendar.tsx
@@ -109,6 +109,12 @@ export interface CalendarBaseProps {
   /** Aria-label attributes for controls on different levels */
   ariaLabels?: CalendarAriaLabels;
 
+  /** Arial-label for next button */
+  nextLabel?: string;
+
+  /** Arial-label for previous button */
+  previousLabel?: string;
+
   /** Called when next decade button is clicked */
   onNextDecade?: (date: Date) => void;
 
@@ -172,6 +178,8 @@ export const Calendar = factory<CalendarFactory>((_props, ref) => {
     numberOfColumns,
     columnsToScroll,
     ariaLabels,
+    nextLabel,
+    previousLabel,
     onYearSelect,
     onMonthSelect,
     onYearMouseEnter,
@@ -329,9 +337,9 @@ export const Calendar = factory<CalendarFactory>((_props, ref) => {
           numberOfColumns={numberOfColumns}
           locale={locale}
           levelControlAriaLabel={ariaLabels?.monthLevelControl}
-          nextLabel={ariaLabels?.nextMonth}
+          nextLabel={ariaLabels?.nextMonth ?? nextLabel}
           nextIcon={nextIcon}
-          previousLabel={ariaLabels?.previousMonth}
+          previousLabel={ariaLabels?.previousMonth ?? previousLabel}
           previousIcon={previousIcon}
           monthLabelFormat={monthLabelFormat}
           __onDayClick={__onDayClick}
@@ -359,9 +367,9 @@ export const Calendar = factory<CalendarFactory>((_props, ref) => {
           hasNextLevel={maxLevel !== 'month' && maxLevel !== 'year'}
           onLevelClick={() => setLevel('decade')}
           levelControlAriaLabel={ariaLabels?.yearLevelControl}
-          nextLabel={ariaLabels?.nextYear}
+          nextLabel={ariaLabels?.nextYear ?? nextLabel}
           nextIcon={nextIcon}
-          previousLabel={ariaLabels?.previousYear}
+          previousLabel={ariaLabels?.previousYear ?? previousLabel}
           previousIcon={previousIcon}
           yearLabelFormat={yearLabelFormat}
           __onControlMouseEnter={onMonthMouseEnter}
@@ -388,9 +396,9 @@ export const Calendar = factory<CalendarFactory>((_props, ref) => {
           onNext={handleNextDecade}
           onPrevious={handlePreviousDecade}
           numberOfColumns={numberOfColumns}
-          nextLabel={ariaLabels?.nextDecade}
+          nextLabel={ariaLabels?.nextDecade ?? nextLabel}
           nextIcon={nextIcon}
-          previousLabel={ariaLabels?.previousDecade}
+          previousLabel={ariaLabels?.previousDecade ?? previousLabel}
           previousIcon={previousIcon}
           decadeLabelFormat={decadeLabelFormat}
           __onControlMouseEnter={onYearMouseEnter}


### PR DESCRIPTION
fixes: https://github.com/mantinedev/mantine/issues/6835

Added `nextLabel` and `previousLabel` which was written on docs