### PR TITLE
refactor: switch to `postcss.config.mjs` with types

### DIFF
--- a/apps/help.mantine.dev/postcss.config.mjs
+++ b/apps/help.mantine.dev/postcss.config.mjs
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import('postcss-load-config').Config} */
+export default {
   plugins: {
     'postcss-preset-mantine': {
       autoRem: true,

--- a/apps/mantine.dev/postcss.config.cjs
+++ b/apps/mantine.dev/postcss.config.cjs
@@ -1,1 +1,0 @@
-module.exports = require('../../postcss.config.cjs');

--- a/apps/mantine.dev/postcss.config.mjs
+++ b/apps/mantine.dev/postcss.config.mjs
@@ -1,0 +1,1 @@
+export * from '../../postcss.config.mjs';

--- a/apps/mantine.dev/src/pages/getting-started.mdx
+++ b/apps/mantine.dev/src/pages/getting-started.mdx
@@ -72,10 +72,11 @@ Install PostCSS plugins and [postcss-preset-mantine](/styles/postcss-preset):
 > you may need to configure PostCSS manually. Please refer to the framework's documentation for specific instructions.
 > For instance, if you are using Webpack, it will be necessary to install and set up [postcss-loader](https://webpack.js.org/loaders/postcss-loader/).
 
-Create `postcss.config.cjs` file at the root of your application with the following content:
+Create `postcss.config.mjs` file at the root of your application with the following content:
 
 ```js
-module.exports = {
+/** @type {import('postcss-load-config').Config} */
+export default {
   plugins: {
     'postcss-preset-mantine': {},
     'postcss-simple-vars': {

--- a/apps/mantine.dev/src/pages/guides/gatsby.mdx
+++ b/apps/mantine.dev/src/pages/guides/gatsby.mdx
@@ -32,10 +32,11 @@ Install PostCSS plugins and [postcss-preset-mantine](/styles/postcss-preset):
   dev
 />
 
-Create `postcss.config.cjs` file at the root of your application with the following content:
+Create `postcss.config.mjs` file at the root of your application with the following content:
 
 ```js
-module.exports = {
+/** @type {import('postcss-load-config').Config} */
+export default {
   plugins: {
     'postcss-preset-mantine': {},
     'postcss-simple-vars': {

--- a/apps/mantine.dev/src/pages/guides/next.mdx
+++ b/apps/mantine.dev/src/pages/guides/next.mdx
@@ -30,10 +30,11 @@ Install PostCSS plugins and [postcss-preset-mantine](/styles/postcss-preset):
   dev
 />
 
-Create `postcss.config.cjs` file at the root of your application with the following content:
+Create `postcss.config.mjs` file at the root of your application with the following content:
 
 ```js
-module.exports = {
+/** @type {import('postcss-load-config').Config} */
+export default {
   plugins: {
     'postcss-preset-mantine': {},
     'postcss-simple-vars': {

--- a/apps/mantine.dev/src/pages/guides/react-router.mdx
+++ b/apps/mantine.dev/src/pages/guides/react-router.mdx
@@ -26,10 +26,11 @@ Install PostCSS plugins and [postcss-preset-mantine](/styles/postcss-preset):
   dev
 />
 
-Create `postcss.config.cjs` file at the root of your application with the following content:
+Create `postcss.config.mjs` file at the root of your application with the following content:
 
 ```js
-module.exports = {
+/** @type {import('postcss-load-config').Config} */
+export default {
   plugins: {
     'postcss-preset-mantine': {},
     'postcss-simple-vars': {

--- a/apps/mantine.dev/src/pages/guides/vite.mdx
+++ b/apps/mantine.dev/src/pages/guides/vite.mdx
@@ -29,10 +29,11 @@ Install PostCSS plugins and [postcss-preset-mantine](/styles/postcss-preset):
   dev
 />
 
-Create `postcss.config.cjs` file at the root of your application with the following content:
+Create `postcss.config.mjs` file at the root of your application with the following content:
 
 ```js
-module.exports = {
+/** @type {import('postcss-load-config').Config} */
+export default {
   plugins: {
     'postcss-preset-mantine': {},
     'postcss-simple-vars': {

--- a/apps/mantine.dev/src/pages/styles/postcss-preset.mdx
+++ b/apps/mantine.dev/src/pages/styles/postcss-preset.mdx
@@ -25,10 +25,11 @@ Install `postcss-preset-mantine` as a dev dependency:
 
 Note that setting up PostCSS may be different depending on your build tool/framework, check
 a [dedicated framework guide](/getting-started) to learn more.
-Add `postcss-preset-mantine` to your `postcss.config.cjs` file (usually it is located in the root of your project):
+Add `postcss-preset-mantine` to your `postcss.config.mjs` file (usually it is located in the root of your project):
 
 ```js
-module.exports = {
+/** @type {import('postcss-load-config').Config} */
+export default {
   plugins: {
     'postcss-preset-mantine': {},
   },

--- a/apps/mantine.dev/src/pages/styles/responsive.mdx
+++ b/apps/mantine.dev/src/pages/styles/responsive.mdx
@@ -57,10 +57,11 @@ in your `.css` files, you will need `postcss-simple-vars` package:
 
 <InstallScript dev packages="postcss-simple-vars" />
 
-Add it to your [PostCSS config](/styles/postcss-preset) in `postcss.config.cjs`:
+Add it to your [PostCSS config](/styles/postcss-preset) in `postcss.config.mjs`:
 
 ```js
-module.exports = {
+/** @type {import('postcss-load-config').Config} */
+export default {
   plugins: {
     'postcss-preset-mantine': {},
     'postcss-simple-vars': {

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import('postcss-load-config').Config} */
+export default {
   plugins: {
     'postcss-preset-mantine': {
       autoRem: true,


### PR DESCRIPTION
related: https://github.com/vercel/next.js/pull/63380

## What?

- Use ESM config for PostCSS as [it's been supported for some time ago](https://github.com/postcss/postcss-load-config/issues/230).
- Uses `.mjs` for maximal compatibility

## Why?

- To convert one more file into ESM
- To use more modern format

## How?

- Changed file extension from `.cjs` to `.mjs`
- Changed module format to ESM
- Updated relevant docs
- Added types for `postcss.config.mjs` for autocompletion
