### PR TITLE
Fix unmet dependency on React 19

### DIFF
--- a/packages/@mantine/core/package.json
+++ b/packages/@mantine/core/package.json
@@ -52,7 +52,7 @@
     "clsx": "^2.1.1",
     "react-number-format": "^5.4.2",
     "react-remove-scroll": "^2.6.0",
-    "react-textarea-autosize": "8.5.5",
+    "react-textarea-autosize": "8.5.6",
     "type-fest": "^4.27.0"
   },
   "devDependencies": {


### PR DESCRIPTION
react-textarea-autosize 8.5.6 adds React 19 as an allowed dependency version.