### PR TITLE
fix: add 'wheel' event to use-idle hook

### DIFF
--- a/apps/mantine.dev/src/components/MdxProvider/MdxTemplatesList/community-data.ts
+++ b/apps/mantine.dev/src/components/MdxProvider/MdxTemplatesList/community-data.ts
@@ -62,4 +62,10 @@ export const COMMUNITY_TEMPLATES_DATA: Template[] = [
     link: 'https://github.com/doiska/waku-mantine-starter',
     description: 'Vite + Waku + Mantine template',
   },
+  {
+    type: 'vite',
+    name: 'tanstack-start-cloudflare-template',
+    link: 'https://github.com/tylim88/Tanstack-Start-Mantine-Tailwind-Template',
+    description: 'Tanstack Start + Cloudflare + Mantine template',
+  },
 ];

--- a/packages/@mantine/hooks/src/use-idle/use-idle.test.tsx
+++ b/packages/@mantine/hooks/src/use-idle/use-idle.test.tsx
@@ -16,7 +16,7 @@ describe('@mantine/hooks/use-idle', () => {
     expect(spy).not.toHaveBeenCalled();
 
     const hook = renderHook(() =>
-      useIdle(1000, { initialState: false, events: ['click', 'keypress'] })
+      useIdle(1000, { initialState: false, events: ['click', 'keydown'] })
     );
 
     expect(hook.result.current).toBe(false);
@@ -27,12 +27,12 @@ describe('@mantine/hooks/use-idle', () => {
     }, 1001);
   });
 
-  it('Returns correct value on firing keypress event', () => {
+  it('Returns correct value on firing keydown event', () => {
     const hook = renderHook(() => useIdle(1000));
 
     expect(hook.result.current).toBe(true);
     act(() => {
-      document.dispatchEvent(new KeyboardEvent('keypress'));
+      document.dispatchEvent(new KeyboardEvent('keydown'));
     });
 
     expect(hook.result.current).toBe(false);

--- a/packages/@mantine/hooks/src/use-idle/use-idle.ts
+++ b/packages/@mantine/hooks/src/use-idle/use-idle.ts
@@ -6,6 +6,7 @@ const DEFAULT_EVENTS: (keyof DocumentEventMap)[] = [
   'touchmove',
   'click',
   'scroll',
+  'wheel',
 ];
 const DEFAULT_OPTIONS = {
   events: DEFAULT_EVENTS,

--- a/packages/@mantine/hooks/src/use-idle/use-idle.ts
+++ b/packages/@mantine/hooks/src/use-idle/use-idle.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 const DEFAULT_EVENTS: (keyof DocumentEventMap)[] = [
-  'keypress',
+  'keydown',
   'mousemove',
   'touchmove',
   'click',


### PR DESCRIPTION
# changes 

- Add 'wheel' event to the default events of the use-idle hook.

# after fix 

[Screencast from 2025-04-09 15-35-02.webm](https://github.com/user-attachments/assets/79ebdb08-5f9a-47d3-8538-4d41af11b8af)




fix: #7574 