### PR TITLE
When using stickyHeader with withTableBorder and withColumnBorders, border sometimes shows up and sometimes doesn't

### DIFF
--- a/packages/@docs/demos/src/demos/core/Table/Table.demo.stickyHeader.tsx
+++ b/packages/@docs/demos/src/demos/core/Table/Table.demo.stickyHeader.tsx
@@ -24,7 +24,7 @@ function Demo() {
   ));
 
   return (
-    <Table withTableBorder withColumnBorders stickyHeader stickyHeaderOffset={60}>
+    <Table stickyHeader stickyHeaderOffset={60}>
       <Table.Thead>
         <Table.Tr>
           <Table.Th>Element position</Table.Th>
@@ -51,7 +51,7 @@ export function Demo() {
   ));
 
   return (
-    <Table withTableBorder withColumnBorders stickyHeader stickyHeaderOffset={60}>
+    <Table stickyHeader stickyHeaderOffset={60}>
       <Table.Thead>
         <Table.Tr>
           <Table.Th>Element position</Table.Th>


### PR DESCRIPTION
This pull request includes changes to the `Table` component in the `@mantine/core` package to enhance its functionality and styling. The most important changes include updating the CSS for sticky headers and table borders.

Styling updates for `Table` component:

* [`packages/@mantine/core/src/components/Table/Table.module.css`](diffhunk://#diff-48836b6a87a52fcd25cb522337b4cf12a22517256305afce10d093c4368e361dR102-R113): Updated CSS to handle sticky headers and table borders, including setting the `top` property for `th` elements within sticky headers and adding styles for tables with borders.

Fixes https://github.com/mantinedev/mantine/issues/7593

