### PR TITLE
[@mantine/core] Handle undefined value in matchMedia

### DIFF
--- a/packages/@mantine/core/src/core/MantineProvider/use-mantine-color-scheme/use-provider-color-scheme.ts
+++ b/packages/@mantine/core/src/core/MantineProvider/use-mantine-color-scheme/use-provider-color-scheme.ts
@@ -10,7 +10,7 @@ function setColorSchemeAttribute(
   const hasDarkColorScheme =
     typeof window !== 'undefined' &&
     'matchMedia' in window &&
-    window.matchMedia('(prefers-color-scheme: dark)').matches;
+    window.matchMedia('(prefers-color-scheme: dark)')?.matches;
 
   const computedColorScheme =
     colorScheme !== 'auto' ? colorScheme : hasDarkColorScheme ? 'dark' : 'light';


### PR DESCRIPTION
[This PR](https://github.com/mantinedev/mantine/pull/7147) broke my testing setup. In some cases `window.matchMedia("(prefers-color-scheme: dark)")` returns undefined and breaks my tests. Optional chaining solves it.