### PR TITLE
Combobox: fix selecting elements after opening dropdown with arrow keys

### DIFF
--- a/packages/@mantine/core/src/components/Combobox/use-combobox-target-props/use-combobox-target-props.ts
+++ b/packages/@mantine/core/src/components/Combobox/use-combobox-target-props/use-combobox-target-props.ts
@@ -40,6 +40,7 @@ export function useComboboxTargetProps({
         if (!ctx.store.dropdownOpened) {
           ctx.store.openDropdown('keyboard');
           setSelectedOptionId(ctx.store.selectActiveOption());
+          ctx.store.updateSelectedOptionIndex('selected', { scrollIntoView: true });
         } else {
           setSelectedOptionId(ctx.store.selectNextOption());
         }
@@ -51,6 +52,7 @@ export function useComboboxTargetProps({
         if (!ctx.store.dropdownOpened) {
           ctx.store.openDropdown('keyboard');
           setSelectedOptionId(ctx.store.selectActiveOption());
+          ctx.store.updateSelectedOptionIndex('selected', { scrollIntoView: true });
         } else {
           setSelectedOptionId(ctx.store.selectPreviousOption());
         }


### PR DESCRIPTION
fix #6978 

description:
due to call of combobox.updateSelectedOptionIndex('active', { scrollIntoView: true }); (async) in onDropdownOpen in Select.tsx the reference to the current selected option was set to -1 overwriting 0 from selectActiveOption call. Which then caused the behaviour described in the issue.
Fix provides propper setting reference to the current selected option after opening dropdown with arrows.
