### PR TITLE
[@mantine/core] feat: switch theme variant for buttons

### DIFF
--- a/packages/@docs/demos/src/demos/core/Button/Button.demo.switchThemeVariant.tsx
+++ b/packages/@docs/demos/src/demos/core/Button/Button.demo.switchThemeVariant.tsx
@@ -1,0 +1,49 @@
+import { Button, createTheme, Group, MantineThemeProvider } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { Group, Button, MantineProvider, createTheme } from '@mantine/core';
+
+function Demo() {
+  return (
+    <MantineThemeProvider theme={theme}>
+      <Group>
+        <Button
+          variant={{
+            light: 'filled',
+            dark: 'outline',
+          }}
+        >
+          Primary variant
+        </Button>
+      </Group>
+    </MantineThemeProvider>
+  );
+}
+`;
+
+const theme = createTheme();
+
+function Demo() {
+  return (
+    <MantineThemeProvider theme={theme}>
+      <Group>
+        <Button
+          variant={{
+            light: 'filled',
+            dark: 'outline',
+          }}
+        >
+          Primary variant
+        </Button>
+      </Group>
+    </MantineThemeProvider>
+  );
+}
+
+export const switchThemeVariant: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  centered: true,
+  code,
+};

--- a/packages/@docs/demos/src/demos/core/Button/Button.demo.switchThemeVariant.tsx
+++ b/packages/@docs/demos/src/demos/core/Button/Button.demo.switchThemeVariant.tsx
@@ -4,6 +4,8 @@ import { MantineDemo } from '@mantinex/demo';
 const code = `
 import { Group, Button, MantineProvider, createTheme } from '@mantine/core';
 
+const theme = createTheme();
+
 function Demo() {
   return (
     <MantineThemeProvider theme={theme}>
@@ -14,7 +16,7 @@ function Demo() {
             dark: 'outline',
           }}
         >
-          Primary variant
+          Button
         </Button>
       </Group>
     </MantineThemeProvider>
@@ -34,7 +36,7 @@ function Demo() {
             dark: 'outline',
           }}
         >
-          Primary variant
+          Button
         </Button>
       </Group>
     </MantineThemeProvider>

--- a/packages/@docs/demos/src/demos/core/Button/Button.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/core/Button/Button.demos.story.tsx
@@ -82,3 +82,8 @@ export const Demo_autoContrast = {
   name: '⭐ Demo: autoContrast',
   render: renderDemo(demos.autoContrast),
 };
+
+export const Demo_switchThemeVariant = {
+  name: '⭐ Demo: switchThemeVariant',
+  render: renderDemo(demos.switchThemeVariant),
+};

--- a/packages/@docs/demos/src/demos/core/Button/index.ts
+++ b/packages/@docs/demos/src/demos/core/Button/index.ts
@@ -14,3 +14,4 @@ export { sectionsJustify } from './Button.demo.sectionsJustify';
 export { disabledLink } from './Button.demo.disabledLink';
 export { stylesApi } from './Button.demo.stylesApi';
 export { autoContrast } from './Button.demo.autoContrast';
+export { switchThemeVariant } from './Button.demo.switchThemeVariant';

--- a/packages/@mantine/core/src/components/Button/Button.story.tsx
+++ b/packages/@mantine/core/src/components/Button/Button.story.tsx
@@ -353,6 +353,21 @@ export function ButtonGroup() {
   );
 }
 
+export function SwitchThemeVariant() {
+  return (
+    <div style={{ padding: 40 }}>
+      <Button
+        variant={{
+          light: 'default',
+          dark: 'filled',
+        }}
+      >
+        Default
+      </Button>
+    </div>
+  );
+}
+
 export function Unstyled() {
   return (
     <div style={{ padding: 40 }}>

--- a/packages/@mantine/core/src/components/Button/Button.story.tsx
+++ b/packages/@mantine/core/src/components/Button/Button.story.tsx
@@ -362,7 +362,7 @@ export function SwitchThemeVariant() {
           dark: 'filled',
         }}
       >
-        Default
+        Button
       </Button>
     </div>
   );

--- a/packages/@mantine/core/src/components/Button/Button.tsx
+++ b/packages/@mantine/core/src/components/Button/Button.tsx
@@ -23,7 +23,7 @@ import { ButtonGroup } from './ButtonGroup/ButtonGroup';
 import classes from './Button.module.css';
 
 export type ButtonStylesNames = 'root' | 'inner' | 'loader' | 'section' | 'label';
-export type ButtonVariant =
+export type ButtonVariantTypes =
   | 'filled'
   | 'light'
   | 'outline'
@@ -32,6 +32,10 @@ export type ButtonVariant =
   | 'subtle'
   | 'default'
   | 'gradient';
+
+export type ButtonVariant =
+  | ButtonVariantTypes
+  | { dark?: ButtonVariantTypes; light?: ButtonVariantTypes };
 
 export type ButtonCssVariables = {
   root:

--- a/packages/@mantine/core/src/core/MantineProvider/color-functions/default-variant-colors-resolver/default-variant-colors-resolver.ts
+++ b/packages/@mantine/core/src/core/MantineProvider/color-functions/default-variant-colors-resolver/default-variant-colors-resolver.ts
@@ -1,5 +1,6 @@
 import { rem } from '../../../utils';
 import { MantineColor, MantineGradient, MantineTheme } from '../../theme.types';
+import { useMantineColorScheme } from '../../use-mantine-color-scheme';
 import { darken } from '../darken/darken';
 import { getGradient } from '../get-gradient/get-gradient';
 import { parseThemeColor } from '../parse-theme-color/parse-theme-color';
@@ -8,7 +9,7 @@ import { rgba } from '../rgba/rgba';
 export interface VariantColorsResolverInput {
   color: MantineColor | undefined;
   theme: MantineTheme;
-  variant: string;
+  variant: string | { dark?: string; light?: string };
   gradient?: MantineGradient;
   autoContrast?: boolean;
 }
@@ -33,10 +34,19 @@ export const defaultVariantColorsResolver: VariantColorsResolver = ({
   autoContrast,
 }) => {
   const parsed = parseThemeColor({ color, theme });
+  const { colorScheme } = useMantineColorScheme();
 
   const _autoContrast = typeof autoContrast === 'boolean' ? autoContrast : theme.autoContrast;
+  const realVariant =
+    typeof variant === 'string'
+      ? variant
+      : colorScheme === 'light'
+        ? variant?.light
+        : colorScheme === 'dark'
+          ? variant?.dark
+          : variant;
 
-  if (variant === 'filled') {
+  if (realVariant === 'filled') {
     const textColor = _autoContrast
       ? parsed.isLight
         ? 'var(--mantine-color-black)'
@@ -68,7 +78,7 @@ export const defaultVariantColorsResolver: VariantColorsResolver = ({
     };
   }
 
-  if (variant === 'light') {
+  if (realVariant === 'light') {
     if (parsed.isThemeColor) {
       if (parsed.shade === undefined) {
         return {
@@ -97,7 +107,7 @@ export const defaultVariantColorsResolver: VariantColorsResolver = ({
     };
   }
 
-  if (variant === 'outline') {
+  if (realVariant === 'outline') {
     if (parsed.isThemeColor) {
       if (parsed.shade === undefined) {
         return {
@@ -124,7 +134,7 @@ export const defaultVariantColorsResolver: VariantColorsResolver = ({
     };
   }
 
-  if (variant === 'subtle') {
+  if (realVariant === 'subtle') {
     if (parsed.isThemeColor) {
       if (parsed.shade === undefined) {
         return {
@@ -153,7 +163,7 @@ export const defaultVariantColorsResolver: VariantColorsResolver = ({
     };
   }
 
-  if (variant === 'transparent') {
+  if (realVariant === 'transparent') {
     if (parsed.isThemeColor) {
       if (parsed.shade === undefined) {
         return {
@@ -180,7 +190,7 @@ export const defaultVariantColorsResolver: VariantColorsResolver = ({
     };
   }
 
-  if (variant === 'white') {
+  if (realVariant === 'white') {
     if (parsed.isThemeColor) {
       if (parsed.shade === undefined) {
         return {
@@ -207,7 +217,7 @@ export const defaultVariantColorsResolver: VariantColorsResolver = ({
     };
   }
 
-  if (variant === 'gradient') {
+  if (realVariant === 'gradient') {
     return {
       background: getGradient(gradient, theme),
       hover: getGradient(gradient, theme),
@@ -216,7 +226,7 @@ export const defaultVariantColorsResolver: VariantColorsResolver = ({
     };
   }
 
-  if (variant === 'default') {
+  if (realVariant === 'default') {
     return {
       background: 'var(--mantine-color-default)',
       hover: 'var(--mantine-color-default-hover)',

--- a/packages/@mantine/core/src/core/factory/factory.tsx
+++ b/packages/@mantine/core/src/core/factory/factory.tsx
@@ -10,7 +10,7 @@ export interface FactoryPayload {
   ref?: any;
   stylesNames?: string;
   vars?: any;
-  variant?: string;
+  variant?: string | { dark?: string; light?: string };
   staticComponents?: Record<string, any>;
   // Compound components cannot have classNames, styles and vars on MantineProvider
   compound?: boolean;

--- a/packages/@mantine/core/src/core/styles-api/styles-api.types.ts
+++ b/packages/@mantine/core/src/core/styles-api/styles-api.types.ts
@@ -45,7 +45,9 @@ export type StylesRecord<StylesNames extends string, Payload> = Partial<
 
 export interface StylesApiProps<Payload extends FactoryPayload> {
   unstyled?: boolean;
-  variant?: Payload['variant'] extends string ? Payload['variant'] | (string & {}) : string;
+  variant?: Payload['variant'] extends string | { dark?: string; light?: string }
+    ? Payload['variant']
+    : string | { dark?: string; light?: string };
   classNames?: ClassNames<Payload>;
   styles?: Styles<Payload>;
   vars?: PartialVarsResolver<Payload>;


### PR DESCRIPTION
```javascript
<Button
  variant={{
    light: 'filled',
    dark: 'outline',
  }}
>
  Button
</Button>
``` 

actually this is just an idea, this can be applied to all other components. i think it is a good idea as a user experience.