### PR TITLE
Feature/fix refs usage

### DIFF
--- a/apps/mantine.dev/src/pages/hooks/use-click-outside.mdx
+++ b/apps/mantine.dev/src/pages/hooks/use-click-outside.mdx
@@ -14,7 +14,7 @@ export default Layout(MDX_DATA.useClickOutside);
 
 - `handler` – function that is called on outside click
 - `events` – optional list of events that trigger outside click, `['mousedown', 'touchstart']` by default
-- `nodes` - optional list of nodes that should not trigger outside click event
+- `excludedNodes` - optional list of nodes that should not trigger outside click event
 
 The hook returns a `ref` object that must be passed to the element
 based on which outside clicks should be captured.
@@ -84,6 +84,6 @@ const ref = useClickOutside<HTMLDivElement>(() =>
 function useClickOutside<T extends HTMLElement = any>(
   handler: () => void,
   events?: string[] | null,
-  nodes?: HTMLElement[]
+  excludedNodes?: HTMLElement[]
 ): React.MutableRefObject<T>;
 ```

--- a/packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.tsx
+++ b/packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type RefCallback } from 'react';
 import { useMove, useUncontrolled } from '@mantine/hooks';
 import {
   BoxProps,
@@ -340,10 +340,20 @@ export const RangeSlider = factory<RangeSliderFactory>((_props, ref) => {
     }
   };
 
-  const { ref: container, active } = useMove(
+  const container = useRef<any>(null);
+
+  const { ref: onMoveRefChange, active } = useMove(
     ({ x }) => handleChange(x),
     { onScrubEnd: () => !disabled && onChangeEnd?.(valueRef.current) },
     dir
+  );
+
+  const onContainerRefChange: RefCallback<any> = useCallback(
+    (containerNode: any) => {
+      onMoveRefChange(containerNode);
+      container.current = containerNode;
+    },
+    [onMoveRefChange]
   );
 
   function handleThumbMouseDown(index: number) {
@@ -489,7 +499,7 @@ export const RangeSlider = factory<RangeSliderFactory>((_props, ref) => {
           value={_value[1]}
           disabled={disabled}
           containerProps={{
-            ref: container as any,
+            ref: onContainerRefChange,
             onMouseEnter: showLabelOnHover ? () => setHovered(true) : undefined,
             onMouseLeave: showLabelOnHover ? () => setHovered(false) : undefined,
             onTouchStartCapture: handleTrackMouseDownCapture,

--- a/packages/@mantine/hooks/src/use-click-outside/use-click-outside.ts
+++ b/packages/@mantine/hooks/src/use-click-outside/use-click-outside.ts
@@ -9,24 +9,26 @@ export function useClickOutside<T extends HTMLElement = any>(
 ) {
   const [node, setNode] = useState<T | null>(null);
 
-  const listener = useCallback((event: Event) => {
-    const { target } = event ?? {};
+  const listener = useCallback(
+    (event: Event) => {
+      const { target } = event ?? {};
 
-    if (Array.isArray(excludedNodes)) {
-      const shouldIgnore =
-        (target as Element)?.hasAttribute?.('data-ignore-outside-clicks') ||
-        (!document.body.contains(target as Node) && (target as Element)?.tagName !== 'HTML');
+      if (Array.isArray(excludedNodes)) {
+        const shouldIgnore =
+          (target as Element)?.hasAttribute?.('data-ignore-outside-clicks') ||
+          (!document.body.contains(target as Node) && (target as Element)?.tagName !== 'HTML');
 
-      const shouldTrigger = excludedNodes.every((excludedNode) => (
-        !!excludedNode && !event.composedPath().includes(excludedNode)
-        )
-      );
+        const shouldTrigger = excludedNodes.every(
+          (excludedNode) => !!excludedNode && !event.composedPath().includes(excludedNode)
+        );
 
-      shouldTrigger && !shouldIgnore && handler();
-    } else if (node && !node.contains(target as Node)) {
-      handler();
-    }
-  }, [node, handler, excludedNodes]);
+        shouldTrigger && !shouldIgnore && handler();
+      } else if (node && !node.contains(target as Node)) {
+        handler();
+      }
+    },
+    [node, handler, excludedNodes]
+  );
 
   useEffect(() => {
     (events || DEFAULT_EVENTS).forEach((eventName) => {

--- a/packages/@mantine/hooks/src/use-event-listener/use-event-listener.ts
+++ b/packages/@mantine/hooks/src/use-event-listener/use-event-listener.ts
@@ -7,25 +7,26 @@ export function useEventListener<K extends keyof HTMLElementEventMap, T extends 
 ) {
   const cleanupAbortControllerRef = useRef<AbortController>(null);
 
-  const onRefChange: RefCallback<T> = useCallback((node) => {
-    cleanupAbortControllerRef.current?.abort();
+  const onRefChange: RefCallback<T> = useCallback(
+    (node) => {
+      cleanupAbortControllerRef.current?.abort();
 
-    cleanupAbortControllerRef.current = new AbortController();
-    const {signal, abort} = cleanupAbortControllerRef.current;
+      cleanupAbortControllerRef.current = new AbortController();
+      const { signal, abort } = cleanupAbortControllerRef.current;
 
-    let parsedOptions = {};
+      let parsedOptions = {};
 
-    if (options && typeof options === 'object') {
-      options.signal?.addEventListener('abort', abort);
-      parsedOptions = { ...options, signal };
-    }
-    else if (typeof options === 'boolean') {
-      parsedOptions = { capture: options };
-    }
+      if (options && typeof options === 'object') {
+        options.signal?.addEventListener('abort', abort);
+        parsedOptions = { ...options, signal };
+      } else if (typeof options === 'boolean') {
+        parsedOptions = { capture: options };
+      }
 
-
-    node?.addEventListener(type, listener, parsedOptions);
-  }, [type, listener, options]);
+      node?.addEventListener(type, listener, parsedOptions);
+    },
+    [type, listener, options]
+  );
 
   return onRefChange;
 }

--- a/packages/@mantine/hooks/src/use-focus-within/use-focus-within.ts
+++ b/packages/@mantine/hooks/src/use-focus-within/use-focus-within.ts
@@ -41,15 +41,18 @@ export function useFocusWithin<T extends HTMLElement = any>({
     }
   };
 
-  const onRefChange: RefCallback<T> = useCallback((node) => {
-    cleanupAbortControllerRef.current?.abort();
+  const onRefChange: RefCallback<T> = useCallback(
+    (node) => {
+      cleanupAbortControllerRef.current?.abort();
 
-    cleanupAbortControllerRef.current = new AbortController();
-    const {signal} = cleanupAbortControllerRef.current;
+      cleanupAbortControllerRef.current = new AbortController();
+      const { signal } = cleanupAbortControllerRef.current;
 
-    node?.addEventListener('focusin', handleFocusIn, { signal });
-    node?.addEventListener('focusout', handleFocusOut, { signal });
-  }, [handleFocusIn, handleFocusOut]);
+      node?.addEventListener('focusin', handleFocusIn, { signal });
+      node?.addEventListener('focusout', handleFocusOut, { signal });
+    },
+    [handleFocusIn, handleFocusOut]
+  );
 
   return { ref: onRefChange, focused };
 }

--- a/packages/@mantine/hooks/src/use-hover/use-hover.test.tsx
+++ b/packages/@mantine/hooks/src/use-hover/use-hover.test.tsx
@@ -1,8 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { useHover } from './use-hover';
+import { useState } from 'react';
 
 const Target: React.FunctionComponent<any> = () => {
   const { ref, hovered } = useHover();
+
+  console.log({hovered});
 
   return (
     <div data-testid="target" ref={ref}>
@@ -11,11 +14,35 @@ const Target: React.FunctionComponent<any> = () => {
   );
 };
 
+const AppearingTarget: React.FunctionComponent<any> = ({showTarget}: {showTarget: boolean}) => {
+  const { ref, hovered } = useHover();
+
+  return showTarget && (
+      <div data-testid="target" ref={ref}>
+        {hovered ? 'true' : 'false'}
+      </div>
+    );
+};
+
 describe('@mantine/hooks/use-hover', () => {
   it('changes `hovered` on mouseenter/mouseleave correctly', () => {
     render(<Target />);
     const target = screen.getByTestId('target');
 
+    expect(target).toHaveTextContent('false');
+
+    fireEvent.mouseEnter(target);
+    expect(target).toHaveTextContent('true');
+
+    fireEvent.mouseLeave(target);
+    expect(target).toHaveTextContent('false');
+  });
+
+  it('changes `hovered` when element was unmounted at first', async () => {
+    const {rerender} = render(<AppearingTarget showDiv={false} />);
+    rerender(<AppearingTarget showDiv />);
+
+    const target = screen.getByTestId('target');
     expect(target).toHaveTextContent('false');
 
     fireEvent.mouseEnter(target);

--- a/packages/@mantine/hooks/src/use-hover/use-hover.test.tsx
+++ b/packages/@mantine/hooks/src/use-hover/use-hover.test.tsx
@@ -39,8 +39,8 @@ describe('@mantine/hooks/use-hover', () => {
   });
 
   it('changes `hovered` when element was unmounted at first', async () => {
-    const {rerender} = render(<AppearingTarget showDiv={false} />);
-    rerender(<AppearingTarget showDiv />);
+    const {rerender} = render(<AppearingTarget showTarget={false} />);
+    rerender(<AppearingTarget showTarget />);
 
     const target = screen.getByTestId('target');
     expect(target).toHaveTextContent('false');

--- a/packages/@mantine/hooks/src/use-hover/use-hover.test.tsx
+++ b/packages/@mantine/hooks/src/use-hover/use-hover.test.tsx
@@ -1,11 +1,11 @@
+import { useState } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { useHover } from './use-hover';
-import { useState } from 'react';
 
 const Target: React.FunctionComponent<any> = () => {
   const { ref, hovered } = useHover();
 
-  console.log({hovered});
+  console.log({ hovered });
 
   return (
     <div data-testid="target" ref={ref}>
@@ -14,14 +14,16 @@ const Target: React.FunctionComponent<any> = () => {
   );
 };
 
-const AppearingTarget: React.FunctionComponent<any> = ({showTarget}: {showTarget: boolean}) => {
+const AppearingTarget: React.FunctionComponent<any> = ({ showTarget }: { showTarget: boolean }) => {
   const { ref, hovered } = useHover();
 
-  return showTarget && (
+  return (
+    showTarget && (
       <div data-testid="target" ref={ref}>
         {hovered ? 'true' : 'false'}
       </div>
-    );
+    )
+  );
 };
 
 describe('@mantine/hooks/use-hover', () => {
@@ -39,7 +41,7 @@ describe('@mantine/hooks/use-hover', () => {
   });
 
   it('changes `hovered` when element was unmounted at first', async () => {
-    const {rerender} = render(<AppearingTarget showTarget={false} />);
+    const { rerender } = render(<AppearingTarget showTarget={false} />);
     rerender(<AppearingTarget showTarget />);
 
     const target = screen.getByTestId('target');

--- a/packages/@mantine/hooks/src/use-hover/use-hover.ts
+++ b/packages/@mantine/hooks/src/use-hover/use-hover.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState, useRef, type RefCallback } from 'react';
+import { useCallback, useRef, useState, type RefCallback } from 'react';
 
 export function useHover<T extends HTMLElement = any>() {
   const [hovered, setHovered] = useState(false);
@@ -11,13 +11,13 @@ export function useHover<T extends HTMLElement = any>() {
     cleanupAbortControllerRef.current?.abort();
 
     const controller = new AbortController();
-    const {signal} = controller;
+    const { signal } = controller;
 
     node?.addEventListener('mouseenter', onMouseEnter, { signal });
     node?.addEventListener('mouseleave', onMouseLeave, { signal });
 
     cleanupAbortControllerRef.current = controller;
-  }, [])
+  }, []);
 
   return { ref: onRefChange, hovered };
 }

--- a/packages/@mantine/hooks/src/use-hover/use-hover.ts
+++ b/packages/@mantine/hooks/src/use-hover/use-hover.ts
@@ -1,26 +1,20 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState, useRef, type RefCallback } from 'react';
 
 export function useHover<T extends HTMLElement = any>() {
   const [hovered, setHovered] = useState(false);
-  const ref = useRef<T>(null);
+  const lastNodeRef = useRef<T>(null);
   const onMouseEnter = useCallback(() => setHovered(true), []);
   const onMouseLeave = useCallback(() => setHovered(false), []);
 
-  useEffect(() => {
-    const node = ref.current;
+  const onRefChange: RefCallback<T> = useCallback((node) => {
+    lastNodeRef.current?.removeEventListener('mouseenter', onMouseEnter);
+    lastNodeRef.current?.removeEventListener('mouseleave', onMouseLeave);
 
-    if (node) {
-      node.addEventListener('mouseenter', onMouseEnter);
-      node.addEventListener('mouseleave', onMouseLeave);
+    node?.addEventListener('mouseenter', onMouseEnter);
+    node?.addEventListener('mouseleave', onMouseLeave);
 
-      return () => {
-        node?.removeEventListener('mouseenter', onMouseEnter);
-        node?.removeEventListener('mouseleave', onMouseLeave);
-      };
-    }
+    lastNodeRef.current = node;
+  }, [])
 
-    return undefined;
-  }, [ref.current]);
-
-  return { ref, hovered };
+  return { ref: onRefChange, hovered };
 }

--- a/packages/@mantine/hooks/src/use-mouse/use-mouse.test.tsx
+++ b/packages/@mantine/hooks/src/use-mouse/use-mouse.test.tsx
@@ -15,7 +15,7 @@ describe('@mantine/hook/use-mouse', () => {
   it('returns correct initial position (0, 0)', () => {
     const { result } = renderHook(() => useMouse());
 
-    expect(result.current).toEqual({ ref: expect.any(Object), x: 0, y: 0 });
+    expect(result.current).toEqual({ ref: expect.any(Function), x: 0, y: 0 });
   });
 
   it('updates the position without a ref', () => {
@@ -23,7 +23,7 @@ describe('@mantine/hook/use-mouse', () => {
 
     fireEvent.mouseMove(document, { clientX: 123, clientY: 456 });
 
-    expect(result.current).toEqual({ ref: expect.any(Object), x: 123, y: 456 });
+    expect(result.current).toEqual({ ref: expect.any(Function), x: 123, y: 456 });
   });
 
   it('updates the position', () => {
@@ -50,10 +50,10 @@ describe('@mantine/hook/use-mouse', () => {
 
     fireEvent.mouseMove(document, { clientX: 123, clientY: 456 });
 
-    expect(result.current).toEqual({ ref: expect.any(Object), x: 123, y: 456 });
+    expect(result.current).toEqual({ ref: expect.any(Function), x: 123, y: 456 });
 
     fireEvent.mouseLeave(document);
 
-    expect(result.current).toEqual({ ref: expect.any(Object), x: 0, y: 0 });
+    expect(result.current).toEqual({ ref: expect.any(Function), x: 0, y: 0 });
   });
 });

--- a/packages/@mantine/hooks/src/use-mouse/use-mouse.ts
+++ b/packages/@mantine/hooks/src/use-mouse/use-mouse.ts
@@ -1,4 +1,4 @@
-import { type MouseEvent, useEffect, useState } from 'react';
+import { useEffect, useState, type MouseEvent } from 'react';
 
 export function useMouse<T extends HTMLElement = any>(
   options: { resetOnExit?: boolean } = { resetOnExit: false }

--- a/packages/@mantine/hooks/src/use-mouse/use-mouse.ts
+++ b/packages/@mantine/hooks/src/use-mouse/use-mouse.ts
@@ -1,14 +1,14 @@
-import { MouseEvent, useEffect, useRef, useState } from 'react';
+import { type MouseEvent, useEffect, useState } from 'react';
 
 export function useMouse<T extends HTMLElement = any>(
   options: { resetOnExit?: boolean } = { resetOnExit: false }
 ) {
   const [position, setPosition] = useState({ x: 0, y: 0 });
 
-  const ref = useRef<T>(null);
+  const [node, setNode] = useState<T | null>(null);
 
   const setMousePosition = (event: MouseEvent<HTMLElement>) => {
-    if (ref.current) {
+    if (node) {
       const rect = event.currentTarget.getBoundingClientRect();
 
       const x = Math.max(
@@ -30,7 +30,8 @@ export function useMouse<T extends HTMLElement = any>(
   const resetMousePosition = () => setPosition({ x: 0, y: 0 });
 
   useEffect(() => {
-    const element = ref?.current ? ref.current : document;
+    const element = node ?? document;
+
     element.addEventListener('mousemove', setMousePosition as any);
     if (options.resetOnExit) {
       element.addEventListener('mouseleave', resetMousePosition as any);
@@ -42,7 +43,7 @@ export function useMouse<T extends HTMLElement = any>(
         element.removeEventListener('mouseleave', resetMousePosition as any);
       }
     };
-  }, [ref.current]);
+  }, [node]);
 
-  return { ref, ...position };
+  return { ref: setNode, ...position };
 }

--- a/packages/@mantine/hooks/src/use-move/use-move.ts
+++ b/packages/@mantine/hooks/src/use-move/use-move.ts
@@ -68,7 +68,7 @@ export function useMove<T extends HTMLElement = any>(
     const startScrubbing = () => {
       if (!isSliding.current) {
         isSliding.current = true;
-        typeof handlers?.onScrubStart === 'function' && handlers.onScrubStart();
+        handlers?.onScrubStart?.();
         setActive(true);
         bindEvents();
       }
@@ -80,7 +80,7 @@ export function useMove<T extends HTMLElement = any>(
         setActive(false);
         unbindEvents();
         setTimeout(() => {
-          typeof handlers?.onScrubEnd === 'function' && handlers.onScrubEnd();
+           handlers?.onScrubEnd?.();
         }, 0);
       }
     };

--- a/packages/@mantine/hooks/src/use-move/use-move.ts
+++ b/packages/@mantine/hooks/src/use-move/use-move.ts
@@ -29,97 +29,100 @@ export function useMove<T extends HTMLElement = any>(
 
   const cleanupAbortControllerRef = useRef<AbortController>(null);
 
-  const onRefChange: RefCallback<T> = useCallback((node) => {
-    const onScrub = ({ x, y }: UseMovePosition) => {
-      cancelAnimationFrame(frame.current);
+  const onRefChange: RefCallback<T> = useCallback(
+    (node) => {
+      const onScrub = ({ x, y }: UseMovePosition) => {
+        cancelAnimationFrame(frame.current);
 
-      frame.current = requestAnimationFrame(() => {
-        if (!node) {
-          return;
+        frame.current = requestAnimationFrame(() => {
+          if (!node) {
+            return;
+          }
+
+          node.style.userSelect = 'none';
+          const rect = node.getBoundingClientRect();
+
+          if (rect.width && rect.height) {
+            const _x = clamp((x - rect.left) / rect.width, 0, 1);
+            onChange({
+              x: dir === 'ltr' ? _x : 1 - _x,
+              y: clamp((y - rect.top) / rect.height, 0, 1),
+            });
+          }
+        });
+      };
+
+      const bindEvents = () => {
+        document.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', stopScrubbing);
+        document.addEventListener('touchmove', onTouchMove);
+        document.addEventListener('touchend', stopScrubbing);
+      };
+
+      const unbindEvents = () => {
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', stopScrubbing);
+        document.removeEventListener('touchmove', onTouchMove);
+        document.removeEventListener('touchend', stopScrubbing);
+      };
+
+      const startScrubbing = () => {
+        if (!isSliding.current) {
+          isSliding.current = true;
+          handlers?.onScrubStart?.();
+          setActive(true);
+          bindEvents();
+        }
+      };
+
+      const stopScrubbing = () => {
+        if (isSliding.current) {
+          isSliding.current = false;
+          setActive(false);
+          unbindEvents();
+          setTimeout(() => {
+            handlers?.onScrubEnd?.();
+          }, 0);
+        }
+      };
+
+      const onMouseDown = (event: MouseEvent) => {
+        startScrubbing();
+        event.preventDefault();
+        onMouseMove(event);
+      };
+
+      const onMouseMove = (event: MouseEvent) => onScrub({ x: event.clientX, y: event.clientY });
+
+      const onTouchStart = (event: TouchEvent) => {
+        if (event.cancelable) {
+          event.preventDefault();
         }
 
-        node.style.userSelect = 'none';
-        const rect = node.getBoundingClientRect();
+        startScrubbing();
+        onTouchMove(event);
+      };
 
-        if (rect.width && rect.height) {
-          const _x = clamp((x - rect.left) / rect.width, 0, 1);
-          onChange({
-            x: dir === 'ltr' ? _x : 1 - _x,
-            y: clamp((y - rect.top) / rect.height, 0, 1),
-          });
+      const onTouchMove = (event: TouchEvent) => {
+        if (event.cancelable) {
+          event.preventDefault();
         }
-      });
-    };
 
-    const bindEvents = () => {
-      document.addEventListener('mousemove', onMouseMove);
-      document.addEventListener('mouseup', stopScrubbing);
-      document.addEventListener('touchmove', onTouchMove);
-      document.addEventListener('touchend', stopScrubbing);
-    };
+        onScrub({ x: event.changedTouches[0].clientX, y: event.changedTouches[0].clientY });
+      };
 
-    const unbindEvents = () => {
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', stopScrubbing);
-      document.removeEventListener('touchmove', onTouchMove);
-      document.removeEventListener('touchend', stopScrubbing);
-    };
+      cleanupAbortControllerRef.current?.abort();
 
-    const startScrubbing = () => {
-      if (!isSliding.current) {
-        isSliding.current = true;
-        handlers?.onScrubStart?.();
-        setActive(true);
-        bindEvents();
-      }
-    };
+      const controller = new AbortController();
+      const { signal } = controller;
 
-    const stopScrubbing = () => {
-      if (isSliding.current) {
-        isSliding.current = false;
-        setActive(false);
-        unbindEvents();
-        setTimeout(() => {
-           handlers?.onScrubEnd?.();
-        }, 0);
-      }
-    };
+      node?.addEventListener('mousedown', onMouseDown, { signal });
+      node?.addEventListener('touchstart', onTouchStart, { signal, passive: false });
 
-    const onMouseDown = (event: MouseEvent) => {
-      startScrubbing();
-      event.preventDefault();
-      onMouseMove(event);
-    };
-
-    const onMouseMove = (event: MouseEvent) => onScrub({ x: event.clientX, y: event.clientY });
-
-    const onTouchStart = (event: TouchEvent) => {
-      if (event.cancelable) {
-        event.preventDefault();
-      }
-
-      startScrubbing();
-      onTouchMove(event);
-    };
-
-    const onTouchMove = (event: TouchEvent) => {
-      if (event.cancelable) {
-        event.preventDefault();
-      }
-
-      onScrub({ x: event.changedTouches[0].clientX, y: event.changedTouches[0].clientY });
-    };
-
-    cleanupAbortControllerRef.current?.abort();
-
-    const controller = new AbortController();
-    const {signal} = controller;
-
-    node?.addEventListener('mousedown', onMouseDown, { signal });
-    node?.addEventListener('touchstart', onTouchStart, { signal, passive: false });
-
-    cleanupAbortControllerRef.current = controller;
-  }, [dir, onChange]);
+      cleanupAbortControllerRef.current = controller;
+    },
+    [dir, onChange]
+  );
 
   return { ref: onRefChange, active };
 }


### PR DESCRIPTION
fixing #7406 
In short, I changed most of hook relying on refs to use the ref callback instead.
this fixes issues described thoroughly at #7406 , such as hooks not working when the ref is changed.

Strictly speaking, this is a breaking change because it changes the return value of the hooks to RefCallback instead of RefObject.
Also this is my first time contributint to open source so I may have missed steps (?)
(I'm not sure if I'm suppposed to bump the version or not etc.)