### PR TITLE
Fix Avatar initials color hashing to use full name

### DIFF
--- a/packages/@mantine/core/src/components/Avatar/get-initials-color/get-initials-color.test.ts
+++ b/packages/@mantine/core/src/components/Avatar/get-initials-color/get-initials-color.test.ts
@@ -3,8 +3,8 @@ import { getInitialsColor } from './get-initials-color';
 describe('@mantine/core/Avatar/get-initials-color', () => {
   it('should return color based on initials', () => {
     expect(getInitialsColor('John Mol')).toBe('orange');
-    expect(getInitialsColor('John')).toBe('red');
-    expect(getInitialsColor('John Doe')).toBe('red');
-    expect(getInitialsColor('John Doe', ['red', 'blue'])).toBe('red');
+    expect(getInitialsColor('John')).toBe('pink');
+    expect(getInitialsColor('John Doe')).toBe('lime');
+    expect(getInitialsColor('John Doe', ['red', 'blue'])).toBe('blue');
   });
 });

--- a/packages/@mantine/core/src/components/Avatar/get-initials-color/get-initials-color.ts
+++ b/packages/@mantine/core/src/components/Avatar/get-initials-color/get-initials-color.ts
@@ -1,5 +1,4 @@
 import { MantineColor } from '../../../core';
-import { getInitials } from '../get-initials/get-initials';
 
 function hashCode(input: string) {
   let hash = 0;

--- a/packages/@mantine/core/src/components/Avatar/get-initials-color/get-initials-color.ts
+++ b/packages/@mantine/core/src/components/Avatar/get-initials-color/get-initials-color.ts
@@ -26,7 +26,7 @@ const defaultColors: MantineColor[] = [
 ];
 
 export function getInitialsColor(name: string, colors: MantineColor[] = defaultColors) {
-  const hash = hashCode(getInitials(name));
+  const hash = hashCode(name);
   const index = Math.abs(hash) % colors.length;
   return colors[index];
 }


### PR DESCRIPTION
**Problem:**
In the Avatar component, the `getInitialsColor` function was using only the initials of a name to generate a hash, which determined the color of the avatar. This led to the issue where different names with the same initials would receive the same color, even if the full names were different.

**Solution:**
The function now uses the full name to generate the hash. By removing the use of `getInitials()` inside the `hashCode()` call, each unique name will produce a unique hash, ensuring a unique color for each different name.

**Details:**
- The `hashCode()` call is updated to process the entire name, not just the initials.
- This change maintains the internal implementation without affecting the public API.
- The behavior of the `getInitialsColor` function remains consistent, mapping the hash to an index in the colors array.

**Impact:**
- Resolves the issue of same initials leading to same colors.
- Enhances the distinguishability of avatars in user interfaces.