### PR TITLE
add reference area to chart components

### DIFF
--- a/packages/@docs/styles-api/src/data/AreaChart.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/AreaChart.styles-api.ts
@@ -21,6 +21,7 @@ export const AreaChartStylesApi: StylesApiData<AreaChartFactory> = {
     tooltipItemData: 'Tooltip item data',
     tooltipLabel: 'Label of the tooltip',
     referenceLine: 'Reference line',
+    referenceArea: 'Reference area',
     axisLabel: 'X and Y axis labels',
   },
 

--- a/packages/@docs/styles-api/src/data/BarChart.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/BarChart.styles-api.ts
@@ -21,6 +21,7 @@ export const BarChartStylesApi: StylesApiData<BarChartFactory> = {
     tooltipItemData: 'Tooltip item data',
     tooltipLabel: 'Label of the tooltip',
     referenceLine: 'Reference line',
+    referenceArea: 'Reference area',
     axisLabel: 'X and Y axis labels',
   },
 

--- a/packages/@docs/styles-api/src/data/CompositeChart.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/CompositeChart.styles-api.ts
@@ -23,6 +23,7 @@ export const CompositeChartStylesApi: StylesApiData<CompositeChartFactory> = {
     tooltipItemData: 'Tooltip item data',
     tooltipLabel: 'Label of the tooltip',
     referenceLine: 'Reference line',
+    referenceArea: 'Reference area',
     axisLabel: 'X and Y axis labels',
   },
 

--- a/packages/@docs/styles-api/src/data/LineChart.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/LineChart.styles-api.ts
@@ -21,6 +21,7 @@ export const LineChartStylesApi: StylesApiData<LineChartFactory> = {
     tooltipItemData: 'Tooltip item data',
     tooltipLabel: 'Label of the tooltip',
     referenceLine: 'Reference line',
+    referenceArea: 'Reference area',
     axisLabel: 'X and Y axis labels',
   },
 

--- a/packages/@docs/styles-api/src/data/ScatterChart.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/ScatterChart.styles-api.ts
@@ -21,6 +21,7 @@ export const ScatterChartStylesApi: StylesApiData<ScatterChartFactory> = {
     tooltipItemData: 'Tooltip item data',
     tooltipLabel: 'Label of the tooltip',
     referenceLine: 'Reference line',
+    referenceArea: 'Reference area',
     axisLabel: 'X and Y axis labels',
   },
 

--- a/packages/@mantine/charts/src/BarChart/BarChart.story.tsx
+++ b/packages/@mantine/charts/src/BarChart/BarChart.story.tsx
@@ -177,3 +177,64 @@ export function VerticalOrientationValueFormatter() {
     />
   );
 }
+
+export function ReferenceAreas() {
+  return (
+    <div style={{ padding: 40 }}>
+      <BarChart
+        h={300}
+        data={simpleData}
+        dataKey="product"
+        series={[{ name: 'sales', color: 'indigo.6' }]}
+        referenceAreas={[
+          {
+            x1: 'Laptop',
+            x2: 'Tablet',
+            color: 'green.5',
+            label: 'High-value products',
+            labelPosition: 'insideTopLeft',
+            fillOpacity: 0.2,
+          },
+          {
+            y1: 100,
+            y2: 500,
+            color: 'red.5',
+            label: 'Low sales zone',
+            labelPosition: 'insideBottomRight',
+            fillOpacity: 0.2,
+          },
+        ]}
+        withLegend
+      />
+    </div>
+  );
+}
+
+export function VerticalWithReferenceAreas() {
+  return (
+    <div style={{ padding: 40 }}>
+      <BarChart
+        h={300}
+        data={data}
+        dataKey="month"
+        orientation="vertical"
+        series={[
+          { name: 'Smartphones', color: 'indigo.6' },
+          { name: 'Laptops', color: 'blue.6' },
+        ]}
+        referenceAreas={[
+          {
+            x1: 0,
+            x2: 40,
+            color: 'cyan.5',
+            label: 'Focus Period',
+            labelPosition: 'insideTopLeft',
+            fillOpacity: 0.2,
+          },
+        ]}
+        withLegend
+        withBarValueLabel
+      />
+    </div>
+  );
+}

--- a/packages/@mantine/charts/src/BarChart/BarChart.tsx
+++ b/packages/@mantine/charts/src/BarChart/BarChart.tsx
@@ -9,6 +9,7 @@ import {
   LabelListProps,
   Legend,
   BarChart as ReChartsBarChart,
+  ReferenceArea,
   ReferenceLine,
   ResponsiveContainer,
   Tooltip,
@@ -109,6 +110,28 @@ export interface BarChartProps
 
   /** A function to assign dynamic bar color based on its value */
   getBarColor?: (value: number, series: BarChartSeries) => MantineColor;
+
+  /** Reference areas to display on the chart */
+  referenceAreas?: Array<
+    Omit<React.ComponentProps<typeof ReferenceArea>, 'ref'> & {
+      color?: MantineColor;
+      label?: string;
+      labelPosition?:
+        | 'top'
+        | 'bottom'
+        | 'left'
+        | 'right'
+        | 'center'
+        | 'insideLeft'
+        | 'insideRight'
+        | 'insideTop'
+        | 'insideBottom'
+        | 'insideTopLeft'
+        | 'insideTopRight'
+        | 'insideBottomLeft'
+        | 'insideBottomRight';
+    }
+  >;
 }
 
 export type BarChartFactory = Factory<{
@@ -221,6 +244,7 @@ export const BarChart = factory<BarChartFactory>((_props, ref) => {
     getBarColor,
     gridColor,
     textColor,
+    referenceAreas,
     ...others
   } = props;
 
@@ -330,6 +354,31 @@ export const BarChart = factory<BarChartFactory>((_props, ref) => {
     tickFormatter: orientation === 'vertical' ? undefined : tickFormatter,
     ...getStyles('axis'),
   };
+
+  const referenceAreasItems = referenceAreas?.map((area, index) => {
+    const color = getThemeColor(area.color, theme);
+    return (
+      <ReferenceArea
+        key={`area-${index}`}
+        fill={area.color ? `${color}30` : 'var(--chart-grid-color)30'}
+        stroke={area.color ? color : 'var(--chart-grid-color)'}
+        strokeWidth={1}
+        yAxisId={area.yAxisId || 'left'}
+        {...area}
+        label={
+          area.label
+            ? {
+                value: area.label,
+                fill: area.color ? color : 'currentColor',
+                fontSize: 12,
+                position: area.labelPosition ?? 'insideTopLeft',
+              }
+            : undefined
+        }
+        {...getStyles('bar')}
+      />
+    );
+  });
 
   return (
     <Box
@@ -474,6 +523,7 @@ export const BarChart = factory<BarChartFactory>((_props, ref) => {
 
           {bars}
           {referenceLinesItems}
+          {referenceAreasItems}
           {children}
         </ReChartsBarChart>
       </ResponsiveContainer>

--- a/packages/@mantine/charts/src/types.ts
+++ b/packages/@mantine/charts/src/types.ts
@@ -28,6 +28,7 @@ export type BaseChartStylesNames =
   | 'axis'
   | 'grid'
   | 'referenceLine'
+  | 'referenceArea'
   | 'axisLabel';
 
 export type ChartData = Record<string, any>[];


### PR DESCRIPTION
## Overview (fixes issue: #7562 )

This PR adds support for reference areas in the BarChart component, allowing users to highlight specific regions on the chart. Reference areas are useful for visualizing target zones, thresholds, or important data ranges.


## Changes

- Added `ReferenceArea` import from recharts
- Added referenceAreas prop to the BarChart component interface
- Implemented rendering of reference areas with customizable styling
- Added support for labels within reference areas
- Added story examples demonstrating reference area functionality
- Updated styles API to include reference area styling


## Examples

The PR includes two new story examples:
- ReferenceAreas - Demonstrates basic reference areas with both x-axis and y-axis based highlighting
- VerticalWithReferenceAreas - Shows how reference areas work with vertical orientation


## Testing
The implementation has been tested with:
- Different chart orientations (vertical/horizontal)
- Various label positions
- Different color schemes
- Multiple reference areas on the same chart




