### PR TITLE
Add better typings to `useClickOutside` hook

### DIFF
--- a/packages/@mantine/hooks/src/use-click-outside/use-click-outside.ts
+++ b/packages/@mantine/hooks/src/use-click-outside/use-click-outside.ts
@@ -7,7 +7,7 @@ export function useClickOutside<T extends HTMLElement = any>(
   events?: string[] | null,
   nodes?: (HTMLElement | null)[]
 ) {
-  const ref = useRef<T>();
+  const ref = useRef<T|null>(null);
 
   useEffect(() => {
     const listener = (event: any) => {

--- a/packages/@mantine/hooks/src/use-click-outside/use-click-outside.ts
+++ b/packages/@mantine/hooks/src/use-click-outside/use-click-outside.ts
@@ -7,7 +7,7 @@ export function useClickOutside<T extends HTMLElement = any>(
   events?: string[] | null,
   nodes?: (HTMLElement | null)[]
 ) {
-  const ref = useRef<T|null>(null);
+  const ref = useRef<T | null>(null);
 
   useEffect(() => {
     const listener = (event: any) => {


### PR DESCRIPTION
Right now, the return type of the hook is `MutableRefObject<T | undefined>` which results in typescript errors when binding it to input elements.

![image](https://github.com/user-attachments/assets/a2a313b3-52de-4ab5-aea8-e7134ca0fc4a)
![image](https://github.com/user-attachments/assets/542808ca-68ba-4bdd-8499-1a1fd4e588f3)

here is the entire error:
![image](https://github.com/user-attachments/assets/fe463ab7-3e2a-489a-8a65-61057850eae6)

This PR changes the return type to `MutableRefObject<T | null>` so that it binds to input elements correctly.