### PR TITLE
[@mantine/charts] RadarChart: Add Tooltips and Dots

### DIFF
--- a/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demo.customTooltip.tsx
+++ b/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demo.customTooltip.tsx
@@ -1,7 +1,7 @@
 import { RadarChart } from '@mantine/charts';
+import { Paper, Text } from '@mantine/core';
 import { MantineDemo } from '@mantinex/demo';
 import { multiData, multiDataCode } from './_data';
-import { Paper, Text } from '@mantine/core';
 
 const code = `
 import { RadarChart } from '@mantine/charts';

--- a/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demo.customTooltip.tsx
+++ b/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demo.customTooltip.tsx
@@ -36,6 +36,8 @@ function Demo() {
       data={data}
       dataKey="product"
       withPolarRadiusAxis
+      withTooltip
+      withDots
       tooltipProps={{
         content: ({ label, payload }) => <ChartTooltip label={label} payload={payload} />,
       }}
@@ -79,6 +81,8 @@ function Demo() {
       data={multiData}
       dataKey="product"
       withPolarRadiusAxis
+      withDots
+      withTooltip
       tooltipProps={{
         content: ({ label, payload }) => <ChartTooltip label={label} payload={payload} />,
       }}

--- a/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demo.customTooltip.tsx
+++ b/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demo.customTooltip.tsx
@@ -1,0 +1,100 @@
+import { RadarChart } from '@mantine/charts';
+import { MantineDemo } from '@mantinex/demo';
+import { multiData, multiDataCode } from './_data';
+import { Paper, Text } from '@mantine/core';
+
+const code = `
+import { RadarChart } from '@mantine/charts';
+import { data } from './data';
+
+interface ChartTooltipProps {
+  label: string;
+  payload: Record<string, any>[] | undefined;
+}
+
+function ChartTooltip({ label, payload }: ChartTooltipProps) {
+  if (!payload) return null;
+
+  return (
+    <Paper px="md" py="sm" withBorder shadow="md" radius="md">
+      <Text fw={500} mb={5}>
+        {label}
+      </Text>
+      {payload.map((item: any) => (
+        <Text key={item.name} c={item.color} fz="sm">
+          {item.name}: {item.value}
+        </Text>
+      ))}
+    </Paper>
+  );
+}
+
+function Demo() {
+  return (
+    <RadarChart
+      h={300}
+      data={data}
+      dataKey="product"
+      withPolarRadiusAxis
+      tooltipProps={{
+        content: ({ label, payload }) => <ChartTooltip label={label} payload={payload} />,
+      }}
+      series={[
+        { name: 'Sales January', color: 'lime.4', opacity: 0.1 },
+        { name: 'Sales February', color: 'cyan.4', opacity: 0.1 },
+      ]}
+    />
+  );
+}
+`;
+
+interface ChartTooltipProps {
+  label: string;
+  payload: Record<string, any>[] | undefined;
+}
+
+function ChartTooltip({ label, payload }: ChartTooltipProps) {
+  if (!payload) {
+    return null;
+  }
+
+  return (
+    <Paper px="md" py="sm" withBorder shadow="md" radius="md">
+      <Text fw={500} mb={5}>
+        {label}
+      </Text>
+      {payload.map((item: any) => (
+        <Text key={item.name} c={item.color} fz="sm">
+          {item.name}: {item.value}
+        </Text>
+      ))}
+    </Paper>
+  );
+}
+
+function Demo() {
+  return (
+    <RadarChart
+      h={300}
+      data={multiData}
+      dataKey="product"
+      withPolarRadiusAxis
+      tooltipProps={{
+        content: ({ label, payload }) => <ChartTooltip label={label} payload={payload} />,
+      }}
+      series={[
+        { name: 'Sales January', color: 'lime.4', opacity: 0.1 },
+        { name: 'Sales February', color: 'cyan.4', opacity: 0.1 },
+      ]}
+    />
+  );
+}
+
+export const customTooltip: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code: [
+    { code, language: 'tsx', fileName: 'Demo.tsx' },
+    { code: multiDataCode, language: 'tsx', fileName: 'data.ts' },
+  ],
+};

--- a/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demo.parts.tsx
+++ b/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demo.parts.tsx
@@ -50,5 +50,6 @@ export const parts: MantineDemo = {
     { type: 'boolean', prop: 'withPolarGrid', initialValue: true, libraryValue: null },
     { type: 'boolean', prop: 'withPolarAngleAxis', initialValue: true, libraryValue: null },
     { type: 'boolean', prop: 'withPolarRadiusAxis', initialValue: true, libraryValue: null },
+    { type: 'boolean', prop: 'withTooltip', initialValue: true, libraryValue: null },
   ],
 };

--- a/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demo.parts.tsx
+++ b/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demo.parts.tsx
@@ -51,5 +51,6 @@ export const parts: MantineDemo = {
     { type: 'boolean', prop: 'withPolarAngleAxis', initialValue: true, libraryValue: null },
     { type: 'boolean', prop: 'withPolarRadiusAxis', initialValue: true, libraryValue: null },
     { type: 'boolean', prop: 'withTooltip', initialValue: true, libraryValue: null },
+    { type: 'boolean', prop: 'withDots', initialValue: true, libraryValue: null },
   ],
 };

--- a/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demo.parts.tsx
+++ b/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demo.parts.tsx
@@ -50,7 +50,7 @@ export const parts: MantineDemo = {
     { type: 'boolean', prop: 'withPolarGrid', initialValue: true, libraryValue: null },
     { type: 'boolean', prop: 'withPolarAngleAxis', initialValue: true, libraryValue: null },
     { type: 'boolean', prop: 'withPolarRadiusAxis', initialValue: true, libraryValue: null },
-    { type: 'boolean', prop: 'withTooltip', initialValue: true, libraryValue: null },
-    { type: 'boolean', prop: 'withDots', initialValue: true, libraryValue: null },
+    { type: 'boolean', prop: 'withTooltip', initialValue: false, libraryValue: null },
+    { type: 'boolean', prop: 'withDots', initialValue: false, libraryValue: null },
   ],
 };

--- a/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demo.tooltip.tsx
+++ b/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demo.tooltip.tsx
@@ -1,0 +1,52 @@
+import { RadarChart } from '@mantine/charts';
+import { MantineDemo } from '@mantinex/demo';
+import { multiData, multiDataCode } from './_data';
+
+const code = `
+import { RadarChart } from '@mantine/charts';
+import { data } from './data';
+
+
+function Demo() {
+  return (
+    <RadarChart
+      h={300}
+      data={data}
+      dataKey="product"
+      withTooltip
+      withDots
+      series={[
+        { name: 'Sales January', color: 'lime.4', opacity: 0.1 },
+        { name: 'Sales February', color: 'cyan.4', opacity: 0.1 },
+      ]}
+      {{props}}
+    />
+  );
+}
+`;
+
+function Demo(props: any) {
+  return (
+    <RadarChart
+      h={300}
+      data={multiData}
+      dataKey="product"
+      withTooltip
+      withDots
+      series={[
+        { name: 'Sales January', color: 'lime.4', opacity: 0.1 },
+        { name: 'Sales February', color: 'cyan.4', opacity: 0.1 },
+      ]}
+      {...props}
+    />
+  );
+}
+
+export const tooltip: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code: [
+    { code, language: 'tsx', fileName: 'Demo.tsx' },
+    { code: multiDataCode, language: 'tsx', fileName: 'data.ts' },
+  ],
+};

--- a/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demos.story.tsx
@@ -26,7 +26,7 @@ export const Demo_parts = {
 export const Demo_customTooltip = {
   name: '⭐ Demo: customTooltip',
   render: renderDemo(demos.customTooltip),
-}
+};
 
 export const Demo_rechartsProps = {
   name: '⭐ Demo: rechartsProps',

--- a/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demos.story.tsx
@@ -23,6 +23,11 @@ export const Demo_parts = {
   render: renderDemo(demos.parts),
 };
 
+export const Demo_tooltip = {
+  name: '⭐ Demo: tooltip',
+  render: renderDemo(demos.tooltip),
+};
+
 export const Demo_customTooltip = {
   name: '⭐ Demo: customTooltip',
   render: renderDemo(demos.customTooltip),

--- a/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/charts/RadarChart/RadarChart.demos.story.tsx
@@ -23,6 +23,11 @@ export const Demo_parts = {
   render: renderDemo(demos.parts),
 };
 
+export const Demo_customTooltip = {
+  name: '⭐ Demo: customTooltip',
+  render: renderDemo(demos.customTooltip),
+}
+
 export const Demo_rechartsProps = {
   name: '⭐ Demo: rechartsProps',
   render: renderDemo(demos.rechartsProps),

--- a/packages/@docs/demos/src/demos/charts/RadarChart/index.ts
+++ b/packages/@docs/demos/src/demos/charts/RadarChart/index.ts
@@ -2,5 +2,6 @@ export { usage } from './RadarChart.demo.usage';
 export { color } from './RadarChart.demo.color';
 export { multiple } from './RadarChart.demo.multiple';
 export { parts } from './RadarChart.demo.parts';
+export { customTooltip } from './RadarChart.demo.customTooltip';
 export { rechartsProps } from './RadarChart.demo.rechartsProps';
 export { legend } from './RadarChart.demo.legend';

--- a/packages/@docs/demos/src/demos/charts/RadarChart/index.ts
+++ b/packages/@docs/demos/src/demos/charts/RadarChart/index.ts
@@ -2,6 +2,7 @@ export { usage } from './RadarChart.demo.usage';
 export { color } from './RadarChart.demo.color';
 export { multiple } from './RadarChart.demo.multiple';
 export { parts } from './RadarChart.demo.parts';
+export { tooltip } from './RadarChart.demo.tooltip';
 export { customTooltip } from './RadarChart.demo.customTooltip';
 export { rechartsProps } from './RadarChart.demo.rechartsProps';
 export { legend } from './RadarChart.demo.legend';

--- a/packages/@docs/styles-api/src/data/RadarChart.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/RadarChart.styles-api.ts
@@ -5,6 +5,14 @@ export const RadarChartStylesApi: StylesApiData<RadarChartFactory> = {
   selectors: {
     root: 'Root element',
     container: 'Recharts ResponsiveContainer component',
+    tooltip: 'Tooltip root element',
+    tooltipBody: 'Tooltip wrapper around all items',
+    tooltipItem: 'Tooltip item representing data series',
+    tooltipItemBody: 'Tooltip item wrapper around item color and name',
+    tooltipItemColor: 'Tooltip item color',
+    tooltipItemName: 'Tooltip item name',
+    tooltipItemData: 'Tooltip item data',
+    tooltipLabel: 'Label of the tooltip',
   },
 
   vars: {

--- a/packages/@mantine/charts/src/RadarChart/RadarChart.tsx
+++ b/packages/@mantine/charts/src/RadarChart/RadarChart.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import {
+  DotProps,
   Legend,
   LegendProps,
   PolarAngleAxis,
@@ -107,6 +108,15 @@ export interface RadarChartProps
   /** Determines whether the legend should be displayed, `false` by default */
   withLegend?: boolean;
 
+  /** Determines whether dots should be displayed, `true` by default */
+  withDots?: boolean;
+
+  /** Props passed down to all dots. Ignored if `withDots={false}` is set. */
+  dotProps?: Omit<DotProps, 'ref'>;
+
+  /** Props passed down to all active dots. Ignored if `withDots={false}` is set. */
+  activeDotProps?: Omit<DotProps, 'ref'>;
+
   /** Additional components that are rendered inside recharts `RadarChart` component */
   children?: React.ReactNode;
 }
@@ -123,6 +133,7 @@ const defaultProps: Partial<RadarChartProps> = {
   withPolarAngleAxis: true,
   withPolarRadiusAxis: false,
   withTooltip: true,
+  withDots: true,
   tooltipAnimationDuration: 0,
 };
 
@@ -160,6 +171,9 @@ export const RadarChart = factory<RadarChartFactory>((_props, ref) => {
     tooltipAnimationDuration,
     children,
     withLegend,
+    withDots,
+    dotProps,
+    activeDotProps,
     legendProps,
     ...others
   } = props;
@@ -201,6 +215,27 @@ export const RadarChart = factory<RadarChartFactory>((_props, ref) => {
             : 0.05
           : item.opacity || 0.4
       }
+      dot={
+        withDots
+          ? {
+              fillOpacity: 1,
+              strokeOpacity: 0,
+              strokeWidth: 1,
+              fill: getThemeColor(item.color, theme),
+              stroke: getThemeColor(item.color, theme),
+              ...dotProps,
+            }
+          : false
+      }
+      activeDot={
+        withDots
+          ? {
+              fill: getThemeColor(item.color, theme),
+              stroke: getThemeColor(item.color, theme),
+              ...activeDotProps,
+            }
+          : false
+      }
       strokeOpacity={highlightedArea ? (highlightedArea === item.name ? 1 : 0.1) : 1}
       isAnimationActive={false}
       {...(typeof radarProps === 'function' ? radarProps(item) : radarProps)}
@@ -238,6 +273,10 @@ export const RadarChart = factory<RadarChartFactory>((_props, ref) => {
             <Tooltip
               animationDuration={tooltipAnimationDuration}
               isAnimationActive={tooltipAnimationDuration !== 0}
+              cursor={{
+                stroke: 'var(--chart-grid-color)',
+                strokeWidth: 1,
+              }}
               content={({ label, payload }) => (
                 <ChartTooltip
                   label={label}

--- a/packages/@mantine/charts/src/RadarChart/RadarChart.tsx
+++ b/packages/@mantine/charts/src/RadarChart/RadarChart.tsx
@@ -12,6 +12,8 @@ import {
   RadarProps,
   RadarChart as ReChartsRadarChart,
   ResponsiveContainer,
+  Tooltip,
+  TooltipProps,
 } from 'recharts';
 import {
   Box,
@@ -29,6 +31,7 @@ import {
   useStyles,
 } from '@mantine/core';
 import { ChartLegend } from '../ChartLegend';
+import { ChartTooltip, ChartTooltipStylesNames } from '../ChartTooltip';
 import classes from './RadarChart.module.css';
 
 export interface RadarChartSeries {
@@ -39,7 +42,7 @@ export interface RadarChartSeries {
   label?: string;
 }
 
-export type RadarChartStylesNames = 'root' | 'container';
+export type RadarChartStylesNames = 'root' | 'container' | ChartTooltipStylesNames;
 export type RadarChartCssVariables = {
   root: '--chart-grid-color' | '--chart-text-color';
 };
@@ -72,6 +75,9 @@ export interface RadarChartProps
   /** Determines whether PolarRadiusAxisProps component should be displayed, `false` by default */
   withPolarRadiusAxis?: boolean;
 
+  /** Determines whether Tooltip component should be displayed, `true` by default */
+  withTooltip?: boolean;
+
   /** Props passed down to recharts Radar component */
   radarProps?:
     | ((series: RadarChartSeries) => Partial<Omit<RadarProps, 'ref'>>)
@@ -92,6 +98,12 @@ export interface RadarChartProps
   /** Props passed down to recharts Legend component */
   legendProps?: Omit<LegendProps, 'ref'>;
 
+  /** Props passed down to recharts Tooltip component */
+  tooltipProps?: Omit<TooltipProps<any, any>, 'ref'>;
+
+  /** Tooltip position animation duration in ms, `0` by default */
+  tooltipAnimationDuration?: number;
+
   /** Determines whether the legend should be displayed, `false` by default */
   withLegend?: boolean;
 
@@ -110,6 +122,8 @@ const defaultProps: Partial<RadarChartProps> = {
   withPolarGrid: true,
   withPolarAngleAxis: true,
   withPolarRadiusAxis: false,
+  withTooltip: true,
+  tooltipAnimationDuration: 0,
 };
 
 const varsResolver = createVarsResolver<RadarChartFactory>((theme, { gridColor, textColor }) => ({
@@ -138,9 +152,12 @@ export const RadarChart = factory<RadarChartFactory>((_props, ref) => {
     polarGridProps,
     polarAngleAxisProps,
     polarRadiusAxisProps,
+    tooltipProps,
     withPolarGrid,
     withPolarAngleAxis,
     withPolarRadiusAxis,
+    withTooltip,
+    tooltipAnimationDuration,
     children,
     withLegend,
     legendProps,
@@ -215,6 +232,22 @@ export const RadarChart = factory<RadarChartFactory>((_props, ref) => {
                 />
               )}
               {...legendProps}
+            />
+          )}
+          {withTooltip && (
+            <Tooltip
+              animationDuration={tooltipAnimationDuration}
+              isAnimationActive={tooltipAnimationDuration !== 0}
+              content={({ label, payload }) => (
+                <ChartTooltip
+                  label={label}
+                  payload={payload}
+                  classNames={resolvedClassNames}
+                  styles={resolvedStyles}
+                  series={series}
+                />
+              )}
+              {...tooltipProps}
             />
           )}
           {children}

--- a/packages/@mantine/charts/src/RadarChart/RadarChart.tsx
+++ b/packages/@mantine/charts/src/RadarChart/RadarChart.tsx
@@ -76,7 +76,7 @@ export interface RadarChartProps
   /** Determines whether PolarRadiusAxisProps component should be displayed, `false` by default */
   withPolarRadiusAxis?: boolean;
 
-  /** Determines whether Tooltip component should be displayed, `true` by default */
+  /** Determines whether Tooltip component should be displayed, `false` by default */
   withTooltip?: boolean;
 
   /** Props passed down to recharts Radar component */
@@ -108,7 +108,7 @@ export interface RadarChartProps
   /** Determines whether the legend should be displayed, `false` by default */
   withLegend?: boolean;
 
-  /** Determines whether dots should be displayed, `true` by default */
+  /** Determines whether dots should be displayed, `false` by default */
   withDots?: boolean;
 
   /** Props passed down to all dots. Ignored if `withDots={false}` is set. */
@@ -132,8 +132,8 @@ const defaultProps: Partial<RadarChartProps> = {
   withPolarGrid: true,
   withPolarAngleAxis: true,
   withPolarRadiusAxis: false,
-  withTooltip: true,
-  withDots: true,
+  withTooltip: false,
+  withDots: false,
   tooltipAnimationDuration: 0,
 };
 
@@ -251,24 +251,6 @@ export const RadarChart = factory<RadarChartFactory>((_props, ref) => {
           {withPolarRadiusAxis && (
             <PolarRadiusAxis stroke="var(--chart-grid-color)" {...polarRadiusAxisProps} />
           )}
-          {radars}
-          {withLegend && (
-            <Legend
-              verticalAlign="bottom"
-              content={(payload) => (
-                <ChartLegend
-                  payload={payload.payload}
-                  onHighlight={setHighlightedArea}
-                  legendPosition={legendProps?.verticalAlign || 'bottom'}
-                  classNames={resolvedClassNames}
-                  styles={resolvedStyles}
-                  series={series}
-                  centered
-                />
-              )}
-              {...legendProps}
-            />
-          )}
           {withTooltip && (
             <Tooltip
               animationDuration={tooltipAnimationDuration}
@@ -289,6 +271,25 @@ export const RadarChart = factory<RadarChartFactory>((_props, ref) => {
               {...tooltipProps}
             />
           )}
+          {radars}
+          {withLegend && (
+            <Legend
+              verticalAlign="bottom"
+              content={(payload) => (
+                <ChartLegend
+                  payload={payload.payload}
+                  onHighlight={setHighlightedArea}
+                  legendPosition={legendProps?.verticalAlign || 'bottom'}
+                  classNames={resolvedClassNames}
+                  styles={resolvedStyles}
+                  series={series}
+                  centered
+                />
+              )}
+              {...legendProps}
+            />
+          )}
+
           {children}
         </ReChartsRadarChart>
       </ResponsiveContainer>


### PR DESCRIPTION
In the latest Mantine version `7.17.5` RadarChart does not have any tooltips. This PR implements them with a Storybook demo of custom tooltip.

Tooltip example:
<img width="476" alt="image" src="https://github.com/user-attachments/assets/040a695b-001e-41d2-99c0-2d1632ed440c" />

Custom tooltip demo:
<img width="434" alt="image" src="https://github.com/user-attachments/assets/ab9790f9-64f5-466f-9eef-b4a21125b6d2" />