### PR TITLE
[@mantine/core] Checkbox - Set indeterminate prop (#7608)

### DIFF
--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.test.tsx
@@ -95,12 +95,21 @@ describe('@mantine/core/Checkbox', () => {
     expect(screen.getByRole('checkbox')).toBeChecked();
   });
 
-  it('sets data-indeterminate attribute based on indeterminate prop', () => {
-    const { rerender } = render(<Checkbox indeterminate />);
+  it('sets data-indeterminate and indeterminate property based on indeterminate prop', () => {
+    const ref = createRef<HTMLInputElement>();
+
+    const { rerender } = render(<Checkbox indeterminate ref={ref} />);
     expect(screen.getByRole('checkbox')).toHaveAttribute('data-indeterminate');
+    expect(screen.getByRole('checkbox')).toBePartiallyChecked();
+    expect(ref.current).toBePartiallyChecked();
+
+    rerender(<Checkbox indeterminate />);
+    expect(screen.getByRole('checkbox')).toHaveAttribute('data-indeterminate');
+    expect(screen.getByRole('checkbox')).toBePartiallyChecked();
 
     rerender(<Checkbox indeterminate={false} />);
     expect(screen.getByRole('checkbox')).not.toHaveAttribute('data-indeterminate');
+    expect(screen.getByRole('checkbox')).not.toBePartiallyChecked();
   });
 
   it('sets data-error attribute based on error prop', () => {

--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { useId } from '@mantine/hooks';
 import {
   Box,
@@ -122,7 +123,7 @@ const varsResolver = createVarsResolver<CheckboxFactory>(
   }
 );
 
-export const Checkbox = factory<CheckboxFactory>((_props, ref) => {
+export const Checkbox = factory<CheckboxFactory>((_props, forwardedRef) => {
   const props = useProps('Checkbox', defaultProps, _props);
   const {
     classNames,
@@ -182,6 +183,15 @@ export const Checkbox = factory<CheckboxFactory>((_props, ref) => {
         },
       }
     : {};
+
+  const fallbackRef = useRef<HTMLInputElement>(null);
+  const ref = forwardedRef || fallbackRef;
+
+  useEffect(() => {
+    if (ref && 'current' in ref && ref.current) {
+      ref.current.indeterminate = indeterminate || false;
+    }
+  }, [indeterminate, ref]);
 
   return (
     <InlineInput


### PR DESCRIPTION
Closes https://github.com/mantinedev/mantine/issues/7608

Set `indeterminate` property in native `input` element when `indeterminate` component prop is true. Prefer `indeterminate` over `aria-checked` per spec (https://www.w3.org/TR/html-aria/#att-checked).

References
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/indeterminate
- https://github.com/testing-library/jest-dom/blob/main/src/to-be-partially-checked.js
- https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/examples/checkbox-mixed/
- https://medium.com/indigoag-eng/indeterminate-checkboxes-are-weird-704b246c0f19