### PR TITLE
[@mantine/core] fix: `isNumberLike` should only check for valid css

### DIFF
--- a/packages/@mantine/core/src/core/utils/is-number-like/is-number-like.test.ts
+++ b/packages/@mantine/core/src/core/utils/is-number-like/is-number-like.test.ts
@@ -36,4 +36,11 @@ describe('@mantine/core/isNumberLike', () => {
     expect(isNumberLike('a')).toBe(false);
     expect(isNumberLike('a1')).toBe(false);
   });
+
+  it('returns false for custom sizes', () => {
+    expect(isNumberLike('2xl')).toBe(false);
+    expect(isNumberLike('3xl')).toBe(false);
+    expect(isNumberLike('2xs')).toBe(false);
+    expect(isNumberLike('3xs')).toBe(false);
+  });
 });

--- a/packages/@mantine/core/src/core/utils/is-number-like/is-number-like.ts
+++ b/packages/@mantine/core/src/core/utils/is-number-like/is-number-like.ts
@@ -12,7 +12,10 @@ export function isNumberLike(value: unknown) {
       return true;
     }
 
-    return /[0-9]/.test(value.trim().replace('-', '')[0]);
+    const cssUnitsRegex =
+      /^[+-]?[0-9]+(\.[0-9]+)?(px|em|rem|ex|ch|lh|rlh|vw|vh|vmin|vmax|vb|vi|svw|svh|lvw|lvh|dvw|dvh|cm|mm|in|pt|pc|q|%)?$/;
+    const values = value.trim().split(/\s+/);
+    return values.every((val) => cssUnitsRegex.test(val));
   }
 
   return false;


### PR DESCRIPTION
fixes: https://github.com/mantinedev/mantine/issues/6853

updated `isNumberLike` func so that it'll return true when it's valid css props. otherwise false. 
eg) 2xl

I've checked all test passes, and added test for custom sizes