### PR TITLE
fix: changed spreading order in form.resetDirty to make it behave correctly

### DIFF
--- a/packages/@mantine/form/src/hooks/use-form-status/use-form-status.ts
+++ b/packages/@mantine/form/src/hooks/use-form-status/use-form-status.ts
@@ -81,7 +81,7 @@ export function useFormStatus<Values extends Record<string, any>>({
 
   const resetDirty: ResetDirty<Values> = useCallback((values) => {
     const newSnapshot = values
-      ? { ...values, ...$values.refValues.current }
+      ? { ...$values.refValues.current, ...values }
       : $values.refValues.current;
     $values.setValuesSnapshot(newSnapshot);
     setDirty({});

--- a/packages/@mantine/form/src/tests/use-form/resetDirty.test.ts
+++ b/packages/@mantine/form/src/tests/use-form/resetDirty.test.ts
@@ -34,6 +34,14 @@ function tests(mode: FormMode) {
 
     expect(hook.result.current.isDirty()).toBe(false);
   });
+
+  it('should handle reseting with new values', () => {
+    const hook = renderHook(() => useForm({ mode, initialValues: { a: 1, b: 2 } }));
+    expect(hook.result.current.isDirty()).toBe(false);
+
+    act(() => hook.result.current.resetDirty({ a: 2, b: 2 }));
+    expect(hook.result.current.isDirty()).toBe(true);
+  });
 }
 
 describe('@mantine/form/resetDirty-controlled', () => {


### PR DESCRIPTION
When using `form.resetDirty` and passing an object as argument, it's expected that the object being passed should act as the new baseline for the dirty checking. Currently, because of how the objects are being spread it does not behave like this and in fact basically does the same thing as not having passed any argument at all.

This PR should fix this :)