### PR TITLE
[@mantine/core] refactor: type ClientRect to DOMRect

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollAreaScrollbar/Scrollbar.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollAreaScrollbar/Scrollbar.tsx
@@ -38,7 +38,7 @@ export const Scrollbar = forwardRef<HTMLDivElement, ScrollbarProps>((props, forw
   const context = useScrollAreaContext();
   const [scrollbar, setScrollbar] = useState<HTMLDivElement | null>(null);
   const composeRefs = useMergedRef(forwardedRef, (node) => setScrollbar(node));
-  const rectRef = useRef<ClientRect | null>(null);
+  const rectRef = useRef<DOMRect | null>(null);
   const prevWebkitUserSelectRef = useRef<string>('');
   const { viewport } = context;
   const maxScrollPos = sizes.content - sizes.viewport;


### PR DESCRIPTION
`ClientRect` is deprecated in TypeScript 4.4.
Then I refactored `ClientRect` to `DOMRect`.