### PR TITLE
[@mantine/core] CodeHighlightTabs.tsx: Fallback unsupported language to plaintext

### DIFF
--- a/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
@@ -184,7 +184,7 @@ export const CodeHighlightTabs = factory<CodeHighlightTabsFactory>((_props, ref)
   const currentCode = nodes[value];
 
   const highlighted = hljs.highlight(currentCode.code.trim(), {
-    language: hljs.getLanguage(currentCode.language) ? language : 'plaintext',
+    language: hljs.getLanguage(currentCode.language) ? currentCode.language : 'plaintext',
   }).value;
 
   const files = nodes.map((node, index) => (

--- a/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
@@ -184,7 +184,7 @@ export const CodeHighlightTabs = factory<CodeHighlightTabsFactory>((_props, ref)
   const currentCode = nodes[value];
 
   const highlighted = hljs.highlight(currentCode.code.trim(), {
-    language: currentCode.language || 'plaintext',
+    language: hljs.getLanguage(language) ? language : 'plaintext',
   }).value;
 
   const files = nodes.map((node, index) => (

--- a/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
@@ -184,7 +184,7 @@ export const CodeHighlightTabs = factory<CodeHighlightTabsFactory>((_props, ref)
   const currentCode = nodes[value];
 
   const highlighted = hljs.highlight(currentCode.code.trim(), {
-    language: hljs.getLanguage(language) ? language : 'plaintext',
+    language: hljs.getLanguage(currentCode.language) ? language : 'plaintext',
   }).value;
 
   const files = nodes.map((node, index) => (


### PR DESCRIPTION
Instead of throwing `unsupported code` error, it fallback to `plaintext`. 

It's the current behaviour of `CodeHighlight` component.  