### PR TITLE
[@mantine/core] Update create-polymorphic-component.ts

### DIFF
--- a/packages/@mantine/core/src/core/factory/create-polymorphic-component.ts
+++ b/packages/@mantine/core/src/core/factory/create-polymorphic-component.ts
@@ -33,7 +33,7 @@ export function createPolymorphicComponent<
   type ComponentProps<C> = PolymorphicComponentProps<C, Props>;
 
   type _PolymorphicComponent = <C = ComponentDefaultType>(
-    props: ComponentProps<C>
+    props: ComponentProps<C> & Props
   ) => React.ReactElement;
 
   type ComponentProperties = Omit<React.FunctionComponent<ComponentProps<any>>, never>;


### PR DESCRIPTION
Prevents TypeScript from showing the error: "Expression produces a union type that is too complex to represent.", when props are extended from interfaces such as StackProps and provided as explicit type to createPolymorphicComponent.