### PR TITLE
Multi-line paragraphs in list items in RichTextEditor have the marker bottom aligned - fix

### DIFF
--- a/packages/@mantine/tiptap/src/RichTextEditor.module.css
+++ b/packages/@mantine/tiptap/src/RichTextEditor.module.css
@@ -18,7 +18,6 @@
 
   & li > p {
     margin: 0;
-    display: inline-block;
   }
 
   & ul li,


### PR DESCRIPTION
Fixed the css which was causing issue of marker alignment for Multi-line paragraphs in list items in RichTextEditor

fix for #7254 