### PR TITLE
Replace backslashes by slashes so it works on Windows with git bash too

### DIFF
--- a/apps/mantine.dev/src/pages/styles/sass.mdx
+++ b/apps/mantine.dev/src/pages/styles/sass.mdx
@@ -35,7 +35,7 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {
         api: 'modern-compiler',
-        additionalData: `@use "${path.join(process.cwd(), 'src/_mantine')}" as mantine;`,
+        additionalData: `@use "${path.join(process.cwd(), 'src/_mantine').replace(/\\/g, '/')}" as mantine;`,
       },
     },
   },
@@ -154,7 +154,7 @@ export default {
   // ...other config
   sassOptions: {
     implementation: 'sass-embedded',
-    additionalData: `@use "${path.join(process.cwd(), '_mantine')}" as mantine;`,
+    additionalData: `@use "${path.join(process.cwd(), '_mantine').replace(/\\/g, '/')}" as mantine;`,
   },
 };
 ```


### PR DESCRIPTION
Not sure this fix also works for PowerShell, but is required for git bash to resolve the path the the _mantine sass file.

Fixes #7237 