### PR TITLE
Clarify that hooks also count as Mantine components

### DIFF
--- a/apps/help.mantine.dev/src/pages/q/mantine-provider-missing.mdx
+++ b/apps/help.mantine.dev/src/pages/q/mantine-provider-missing.mdx
@@ -18,7 +18,7 @@ export default Layout(meta);
 The error above occurs in the following cases:
 
 - You are do not have `MantineProvider` in your app at all
-- You are rendering Mantine components outside of `MantineProvider` context
+- You are rendering Mantine components outside of `MantineProvider` context (this includes hooks, e.g. `useMantineColorScheme()`)
 - You have different versions of `@mantine/*` packages in your application.
   For example, you have `@mantine/core@7.0.0` and `@mantine/dates@7.1.0` installed.
 - There was an issue during packages installation. Usually this happens with pnpm.


### PR DESCRIPTION
Both hooks and components need to be inside the MantineProvider.