### PR TITLE
fix: `AppShell[disabled]` does not cancel aside and footer margins

### DIFF
--- a/packages/@mantine/core/src/components/AppShell/AppShell.module.css
+++ b/packages/@mantine/core/src/components/AppShell/AppShell.module.css
@@ -6,6 +6,8 @@
   &[data-disabled] {
     --app-shell-header-offset: 0rem !important;
     --app-shell-navbar-offset: 0rem !important;
+    --app-shell-aside-offset: 0rem !important;
+    --app-shell-footer-offset: 0rem !important;
   }
 
   @mixin light {


### PR DESCRIPTION
[AppShell's disabled prop](https://mantine.dev/core/app-shell/#disabled-prop) doesn't disable aside and footer margins, which means that currently AppShell create margins at bottom and right (right margin is 316, bottom margin is 76):
<img width="1011" alt="スクリーンショット 2025-03-20 16 40 26" src="https://github.com/user-attachments/assets/bf364747-1a68-4d11-9491-cd02d361a0a8" />

This PR will remove margins.