### PR TITLE
Docs - Tabs - added @tanstack/react-router example

### DIFF
--- a/apps/mantine.dev/src/pages/core/tabs.mdx
+++ b/apps/mantine.dev/src/pages/core/tabs.mdx
@@ -184,6 +184,33 @@ function Demo() {
 }
 ```
 
+## Usage with @tanstack/react-router
+
+```tsx
+import { useNavigate, useParams } from '@tanstack/react-router';
+import { Tabs } from '@mantine/core';
+
+function Demo() {
+  const navigate = useNavigate();
+  const { tabValue } = useParams({ from: '/tabs/$tabId' });
+
+  return (
+    <Tabs
+      value={tabValue}
+      onChange={(value) => navigate({
+        to: `/tabs/$tabId`,
+        params: { tabId: value }
+      })}
+    >
+      <Tabs.List>
+        <Tabs.Tab value="first">First tab</Tabs.Tab>
+        <Tabs.Tab value="second">Second tab</Tabs.Tab>
+      </Tabs.List>
+    </Tabs>
+  );
+}
+```
+
 ## Usage with Next.js router
 
 ```tsx


### PR DESCRIPTION
* added the most basic and naive example of how to use Tabs component with `@tanstack/react-router`
![image](https://github.com/user-attachments/assets/0c70d64b-a4b7-4f4e-9214-69fd14c70820)
