### PR TITLE
Issue #7010 key prop added to area chart

### DIFF
--- a/packages/@mantine/charts/src/CompositeChart/CompositeChart.tsx
+++ b/packages/@mantine/charts/src/CompositeChart/CompositeChart.tsx
@@ -286,6 +286,7 @@ export const CompositeChart = factory<CompositeChartFactory>((_props, ref) => {
       return (
         <Area
           {...getStyles('area')}
+          key={item.name}
           name={item.name}
           type={curveType}
           dataKey={item.name}


### PR DESCRIPTION
Fixes #7010
The unique key property has been added to the area type of the composite chart to resolve the console error.