### PR TITLE
[@mantine/core] Tooltip: add target option for portal

### DIFF
--- a/src/mantine-core/src/Tooltip/Tooltip.tsx
+++ b/src/mantine-core/src/Tooltip/Tooltip.tsx
@@ -90,6 +90,7 @@ const _Tooltip = forwardRef<HTMLElement, TooltipProps>((props, ref) => {
     onPositionChange,
     opened,
     withinPortal,
+    target,
     radius,
     color,
     classNames,
@@ -145,7 +146,7 @@ const _Tooltip = forwardRef<HTMLElement, TooltipProps>((props, ref) => {
 
   return (
     <>
-      <OptionalPortal withinPortal={withinPortal}>
+      <OptionalPortal withinPortal={withinPortal} target={target}>
         <Transition
           mounted={!disabled && tooltip.opened}
           transition={transition}

--- a/src/mantine-core/src/Tooltip/Tooltip.types.ts
+++ b/src/mantine-core/src/Tooltip/Tooltip.types.ts
@@ -22,6 +22,9 @@ export interface TooltipBaseProps
   /** Determines whether tooltip should be rendered within Portal */
   withinPortal?: boolean;
 
+  /** Target element of Portal component */
+  target?: HTMLElement | string;
+
   /** Radius from theme.radius or number to set border-radius in px */
   radius?: MantineNumberSize;
 


### PR DESCRIPTION
Hey, we are still using mantine v5. There we had the problem, that for a tooltip it was not possible to add a target when rendered in a portal (with withinPortal property).

I added the target option to tooltip that is passed to the OptionalPortal.


Ps: This is my first contribution to open source. Im not sure if im done it correctly. Sorry if not.
Ive tried to use the information on https://v5.mantine.dev/pages/contributing/