### PR TITLE
[@mantine/hooks] Support ref cleanup function in React 19 with useMergedRef

### DIFF
--- a/packages/@mantine/hooks/src/use-merged-ref/use-merged-ref.test.tsx
+++ b/packages/@mantine/hooks/src/use-merged-ref/use-merged-ref.test.tsx
@@ -19,4 +19,69 @@ describe('@mantine/hook/use-merged-ref', () => {
     expect(fnRefValue! instanceof HTMLButtonElement).toBe(true);
     expect(objectRef.current instanceof HTMLButtonElement).toBe(true);
   });
+
+  it('when ref callback does not return a function, ref callback is called with null on unmount', () => {
+    const refCalled: unknown[] = [];
+
+    const fnRef = (node: HTMLButtonElement | null) => {
+      refCalled.push(node);
+    };
+
+    const { unmount } = render(<TestComponent refs={[fnRef]} />);
+    expect(refCalled).toEqual([expect.any(HTMLButtonElement)]);
+
+    unmount();
+    expect(refCalled).toEqual([expect.any(HTMLButtonElement), null]);
+  });
+
+  describe('react 18', () => {
+    it('when ref callback returns a function, ref callback is called with null on unmount', () => {
+      const refCalled: unknown[] = [];
+      const cleanupCalled: unknown[] = [];
+
+      const fnRef = (node: HTMLButtonElement | null) => {
+        refCalled.push(node);
+        return () => {
+          cleanupCalled.push(node);
+        };
+      };
+
+      const { unmount } = render(<TestComponent refs={[fnRef]} />);
+      expect(refCalled).toEqual([expect.any(HTMLButtonElement)]);
+      expect(cleanupCalled).toEqual([]);
+
+      unmount();
+      expect(refCalled).toEqual([expect.any(HTMLButtonElement), null]);
+      expect(cleanupCalled).toEqual([]);
+    });
+
+    it('when ref callbacks that return a function and those that do not are mixed, each behaves accordingly', () => {
+      const refCalled: unknown[] = [];
+      const cleanupCalled: unknown[] = [];
+
+      const fnRef = (node: HTMLButtonElement | null) => {
+        refCalled.push(node);
+        return () => {
+          cleanupCalled.push(node);
+        };
+      };
+
+      const ref2Called: unknown[] = [];
+      const fnRef2 = (node: HTMLButtonElement | null) => {
+        ref2Called.push(node);
+      };
+
+      const { unmount } = render(<TestComponent refs={[fnRef, fnRef2]} />);
+
+      expect(refCalled).toEqual([expect.any(HTMLButtonElement)]);
+      expect(ref2Called).toEqual([expect.any(HTMLButtonElement)]);
+      expect(cleanupCalled).toEqual([]);
+
+      unmount();
+
+      expect(refCalled).toEqual([expect.any(HTMLButtonElement), null]);
+      expect(ref2Called).toEqual([expect.any(HTMLButtonElement), null]);
+      expect(cleanupCalled).toEqual([]);
+    });
+  });
 });

--- a/packages/@mantine/hooks/src/use-merged-ref/use-merged-ref.ts
+++ b/packages/@mantine/hooks/src/use-merged-ref/use-merged-ref.ts
@@ -1,4 +1,4 @@
-import { Ref, useCallback, type RefCallback, type RefObject } from 'react';
+import { Ref, useCallback, type RefCallback } from 'react';
 
 type PossibleRef<T> = Ref<T> | undefined;
 
@@ -33,6 +33,7 @@ export function mergeRefs<T>(...refs: PossibleRef<T>[]) {
             assignRef(ref, null);
           }
         });
+        cleanupMap.clear();
       };
     }
   };


### PR DESCRIPTION
fixes #7269 

useMergedRef now properly handles ref callbacks that return cleanup functions in React 19. 
For backward compatibility with React 18, it maintains the previous behavior of calling refs with null during unmount.

I have verified the functionality through a separate test repository, as direct testing within Mantine is not possible due to its React 18 dependency.
https://github.com/elecdeer/react-19-use-merge-ref/blob/main/react19/src/use-merged.ref.test.tsx
