### PR TITLE
[@mantine/dates] Fix `hasNextLevel` prop type leak to DateTimePicker component

### DIFF
--- a/packages/@mantine/dates/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/packages/@mantine/dates/src/components/DateTimePicker/DateTimePicker.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mantine/core';
 import { useDidUpdate, useDisclosure, useMergedRef } from '@mantine/hooks';
 import { useUncontrolledDates } from '../../hooks';
-import { DateValue } from '../../types';
+import { CalendarLevel, DateValue } from '../../types';
 import { assignTime, shiftTimezone } from '../../utils';
 import {
   CalendarBaseProps,
@@ -47,7 +47,7 @@ export interface DateTimePickerProps
       'classNames' | 'styles' | 'closeOnChange' | 'size' | 'valueFormatter'
     >,
     Omit<CalendarBaseProps, 'defaultDate'>,
-    Omit<CalendarSettings, 'onYearMouseEnter' | 'onMonthMouseEnter'>,
+    Omit<CalendarSettings, 'onYearMouseEnter' | 'onMonthMouseEnter' | 'hasNextLevel'>,
     StylesApiProps<DateTimePickerFactory> {
   /** Dayjs format to display input value, "DD/MM/YYYY HH:mm" by default  */
   valueFormat?: string;
@@ -71,6 +71,9 @@ export interface DateTimePickerProps
 
   /** Determines whether seconds input should be rendered */
   withSeconds?: boolean;
+
+  /** Max level that user can go up to (decade, year, month), defaults to decade */
+  maxLevel?: CalendarLevel;
 }
 
 export type DateTimePickerFactory = Factory<{


### PR DESCRIPTION
fixes #7305 

Corrected with reference to fix #7229.