### PR TITLE
fix: Prevent invalid index access on Backspace with empty selection

### DIFF
--- a/apps/mantine.dev/src/combobox-examples/examples/ActiveOptionsFilter/ActiveOptionsFilter.tsx
+++ b/apps/mantine.dev/src/combobox-examples/examples/ActiveOptionsFilter/ActiveOptionsFilter.tsx
@@ -49,7 +49,7 @@ export function ActiveOptionsFilter() {
                 type="hidden"
                 onBlur={() => combobox.closeDropdown()}
                 onKeyDown={(event) => {
-                  if (event.key === 'Backspace') {
+                  if (event.key === 'Backspace' && value.length > 0) {
                     event.preventDefault();
                     handleValueRemove(value[value.length - 1]);
                   }

--- a/apps/mantine.dev/src/combobox-examples/examples/BasicMultiSelect/BasicMultiSelect.tsx
+++ b/apps/mantine.dev/src/combobox-examples/examples/BasicMultiSelect/BasicMultiSelect.tsx
@@ -50,7 +50,7 @@ export function BasicMultiSelect() {
                 type="hidden"
                 onBlur={() => combobox.closeDropdown()}
                 onKeyDown={(event) => {
-                  if (event.key === 'Backspace') {
+                  if (event.key === 'Backspace' && value.length > 0) {
                     event.preventDefault();
                     handleValueRemove(value[value.length - 1]);
                   }

--- a/apps/mantine.dev/src/combobox-examples/examples/MaxDisplayedItems/MaxDisplayedItems.tsx
+++ b/apps/mantine.dev/src/combobox-examples/examples/MaxDisplayedItems/MaxDisplayedItems.tsx
@@ -62,7 +62,7 @@ export function MaxDisplayedItems() {
                 type="hidden"
                 onBlur={() => combobox.closeDropdown()}
                 onKeyDown={(event) => {
-                  if (event.key === 'Backspace') {
+                  if (event.key === 'Backspace' && value.length > 0) {
                     event.preventDefault();
                     handleValueRemove(value[value.length - 1]);
                   }

--- a/apps/mantine.dev/src/combobox-examples/examples/MaxSelectedItems/MaxSelectedItems.tsx
+++ b/apps/mantine.dev/src/combobox-examples/examples/MaxSelectedItems/MaxSelectedItems.tsx
@@ -57,7 +57,7 @@ export function MaxSelectedItems() {
                 type="hidden"
                 onBlur={() => combobox.closeDropdown()}
                 onKeyDown={(event) => {
-                  if (event.key === 'Backspace') {
+                  if (event.key === 'Backspace' && value.length > 0) {
                     event.preventDefault();
                     handleValueRemove(value[value.length - 1]);
                   }

--- a/apps/mantine.dev/src/combobox-examples/examples/MultiSelectCheckbox/MultiSelectCheckbox.tsx
+++ b/apps/mantine.dev/src/combobox-examples/examples/MultiSelectCheckbox/MultiSelectCheckbox.tsx
@@ -56,7 +56,7 @@ export function MultiSelectCheckbox() {
                 type="hidden"
                 onBlur={() => combobox.closeDropdown()}
                 onKeyDown={(event) => {
-                  if (event.key === 'Backspace') {
+                  if (event.key === 'Backspace' && value.length > 0) {
                     event.preventDefault();
                     handleValueRemove(value[value.length - 1]);
                   }

--- a/apps/mantine.dev/src/combobox-examples/examples/MultiSelectCreatable/MultiSelectCreatable.tsx
+++ b/apps/mantine.dev/src/combobox-examples/examples/MultiSelectCreatable/MultiSelectCreatable.tsx
@@ -66,7 +66,7 @@ export function MultiSelectCreatable() {
                   setSearch(event.currentTarget.value);
                 }}
                 onKeyDown={(event) => {
-                  if (event.key === 'Backspace' && search.length === 0) {
+                  if (event.key === 'Backspace' && search.length === 0 && value.length > 0) {
                     event.preventDefault();
                     handleValueRemove(value[value.length - 1]);
                   }

--- a/apps/mantine.dev/src/combobox-examples/examples/MultiSelectValueRenderer/MultiSelectValueRenderer.tsx
+++ b/apps/mantine.dev/src/combobox-examples/examples/MultiSelectValueRenderer/MultiSelectValueRenderer.tsx
@@ -56,7 +56,7 @@ export function MultiSelectValueRenderer() {
                 type="hidden"
                 onBlur={() => combobox.closeDropdown()}
                 onKeyDown={(event) => {
-                  if (event.key === 'Backspace') {
+                  if (event.key === 'Backspace' && value.length > 0) {
                     event.preventDefault();
                     handleValueRemove(value[value.length - 1]);
                   }

--- a/apps/mantine.dev/src/combobox-examples/examples/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/apps/mantine.dev/src/combobox-examples/examples/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -55,7 +55,7 @@ export function SearchableMultiSelect() {
                   setSearch(event.currentTarget.value);
                 }}
                 onKeyDown={(event) => {
-                  if (event.key === 'Backspace' && search.length === 0) {
+                  if (event.key === 'Backspace' && search.length === 0 && value.length > 0) {
                     event.preventDefault();
                     handleValueRemove(value[value.length - 1]);
                   }

--- a/packages/@docs/demos/src/demos/core/Combobox/Combobox.demo.multiselect.tsx
+++ b/packages/@docs/demos/src/demos/core/Combobox/Combobox.demo.multiselect.tsx
@@ -55,7 +55,7 @@ function Demo() {
                 type="hidden"
                 onBlur={() => combobox.closeDropdown()}
                 onKeyDown={(event) => {
-                  if (event.key === 'Backspace') {
+                  if (event.key === 'Backspace' && value.length > 0) {
                     event.preventDefault();
                     handleValueRemove(value[value.length - 1]);
                   }
@@ -123,7 +123,7 @@ function Demo() {
                 type="hidden"
                 onBlur={() => combobox.closeDropdown()}
                 onKeyDown={(event) => {
-                  if (event.key === 'Backspace') {
+                  if (event.key === 'Backspace' && value.length > 0) {
                     event.preventDefault();
                     handleValueRemove(value[value.length - 1]);
                   }

--- a/packages/@docs/demos/src/demos/core/Combobox/Combobox.demo.searchableMultiselect.tsx
+++ b/packages/@docs/demos/src/demos/core/Combobox/Combobox.demo.searchableMultiselect.tsx
@@ -60,7 +60,7 @@ function Demo() {
                   setSearch(event.currentTarget.value);
                 }}
                 onKeyDown={(event) => {
-                  if (event.key === 'Backspace' && search.length === 0) {
+                  if (event.key === 'Backspace' && search.length === 0 && value.length > 0) {
                     event.preventDefault();
                     handleValueRemove(value[value.length - 1]);
                   }
@@ -135,7 +135,7 @@ function Demo() {
                   setSearch(event.currentTarget.value);
                 }}
                 onKeyDown={(event) => {
-                  if (event.key === 'Backspace' && search.length === 0) {
+                  if (event.key === 'Backspace' && search.length === 0 && value.length > 0) {
                     event.preventDefault();
                     handleValueRemove(value[value.length - 1]);
                   }


### PR DESCRIPTION
This PR addresses a potential runtime error in Combobox multiselect components when pressing Backspace with no selected values, while maintaining contribution guidelines compliance.

**Changes:**

✅ Validation improvements:
   - Merged conditional checks in event handlers
   - Added explicit array length checks before removal
   - Maintained browser default behavior when no values selected

**Compliance:**
- 🔄 Follows project contribution workflow:
  1. Identified edge case in existing components
  2. Implemented targeted fix without API changes
  3. Maintained existing code style and patterns

**Impact:**
- Prevents `value[-1]` access attempts in all multiselect implementations
- Affects documentation examples and component demos
- No breaking changes introduced