### PR TITLE
[@mantine/chart] remove unused css from `PieChart`

### DIFF
--- a/packages/@mantine/charts/src/PieChart/PieChart.module.css
+++ b/packages/@mantine/charts/src/PieChart/PieChart.module.css
@@ -8,8 +8,3 @@
     outline: 0;
   }
 }
-
-.label {
-  fill: var(--mantine-color-white);
-  font-size: var(--mantine-font-size-xs);
-}


### PR DESCRIPTION
Removed unused css from PieChart. Probably copied and pasted from DonutChart was left in place.