### PR TITLE
[@mantine/charts] fix: Object literal may only specify known properties, and label does not exist in type RadarChartSeries

### DIFF
--- a/packages/@mantine/charts/src/RadarChart/RadarChart.tsx
+++ b/packages/@mantine/charts/src/RadarChart/RadarChart.tsx
@@ -36,6 +36,7 @@ export interface RadarChartSeries {
   color: MantineColor;
   strokeColor?: MantineColor;
   opacity?: number;
+  label?: string;
 }
 
 export type RadarChartStylesNames = 'root' | 'container';


### PR DESCRIPTION
add new properties in RadarChartSeries