### PR TITLE
[@mantine/core] Update docs for Select, MultiSelect, Autocomplete to warn about data props consisting of unique values

### DIFF
--- a/packages/@mantine/core/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/@mantine/core/src/components/Autocomplete/Autocomplete.tsx
@@ -33,7 +33,7 @@ export interface AutocompleteProps
     Omit<ComboboxLikeProps, 'data'>,
     StylesApiProps<AutocompleteFactory>,
     ElementProps<'input', 'onChange' | 'size'> {
-  /** Data displayed in the dropdown */
+  /** Data displayed in the dropdown. Values must be unique, otherwise an error will be thrown and component will not render. */
   data?: ComboboxStringData;
 
   /** Controlled component value */

--- a/packages/@mantine/core/src/components/Combobox/Combobox.types.ts
+++ b/packages/@mantine/core/src/components/Combobox/Combobox.types.ts
@@ -32,7 +32,7 @@ export type ComboboxParsedItem = ComboboxItem | ComboboxParsedItemGroup;
 export type ComboboxLikeStylesNames = Exclude<ComboboxStylesNames, 'header' | 'footer' | 'search'>;
 
 export interface ComboboxLikeProps {
-  /** Data used to generate options */
+  /** Data used to generate options. Values must be unique, otherwise an error will be thrown and component will not render. */
   data?: ComboboxData;
 
   /** Controlled dropdown opened state */

--- a/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
+++ b/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
@@ -45,7 +45,7 @@ export interface TagsInputProps
     Omit<ComboboxLikeProps, 'data'>,
     StylesApiProps<TagsInputFactory>,
     ElementProps<'input', 'size' | 'value' | 'defaultValue' | 'onChange'> {
-  /** Data displayed in the dropdown */
+  /** Data displayed in the dropdown. Values must be unique, otherwise an error will be thrown and component will not render. */
   data?: ComboboxStringData;
 
   /** Controlled component value */


### PR DESCRIPTION
Since we decided not to change the validation requirement for the options, we should add some docs about this constraint.

See https://github.com/mantinedev/mantine/issues/7176 for previous discussion