### PR TITLE
[@mantine/core] better type support for size related theme overrides

### DIFF
--- a/apps/mantine.dev/src/pages/guides/typescript.mdx
+++ b/apps/mantine.dev/src/pages/guides/typescript.mdx
@@ -207,6 +207,34 @@ declare module '@mantine/core' {
 }
 ```
 
+You can also customize size related types for `theme.spacing`, `theme.radius`,
+`theme.breakpoints`, `theme.fontSizes`, `theme.lineHeights`, and `theme.shadows` similarly.
+
+To override `theme.spacing` and `theme.radius`
+
+```tsx
+import {
+  DefaultMantineSize,
+  MantineThemeSizesOverride,
+} from '@mantine/core';
+
+type ExtendedCustomSpacing =
+  | 'myCustomSpacing'
+  | 'anotherCustomSpacing'
+  | DefaultMantineSize;
+
+type ExtendedCustomRadius =
+  | 'myCustomRadius'
+  | DefaultMantineSize;
+
+declare module '@mantine/core' {
+  export interface MantineThemeSizesOverride {
+    spacing: Record<ExtendedCustomSpacing, string>;
+    radius: Record<ExtendedCustomRadius, string>;
+  }
+}
+```
+
 Note that extending theme type is not required, it is only needed if you want to
 make your theme object types more strict and add autocomplete in your editor.
 

--- a/packages/@mantine/core/src/components/Flex/Flex.tsx
+++ b/packages/@mantine/core/src/components/Flex/Flex.tsx
@@ -22,13 +22,13 @@ export type FlexStylesNames = 'root';
 
 export interface FlexProps extends BoxProps, StylesApiProps<FlexFactory>, ElementProps<'div'> {
   /** `gap` CSS property */
-  gap?: StyleProp<MantineSpacing | number>;
+  gap?: StyleProp<MantineSpacing>;
 
   /** `row-gap` CSS property */
-  rowGap?: StyleProp<MantineSpacing | number>;
+  rowGap?: StyleProp<MantineSpacing>;
 
   /** `column-gap` CSS property */
-  columnGap?: StyleProp<MantineSpacing | number>;
+  columnGap?: StyleProp<MantineSpacing>;
 
   /** `align-items` CSS property */
   align?: StyleProp<React.CSSProperties['alignItems']>;

--- a/packages/@mantine/core/src/components/Flex/Flex.tsx
+++ b/packages/@mantine/core/src/components/Flex/Flex.tsx
@@ -4,7 +4,7 @@ import {
   ElementProps,
   filterProps,
   InlineStyles,
-  MantineSize,
+  MantineSpacing,
   parseStyleProps,
   polymorphicFactory,
   PolymorphicFactory,
@@ -22,13 +22,13 @@ export type FlexStylesNames = 'root';
 
 export interface FlexProps extends BoxProps, StylesApiProps<FlexFactory>, ElementProps<'div'> {
   /** `gap` CSS property */
-  gap?: StyleProp<MantineSize | (string & {}) | number>;
+  gap?: StyleProp<MantineSpacing | number>;
 
   /** `row-gap` CSS property */
-  rowGap?: StyleProp<MantineSize | (string & {}) | number>;
+  rowGap?: StyleProp<MantineSpacing | number>;
 
   /** `column-gap` CSS property */
-  columnGap?: StyleProp<MantineSize | (string & {}) | number>;
+  columnGap?: StyleProp<MantineSpacing | number>;
 
   /** `align-items` CSS property */
   align?: StyleProp<React.CSSProperties['alignItems']>;

--- a/packages/@mantine/core/src/components/Input/InputDescription/InputDescription.tsx
+++ b/packages/@mantine/core/src/components/Input/InputDescription/InputDescription.tsx
@@ -6,7 +6,7 @@ import {
   factory,
   Factory,
   getFontSize,
-  MantineSize,
+  MantineFontSize,
   rem,
   StylesApiProps,
   useProps,
@@ -28,7 +28,7 @@ export interface InputDescriptionProps
   __inheritStyles?: boolean;
 
   /** Controls description `font-size`, `'sm'` by default */
-  size?: MantineSize | (string & {});
+  size?: MantineFontSize;
 }
 
 export type InputDescriptionFactory = Factory<{

--- a/packages/@mantine/core/src/components/Input/InputError/InputError.tsx
+++ b/packages/@mantine/core/src/components/Input/InputError/InputError.tsx
@@ -6,7 +6,7 @@ import {
   factory,
   Factory,
   getFontSize,
-  MantineSize,
+  MantineFontSize,
   rem,
   StylesApiProps,
   useProps,
@@ -28,7 +28,7 @@ export interface InputErrorProps
   __inheritStyles?: boolean;
 
   /** Controls error `font-size`, `'sm'` by default */
-  size?: MantineSize | (string & {});
+  size?: MantineFontSize;
 }
 
 export type InputErrorFactory = Factory<{

--- a/packages/@mantine/core/src/components/Input/InputLabel/InputLabel.tsx
+++ b/packages/@mantine/core/src/components/Input/InputLabel/InputLabel.tsx
@@ -6,7 +6,7 @@ import {
   factory,
   Factory,
   getFontSize,
-  MantineSize,
+  MantineFontSize,
   StylesApiProps,
   useProps,
   useStyles,
@@ -29,7 +29,7 @@ export interface InputLabelProps
   required?: boolean;
 
   /** Controls label `font-size`, `'sm'` by default */
-  size?: MantineSize | (string & {});
+  size?: MantineFontSize;
 
   /** Root element of the label, `'label'` by default */
   labelElement?: 'label' | 'div';

--- a/packages/@mantine/core/src/components/Input/InputWrapper/InputWrapper.tsx
+++ b/packages/@mantine/core/src/components/Input/InputWrapper/InputWrapper.tsx
@@ -8,7 +8,7 @@ import {
   factory,
   Factory,
   getFontSize,
-  MantineSize,
+  MantineFontSize,
   rem,
   StylesApiProps,
   useProps,
@@ -89,7 +89,7 @@ export interface InputWrapperProps
   id?: string;
 
   /** Controls size of `Input.Label`, `Input.Description` and `Input.Error` components */
-  size?: MantineSize | (string & {});
+  size?: MantineFontSize;
 
   /** `Input.Label` root element, `'label'` by default */
   labelElement?: 'label' | 'div';

--- a/packages/@mantine/core/src/components/NavLink/NavLink.tsx
+++ b/packages/@mantine/core/src/components/NavLink/NavLink.tsx
@@ -5,7 +5,7 @@ import {
   createVarsResolver,
   getSpacing,
   MantineColor,
-  MantineSize,
+  MantineSpacing,
   polymorphicFactory,
   PolymorphicFactory,
   StylesApiProps,
@@ -70,7 +70,7 @@ export interface NavLinkProps extends BoxProps, StylesApiProps<NavLinkFactory> {
   disableRightSectionRotation?: boolean;
 
   /** Key of `theme.spacing` or any valid CSS value to set collapsed links `padding-left`, `'lg'` by default */
-  childrenOffset?: MantineSize | (string & {}) | number;
+  childrenOffset?: MantineSpacing;
 
   /** If set, disabled styles will be added to the root element, `false` by default */
   disabled?: boolean;

--- a/packages/@mantine/core/src/components/Pagination/Pagination.tsx
+++ b/packages/@mantine/core/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import { factory, Factory, MantineSize, useProps } from '../../core';
+import { factory, Factory, MantineSpacing, useProps } from '../../core';
 import { Group } from '../Group/Group';
 import { PaginationIcon } from './Pagination.icons';
 import { PaginationControl } from './PaginationControl/PaginationControl';
@@ -47,7 +47,7 @@ export interface PaginationProps extends PaginationRootProps {
   dotsIcon?: PaginationIcon;
 
   /** Key of `theme.spacing`, gap between controls, `8` by default */
-  gap?: MantineSize | (string & {}) | number;
+  gap?: MantineSpacing;
 
   /** Determines whether the pagination should be hidden when only one page is available (`total={1}`), `false` by default */
   hideWithOnePage?: boolean;

--- a/packages/@mantine/core/src/components/Text/Text.tsx
+++ b/packages/@mantine/core/src/components/Text/Text.tsx
@@ -9,6 +9,7 @@ import {
   MantineColor,
   MantineFontSize,
   MantineGradient,
+  MantineLineHeight,
   polymorphicFactory,
   PolymorphicFactory,
   StylesApiProps,
@@ -41,7 +42,7 @@ export interface TextProps extends BoxProps, StylesApiProps<TextFactory> {
   __staticSelector?: string;
 
   /** Controls `font-size` and `line-height`, `'md'` by default */
-  size?: MantineFontSize;
+  size?: MantineFontSize & MantineLineHeight;
 
   /** Number of lines after which Text will be truncated */
   lineClamp?: number;

--- a/packages/@mantine/core/src/components/Text/Text.tsx
+++ b/packages/@mantine/core/src/components/Text/Text.tsx
@@ -7,8 +7,8 @@ import {
   getLineHeight,
   getThemeColor,
   MantineColor,
+  MantineFontSize,
   MantineGradient,
-  MantineSize,
   polymorphicFactory,
   PolymorphicFactory,
   StylesApiProps,
@@ -41,7 +41,7 @@ export interface TextProps extends BoxProps, StylesApiProps<TextFactory> {
   __staticSelector?: string;
 
   /** Controls `font-size` and `line-height`, `'md'` by default */
-  size?: MantineSize | (string & {});
+  size?: MantineFontSize;
 
   /** Number of lines after which Text will be truncated */
   lineClamp?: number;

--- a/packages/@mantine/core/src/components/Title/Title.tsx
+++ b/packages/@mantine/core/src/components/Title/Title.tsx
@@ -5,7 +5,7 @@ import {
   ElementProps,
   factory,
   Factory,
-  MantineSize,
+  MantineFontSize,
   StylesApiProps,
   useProps,
   useStyles,
@@ -14,7 +14,7 @@ import { getTitleSize } from './get-title-size';
 import classes from './Title.module.css';
 
 export type TitleOrder = 1 | 2 | 3 | 4 | 5 | 6;
-export type TitleSize = `h${TitleOrder}` | React.CSSProperties['fontSize'] | MantineSize;
+export type TitleSize = `h${TitleOrder}` | React.CSSProperties['fontSize'] | MantineFontSize;
 
 export type TitleStylesNames = 'root';
 export type TitleCssVariables = {

--- a/packages/@mantine/core/src/core/MantineProvider/theme.types.ts
+++ b/packages/@mantine/core/src/core/MantineProvider/theme.types.ts
@@ -187,9 +187,9 @@ export type MantineRadiusValues = Record<_MantineRadius, string>;
 
 type _MantineSpacing =
   | (MantineThemeSizesOverride extends {
-      spacing: Record<infer CustomRadius, string>;
+      spacing: Record<infer CustomSpacing, string>;
     }
-      ? CustomRadius
+      ? CustomSpacing
       : MantineSize)
   | (string & {});
 export type MantineSpacing = _MantineSpacing | number;

--- a/packages/@mantine/core/src/core/MantineProvider/theme.types.ts
+++ b/packages/@mantine/core/src/core/MantineProvider/theme.types.ts
@@ -154,19 +154,64 @@ export interface HeadingStyle {
 }
 
 export type MantineSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-export type MantineBreakpointsValues = Record<MantineSize | (string & {}), string>;
-export type MantineFontSizesValues = Record<MantineSize | (string & {}), string>;
-export type MantineRadiusValues = Record<MantineSize | (string & {}), string>;
-export type MantineSpacingValues = Record<MantineSize | (string & {}), string>;
-export type MantineShadowsValues = Record<MantineSize | (string & {}), string>;
-export type MantineLineHeightValues = Record<MantineSize | (string & {}), string>;
+export type DefaultMantineSize = MantineSize;
+export interface MantineThemeSizesOverride {}
 
-export type MantineBreakpoint = keyof MantineBreakpointsValues;
-export type MantineFontSize = keyof MantineFontSizesValues;
-export type MantineRadius = keyof MantineRadiusValues | (string & {}) | number;
-export type MantineSpacing = keyof MantineSpacingValues | (string & {}) | number;
-export type MantineShadow = keyof MantineShadowsValues | (string & {});
-export type MantineLineHeight = keyof MantineLineHeightValues;
+export type MantineBreakpoint =
+  | (MantineThemeSizesOverride extends {
+      breakpoints: Record<infer CustomBreakpoints, string>;
+    }
+      ? CustomBreakpoints
+      : MantineSize)
+  | (string & {});
+export type MantineBreakpointsValues = Record<MantineBreakpoint, string>;
+
+export type MantineFontSize =
+  | (MantineThemeSizesOverride extends {
+      fontSizes: Record<infer CustomFontSizes, string>;
+    }
+      ? CustomFontSizes
+      : MantineSize)
+  | (string & {});
+export type MantineFontSizesValues = Record<MantineFontSize, string>;
+
+type _MantineRadius =
+  | (MantineThemeSizesOverride extends {
+      radius: Record<infer CustomRadius, string>;
+    }
+      ? CustomRadius
+      : MantineSize)
+  | (string & {});
+export type MantineRadius = _MantineRadius | number;
+export type MantineRadiusValues = Record<_MantineRadius, string>;
+
+type _MantineSpacing =
+  | (MantineThemeSizesOverride extends {
+      spacing: Record<infer CustomRadius, string>;
+    }
+      ? CustomRadius
+      : MantineSize)
+  | (string & {});
+export type MantineSpacing = _MantineSpacing | number;
+export type MantineSpacingValues = Record<MantineSpacing, string>;
+
+export type MantineShadow =
+  | (MantineThemeSizesOverride extends {
+      shadows: Record<infer CustomShadow, string>;
+    }
+      ? CustomShadow
+      : MantineSize)
+  | (string & {});
+export type MantineShadowsValues = Record<MantineShadow, string>;
+
+export type MantineLineHeight =
+  | (MantineThemeSizesOverride extends {
+      lineHeights: Record<infer CustomLineHeight, string>;
+    }
+      ? CustomLineHeight
+      : MantineSize)
+  | (string & {});
+export type MantineLineHeightValues = Record<MantineLineHeight, string>;
 
 export interface MantineThemeOther {
   [key: string]: any;


### PR DESCRIPTION
This PR is to address issue #7642
Fixes #7642 

What's changed:
- Export `MantineThemeSizesOverride`, which can help to enhance types for size related theme overrides, like `MantineThemeColorsOverride` is to `theme.colors`.
- Updated docs on how to augment sizes override.
- Updated `size` prop types in some components (from referencing `MantineSize` to referencing more dedicated size, like `MantineFontSize`, `MantineSpacing`, etc..)
  - only those have clear clues that the prop expects a certain kind of size, were updated (e.g. `Text.size`)
  - some components use size prop for multiple purposes, like `Button.size`, and should be kept as they were (referencing `MantineSize`)

All changes should be backward compatible, not breaking anything (to the best of my knowledge).