### PR TITLE
Narrow type of `NotificationData`

### DIFF
--- a/packages/@mantine/notifications/src/notifications.store.ts
+++ b/packages/@mantine/notifications/src/notifications.store.ts
@@ -10,7 +10,9 @@ export type NotificationPosition =
   | 'bottom-right'
   | 'bottom-center';
 
-export interface NotificationData extends Omit<NotificationProps, 'onClose'>, Record<`data-${string}`, any> {
+export interface NotificationData
+  extends Omit<NotificationProps, 'onClose'>,
+    Record<`data-${string}`, any> {
   /** Notification id, can be used to close or update notification */
   id?: string;
 

--- a/packages/@mantine/notifications/src/notifications.store.ts
+++ b/packages/@mantine/notifications/src/notifications.store.ts
@@ -10,7 +10,7 @@ export type NotificationPosition =
   | 'bottom-right'
   | 'bottom-center';
 
-export interface NotificationData extends Omit<NotificationProps, 'onClose'>, Record<string, any> {
+export interface NotificationData extends Omit<NotificationProps, 'onClose'>, Record<`data-${string}`, any> {
   /** Notification id, can be used to close or update notification */
   id?: string;
 


### PR DESCRIPTION
e78a9bb9d23654349cf9413674dce08051322762 fixed #5640, but made the `NotificationData` type [overly broad](https://github.com/mantinedev/mantine/issues/5640#issuecomment-1936799846).

This change limits the additional keys to those that start with `data-`. This allows passing `data-` attributes _and_ narrowing the type.