### PR TITLE
[mantine.dev] Add `not-hover` underline option to Anchor documentation and demo

### DIFF
--- a/apps/mantine.dev/src/pages/core/anchor.mdx
+++ b/apps/mantine.dev/src/pages/core/anchor.mdx
@@ -15,6 +15,7 @@ Use `underline` prop to configure `text-decoration` property. It accepts the fol
 - `always` - link is always underlined
 - `hover` - link is underlined on hover
 - `never` - link is never underlined
+- `not-hover` - link is underlined when not hovered
 
 <Demo data={AnchorDemos.decoration} />
 

--- a/packages/@docs/demos/src/demos/core/Anchor/Anchor.demo.decoration.tsx
+++ b/packages/@docs/demos/src/demos/core/Anchor/Anchor.demo.decoration.tsx
@@ -16,6 +16,9 @@ function Demo() {
       <Anchor href="https://mantine.dev/" target="_blank" underline="never">
         Underline never
       </Anchor>
+      <Anchor href="https://mantine.dev/" target="_blank" underline="not-hover">
+        Underline not-hover
+      </Anchor>
     </Group>
   );
 }
@@ -32,6 +35,9 @@ function Demo() {
       </Anchor>
       <Anchor href="https://mantine.dev/" target="_blank" underline="never">
         Underline never
+      </Anchor>
+      <Anchor href="https://mantine.dev/" target="_blank" underline="not-hover">
+        Underline not-hover
       </Anchor>
     </Group>
   );


### PR DESCRIPTION
Saw in the changelog for the latest version that a `not-hover` value was added for the `underline` prop of the `Anchor` component, but the new value has not been added neither in the documentation page nor in the example. 

I added both of these changes.

Hope it's all good!