### PR TITLE
Feature/fix use hover ref

### DIFF
--- a/packages/@mantine/hooks/src/use-hover/use-hover.test.tsx
+++ b/packages/@mantine/hooks/src/use-hover/use-hover.test.tsx
@@ -11,11 +11,37 @@ const Target: React.FunctionComponent<any> = () => {
   );
 };
 
+const AppearingTarget: React.FunctionComponent<any> = ({ showTarget }: { showTarget: boolean }) => {
+  const { ref, hovered } = useHover();
+
+  return (
+    showTarget && (
+      <div data-testid="target" ref={ref}>
+        {hovered ? 'true' : 'false'}
+      </div>
+    )
+  );
+};
+
 describe('@mantine/hooks/use-hover', () => {
   it('changes `hovered` on mouseenter/mouseleave correctly', () => {
     render(<Target />);
     const target = screen.getByTestId('target');
 
+    expect(target).toHaveTextContent('false');
+
+    fireEvent.mouseEnter(target);
+    expect(target).toHaveTextContent('true');
+
+    fireEvent.mouseLeave(target);
+    expect(target).toHaveTextContent('false');
+  });
+
+  it('changes `hovered` when element was not mounted at first', async () => {
+    const { rerender } = render(<AppearingTarget showTarget={false} />);
+    rerender(<AppearingTarget showTarget />);
+
+    const target = screen.getByTestId('target');
     expect(target).toHaveTextContent('false');
 
     fireEvent.mouseEnter(target);


### PR DESCRIPTION
Fix of #7406 only to the use hover hook as poc
Added a ut for the failing use case of when the ref is not initialized in the first render (and there are no renders after it is initialized) which fails in master.

Strictly, it is breaking change turning the ref return value from `RefObject` to `RefCallback`