### PR TITLE
[@mantine/modals] Expose Modals Manager props

### DIFF
--- a/packages/@mantine/modals/src/ModalsProvider.tsx
+++ b/packages/@mantine/modals/src/ModalsProvider.tsx
@@ -148,8 +148,8 @@ export function ModalsProvider({ children, modalProps, labels, modals }: ModalsP
   );
 
   const updateContextModal = useCallback(
-    (payload: { modalId: string } & Partial<OpenContextModal<any>>) => {
-      dispatch({ type: 'UPDATE', modalId: payload.modalId, newProps: payload });
+    ({ modalId, ...newProps }: { modalId: string } & Partial<OpenContextModal<any>>) => {
+      dispatch({ type: 'UPDATE', modalId, newProps });
     },
     [dispatch]
   );

--- a/packages/@mantine/modals/src/ModalsProvider.tsx
+++ b/packages/@mantine/modals/src/ModalsProvider.tsx
@@ -166,6 +166,7 @@ export function ModalsProvider({ children, modalProps, labels, modals }: ModalsP
   });
 
   const ctx: ModalsContextProps = {
+    modalProps,
     modals: state.modals,
     openModal,
     openConfirmModal,

--- a/packages/@mantine/modals/src/ModalsProvider.tsx
+++ b/packages/@mantine/modals/src/ModalsProvider.tsx
@@ -166,7 +166,7 @@ export function ModalsProvider({ children, modalProps, labels, modals }: ModalsP
   });
 
   const ctx: ModalsContextProps = {
-    modalProps,
+    modalProps: modalProps || {},
     modals: state.modals,
     openModal,
     openConfirmModal,

--- a/packages/@mantine/modals/src/context.ts
+++ b/packages/@mantine/modals/src/context.ts
@@ -24,7 +24,7 @@ export type ModalState =
   | { id: string; props: OpenContextModal; type: 'context'; ctx: string };
 
 export interface ModalsContextProps {
-  modalProps?: ModalSettings,
+  modalProps: ModalSettings,
   modals: ModalState[];
   openModal: (props: ModalSettings) => string;
   openConfirmModal: (props: OpenConfirmModal) => string;

--- a/packages/@mantine/modals/src/context.ts
+++ b/packages/@mantine/modals/src/context.ts
@@ -24,6 +24,7 @@ export type ModalState =
   | { id: string; props: OpenContextModal; type: 'context'; ctx: string };
 
 export interface ModalsContextProps {
+  modalProps?: ModalSettings,
   modals: ModalState[];
   openModal: (props: ModalSettings) => string;
   openConfirmModal: (props: OpenConfirmModal) => string;

--- a/packages/@mantine/modals/src/context.ts
+++ b/packages/@mantine/modals/src/context.ts
@@ -24,7 +24,7 @@ export type ModalState =
   | { id: string; props: OpenContextModal; type: 'context'; ctx: string };
 
 export interface ModalsContextProps {
-  modalProps: ModalSettings,
+  modalProps: ModalSettings;
   modals: ModalState[];
   openModal: (props: ModalSettings) => string;
   openConfirmModal: (props: OpenConfirmModal) => string;


### PR DESCRIPTION
I had a use case in my application where I needed to read from the Modals manager props, so I created this PR to allow them to be exposed to the user.

EDIT: I also discovered an error in my implementation of `updateContextModal`, which would throw the following error:
```hook.js:608 Warning: React does not recognize the `modalId` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `modalid` instead. If you accidentally passed it from a parent component, remove it from the DOM element. Error Component Stack```

This occurred because the modalId was unintentionally included in the props passed to the modal component. I have resolved this in the PR by ensuring that modalId is excluded from the props spread onto the modal.