### PR TITLE
[@mantine/core] Slider: Fix thumb children color in dark theme

### DIFF
--- a/packages/@mantine/core/src/components/Slider/Slider.module.css
+++ b/packages/@mantine/core/src/components/Slider/Slider.module.css
@@ -97,6 +97,12 @@
     border-color: var(--mantine-color-white);
     background-color: var(--slider-color);
   }
+
+  & > svg {
+    @mixin where-dark {
+      stroke: var(--mantine-color-white);
+    }
+  }
 }
 
 .trackContainer {


### PR DESCRIPTION
Fixes #7231 

![image](https://github.com/user-attachments/assets/c8cfd119-8c5d-48e5-9adc-0ad02dce6aad)
