### PR TITLE
Export date hooks

### DIFF
--- a/packages/@mantine/dates/src/index.ts
+++ b/packages/@mantine/dates/src/index.ts
@@ -1,5 +1,6 @@
 export * from './types/index.js';
 export * from './utils/index.js';
+export * from './hooks/index.js';
 
 export * from './components/DatesProvider/index.js';
 export * from './components/HiddenDatesInput/index.js';


### PR DESCRIPTION
Currently the date hooks are not exported, making it hard to create your own DatePickerInput. Since all other types/utils and components are exported, I think it makes sense to export the hooks as well.