### PR TITLE
Wrap resetDirty in a useCallback

### DIFF
--- a/packages/@mantine/form/src/hooks/use-form-status/use-form-status.ts
+++ b/packages/@mantine/form/src/hooks/use-form-status/use-form-status.ts
@@ -79,13 +79,13 @@ export function useFormStatus<Values extends Record<string, any>>({
 
   const resetTouched: ResetStatus = useCallback(() => setTouched({}), []);
 
-  const resetDirty: ResetDirty<Values> = (values) => {
+  const resetDirty: ResetDirty<Values> = useCallback((values) => {
     const newSnapshot = values
       ? { ...values, ...$values.refValues.current }
       : $values.refValues.current;
     $values.setValuesSnapshot(newSnapshot);
     setDirty({});
-  };
+  }, []);
 
   const setFieldTouched: SetFieldTouched<Values> = useCallback((path, touched) => {
     setTouched((currentTouched) => {


### PR DESCRIPTION
I am using `useForm` and had the result in a dependency array. I noticed that it caused needless executions. I ended up destructuring the result of `useForm` and adding those items to the dependency array. I noticed it worked except for `resetDirty`. It appears it's the only action not wrapped in a `useCallback`. I don't see any reason why it couldn't be so I cut  a quick PR.

Semi-related issue: https://github.com/mantinedev/mantine/issues/5338
