### PR TITLE
Introducing Mantine Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Help wanted](https://img.shields.io/github/labels/mantinedev/mantine/help%20wanted?label=Contribute)](https://github.com/mantinedev/mantine/labels/help%20wanted)
 [![Discord](https://img.shields.io/badge/Chat%20on-Discord-%235865f2)](https://discord.gg/wbH82zuWMN)
 [![X Follow](https://img.shields.io/twitter/follow/mantinedev?style=social)](https://x.com/mantinedev)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Mantine%20Guru-006BFF)](https://gurubase.io/g/mantine)
 
 ## Links
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Mantine Guru](https://gurubase.io/g/mantine) to Gurubase. Mantine Guru uses the data from this repo and data from the [docs](https://mantine.dev/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Mantine Guru", which highlights that Mantine now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Mantine Guru in Gurubase, just let me know that's totally fine.
