### PR TITLE
[@mantine/hooks] useDebouncedCallback flushOnUnmount does not work #7684

### DIFF
--- a/packages/@docs/demos/src/demos/hooks/Hooks.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/hooks/Hooks.demos.story.tsx
@@ -303,6 +303,11 @@ export const Demo_useDebouncedCallbackUsage = {
   render: renderDemo(demos.useDebouncedCallbackUsage),
 };
 
+export const Demo_useDebouncedCallbackUnmount = {
+  name: '⭐ Demo: useDebouncedCallbackUnmount',
+  render: renderDemo(demos.useDebouncedCallbackUnmount),
+};
+
 export const Demo_useThrottledStateUsage = {
   name: '⭐ Demo: useThrottledStateUsage',
   render: renderDemo(demos.useThrottledStateUsage),

--- a/packages/@docs/demos/src/demos/hooks/index.ts
+++ b/packages/@docs/demos/src/demos/hooks/index.ts
@@ -58,6 +58,7 @@ export { useFetchUsage } from './use-fetch.demo.usage';
 export { useMapUsage } from './use-map.demo.usage';
 export { useSetUsage } from './use-set.demo.usage';
 export { useDebouncedCallbackUsage } from './use-debounced-callback.demo.usage';
+export { useDebouncedCallbackUnmount } from './use-debounced-callback.demo.unmount';
 export { useThrottledStateUsage } from './use-throttled-state.demo.usage';
 export { useThrottledValueUsage } from './use-throttled-value.demo.usage';
 export { useThrottledCallbackUsage } from './use-throttled-callback.demo.usage';

--- a/packages/@docs/demos/src/demos/hooks/use-debounced-callback.demo.unmount.tsx
+++ b/packages/@docs/demos/src/demos/hooks/use-debounced-callback.demo.unmount.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { Button, Group, Stack, Text } from '@mantine/core';
+import { useDebouncedCallback } from '@mantine/hooks';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { useState } from 'react';
+import { Button, Group, Stack, Text } from '@mantine/core';
+import { useDebouncedCallback } from '@mantine/hooks';
+
+function InputWithDebounce({ onChange }) {
+  const [innerValue, setInnerValue] = useState('');
+  const debouncedCallback = useDebouncedCallback(
+    (newInnerValue) => {
+      onChange(newInnerValue);
+    },
+    { delay: 2000, flushOnUnmount: true }
+  );
+
+  const handleChange = (newInnerValue) => {
+    setInnerValue(newInnerValue);
+    debouncedCallback(newInnerValue);
+  };
+
+  return (
+    <input
+      placeholder="Enter text..."
+      value={innerValue}
+      onChange={(event) => handleChange(event.target.value)}
+      style={{ padding: '8px', width: '100%' }}
+    />
+  );
+}
+
+function Demo() {
+  const [outerValue, setOuterValue] = useState('');
+  const [visible, setVisible] = useState(true);
+
+  return (
+    <Stack>
+      <Text fw={700}>Output value: {outerValue || '(none)'}</Text>
+
+      <Group>
+        <Button onClick={() => setVisible(!visible)}>
+          {visible ? 'Hide component' : 'Show component'}
+        </Button>
+      </Group>
+
+      {visible ? <InputWithDebounce onChange={setOuterValue} /> : null}
+
+      <Text size="sm" c="dimmed">
+        1. Type text and wait 2 seconds for the value to be transmitted.
+        2. Type text and immediately click the 'Hide component' button.
+           The value will be transmitted immediately due to the flushOnUnmount option.
+      </Text>
+    </Stack>
+  );
+}
+`;
+
+function InputWithDebounce({ onChange }: { onChange: (value: string) => void }) {
+  const [innerValue, setInnerValue] = useState('');
+  const debouncedCallback = useDebouncedCallback(
+    (newInnerValue: string) => {
+      onChange(newInnerValue);
+    },
+    { delay: 2000, flushOnUnmount: true }
+  );
+
+  const handleChange = (newInnerValue: string) => {
+    setInnerValue(newInnerValue);
+    debouncedCallback(newInnerValue);
+  };
+
+  return (
+    <input
+      placeholder="Enter text..."
+      value={innerValue}
+      onChange={(event) => handleChange(event.target.value)}
+      style={{ padding: '8px', width: '100%' }}
+    />
+  );
+}
+
+function Demo() {
+  const [outerValue, setOuterValue] = useState('');
+  const [visible, setVisible] = useState(true);
+
+  return (
+    <Stack>
+      <Text fw={700}>Output value: {outerValue || '(none)'}</Text>
+
+      <Group>
+        <Button onClick={() => setVisible(!visible)}>
+          {visible ? 'Hide component' : 'Show component'}
+        </Button>
+      </Group>
+
+      {visible ? <InputWithDebounce onChange={setOuterValue} /> : null}
+
+      <Text size="sm" c="dimmed">
+        1. Type text and wait 2 seconds for the value to be transmitted. 2. Type text and
+        immediately click the 'Hide component' button. The value will be transmitted immediately due
+        to the flushOnUnmount option.
+      </Text>
+    </Stack>
+  );
+}
+
+export const useDebouncedCallbackUnmount: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+  centered: true,
+  maxWidth: 500,
+};

--- a/packages/@mantine/form/src/use-field.ts
+++ b/packages/@mantine/form/src/use-field.ts
@@ -187,7 +187,7 @@ export function useField<
         _validate();
       }
     },
-    [error, clearErrorOnChange]
+    [error, clearErrorOnChange, onValueChange]
   );
 
   const reset = useCallback(() => {

--- a/packages/@mantine/hooks/src/use-debounced-callback/use-debounced-callback.ts
+++ b/packages/@mantine/hooks/src/use-debounced-callback/use-debounced-callback.ts
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useCallbackRef } from '../use-callback-ref/use-callback-ref';
 
-const noop = () => {};
-
 export function useDebouncedCallback<T extends (...args: any[]) => any>(
   callback: T,
   options: number | { delay: number; flushOnUnmount?: boolean }
@@ -11,33 +9,48 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
   const flushOnUnmount = typeof options === 'number' ? false : options.flushOnUnmount;
   const handleCallback = useCallbackRef(callback);
   const debounceTimerRef = useRef(0);
+  const isPendingRef = useRef(false);
+
+  const lastArgsRef = useRef<Parameters<T> | null>(null);
+
+  const flush = useCallback(() => {
+    if (debounceTimerRef.current !== 0) {
+      window.clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = 0;
+
+      if (lastArgsRef.current !== null) {
+        isPendingRef.current = false;
+        handleCallback(...lastArgsRef.current);
+      }
+    }
+  }, [handleCallback]);
 
   const lastCallback = Object.assign(
     useCallback(
       (...args: Parameters<T>) => {
+        lastArgsRef.current = args;
+        isPendingRef.current = true;
+
         window.clearTimeout(debounceTimerRef.current);
-        const flush = () => {
-          if (debounceTimerRef.current !== 0) {
-            debounceTimerRef.current = 0;
-            handleCallback(...args);
-          }
-        };
-        lastCallback.flush = flush;
-        debounceTimerRef.current = window.setTimeout(flush, delay);
+        debounceTimerRef.current = window.setTimeout(() => {
+          debounceTimerRef.current = 0;
+          isPendingRef.current = false;
+          handleCallback(...args);
+        }, delay);
       },
-      [handleCallback, delay]
+      [handleCallback, delay, flush]
     ),
-    { flush: noop }
+    { flush }
   );
 
   useEffect(
     () => () => {
       window.clearTimeout(debounceTimerRef.current);
-      if (flushOnUnmount) {
-        lastCallback.flush();
+      if (flushOnUnmount && isPendingRef.current && lastArgsRef.current !== null) {
+        handleCallback(...lastArgsRef.current);
       }
     },
-    [lastCallback, flushOnUnmount]
+    [flushOnUnmount, handleCallback]
   );
 
   return lastCallback;


### PR DESCRIPTION
Fixes #7684 

Fixed the hook by adding isPendingRef to track pending callbacks. Now it only executes on unmount when truly necessary, passing the failing test. Added a Storybook demo to show the flushOnUnmount functionality in action

Issue
In the previous implementation of useDebouncedCallback, the flushOnUnmount option didn't work correctly in certain cases. When a component unmounted, even with flushOnUnmount: true, the debounced value wasn't properly applied.
The issue was that lastCallback.flush was initially set to noop and dynamically reassigned during each invocation, but the cleanup function in useEffect didn't always have access to the latest version of this function.
Fix
Modified the implementation to
Add isPendingRef to explicitly track whether there's a pending callback awaiting execution
Use lastArgsRef to store the latest arguments passed to the callback
Call handleCallback directly during unmount when appropriate, instead of relying on the potentially stale lastCallback.flush function