### PR TITLE
[@mantine/core] fix: apply flex-wrap in breadcrumbs

### DIFF
--- a/packages/@mantine/core/src/components/Breadcrumbs/Breadcrumbs.module.css
+++ b/packages/@mantine/core/src/components/Breadcrumbs/Breadcrumbs.module.css
@@ -1,6 +1,7 @@
 .root {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .breadcrumb {


### PR DESCRIPTION
Fixes #6862 

This fix addresses the issue of the Breadcrumbs component breaking on mobile and similar devices. By adding `flex-wrap: wrap;` to the **root** style, the layout will now adjust correctly on smaller screens, preventing UI breakage.

Before: 
![Screen Shot 2024-09-21 at 16 11 16 PM](https://github.com/user-attachments/assets/b0ae8002-8d08-4efb-93b3-ff30e6ff422f)

After:
![Screen Shot 2024-09-21 at 16 11 49 PM](https://github.com/user-attachments/assets/50dd06c5-8d15-4986-b39c-f63a79322f84)
