### PR TITLE
fix: Scrollbars remain interactive with offsetScrollbars="present" when thumb is hidden

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -202,7 +202,7 @@ export const ScrollArea = factory<ScrollAreaFactory>((_props, ref) => {
         <ScrollAreaScrollbar
           {...getStyles('scrollbar')}
           orientation="horizontal"
-          data-hidden={type === 'never' || undefined}
+          data-hidden={type === 'never' || !horizontalThumbVisible || undefined}
           forceMount
           onMouseEnter={() => setScrollbarHovered(true)}
           onMouseLeave={() => setScrollbarHovered(false)}
@@ -215,7 +215,7 @@ export const ScrollArea = factory<ScrollAreaFactory>((_props, ref) => {
         <ScrollAreaScrollbar
           {...getStyles('scrollbar')}
           orientation="vertical"
-          data-hidden={type === 'never' || undefined}
+          data-hidden={type === 'never' || !verticalThumbVisible || undefined}
           forceMount
           onMouseEnter={() => setScrollbarHovered(true)}
           onMouseLeave={() => setScrollbarHovered(false)}


### PR DESCRIPTION
When using `offsetScrollbars="present"`, it was possible to hover over and reveal the scrollbar background even when the thumb was hidden. This behavior was incorrect, as the scrollbar should be entirely hidden when the thumb isn't visible.

This is how it looked when hovering over a vertical scrollbar that is hidden using `offsetScrollbars=present`:

![image](https://github.com/user-attachments/assets/ed5696bb-6649-4402-ad54-0d519ad9ec4d)

With this PR, the scrollbar background no longer appears when the thumb is hidden, as expected.