### PR TITLE
Update CodeHighlightTabs.tsx: Fallback unsupported code to plaintext

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+yarn = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,0 @@
-[tools]
-yarn = "latest"

--- a/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
@@ -184,7 +184,7 @@ export const CodeHighlightTabs = factory<CodeHighlightTabsFactory>((_props, ref)
   const currentCode = nodes[value];
 
   const language = currentCode.language != null
-  ? hljs.getLanguage(currentCode.language ?? '') ? currentCode.language : 'plaintext'
+    ? hljs.getLanguage(currentCode.language ?? '') ? currentCode.language : 'plaintext'
     : 'plaintext';
 
   const highlighted = hljs.highlight(currentCode.code.trim(), {

--- a/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
@@ -184,7 +184,7 @@ export const CodeHighlightTabs = factory<CodeHighlightTabsFactory>((_props, ref)
   const currentCode = nodes[value];
 
   const highlighted = hljs.highlight(currentCode.code.trim(), {
-    language: hljs.getLanguage(currentCode.language) ? language : 'plaintext',
+    language: hljs.getLanguage(currentCode.language) ? currentCode.language : 'plaintext',
   }).value;
 
   const files = nodes.map((node, index) => (

--- a/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
@@ -183,9 +183,12 @@ export const CodeHighlightTabs = factory<CodeHighlightTabsFactory>((_props, ref)
   const nodes = Array.isArray(code) ? code : [code];
   const currentCode = nodes[value];
 
-  const language = currentCode.language != null
-    ? hljs.getLanguage(currentCode.language ?? '') ? currentCode.language : 'plaintext'
-    : 'plaintext';
+  const language =
+    currentCode.language != null
+      ? hljs.getLanguage(currentCode.language ?? '')
+        ? currentCode.language
+        : 'plaintext'
+      : 'plaintext';
 
   const highlighted = hljs.highlight(currentCode.code.trim(), {
     language,

--- a/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
@@ -184,7 +184,7 @@ export const CodeHighlightTabs = factory<CodeHighlightTabsFactory>((_props, ref)
   const currentCode = nodes[value];
 
   const highlighted = hljs.highlight(currentCode.code.trim(), {
-    language: currentCode.language || 'plaintext',
+    language: hljs.getLanguage(language) ? language : 'plaintext',
   }).value;
 
   const files = nodes.map((node, index) => (

--- a/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
@@ -183,8 +183,12 @@ export const CodeHighlightTabs = factory<CodeHighlightTabsFactory>((_props, ref)
   const nodes = Array.isArray(code) ? code : [code];
   const currentCode = nodes[value];
 
+  const language = currentCode.language != null
+  ? hljs.getLanguage(currentCode.language ?? '') ? currentCode.language : 'plaintext'
+    : 'plaintext';
+
   const highlighted = hljs.highlight(currentCode.code.trim(), {
-    language: hljs.getLanguage(currentCode.language) ? currentCode.language : 'plaintext',
+    language,
   }).value;
 
   const files = nodes.map((node, index) => (

--- a/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightTabs.tsx
@@ -184,7 +184,7 @@ export const CodeHighlightTabs = factory<CodeHighlightTabsFactory>((_props, ref)
   const currentCode = nodes[value];
 
   const highlighted = hljs.highlight(currentCode.code.trim(), {
-    language: hljs.getLanguage(language) ? language : 'plaintext',
+    language: hljs.getLanguage(currentCode.language) ? language : 'plaintext',
   }).value;
 
   const files = nodes.map((node, index) => (


### PR DESCRIPTION
Instead of throwing unsupported code error, it fallback to plaintext.

It's the current behaviour of CodeHighlight component.
