### PR TITLE
[@mantine/hook] useHotkeys: Correctly handle key matcher for FR keyboard layout

### DIFF
--- a/packages/@mantine/hooks/src/use-hotkeys/parse-hotkey.test.ts
+++ b/packages/@mantine/hooks/src/use-hotkeys/parse-hotkey.test.ts
@@ -78,6 +78,28 @@ describe('@mantine/hooks/use-hot-key/parse-hotkey', () => {
         })
       )
     ).toBe(false);
+
+    expect(
+      getHotkeyMatcher('ctrl+Z', true)(
+        new KeyboardEvent('keydown', {
+          ctrlKey: true,
+          altKey: false,
+          shiftKey: false,
+          key: 'Z',
+        })
+      )
+    ).toBe(true);
+
+    expect(
+      getHotkeyMatcher('ctrl+Z', true)(
+        new KeyboardEvent('keydown', {
+          ctrlKey: true,
+          altKey: false,
+          shiftKey: false,
+          key: 'W',
+        })
+      )
+    ).toBe(false);
   });
 
   it('parses [plus] key correctly', () => {

--- a/packages/@mantine/hooks/src/use-hotkeys/parse-hotkey.ts
+++ b/packages/@mantine/hooks/src/use-hotkeys/parse-hotkey.ts
@@ -65,7 +65,7 @@ function isExactHotkey(hotkey: Hotkey, event: KeyboardEvent, usePhysicalKeys?: b
   if (
     key &&
     ((!usePhysicalKeys && pressedKey.toLowerCase() === key.toLowerCase()) ||
-      pressedCode.replace('Key', '').toLowerCase() === key.toLowerCase())
+      (!usePhysicalKeys && pressedCode.replace('Key', '').toLowerCase() === key.toLowerCase()))
   ) {
     return true;
   }


### PR DESCRIPTION
Fix issue with `useHotkeys` hook with a French ISO layout. `Q` and `A` as long as `Z` and `W` keys are interverted with a FR keyboard layout. Using both the `key` and the `code` property currently triggers both events (on `Z` and `W` for example). This fix will prevent using the `code` property that lead to this issue.

See more details here https://github.com/mantinedev/mantine/pull/7390