### PR TITLE
[@mantine/core] Added height to scrollContainer

### DIFF
--- a/packages/@mantine/core/src/components/Table/Table.module.css
+++ b/packages/@mantine/core/src/components/Table/Table.module.css
@@ -100,6 +100,7 @@
 
 .scrollContainer {
   overflow-x: var(--table-overflow);
+  height: 95vh;
 }
 
 .scrollContainerInner {


### PR DESCRIPTION
Fix for the sticky header bug on the issue #6960.

- Bug: [Stackblitz-link](https://stackblitz.com/edit/mantine-bug-table-sticky-header-with-scrollcontainer?file=src%2FTableDemo.tsx)
- Fix: [Stackblitz-link](https://stackblitz.com/edit/mantine-bug-table-sticky-header-with-scrollcontai-u3wnif?file=vite.config.ts,package.json,src%2FApp.tsx,src%2Fdata.ts,src%2FTableDemo.tsx)