### PR TITLE
[@mantine/dates] DateTimePicker: prevent converting value to DateProvider twice

### DIFF
--- a/packages/@mantine/dates/src/components/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/@mantine/dates/src/components/DateTimePicker/DateTimePicker.test.tsx
@@ -192,15 +192,15 @@ describe('@mantine/dates/DateTimePicker', () => {
         />
       </DatesProvider>
     );
-    expectValue(container, '01/02/2022 09:00 +00:00');
+    expectValue(container, '01/02/2022 04:00 +00:00');
 
     await clickInput(container);
     await userEvent.click(container.querySelectorAll('table button')[6]);
-    expectValue(container, '06/02/2022 09:00 +00:00');
+    expectValue(container, '06/02/2022 04:00 +00:00');
 
     await userEvent.clear(getTimeInput());
     await userEvent.type(getTimeInput(), '14:45');
-    expectValue(container, '06/02/2022 19:45 +00:00');
+    expectValue(container, '06/02/2022 14:45 +00:00');
   });
 
   it('supports controlled state', async () => {
@@ -229,11 +229,11 @@ describe('@mantine/dates/DateTimePicker', () => {
         />
       </DatesProvider>
     );
-    expectValue(container, '01/02/2022 09:00 +00:00');
+    expectValue(container, '01/02/2022 04:00 +00:00');
 
     await clickInput(container);
     await userEvent.click(container.querySelectorAll('table button')[6]);
-    expectValue(container, '01/02/2022 09:00 +00:00');
+    expectValue(container, '01/02/2022 04:00 +00:00');
     expect(spy).toHaveBeenLastCalledWith(new Date(2022, 1, 5, 23));
   });
 

--- a/packages/@mantine/dates/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/packages/@mantine/dates/src/components/DateTimePicker/DateTimePicker.tsx
@@ -154,7 +154,7 @@ export const DateTimePicker = factory<DateTimePickerFactory>((_props, ref) => {
 
   const [dropdownOpened, dropdownHandlers] = useDisclosure(false);
   const formattedValue = _value
-    ? dayjs(_value).locale(ctx.getLocale(locale)).tz(ctx.getTimezone()).format(_valueFormat)
+    ? dayjs(_value).locale(ctx.getLocale(locale)).tz(ctx.getTimezone(), true).format(_valueFormat)
     : '';
 
   const handleTimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
`DateTimePicker` uses `useUncontrolledDates` hook which is already using the context from the `DateProvider` to convert the default value into the `DateProvider`s timezone. 

In the `DateTimePicker` we shouldn't do another `.tz()` that will convert the date & time into the `DateProvider`'s timezone, the result will be incorrect if that's the implementation. 

Fix was to pass `true` to the `.tz()`'s second parameter (`keepLocalTime`), which doesn't convert the value again to the `DateProvider`'s timezone.

### Before
![before](https://github.com/user-attachments/assets/9d839914-047a-4419-8150-e10e4e1d68c8)  

### After
 ![after](https://github.com/user-attachments/assets/f2aa648a-a5ab-4380-9578-ad8f00af066c)

Closes https://github.com/mantinedev/mantine/issues/7388