### PR TITLE
[@mantine/dates]:DateInput component freezes the page on Safari 

### DIFF
--- a/packages/@mantine/dates/src/components/Month/get-month-days/get-month-days.ts
+++ b/packages/@mantine/dates/src/components/Month/get-month-days/get-month-days.ts
@@ -15,7 +15,7 @@ export function getMonthDays({
   consistentWeeks,
 }: GetMonthDaysInput): Date[][] {
   const day = dayjs(month).subtract(dayjs(month).date() - 1, 'day');
-  const start = dayjs(day);
+  const start = dayjs(day).startOf('day');
   const startOfMonth = start.toDate();
   const endOfMonth = start.add(+start.daysInMonth() - 1, 'day').toDate();
   const endDate = getEndOfWeek(endOfMonth, firstDayOfWeek);

--- a/packages/@mantine/dates/src/components/Month/get-month-days/get-month-days.ts
+++ b/packages/@mantine/dates/src/components/Month/get-month-days/get-month-days.ts
@@ -15,7 +15,7 @@ export function getMonthDays({
   consistentWeeks,
 }: GetMonthDaysInput): Date[][] {
   const day = dayjs(month).subtract(dayjs(month).date() - 1, 'day');
-  const start = dayjs(day.format('YYYY-M-D'));
+  const start = dayjs(day);
   const startOfMonth = start.toDate();
   const endOfMonth = start.add(+start.daysInMonth() - 1, 'day').toDate();
   const endDate = getEndOfWeek(endOfMonth, firstDayOfWeek);


### PR DESCRIPTION
fixes https://github.com/mantinedev/mantine/issues/7441

**Issue:**

The original code encountered an issue when creating a dayjs object using a formatted string (dayjs(day.format('YYYY-M-D'))). This resulted in Safari producing invalid dates, leading to NaN values. This caused the while loop to continuously execute the getEndOfWeek() function, ultimately freezing the component in Safari.

**Root Cause:**
The format() method in dayjs converts the date to a string (ISO format), which Safari does not parse correctly in certain edge cases, especially with extreme years (e.g., 4543 as described in https://github.com/mantinedev/mantine/issues/7441). When re-parsed back into a dayjs object, the resulting date was invalid, causing subsequent calculations and date manipulations to fail.


**Fix:**
- Removed the unnecessary string formatting step, which was responsible for the invalid date in Safari.
- Replaced the .format() method with direct usage of dayjs’s native date handling methods to ensure correct date parsing and to avoid compatibility issues with Safari.

