### PR TITLE
[@mantine/core] Add support for custom variant in PasswordInput visibility toggle button

### DIFF
--- a/packages/@mantine/core/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/@mantine/core/src/components/PasswordInput/PasswordInput.tsx
@@ -152,7 +152,7 @@ export const PasswordInput = factory<PasswordInputFactory>((_props, ref) => {
       aria-hidden={!visibilityToggleButtonProps}
       tabIndex={-1}
       {...visibilityToggleButtonProps}
-      variant={visibilityToggleButtonProps?.variant ?? "subtle"}
+      variant={visibilityToggleButtonProps?.variant ?? 'subtle'}
       color="gray"
       unstyled={unstyled}
       onTouchEnd={(event) => {


### PR DESCRIPTION
The variant prop for the visibility toggle button is now taken from `visibilityToggleButtonProps` if provided.

Defaults to "subtle" when no variant is specified in `visibilityToggleButtonProps`.