### PR TITLE
fix: modal exports for node16

### DIFF
--- a/packages/@mantine/modals/src/index.ts
+++ b/packages/@mantine/modals/src/index.ts
@@ -9,7 +9,7 @@ export {
   updateModal,
   updateContextModal,
   modals,
-} from './events';
+} from './events.js';
 
 export type { ModalsProviderProps } from './ModalsProvider';
 export type {
@@ -17,4 +17,4 @@ export type {
   MantineModalsOverride,
   MantineModals,
   MantineModal,
-} from './context';
+} from './context.js';


### PR DESCRIPTION
I have a type checking issue in my repository, similar to the one described in https://github.com/mantinedev/mantine/issues/4991#issuecomment-1784254633 with `@mantine/modals/lib/index.d.mts`
Which was then fixed in https://github.com/mantinedev/mantine/pull/5697

![image](https://github.com/user-attachments/assets/da2963fa-2560-4fc9-8df5-70138e81cb06)

I couldn't get the [paths workaround](https://github.com/mantinedev/mantine/issues/4991#issuecomment-1784456011) working, so to solve this locally I can
1. Delete`@mantine/modals/lib/index.d.mts` in `postinstall` script and it will rely on the non-module file `@mantine/modals/lib/index.d.ts`
2. Or, patch the file to add `.js` to exports
![image](https://github.com/user-attachments/assets/09dd59af-b0a5-4ec8-8cb6-9d68a94210cf)

This PR makes the change to do `2.`
Tbh I don't really know what I'm doing, I suspect we don't want to do this because I believe it will also add `.js` to the non-module `@mantine/modals/lib/index.d.ts` file which we probs don't want.

Was hoping that @waweber might be able to help 🙏  