### PR TITLE
[docs] Fix typo with import of `@mantine/hooks` in code example in `use-interval.mdx`

### DIFF
--- a/apps/mantine.dev/src/pages/hooks/use-interval.mdx
+++ b/apps/mantine.dev/src/pages/hooks/use-interval.mdx
@@ -25,7 +25,7 @@ const interval = useInterval(
 ## API
 
 ```tsx
-import { useInterval } from '@mantine/hook';
+import { useInterval } from '@mantine/hooks';
 
 const { start, stop, toggle, active } = useInterval(fn, interval);
 ```


### PR DESCRIPTION
Fix typo with import of `@mantine/hooks` in code example in `use-interval.mdx`