### PR TITLE
Fix an issue where Indicator shows above Appshell navbar

### DIFF
--- a/packages/@mantine/core/src/components/AppShell/AppShell.tsx
+++ b/packages/@mantine/core/src/components/AppShell/AppShell.tsx
@@ -103,7 +103,7 @@ const defaultProps: Partial<AppShellProps> = {
   padding: 0,
   transitionDuration: 200,
   transitionTimingFunction: 'ease',
-  zIndex: getDefaultZIndex('app'),
+  zIndex: getDefaultZIndex('modal'),
 };
 
 const varsResolver = createVarsResolver<AppShellFactory>(


### PR DESCRIPTION
Fixes this issue: https://github.com/mantinedev/mantine/issues/7619 (Indicator shows above navbar)

https://github.com/user-attachments/assets/655e4467-b5bb-4824-87b4-e3c2916427aa

Did notice the comment about zIndex says the default is 200: https://github.com/mantinedev/mantine/blob/master/packages/%40mantine/core/src/components/AppShell/AppShell.tsx#L73 

But since the param passed into getDefaultZindex is 'app' it's actually 100. Switching this to 'modal' sets it to 200.