### PR TITLE
[mantine.dev] Add missing configuration for `virtualColors`

### DIFF
--- a/packages/@docs/demos/src/demos/theming/Theming.demo.virtualColors.tsx
+++ b/packages/@docs/demos/src/demos/theming/Theming.demo.virtualColors.tsx
@@ -25,6 +25,7 @@ const theme = createTheme({
       light: 'cyan',
     }),
   },
+  primaryColor: 'primary',
 });
 
 function App() {


### PR DESCRIPTION
Without this property, `virtualColors` won't work