### PR TITLE
[DonutChart] Add render label function

### DIFF
--- a/packages/@mantine/charts/src/DonutChart/DonutChart.tsx
+++ b/packages/@mantine/charts/src/DonutChart/DonutChart.tsx
@@ -245,10 +245,7 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
             paddingAngle={paddingAngle}
             startAngle={startAngle}
             endAngle={endAngle}
-            label={
-              withLabels ? getLabel(labelsType || 'value', valueFormatter)
-                : false
-            }
+            label={withLabels ? getLabel(labelsType || 'value', valueFormatter) : false}
             labelLine={
               withLabelsLine
                 ? {

--- a/packages/@mantine/charts/src/DonutChart/DonutChart.tsx
+++ b/packages/@mantine/charts/src/DonutChart/DonutChart.tsx
@@ -153,7 +153,7 @@ const getLabelValue = (
   return value;
 };
 
-export const getLabel =
+const getLabel =
   (labelsType: 'value' | 'percent', valueFormatter?: DonutChartProps['valueFormatter']): PieLabel =>
   ({ x, y, cx, cy, percent, value }) => (
     <text


### PR DESCRIPTION
Use a similar label render function as the Pie Chart for Donut Chart in order to apply the _valueformatter_ to the label.

Also adds the _labelsType_: value or percent, similar to Pie Chart.

Omitted the inside label option since it doesn't make sense on the Donut Chart in my opinion.