### PR TITLE
[@mantine/hooks] use-hotkey: Clarifying use of physical key assignments

### DIFF
--- a/apps/mantine.dev/src/pages/hooks/use-hotkeys.mdx
+++ b/apps/mantine.dev/src/pages/hooks/use-hotkeys.mdx
@@ -75,6 +75,7 @@ document.body.addEventListener(
 - `alt + shift + L` – you can use whitespace inside hotkey
 - `ArrowLeft` – you can use special keys using [this format](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)
 - `shift + [plus]` – you can use `[plus]` to detect `+` key
+- `Digit1` and `Hotkey1` - You can use physical key assignments [defined on MDN](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values).
 
 ## Types
 
@@ -83,6 +84,7 @@ document.body.addEventListener(
 ```tsx
 interface HotkeyItemOptions {
   preventDefault?: boolean;
+  usePhysicalKeys?: boolean;
 }
 
 type HotkeyItem = [
@@ -91,6 +93,8 @@ type HotkeyItem = [
   HotkeyItemOptions?,
 ];
 ```
+
+`HotkeyItemOptions` provides the `usePhysicalKeys` option to force the physical key assignment. Useful for non-QWERTY keyboard layouts.
 
 `HotkeyItem` type can be used to create hotkey items outside of `use-hotkeys` hook:
 
@@ -105,6 +109,11 @@ const hotkeys: HotkeyItem[] = [
   ],
   ['ctrl+K', () => console.log('Trigger search')],
   ['alt+mod+shift+X', () => console.log('Rick roll')],
+  [
+    'D',
+    () => console.log('Triggers when pressing "E" on Dvorak keyboards!'),
+    { usePhysicalKeys: true }
+  ],
 ];
 
 useHotkeys(hotkeys);

--- a/packages/@mantine/hooks/src/use-hotkeys/use-hotkeys.test.tsx
+++ b/packages/@mantine/hooks/src/use-hotkeys/use-hotkeys.test.tsx
@@ -34,4 +34,25 @@ describe('@mantine/hooks/use-hotkey', () => {
     dispatchEvent({ shiftKey: true, key: '+' });
     expect(handler).toHaveBeenCalled();
   });
+
+  it('correctly handles physical key assignments like Digit1', () => {
+    const handler = jest.fn();
+    renderHook(() => useHotkeys([['Digit1', handler]]));
+    dispatchEvent({ code: 'Digit1' });
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('correctly ignores unclear numerical assignments when usePhyiscalKeys is true', () => {
+    const handler = jest.fn();
+    renderHook(() => useHotkeys([['1', handler, { usePhysicalKeys: true }]], [], true));
+    dispatchEvent({ code: 'Numpad1' });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('correctly assumes physical keys when usePhysicalKeys is true', () => {
+    const handler = jest.fn();
+    renderHook(() => useHotkeys([['A', handler, { usePhysicalKeys: true }]], [], true));
+    dispatchEvent({ code: 'KeyA' });
+    expect(handler).toHaveBeenCalled();
+  });
 });

--- a/packages/@mantine/hooks/src/use-hotkeys/use-hotkeys.ts
+++ b/packages/@mantine/hooks/src/use-hotkeys/use-hotkeys.ts
@@ -29,18 +29,20 @@ export function useHotkeys(
 ) {
   useEffect(() => {
     const keydownListener = (event: KeyboardEvent) => {
-      hotkeys.forEach(([hotkey, handler, options = { preventDefault: true }]) => {
-        if (
-          getHotkeyMatcher(hotkey)(event) &&
-          shouldFireEvent(event, tagsToIgnore, triggerOnContentEditable)
-        ) {
-          if (options.preventDefault) {
-            event.preventDefault();
-          }
+      hotkeys.forEach(
+        ([hotkey, handler, options = { preventDefault: true, usePhysicalKeys: false }]) => {
+          if (
+            getHotkeyMatcher(hotkey, options.usePhysicalKeys)(event) &&
+            shouldFireEvent(event, tagsToIgnore, triggerOnContentEditable)
+          ) {
+            if (options.preventDefault) {
+              event.preventDefault();
+            }
 
-          handler(event);
+            handler(event);
+          }
         }
-      });
+      );
     };
 
     document.documentElement.addEventListener('keydown', keydownListener);


### PR DESCRIPTION
We have multiple users of our apps using non-QWERTY keyboard layouts. Given the nature of the app, and the need for inputs to be collocated sensibly (thinking camera manipulation), this convenience hook caused issues for our non-QWERTY users. 

This change corrects that. Open to feedback & adjustments, and hoping this is useful.

- [KeyboardEvent: code property](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code)
- [Code values for keyboard events](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values)