### PR TITLE
fix: [@mantine/core] update get-gradient deg to use nullish coalescing operators

### DIFF
--- a/packages/@mantine/core/src/core/MantineProvider/color-functions/get-gradient/get-gradient.test.ts
+++ b/packages/@mantine/core/src/core/MantineProvider/color-functions/get-gradient/get-gradient.test.ts
@@ -50,4 +50,17 @@ describe('@mantine/core/get-gradient', () => {
       )
     ).toStrictEqual('linear-gradient(90deg, #FEFEFE 0%, #CDCDCD 100%)');
   });
+
+  it('sets deg to 0', () => {
+    expect(
+      getGradient(
+        {
+          from: '#FEFEFE',
+          to: '#CDCDCD',
+          deg: 0,
+        },
+        DEFAULT_THEME
+      )
+    ).toStrictEqual('linear-gradient(0deg, #FEFEFE 0%, #CDCDCD 100%)');
+  });
 });

--- a/packages/@mantine/core/src/core/MantineProvider/color-functions/get-gradient/get-gradient.ts
+++ b/packages/@mantine/core/src/core/MantineProvider/color-functions/get-gradient/get-gradient.ts
@@ -5,7 +5,7 @@ export function getGradient(gradient: MantineGradient | undefined, theme: Mantin
   const merged = {
     from: gradient?.from || theme.defaultGradient.from,
     to: gradient?.to || theme.defaultGradient.to,
-    deg: gradient?.deg || theme.defaultGradient.deg || 0,
+    deg: gradient?.deg ?? theme.defaultGradient.deg ?? 0,
   };
 
   const fromColor = getThemeColor(merged.from, theme);


### PR DESCRIPTION
Resolves https://github.com/mantinedev/mantine/issues/7439

The bug reporter identified the solution in the report. Because `0` is a valid value but considered falsy in Javascript, using the logical OR (`||`) was causing a `deg={0}` to default to the defaultTheme's `45` value.

Before:

https://github.com/user-attachments/assets/628daa5e-6a47-488d-a5dc-7172efa118e1

After:

https://github.com/user-attachments/assets/a32d452d-410e-453e-8184-189c26171244


