### PR TITLE
fix: add pointer-events: none to disabled state

### DIFF
--- a/packages/@mantine/core/src/components/Pagination/Pagination.module.css
+++ b/packages/@mantine/core/src/components/Pagination/Pagination.module.css
@@ -27,6 +27,7 @@
   }
 
   &:where(:disabled, [data-disabled]) {
+    pointer-events: none;
     cursor: not-allowed;
     opacity: 0.4;
   }


### PR DESCRIPTION
The pagination controls can still be clicked when the disabled prop is present. Adding `pointer-events: none` to the CSS module fixes this bug