### PR TITLE
[@mantine/core] Fix On Escape KeyDown handling to Combobox component

### DIFF
--- a/packages/@mantine/core/src/components/Combobox/use-combobox-target-props/use-combobox-target-props.ts
+++ b/packages/@mantine/core/src/components/Combobox/use-combobox-target-props/use-combobox-target-props.ts
@@ -76,7 +76,7 @@ export function useComboboxTargetProps({
         }
       }
 
-      if (event.nativeEvent.code === 'Escape') {
+      if (event.key === 'Escape') {
         ctx.store.closeDropdown('keyboard');
       }
 


### PR DESCRIPTION
fixes #7337 

The method of judging escape key press events is now the same as for Modal.
https://github.com/mantinedev/mantine/blob/e8f7b01f85149e6f7d9776ef41703bab739f5d4d/packages/%40mantine/core/src/components/ModalBase/use-modal.ts#L37