### PR TITLE
Fix condition for isValidNumber in NumberInput

### DIFF
--- a/packages/@mantine/core/src/components/NumberInput/NumberInput.tsx
+++ b/packages/@mantine/core/src/components/NumberInput/NumberInput.tsx
@@ -38,18 +38,14 @@ function getDecimalPlaces(inputValue: string | number): number {
   return inputValue.toString().replace('.', '').length;
 }
 
-function isValidNumber(
-  floatValue: number | undefined,
-  value: string | undefined
-): floatValue is number {
-  if (typeof value === 'string') {
-    return getDecimalPlaces(value) < 14 && value !== '';
-  }
-
+function isValidNumber(floatValue: number | undefined, value: string): floatValue is number {
   return (
     (typeof floatValue === 'number'
       ? floatValue < Number.MAX_SAFE_INTEGER
-      : !Number.isNaN(Number(floatValue))) && !Number.isNaN(floatValue)
+      : !Number.isNaN(Number(floatValue))) &&
+    !Number.isNaN(floatValue) &&
+    getDecimalPlaces(value) < 14 &&
+    value !== ''
   );
 }
 


### PR DESCRIPTION
Previously values that only contain a minus would have been considered valid which triggers things like min/max clamping even though it should not.

According to the types `value` should always be a string and never undefined which made it easier to collapse the conditions into one. This fixed my reproduction script that was posted in the issue.

Fixes #6969