### PR TITLE
[mantine.dev] make sure to install embla-carousel@7

### DIFF
--- a/apps/mantine.dev/src/components/MdxProvider/MdxPackagesInstallation/data.ts
+++ b/apps/mantine.dev/src/components/MdxProvider/MdxPackagesInstallation/data.ts
@@ -55,7 +55,12 @@ export const PACKAGES_DATA = [
   {
     package: '@mantine/carousel',
     description: 'Embla based carousel component',
-    dependencies: ['@mantine/hooks', '@mantine/core', '@mantine/carousel', 'embla-carousel-react'],
+    dependencies: [
+      '@mantine/hooks',
+      '@mantine/core',
+      '@mantine/carousel',
+      'embla-carousel-react@^7.1.0',
+    ],
   },
   {
     package: '@mantine/spotlight',


### PR DESCRIPTION
modified to specify v7 since the latest version of embla-carousel-react is now v8