### PR TITLE
[@mantine/core] FloatingIndicator: fix translate calculations

### DIFF
--- a/packages/@mantine/core/src/components/FloatingIndicator/use-floating-indicator.ts
+++ b/packages/@mantine/core/src/components/FloatingIndicator/use-floating-indicator.ts
@@ -1,6 +1,7 @@
-import { RefObject, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type RefObject } from 'react';
 import { useMutationObserver, useTimeout } from '@mantine/hooks';
 import { getEnv } from '../../core';
+import { toInt } from '../ScrollArea/utils';
 
 function isParent(
   parentElement: HTMLElement | EventTarget | null,
@@ -41,25 +42,31 @@ export function useFloatingIndicator({
   );
 
   const updatePosition = () => {
-    if (!target || !parent) {
+    if (!target || !parent || !ref.current) {
       return;
     }
 
     const targetRect = target.getBoundingClientRect();
     const parentRect = parent.getBoundingClientRect();
 
+    const targetComputedStyle = window.getComputedStyle(target);
+    const parentComputedStyle = window.getComputedStyle(parent);
+
+    const borderTopWidth =
+      toInt(targetComputedStyle.borderTopWidth) + toInt(parentComputedStyle.borderTopWidth);
+    const borderLeftWidth =
+      toInt(targetComputedStyle.borderLeftWidth) + toInt(parentComputedStyle.borderLeftWidth);
+
     const position = {
-      top: targetRect.top - parentRect.top,
-      left: targetRect.left - parentRect.left,
+      top: targetRect.top - parentRect.top - borderTopWidth,
+      left: targetRect.left - parentRect.left - borderLeftWidth,
       width: targetRect.width,
       height: targetRect.height,
     };
 
-    if (ref.current) {
-      ref.current.style.transform = `translateY(${position.top}px) translateX(${position.left}px)`;
-      ref.current.style.width = `${position.width}px`;
-      ref.current.style.height = `${position.height}px`;
-    }
+    ref.current.style.transform = `translateY(${position.top}px) translateX(${position.left}px)`;
+    ref.current.style.width = `${position.width}px`;
+    ref.current.style.height = `${position.height}px`;
   };
 
   const updatePositionWithoutAnimation = () => {


### PR DESCRIPTION
# Descriptions

The `borderTopWidth` & `borderLeftWidth` from `parent` & `target` should added to translate calculation because [`getBoundingClientRect`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) included that on calculation.

**Before**

![image](https://github.com/user-attachments/assets/b9cceb5a-7d87-4af9-88d4-176913ee6c5d)

**After**

![Screenshot from 2024-12-16 16-24-48](https://github.com/user-attachments/assets/aa26f0b8-7444-4f5b-bfc7-5f989c5465b0)

It's a little bit difficult to see the difference unless you use wider border width.

# Notes

- I reuse [`toInt`](https://github.com/lamualfa/mantine/blob/e5faa0d2c4df522ea981787a7da8076e6e024ec4/packages/%40mantine/core/src/components/FloatingIndicator/use-floating-indicator.ts#L4) helper from `ScrollArea` utils to [convert computed style to int](https://github.com/lamualfa/mantine/blob/e5faa0d2c4df522ea981787a7da8076e6e024ec4/packages/%40mantine/core/src/components/FloatingIndicator/use-floating-indicator.ts#L55). That helper should be on more generic folder/file other than `ScrollArea`. I'm not sure where to put it. This refactor must be in different commit.

