### PR TITLE
[mantine.dev] Add system theme to a color scheme switcher

### DIFF
--- a/apps/mantine.dev/src/pages/_app.tsx
+++ b/apps/mantine.dev/src/pages/_app.tsx
@@ -77,7 +77,7 @@ export default function App({ Component, pageProps, router }: AppProps) {
       <FontsStyle />
       <DirectionProvider initialDirection="ltr" detectDirection={false}>
         <MantineEmotionProvider cache={emotionCache}>
-          <MantineProvider theme={theme} defaultColorScheme="light">
+          <MantineProvider theme={theme} defaultColorScheme="auto">
             <ShikiProvider loadShiki={loadShiki}>
               <Search />
               <Notifications />

--- a/apps/mantine.dev/src/pages/_document.tsx
+++ b/apps/mantine.dev/src/pages/_document.tsx
@@ -8,7 +8,7 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
-        <ColorSchemeScript defaultColorScheme="light" />
+        <ColorSchemeScript defaultColorScheme="auto" />
       </Head>
       <body>
         <Main />

--- a/packages/@mantinex/mantine-header/src/ColorSchemeControl.module.css
+++ b/packages/@mantinex/mantine-header/src/ColorSchemeControl.module.css
@@ -3,22 +3,20 @@
   height: 22px;
 }
 
-.dark {
-  @mixin dark {
-    display: none;
-  }
-
-  @mixin light {
-    display: block;
-  }
+.dark,
+.light,
+.auto {
+  display: none;
 }
 
-.light {
-  @mixin light {
-    display: none;
-  }
+[data-active='dark'] .dark {
+  display: block;
+}
 
-  @mixin dark {
-    display: block;
-  }
+[data-active='light'] .light {
+  display: block;
+}
+
+[data-active='auto'] .auto {
+  display: block;
 }

--- a/packages/@mantinex/mantine-header/src/ColorSchemeControl.tsx
+++ b/packages/@mantinex/mantine-header/src/ColorSchemeControl.tsx
@@ -1,21 +1,31 @@
-import { IconMoon, IconSun } from '@tabler/icons-react';
+import { useEffect } from 'react';
+import { IconMoon, IconSun, IconSunMoon } from '@tabler/icons-react';
 import cx from 'clsx';
-import { useComputedColorScheme, useMantineColorScheme } from '@mantine/core';
+import { MantineColorScheme, useMantineColorScheme } from '@mantine/core';
+import { useToggle } from '@mantine/hooks';
 import { HeaderControl } from './HeaderControl';
 import classes from './ColorSchemeControl.module.css';
 
 export function ColorSchemeControl() {
-  const { setColorScheme } = useMantineColorScheme();
-  const computedColorScheme = useComputedColorScheme('light', { getInitialValueInEffect: true });
+  const { setColorScheme, colorScheme } = useMantineColorScheme();
+  const [scheme, toggle] = useToggle(['light', 'auto', 'dark'] as MantineColorScheme[]);
+  const tooltip =
+    colorScheme === 'auto' ? 'System preferences' : colorScheme === 'light' ? 'Light' : 'Dark';
+
+  useEffect(() => {
+    setColorScheme(scheme);
+  }, [scheme]);
 
   return (
     <HeaderControl
-      onClick={() => setColorScheme(computedColorScheme === 'light' ? 'dark' : 'light')}
-      tooltip={`${computedColorScheme === 'dark' ? 'Light' : 'Dark'} mode`}
+      onClick={() => toggle()}
+      tooltip={`${tooltip} mode`}
       aria-label="Toggle color scheme"
+      data-active={scheme}
     >
       <IconSun className={cx(classes.icon, classes.light)} stroke={1.5} />
       <IconMoon className={cx(classes.icon, classes.dark)} stroke={1.5} />
+      <IconSunMoon className={cx(classes.icon, classes.auto)} stroke={1.5} />
     </HeaderControl>
   );
 }


### PR DESCRIPTION
Sets "auto" by default to follow system theme on the user's device.
Also allows to toggle between 3 states: `light | auto | dark` with saving to a LocalStorage.

https://github.com/user-attachments/assets/62c3cec1-6792-44e5-b3c9-171a396cfb46

