### PR TITLE
[mantine.dev] Fix description in use-isomorphic-effect

### DIFF
--- a/apps/mantine.dev/src/pages/hooks/use-isomorphic-effect.mdx
+++ b/apps/mantine.dev/src/pages/hooks/use-isomorphic-effect.mdx
@@ -6,7 +6,7 @@ export default Layout(MDX_DATA.useIsomorphicEffect);
 
 ## Usage
 
-`use-isomorphic-effect` is a replacement for `useEffect` hook that works in both browser and server environments.
+`use-isomorphic-effect` is a replacement for `useLayoutEffect` hook that works in both browser and server environments.
 
 ```tsx
 import { useIsomorphicEffect } from '@mantine/hooks';


### PR DESCRIPTION
According to implementation notes and meta data it's a replacement for `useLayoutEffect` instead of `useEffect`:

https://github.com/mantinedev/mantine/blob/e8f7b01f85149e6f7d9776ef41703bab739f5d4d/apps/mantine.dev/src/mdx/data/mdx-hooks-data.ts#L93

https://github.com/mantinedev/mantine/blob/e8f7b01f85149e6f7d9776ef41703bab739f5d4d/packages/%40mantine/hooks/src/use-isomorphic-effect/use-isomorphic-effect.ts#L3-L4