### PR TITLE
Normalize milliseconds in picked dateTime in DateTimePicker to 0

### DIFF
--- a/packages/@mantine/dates/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/packages/@mantine/dates/src/components/DateTimePicker/DateTimePicker.tsx
@@ -165,6 +165,7 @@ export const DateTimePicker = factory<DateTimePickerFactory>((_props, ref) => {
       timeDate.setHours(hours);
       timeDate.setMinutes(minutes);
       timeDate.setSeconds(seconds || 0);
+      timeDate.setMilliseconds(0);
       setValue(assignTime(timeDate, _value || shiftTimezone('add', new Date(), ctx.getTimezone())));
     }
   };


### PR DESCRIPTION
### Normalize milliseconds in picked `dateTime` to 0

#### Summary  
This change sets the milliseconds of a picked `dateTime` to 0. This ensures consistency and avoids issues when comparing `Date` objects modified by the datetime picker.

#### Motivation  
When using the datetime picker, the inclusion of milliseconds can lead to unexpected behavior during date comparisons. For example when pick 2025-01-01T16:00+0100 in the DateTimePicker and do this comparison.

```javascript
new Date('2025-01-01T16:00+0100') >= <DatePickedWithDateTimePicker>
```

This comparison will always return false due to the additional milliseconds present in the picked dateTime.

#### Proposed Solution

By normalizing milliseconds to 0, the behavior aligns with the existing practice of setting seconds to 0. This ensures:
- More intuitive and predictable behavior.
- Easier comparisons between Date objects.

#### Expected Behavior
- The milliseconds of all picked dateTime values will now default to 0.
- Comparisons like the example above will behave as expected.

#### Additional Notes

This change is consistent with the datetime picker’s behavior of setting seconds to 0. It enhances the overall usability and developer experience.