### PR TITLE
[@mantine/core] Handle touchend event on password visibility toggle

### DIFF
--- a/packages/@mantine/core/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/@mantine/core/src/components/PasswordInput/PasswordInput.tsx
@@ -155,6 +155,11 @@ export const PasswordInput = factory<PasswordInputFactory>((_props, ref) => {
       variant="subtle"
       color="gray"
       unstyled={unstyled}
+      onTouchEnd={(event) => {
+        event.preventDefault();
+        visibilityToggleButtonProps?.onTouchEnd?.(event);
+        toggleVisibility();
+      }}
       onMouseDown={(event) => {
         event.preventDefault();
         visibilityToggleButtonProps?.onMouseDown?.(event);


### PR DESCRIPTION
Fixes https://github.com/mantinedev/mantine/issues/6652 by handling `touchend` event for password visibility toggle to avoid caret jump.