### PR TITLE
[@mantine/dates] fix timeInputProps defaultValue not working

### DIFF
--- a/packages/@mantine/dates/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/packages/@mantine/dates/src/components/DateTimePicker/DateTimePicker.tsx
@@ -142,7 +142,7 @@ export const DateTimePicker = factory<DateTimePickerFactory>((_props, ref) => {
   });
 
   const formatTime = (dateValue: Date) =>
-    dateValue ? dayjs(dateValue).format(withSeconds ? 'HH:mm:ss' : 'HH:mm') : '';
+    dateValue ? dayjs(dateValue).format(withSeconds ? 'HH:mm:ss' : 'HH:mm') : undefined;
 
   const [timeValue, setTimeValue] = useState(formatTime(_value!));
   const [currentLevel, setCurrentLevel] = useState(level || defaultLevel || 'month');


### PR DESCRIPTION
Fixes #6958 and is self-explanatory