### PR TITLE
Fix: Revert isSame usage due to Day.js calendar bug

### DIFF
--- a/packages/@mantine/dates/src/components/Month/Month.tsx
+++ b/packages/@mantine/dates/src/components/Month/Month.tsx
@@ -23,6 +23,7 @@ import { getMonthDays } from './get-month-days/get-month-days';
 import { getWeekNumber } from './get-week-number/get-week-number';
 import { isAfterMinDate } from './is-after-min-date/is-after-min-date';
 import { isBeforeMaxDate } from './is-before-max-date/is-before-max-date';
+import { isSameMonth } from './is-same-month/is-same-month';
 import classes from './Month.module.css';
 
 export type MonthStylesNames =
@@ -215,7 +216,7 @@ export const Month = factory<MonthFactory>((_props, ref) => {
 
   const rows = dates.map((row, rowIndex) => {
     const cells = row.map((date, cellIndex) => {
-      const outside = !dayjs(date).isSame(dayjs(month), 'month');
+      const outside = !isSameMonth(date, month);
       const ariaLabel =
         getDayAriaLabel?.(date) ||
         dayjs(date)

--- a/packages/@mantine/dates/src/components/Month/get-date-in-tab-order/get-date-in-tab-order.ts
+++ b/packages/@mantine/dates/src/components/Month/get-date-in-tab-order/get-date-in-tab-order.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import { DayProps } from '../../Day/Day';
 import { isAfterMinDate } from '../is-after-min-date/is-after-min-date';
 import { isBeforeMaxDate } from '../is-before-max-date/is-before-max-date';
+import { isSameMonth } from '../is-same-month/is-same-month';
 
 export function getDateInTabOrder(
   dates: Date[][],
@@ -20,7 +21,7 @@ export function getDateInTabOrder(
         isAfterMinDate(date, minDate) &&
         !excludeDate?.(date) &&
         !getDateControlProps?.(date)?.disabled &&
-        (!hideOutsideDates || dayjs(date).isSame(dayjs(month), 'month'))
+        (!hideOutsideDates || isSameMonth(date, month))
     );
 
   const selectedDate = enabledDates.find((date) => getDateControlProps?.(date)?.selected);

--- a/packages/@mantine/dates/src/components/Month/index.ts
+++ b/packages/@mantine/dates/src/components/Month/index.ts
@@ -1,6 +1,7 @@
 export { getEndOfWeek } from './get-end-of-week/get-end-of-week';
 export { getStartOfWeek } from './get-start-of-week/get-start-of-week';
 export { getMonthDays } from './get-month-days/get-month-days';
+export { isSameMonth } from './is-same-month/is-same-month';
 
 export { Month } from './Month';
 export type { MonthProps, MonthSettings, MonthStylesNames, MonthFactory } from './Month';

--- a/packages/@mantine/dates/src/components/Month/is-same-month/is-same-month.test.ts
+++ b/packages/@mantine/dates/src/components/Month/is-same-month/is-same-month.test.ts
@@ -1,0 +1,9 @@
+import { isSameMonth } from './is-same-month';
+
+describe('@mantine/dates/is-same-month', () => {
+  it('detects same month', () => {
+    expect(isSameMonth(new Date(2021, 2, 1), new Date(2021, 2, 2))).toBe(true);
+    expect(isSameMonth(new Date(2021, 3, 1), new Date(2021, 2, 2))).toBe(false);
+    expect(isSameMonth(new Date(2022, 2, 2), new Date(2021, 2, 2))).toBe(false);
+  });
+});

--- a/packages/@mantine/dates/src/components/Month/is-same-month/is-same-month.ts
+++ b/packages/@mantine/dates/src/components/Month/is-same-month/is-same-month.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
 
 export function isSameMonth(date: Date, comparison: Date) {
-  return dayjs(date).format('YYY-MM') === dayjs(comparison).format('YYY-MM');
+  return dayjs(date).format('YYYY-MM') === dayjs(comparison).format('YYYY-MM');
 }

--- a/packages/@mantine/dates/src/components/Month/is-same-month/is-same-month.ts
+++ b/packages/@mantine/dates/src/components/Month/is-same-month/is-same-month.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
 
 export function isSameMonth(date: Date, comparison: Date) {
-  return dayjs(date).format('YYY-MM') && dayjs(comparison).format('YYY-MM');
+  return dayjs(date).format('YYY-MM') === dayjs(comparison).format('YYY-MM');
 }

--- a/packages/@mantine/dates/src/components/Month/is-same-month/is-same-month.ts
+++ b/packages/@mantine/dates/src/components/Month/is-same-month/is-same-month.ts
@@ -1,0 +1,5 @@
+import dayjs from 'dayjs';
+
+export function isSameMonth(date: Date, comparison: Date) {
+  return dayjs(date).format('YYY-MM') && dayjs(comparison).format('YYY-MM');
+}


### PR DESCRIPTION
In [pull request #7302](https://github.com/mantinedev/mantine/pull/7302), two main changes were introduced:

### Support for non-Gregorian calendars:
We patched parts of the codebase to allow the library to work correctly with alternative calendars (e.g., Jalali). This part of the change was successful — we’ve integrated it into our own project and it's now functioning properly within a non-Gregorian calendar setup.

### Replacement of isSameMonth with dayjs().isSame(...):
The assumption was that Day.js’s isSame function would correctly handle month comparisons across all calendar systems. However, we later discovered that isSame does not work reliably for non-Gregorian calendars — it fails to compare months correctly. This PR reverts that change and restores the original internal isSameMonth function to maintain expected behavior.

This fix ensures consistent support for both Gregorian and non-Gregorian calendars and avoids breaking functionality due to incorrect assumptions about Day.js.