### PR TITLE
[@mantine/core] Fix combobox aria-controls attribute

### DIFF
--- a/packages/@mantine/core/src/components/Combobox/use-combobox-target-props/use-combobox-target-props.ts
+++ b/packages/@mantine/core/src/components/Combobox/use-combobox-target-props/use-combobox-target-props.ts
@@ -94,7 +94,7 @@ export function useComboboxTargetProps({
         'aria-haspopup': 'listbox',
         'aria-expanded':
           (withExpandedAttribute && !!(ctx.store.listId && ctx.store.dropdownOpened)) || undefined,
-        'aria-controls': ctx.store.listId,
+        'aria-controls': ctx.store.dropdownOpened ? ctx.store.listId : undefined,
         'aria-activedescendant': ctx.store.dropdownOpened
           ? selectedOptionId || undefined
           : undefined,


### PR DESCRIPTION
Resolves #7085

- Checks if the dropdown is open, if it's true, add "aria-controls" attribute, else, set as undefined.
