### PR TITLE
[@mantine/core] fix: enable overrriding `tabIndex`

### DIFF
--- a/packages/@mantine/core/src/components/Tabs/TabsTab/TabsTab.tsx
+++ b/packages/@mantine/core/src/components/Tabs/TabsTab/TabsTab.tsx
@@ -62,6 +62,7 @@ export const TabsTab = factory<TabsTabFactory>((_props, ref) => {
     styles,
     vars,
     mod,
+    tabIndex,
     ...others
   } = props;
 
@@ -97,7 +98,7 @@ export const TabsTab = factory<TabsTabFactory>((_props, ref) => {
       role="tab"
       id={ctx.getTabId(value)}
       aria-selected={active}
-      tabIndex={active || ctx.value === null ? 0 : -1}
+      tabIndex={tabIndex || active || ctx.value === null ? 0 : -1}
       aria-controls={ctx.getPanelId(value)}
       onClick={activateTab}
       __vars={{ '--tabs-color': color ? getThemeColor(color, theme) : undefined }}


### PR DESCRIPTION
fixes: https://github.com/mantinedev/mantine/issues/7055