### PR TITLE
Add centered overlay demo

### DIFF
--- a/apps/mantine.dev/src/pages/core/overlay.mdx
+++ b/apps/mantine.dev/src/pages/core/overlay.mdx
@@ -30,7 +30,7 @@ Note that `backdrop-filter` [is not supported in all browsers](https://caniuse.c
 
 ## Center
 
-To center the content within the `Overlay`, you can use the `centered` prop:
+To center the content within the `Overlay`, you can use the `center` prop:
 
 <Demo data={OverlayDemos.center} />
 

--- a/apps/mantine.dev/src/pages/core/overlay.mdx
+++ b/apps/mantine.dev/src/pages/core/overlay.mdx
@@ -27,6 +27,14 @@ Note that `backdrop-filter` [is not supported in all browsers](https://caniuse.c
 
 <Demo data={OverlayDemos.blur} />
 
+
+## Center
+
+To center the content within the `Overlay`, you can use the `centered` prop:
+
+<Demo data={OverlayDemos.center} />
+
+
 <Polymorphic
   defaultElement="div"
   changeToElement="a"

--- a/packages/@docs/demos/src/demos/core/Overlay/Overlay.demo.center.tsx
+++ b/packages/@docs/demos/src/demos/core/Overlay/Overlay.demo.center.tsx
@@ -1,0 +1,46 @@
+import { AspectRatio, Card, Overlay, Title } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { Alert, AspectRatio, Overlay } from '@mantine/core';
+
+function Demo() {
+  return (
+    <AspectRatio ratio={16 / 9} maw={600} mx="auto" pos="relative">
+      <img
+        src="https://raw.githubusercontent.com/mantinedev/mantine/master/.demo/images/bg-8.png"
+        alt="Demo"
+      />
+      <Overlay center>
+        <Card bg="blue">
+          <Title>Content Centered</Title>
+          The overlay is centered within the container using the 'center' prop.
+        </Card>
+      </Overlay>
+    </AspectRatio>
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <AspectRatio ratio={16 / 9} maw={600} mx="auto" pos="relative">
+      <img
+        src="https://raw.githubusercontent.com/mantinedev/mantine/master/.demo/images/bg-8.png"
+        alt="Demo"
+      />
+      <Overlay center>
+        <Card>
+          <Title order={3}>Content Centered</Title>
+          Content is centered within the container using the `center` prop.
+        </Card>
+      </Overlay>
+    </AspectRatio>
+  );
+}
+
+export const center: MantineDemo = {
+  type: 'code',
+  code,
+  component: Demo,
+};

--- a/packages/@docs/demos/src/demos/core/Overlay/Overlay.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/core/Overlay/Overlay.demos.story.tsx
@@ -18,7 +18,6 @@ export const Demo_blur = {
   render: renderDemo(demos.blur),
 };
 
-// demo center
 export const Demo_center = {
   name: '⭐ Demo: center',
   render: renderDemo(demos.center),

--- a/packages/@docs/demos/src/demos/core/Overlay/Overlay.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/core/Overlay/Overlay.demos.story.tsx
@@ -17,3 +17,9 @@ export const Demo_blur = {
   name: '⭐ Demo: blur',
   render: renderDemo(demos.blur),
 };
+
+// demo center
+export const Demo_center = {
+  name: '⭐ Demo: center',
+  render: renderDemo(demos.center),
+};

--- a/packages/@docs/demos/src/demos/core/Overlay/index.ts
+++ b/packages/@docs/demos/src/demos/core/Overlay/index.ts
@@ -1,3 +1,4 @@
 export { usage } from './Overlay.demo.usage';
 export { gradient } from './Overlay.demo.gradient';
 export { blur } from './Overlay.demo.blur';
+export { center } from './Overlay.demo.center';


### PR DESCRIPTION
Introduce a new demo showcasing the use of the `center` prop in the `Overlay` component, allowing content to be centered within its container.

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/bfa87f35-ed06-432e-9446-044035d35bab" />

<img width="796" alt="image" src="https://github.com/user-attachments/assets/80d72f0d-0ce1-4d12-a023-69044a406c80" />
