### PR TITLE
fix(hooks): resolve hydration issues by deferring state updates with startTransition in useResizing

### DIFF
--- a/packages/@mantine/core/src/components/AppShell/use-resizing/use-resizing.tsx
+++ b/packages/@mantine/core/src/components/AppShell/use-resizing/use-resizing.tsx
@@ -14,18 +14,25 @@ export function useResizing({ transitionDuration, disabled }: UseResizingInput) 
   useWindowEvent('resize', () => {
     setResizing(true);
     clearTimeout(resizingTimeout.current);
-    resizingTimeout.current = window.setTimeout(() => setResizing(false), 200);
+    resizingTimeout.current = window.setTimeout(
+      () =>
+        startTransition(() => {
+          setResizing(false);
+        }),
+      200
+    );
   });
 
   useIsomorphicEffect(() => {
-    startTransition(() => {
-      setResizing(true);
-      clearTimeout(disabledTimeout.current);
-      disabledTimeout.current = window.setTimeout(
-        () => setResizing(false),
-        transitionDuration || 0
-      );
-    });
+    setResizing(true);
+    clearTimeout(disabledTimeout.current);
+    disabledTimeout.current = window.setTimeout(
+      () =>
+        startTransition(() => {
+          setResizing(false);
+        }),
+      transitionDuration || 0
+    );
   }, [disabled, transitionDuration]);
 
   return resizing;


### PR DESCRIPTION
Fixes [#6883](https://github.com/mantinedev/mantine/issues/6883) and https://github.com/mantinedev/mantine/issues/5979

Here's a screen recording before and after the fix:


https://github.com/user-attachments/assets/ae9a799d-e586-4a27-80f7-a7368e0b68f3

