### PR TITLE
[mantine.dev] update use-favicon hook example to use cookieless domain

### DIFF
--- a/packages/@docs/demos/src/demos/hooks/use-favicon.demo.usage.tsx
+++ b/packages/@docs/demos/src/demos/hooks/use-favicon.demo.usage.tsx
@@ -10,15 +10,15 @@ import { Group, Button } from '@mantine/core';
 
 function Demo() {
   const [favicon, setFavicon] = useState('https://mantine.dev/favicon.svg');
-  const setMantineUIFavicon = () => setFavicon('https://ui.mantine.dev/favicon.svg');
   const setMantineFavicon = () => setFavicon('https://mantine.dev/favicon.svg');
+  const setMantineUIFavicon = () => setFavicon('https://ui.mantine.dev/favicon.svg');
 
   useFavicon(favicon);
 
   return (
     <Group justify="center">
-      <Button onClick={setMantineUIFavicon}>Mantine UI favicon</Button>
       <Button onClick={setMantineFavicon}>Mantine favicon</Button>
+      <Button onClick={setMantineUIFavicon}>Mantine UI favicon</Button>
     </Group>
   );
 }
@@ -26,15 +26,15 @@ function Demo() {
 
 function Demo() {
   const [favicon, setFavicon] = useState('https://mantine.dev/favicon.svg');
-  const setMantineUIFavicon = () => setFavicon('https://ui.mantine.dev/favicon.svg');
   const setMantineFavicon = () => setFavicon('https://mantine.dev/favicon.svg');
+  const setMantineUIFavicon = () => setFavicon('https://ui.mantine.dev/favicon.svg');
 
   useFavicon(favicon);
 
   return (
     <Group justify="center">
-      <Button onClick={setMantineUIFavicon}>Mantine UI favicon</Button>
       <Button onClick={setMantineFavicon}>Mantine favicon</Button>
+      <Button onClick={setMantineUIFavicon}>Mantine UI favicon</Button>
     </Group>
   );
 }

--- a/packages/@docs/demos/src/demos/hooks/use-favicon.demo.usage.tsx
+++ b/packages/@docs/demos/src/demos/hooks/use-favicon.demo.usage.tsx
@@ -10,14 +10,14 @@ import { Group, Button } from '@mantine/core';
 
 function Demo() {
   const [favicon, setFavicon] = useState('https://mantine.dev/favicon.svg');
-  const setXFavicon = () => setFavicon('https://x.com/favicon.ico');
+  const setMantineUIFavicon = () => setFavicon('https://ui.mantine.dev/favicon.svg');
   const setMantineFavicon = () => setFavicon('https://mantine.dev/favicon.svg');
 
   useFavicon(favicon);
 
   return (
     <Group justify="center">
-      <Button onClick={setXFavicon}>X favicon</Button>
+      <Button onClick={setMantineUIFavicon}>Mantine UI favicon</Button>
       <Button onClick={setMantineFavicon}>Mantine favicon</Button>
     </Group>
   );
@@ -26,14 +26,14 @@ function Demo() {
 
 function Demo() {
   const [favicon, setFavicon] = useState('https://mantine.dev/favicon.svg');
-  const setXFavicon = () => setFavicon('https://x.com/favicon.ico');
+  const setMantineUIFavicon = () => setFavicon('https://ui.mantine.dev/favicon.svg');
   const setMantineFavicon = () => setFavicon('https://mantine.dev/favicon.svg');
 
   useFavicon(favicon);
 
   return (
     <Group justify="center">
-      <Button onClick={setXFavicon}>X favicon</Button>
+      <Button onClick={setMantineUIFavicon}>Mantine UI favicon</Button>
       <Button onClick={setMantineFavicon}>Mantine favicon</Button>
     </Group>
   );


### PR DESCRIPTION
With the current example, when logged in to X, Chrome refuses to fetch the icon. I update the example to use another cookieless domain so that the example works for everyone.