### PR TITLE
[mantine.dev] Fix incorrect page title on ReactRouter docs

### DIFF
--- a/apps/mantine.dev/src/pages/guides/react-router.mdx
+++ b/apps/mantine.dev/src/pages/guides/react-router.mdx
@@ -1,7 +1,7 @@
 import { Layout } from '@/layout';
 import { MDX_DATA } from '@/mdx';
 
-export default Layout(MDX_DATA.Remix);
+export default Layout(MDX_DATA.ReactRouter);
 
 # Usage with React Router
 


### PR DESCRIPTION
This PR corrects a page title in the `ReactRouter` documentation that was mistakenly labeled as `Remix`.