### PR TITLE
Add clip paths to floating arrow

### DIFF
--- a/packages/@mantine/core/src/components/Floating/FloatingArrow/get-arrow-position-styles.ts
+++ b/packages/@mantine/core/src/components/Floating/FloatingArrow/get-arrow-position-styles.ts
@@ -96,6 +96,7 @@ export function getArrowPositionStyles({
       right: arrowPlacement,
       borderLeftColor: 'transparent',
       borderBottomColor: 'transparent',
+      clipPath: 'polygon(100% 0, 0 0, 100% 100%)',
     };
   }
 
@@ -106,6 +107,7 @@ export function getArrowPositionStyles({
       left: arrowPlacement,
       borderRightColor: 'transparent',
       borderTopColor: 'transparent',
+      clipPath: 'polygon(0 100%, 0 0, 100% 100%)',
     };
   }
 
@@ -116,6 +118,7 @@ export function getArrowPositionStyles({
       bottom: arrowPlacement,
       borderTopColor: 'transparent',
       borderLeftColor: 'transparent',
+      clipPath: 'polygon(0 100%, 100% 100%, 100% 0)',
     };
   }
 
@@ -126,6 +129,7 @@ export function getArrowPositionStyles({
       top: arrowPlacement,
       borderBottomColor: 'transparent',
       borderRightColor: 'transparent',
+      clipPath: 'polygon(0 100%, 0 0, 100% 0)',
     };
   }
 


### PR DESCRIPTION
Add clip paths to floating arrow to prevent larger arrow sizes from being visible when hovering a child component (like in menus)

Current Arrow with red background color for clarity:
![Menu - Controlled ⋅ Storybook 2024-11-20 at 1 34 46 PM](https://github.com/user-attachments/assets/5d4f2f65-9384-4b7d-9a39-7b27a5fa5d23)

With clip paths:
![Menu - Controlled ⋅ Storybook 2024-11-20 at 1 38 26 PM](https://github.com/user-attachments/assets/af59b751-4bd9-4cc1-ae85-e5ee102dc193)

With clip paths without background for clarity:
![Menu - Controlled ⋅ Storybook 2024-11-20 at 1 39 01 PM](https://github.com/user-attachments/assets/fa750320-2ff3-4bde-933c-2e985417574c)

