### PR TITLE
added resetNestedFieldDirty function

### DIFF
--- a/packages/@mantine/form/src/stories/Form.dirty.story.tsx
+++ b/packages/@mantine/form/src/stories/Form.dirty.story.tsx
@@ -30,11 +30,22 @@ export function Dirty() {
           </ActionIcon>
           <TextInput {...form.getInputProps(`formArray.${index}.one`)} />
           <TextInput {...form.getInputProps(`formArray.${index}.two`)} />
+
+          <Button onClick={() => form.resetNestedFieldDirty(`formArray.${index}`, false)}>
+            Reset
+          </Button>
         </Group>
       ))}
       <Button onClick={() => form.insertListItem('formArray', { one: '', two: '' })}>
         Add item
       </Button>
+
+      {form.values.formArray.map((_item, index) => (
+        <Text key={index}>
+          item #{index} {form.isDirty(`formArray.${index}`) ? 'Dirty' : 'Not Dirty'}
+        </Text>
+      ))}
+
       <Text>{form.isDirty() ? 'Dirty' : 'Not Dirty'}</Text>
       <Code block>{JSON.stringify(form.values, null, 2)}</Code>
     </>

--- a/packages/@mantine/form/src/types.ts
+++ b/packages/@mantine/form/src/types.ts
@@ -253,6 +253,7 @@ export interface UseFormReturnType<
   watch: Watch<Values>;
   key: Key<Values>;
   getInputNode: GetInputNode<Values>;
+  resetNestedFieldDirty: SetFieldDirty<Values>
 }
 
 export type UseForm<

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -282,6 +282,7 @@ export function useForm<
     isDirty: $status.isDirty,
     getTouched: $status.getTouched,
     getDirty: $status.getDirty,
+    resetNestedFieldDirty: $status.resetNestedFieldDirty,
 
     reorderListItem: $list.reorderListItem,
     insertListItem: $list.insertListItem,
@@ -299,6 +300,7 @@ export function useForm<
     key,
 
     getInputNode,
+
   };
 
   useFormActions(name, form);


### PR DESCRIPTION
added a function by which we can reset dirty status of a nested field as I faced an issue where I was unable to reset dirty status in array field for example
```ts
{
	emails: [
		"a@email.com",
		"b@email.com" // I want to reset dirty status of this only
}
```