### PR TITLE
Add withWeekNumbers to pickCalendarProps

### DIFF
--- a/packages/@mantine/dates/src/components/Calendar/pick-calendar-levels-props/pick-calendar-levels-props.ts
+++ b/packages/@mantine/dates/src/components/Calendar/pick-calendar-levels-props/pick-calendar-levels-props.ts
@@ -29,6 +29,7 @@ export function pickCalendarProps<T extends Record<string, any>>(props: T) {
     highlightToday,
     __updateDateOnYearSelect,
     __updateDateOnMonthSelect,
+    withWeekNumbers,
 
     // MonthLevelGroup props
     firstDayOfWeek,
@@ -94,6 +95,7 @@ export function pickCalendarProps<T extends Record<string, any>>(props: T) {
       highlightToday,
       __updateDateOnYearSelect,
       __updateDateOnMonthSelect,
+      withWeekNumbers,
 
       // MonthLevelGroup props
       firstDayOfWeek,


### PR DESCRIPTION
Fixes https://github.com/mantinedev/mantine/issues/7212

The withWeekNumbers prop is currently passed to the input base in DatePickerInput instead of as part of the calendar props

Add it to pickCalendarProps