### PR TITLE
(docs): updated docs, to reflect actual behaviour of allowSingleDateInRange

### DIFF
--- a/packages/@mantine/dates/src/types/PickerBaseProps.ts
+++ b/packages/@mantine/dates/src/types/PickerBaseProps.ts
@@ -16,6 +16,6 @@ export interface PickerBaseProps<Type extends DatePickerType = 'default'> {
   /** Determines whether user can deselect the date by clicking on selected item, applicable only when type="default" */
   allowDeselect?: Type extends 'default' ? boolean : never;
 
-  /** Determines whether single year can be selected as range, applicable only when type="range" */
+  /** Determines whether a single day can be selected as range, applicable only when type="range" */
   allowSingleDateInRange?: Type extends 'range' ? boolean : never;
 }


### PR DESCRIPTION
`allowSingleDateInRange` allows for a single day to be selected, by clicking the same value in the date input for both start and end dates.

This was not reflected in the documentation.