### PR TITLE
[@mantine/core] Fix unintended modal close during IME composition

### DIFF
--- a/packages/@mantine/core/src/components/ModalBase/use-modal.ts
+++ b/packages/@mantine/core/src/components/ModalBase/use-modal.ts
@@ -34,7 +34,7 @@ export function useModal({
   useWindowEvent(
     'keydown',
     (event) => {
-      if (event.key === 'Escape' && closeOnEscape && opened) {
+      if (event.key === 'Escape' && closeOnEscape && !event.isComposing && opened) {
         const shouldTrigger =
           (event.target as HTMLElement)?.getAttribute('data-mantine-stop-propagation') !== 'true';
         shouldTrigger && onClose();


### PR DESCRIPTION
When opening a modal with the `closeOnEscape` option enabled, pressing Escape during IME conversion unintentionally closes the modal.
The expected behavior is that pressing Escape should only cancel the IME composition—not close the modal.
To address this, I added a check for the composing status in the keydown event handler.

## Before

1. Type "とうきょう"
1. Press space to start text conversion
1. Press Escape → modal closes unexpectedly

https://github.com/user-attachments/assets/029c5e43-af0a-4673-aefe-0b8255936633

## After

### with IME conversion

1. Type "とうきょう"
1. Press space to start text conversion
1. Press Escape → cancels conversion
1. Press Escape → cancels input
1. Press Escape → closes modal

https://github.com/user-attachments/assets/d74b9540-458f-431e-939c-16cacc1058d6

### without IME conversion (Same as before)

1. Type "tokyo"
1. Press Escape → closes modal

https://github.com/user-attachments/assets/a04daefe-0416-437a-90fb-4c6fe7416626

## Environment

I tested on macOS using the default Japanese IME