### PR TITLE
[mantine.dev] Unify NumberFormatter and NumberInput prefixSuffix demo

### DIFF
--- a/packages/@docs/demos/src/demos/core/NumberFormatter/NumberFormatter.demo.prefixSuffix.tsx
+++ b/packages/@docs/demos/src/demos/core/NumberFormatter/NumberFormatter.demo.prefixSuffix.tsx
@@ -8,10 +8,10 @@ function Demo() {
   return (
     <>
       <div>
-        With prefix: <NumberFormatter prefix="$ " value={100} />
+        With prefix: <NumberFormatter prefix="$" value={100} />
       </div>
       <div>
-        With suffix: <NumberFormatter value={100} suffix=" RUB" />
+        With suffix: <NumberFormatter value={100} suffix="%" />
       </div>
     </>
   );
@@ -22,10 +22,10 @@ function Demo() {
   return (
     <>
       <div>
-        With prefix: <NumberFormatter prefix="$ " value={100} />
+        With prefix: <NumberFormatter prefix="$" value={100} />
       </div>
       <div>
-        With suffix: <NumberFormatter value={100} suffix=" RUB" />
+        With suffix: <NumberFormatter value={100} suffix="%" />
       </div>
     </>
   );

--- a/packages/@docs/demos/src/demos/core/NumberFormatter/NumberFormatter.demo.usage.tsx
+++ b/packages/@docs/demos/src/demos/core/NumberFormatter/NumberFormatter.demo.usage.tsx
@@ -5,12 +5,12 @@ const code = `
 import { NumberFormatter } from '@mantine/core';
 
 function Demo() {
-  return <NumberFormatter prefix="$ " value={1000000} thousandSeparator />;
+  return <NumberFormatter prefix="$" value={1000000} thousandSeparator />;
 }
 `;
 
 function Demo() {
-  return <NumberFormatter prefix="$ " value={1000000} thousandSeparator />;
+  return <NumberFormatter prefix="$" value={1000000} thousandSeparator />;
 }
 
 export const usage: MantineDemo = {


### PR DESCRIPTION
Hi,
  I changed `<NumberFormatter />` demo to use the same `prefix` and `suffix` values as in `<NumberInput />` demo.