### PR TITLE
[@mantine/hooks] Fix Handling of multiple Entries to useInViewport

### DIFF
--- a/packages/@mantine/hooks/src/use-in-viewport/use-in-viewport.ts
+++ b/packages/@mantine/hooks/src/use-in-viewport/use-in-viewport.ts
@@ -7,8 +7,8 @@ export function useInViewport<T extends HTMLElement = any>() {
   const ref = useCallback((node: T | null) => {
     if (typeof IntersectionObserver !== 'undefined') {
       if (node && !observer.current) {
-        observer.current = new IntersectionObserver(([entry]) =>
-          setInViewport(entry.isIntersecting)
+        observer.current = new IntersectionObserver((entries) =>
+          setInViewport(entries.some((entry) => entry.isIntersecting))
         );
       } else {
         observer.current?.disconnect();


### PR DESCRIPTION
fixes #7340 

IntersectionObserver's Handler now handles cases where there is more than one Entry.
https://codesandbox.io/p/sandbox/mantine-7340-6w3krx?file=%2Fsrc%2FDndList.tsx%3A89%2C1-92%2C12