### PR TITLE
[@mantine/core] ScrollArea: Fix user-select being left as none after interaction with scrollbar

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollAreaScrollbar/Scrollbar.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollAreaScrollbar/Scrollbar.tsx
@@ -102,15 +102,16 @@ export const Scrollbar = forwardRef<HTMLDivElement, ScrollbarProps>((props, forw
         })}
         onPointerMove={composeEventHandlers(props.onPointerMove, handleDragScroll)}
         onPointerUp={composeEventHandlers(props.onPointerUp, (event) => {
-          event.preventDefault();
-
           const element = event.target as HTMLElement;
           if (element.hasPointerCapture(event.pointerId)) {
+            event.preventDefault();
             element.releasePointerCapture(event.pointerId);
           }
+        })}
+        onLostPointerCapture={() => {
           document.body.style.webkitUserSelect = prevWebkitUserSelectRef.current;
           rectRef.current = null;
-        })}
+        }}
       />
     </ScrollbarProvider>
   );


### PR DESCRIPTION
This should be a proper fix for the issue https://github.com/mantinedev/mantine/issues/6681

I think another option would be to also handle `pointercancel` event, but `lostpointercapture` should cover everything. Not sure that handling `pointerup` is even required in this case, but I left it just in case.

Related commit https://github.com/mantinedev/mantine/commit/ccc0f3c42284c6fdbe671732aabee0d9299eb98d

The issue is reproducible on the mantine website

https://github.com/user-attachments/assets/41f041c1-256f-4685-8756-6545987e7ff6