### PR TITLE
Donut chart legend modification

### DIFF
--- a/packages/@mantine/charts/src/DonutChart/DonutChart.story.tsx
+++ b/packages/@mantine/charts/src/DonutChart/DonutChart.story.tsx
@@ -12,7 +12,7 @@ const data = [
 export function Usage() {
   return (
     <div style={{ padding: 40 }}>
-      <DonutChart data={data} strokeWidth={1} strokeColor="red" />
+      <DonutChart data={data} strokeWidth={1} strokeColor="red" legendOrientation="bottom-right" />
     </div>
   );
 }

--- a/packages/@mantine/charts/src/DonutChart/DonutChart.story.tsx
+++ b/packages/@mantine/charts/src/DonutChart/DonutChart.story.tsx
@@ -12,7 +12,7 @@ const data = [
 export function Usage() {
   return (
     <div style={{ padding: 40 }}>
-      <DonutChart data={data} strokeWidth={1} strokeColor="red" legendOrientation="bottom-right" />
+      <DonutChart data={data} strokeWidth={1} strokeColor="red" legendMode="hover" legendOrientation="bottom-right" />
     </div>
   );
 }

--- a/packages/@mantine/charts/src/DonutChart/DonutChart.story.tsx
+++ b/packages/@mantine/charts/src/DonutChart/DonutChart.story.tsx
@@ -12,7 +12,7 @@ const data = [
 export function Usage() {
   return (
     <div style={{ padding: 40 }}>
-      <DonutChart data={data} strokeWidth={1} strokeColor="red" legendMode="hover" legendOrientation="bottom-right" />
+      <DonutChart data={data} strokeWidth={1} strokeColor="red" legendMode="side" legendOrientation="bottom-right" />
     </div>
   );
 }

--- a/packages/@mantine/charts/src/DonutChart/DonutChart.tsx
+++ b/packages/@mantine/charts/src/DonutChart/DonutChart.tsx
@@ -104,6 +104,7 @@ export interface DonutChartProps
 
   /** A function to format values inside the tooltip */
   valueFormatter?: (value: number) => string;
+  legendOrientation?: 'top' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'center-left' | 'center-right';
 }
 
 export type DonutChartFactory = Factory<{
@@ -199,6 +200,7 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
     valueFormatter,
     strokeColor,
     labelsType,
+    legendOrientation,
     ...others
   } = props;
 
@@ -231,6 +233,19 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
       strokeWidth={strokeWidth}
     />
   ));
+
+  const legendPosition = {
+    'top': { x: 0, y: -180 },
+    'bottom': { x: 0, y: 180 },
+    'top-left': { x: -180, y: -180 },
+    'top-right': { x: 180, y: -180 },
+    'bottom-left': { x: -180, y: 180 },
+    'bottom-right': { x: 180, y: 180 },
+    'center-left': { x: -230, y: 0 },
+    'center-right': { x: 230, y: 0 },
+  };
+
+  const legendOffset = legendPosition[legendOrientation || 'center-right'];
 
   return (
     <Box ref={ref} size={size} {...getStyles('root')} {...others}>
@@ -285,6 +300,7 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
                   valueFormatter={valueFormatter}
                 />
               )}
+              position={{ x: legendOffset.x, y: legendOffset.y }}
               {...tooltipProps}
             />
           )}

--- a/packages/@mantine/charts/src/DonutChart/DonutChart.tsx
+++ b/packages/@mantine/charts/src/DonutChart/DonutChart.tsx
@@ -7,6 +7,7 @@ import {
   ResponsiveContainer,
   Tooltip,
   TooltipProps,
+  Legend,
 } from 'recharts';
 import {
   Box,
@@ -104,6 +105,7 @@ export interface DonutChartProps
 
   /** A function to format values inside the tooltip */
   valueFormatter?: (value: number) => string;
+  legendMode?: 'hover' | 'side';
   legendOrientation?: 'top' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'center-left' | 'center-right';
 }
 
@@ -119,7 +121,8 @@ const defaultProps: Partial<DonutChartProps> = {
   withLabelsLine: true,
   paddingAngle: 0,
   thickness: 20,
-  size: 160,
+  size: 240,
+  pieSize: 160,
   strokeWidth: 1,
   startAngle: 0,
   endAngle: 360,
@@ -189,6 +192,7 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
     withLabels,
     withLabelsLine,
     size,
+    pieSize,
     thickness,
     strokeWidth,
     startAngle,
@@ -200,6 +204,7 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
     valueFormatter,
     strokeColor,
     labelsType,
+    legendMode,
     legendOrientation,
     ...others
   } = props;
@@ -245,7 +250,7 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
     'center-right': { x: 230, y: 0 },
   };
 
-  const legendOffset = legendPosition[legendOrientation || 'center-right'];
+  const legendOffset = { x: 260, y: legendPosition[legendOrientation || 'center-right'].y };
 
   return (
     <Box ref={ref} size={size} {...getStyles('root')} {...others}>
@@ -253,8 +258,8 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
         <ReChartsPieChart {...pieChartProps}>
           <Pie
             data={data}
-            innerRadius={size! / 2 - thickness!}
-            outerRadius={size! / 2}
+            innerRadius={pieSize! / 2 - thickness!}
+            outerRadius={pieSize! / 2}
             dataKey="value"
             isAnimationActive={false}
             paddingAngle={paddingAngle}
@@ -286,7 +291,7 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
             </text>
           )}
 
-          {withTooltip && (
+          {legendMode === 'hover' && withTooltip && (
             <Tooltip
               animationDuration={tooltipAnimationDuration}
               isAnimationActive={false}
@@ -302,6 +307,23 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
               )}
               position={{ x: legendOffset.x, y: legendOffset.y }}
               {...tooltipProps}
+            />
+          )}
+
+          {legendMode === 'side' && (
+            <Legend
+              layout="vertical"
+              verticalAlign="middle"
+              align="right"
+              wrapperStyle={{
+                position: 'absolute',
+                left: `${legendOffset.x}px`,
+                top: `${legendOffset.y}px`,
+                fontSize: '14px',
+                fontFamily: 'var(--mantine-font-family)',
+                whiteSpace: 'nowrap',
+                visibility: 'visible',
+              }}
             />
           )}
 

--- a/packages/@mantine/charts/src/DonutChart/DonutChart.tsx
+++ b/packages/@mantine/charts/src/DonutChart/DonutChart.tsx
@@ -27,6 +27,7 @@ import {
 } from '@mantine/core';
 import { ChartTooltip } from '../ChartTooltip/ChartTooltip';
 import classes from './DonutChart.module.css';
+import React, { useState } from 'react';
 
 export interface DonutChartCell {
   name: string;
@@ -76,8 +77,11 @@ export interface DonutChartProps
   /** Controls thickness of the chart segments, `20` by default */
   thickness?: number;
 
-  /** Controls chart width and height, height is increased by 40 if `withLabels` prop is set. Cannot be less than `thickness`. `80` by default */
+  /** Controls chart area size along with side legend */
   size?: number;
+
+  /** Controls chart width and height, height is increased by 40 if `withLabels` prop is set. Cannot be less than `thickness`. `80` by default */
+  pieSize?: number;
 
   /** Controls width of segments stroke, `1` by default */
   strokeWidth?: number;
@@ -105,8 +109,20 @@ export interface DonutChartProps
 
   /** A function to format values inside the tooltip */
   valueFormatter?: (value: number) => string;
+
+  /** Defines the behavior of the legend. Can be 'hover' (hover to highlight segments) or 'side' (static side legend). */
   legendMode?: 'hover' | 'side';
-  legendOrientation?: 'top' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'center-left' | 'center-right';
+
+  /** Specifies the position of the legend on the chart. */
+  legendOrientation?:
+    | 'top'
+    | 'bottom'
+    | 'top-left'
+    | 'top-right'
+    | 'bottom-left'
+    | 'bottom-right'
+    | 'center-left'
+    | 'center-right';
 }
 
 export type DonutChartFactory = Factory<{
@@ -210,6 +226,7 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
   } = props;
 
   const theme = useMantineTheme();
+  const [hoveredSegment, setHoveredSegment] = useState<string | null>(null);
 
   const getStyles = useStyles<DonutChartFactory>({
     name: 'DonutChart',
@@ -236,6 +253,13 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
       fill={getThemeColor(item.color, theme)}
       stroke="var(--chart-stroke-color, var(--mantine-color-body))"
       strokeWidth={strokeWidth}
+      fillOpacity={
+        legendMode === 'side' && hoveredSegment !== null
+          ? hoveredSegment === item.name
+            ? 1
+            : 0.5
+          : 1
+      }
     />
   ));
 
@@ -301,7 +325,9 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
                   classNames={resolvedClassNames}
                   styles={resolvedStyles}
                   type="radial"
-                  segmentId={tooltipDataSource === 'segment' ? payload?.[0]?.name : undefined}
+                  segmentId={
+                    tooltipDataSource === 'segment' ? payload?.[0]?.name : undefined
+                  }
                   valueFormatter={valueFormatter}
                 />
               )}
@@ -315,6 +341,8 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
               layout="vertical"
               verticalAlign="middle"
               align="right"
+              onMouseEnter={(e: any) => setHoveredSegment(e?.value as string)}
+              onMouseLeave={() => setHoveredSegment(null)}
               wrapperStyle={{
                 position: 'absolute',
                 left: `${legendOffset.x}px`,


### PR DESCRIPTION
Resolves https://github.com/orgs/mantinedev/discussions/6987
Added legendMode and legendOrientation properties. The legendMode allows to control how the legend behaves. When set to 'side', the legend is displayed on the side of the chart, and hovering over a row in the legend highlights the corresponding segment in the chart. When set to 'hover', the legend is hidden by default and only appears on hover. 
The legendOrientation property enables the customization of the legend's position.