### PR TITLE
[@mantine/core] Paper: Control border color using dedicated CSS variable

### DIFF
--- a/packages/@mantine/core/src/components/Paper/Paper.module.css
+++ b/packages/@mantine/core/src/components/Paper/Paper.module.css
@@ -10,13 +10,15 @@
   box-shadow: var(--paper-shadow);
   background-color: var(--mantine-color-body);
 
-  &:where([data-with-border]) {
-    @mixin where-light {
-      border: rem(1px) solid var(--mantine-color-gray-3);
-    }
+  @mixin light {
+    --paper-border-color: var(--mantine-color-gray-3);
+  }
 
-    @mixin where-dark {
-      border: rem(1px) solid var(--mantine-color-dark-4);
-    }
+  @mixin dark {
+    --paper-border-color: var(--mantine-color-dark-4);
+  }
+
+  &:where([data-with-border]) {
+    border: rem(1px) solid var(--paper-border-color);
   }
 }


### PR DESCRIPTION
Hello, I noticed the `Paper` component didn't have a dedicated CSS variable for controlling its border color just like the `AppShell` or the `Tabs` components do. Having this setup makes it easier to override when building a custom theme.

I followed [what AppShell does as an example](https://github.com/mantinedev/mantine/blob/master/packages/@mantine/core/src/components/AppShell/AppShell.module.css#L13-L19), i.e:

```css
.root {
  @mixin light {
    --app-shell-border-color: var(--mantine-color-gray-3);
  }

  @mixin dark {
    --app-shell-border-color: var(--mantine-color-dark-4);
  }
}

.navbar {
  &:where([data-with-border]) {
    border-inline-end: 1px solid var(--app-shell-border-color);
  }
}
```