### PR TITLE
fix: typo for onKeyDown method in MenuItem

### DIFF
--- a/packages/@mantine/core/src/components/Menu/MenuItem/MenuItem.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuItem/MenuItem.tsx
@@ -116,7 +116,7 @@ export const MenuItem = polymorphicFactory<MenuItemFactory>((props, ref) => {
         loop: ctx.loop,
         dir,
         orientation: 'vertical',
-        onKeyDown: _others.onKeydown,
+        onKeyDown: _others.onKeyDown,
       })}
       __vars={{
         '--menu-item-color':


### PR DESCRIPTION
Noticed that typo when I wanted to create an advanced interaction.