### PR TITLE
[@mantine/modals] ModalsProvider supports rendering multiple modals and add closeOnEscapeTopOnly prop

### DIFF
--- a/apps/mantine.dev/src/pages/x/modals.mdx
+++ b/apps/mantine.dev/src/pages/x/modals.mdx
@@ -160,10 +160,33 @@ With `modals.open` function you can open a modal with any content:
 
 ## Multiple opened modals
 
-You can open multiple layers of modals. Every opened modal is added as first element in modals queue.
+You can open multiple modals one after another.
+Each modal you open is added to the modals queue, but by default, only the most recently opened modal is visible.
 To close all opened modals call `modals.closeAll()` function:
 
 <Demo data={ModalsDemos.multipleSteps} />
+
+To display all opened modals at once, set the `showAllModals` prop to `true` on `ModalsProvider`.
+All modals will be rendered in the order they were opened, with the most recently opened modal on top:
+
+<Demo data={ModalsDemos.showAllModals} />
+
+By default, when multiple modals are open, only the topmost modal responds to the Escape key press.
+To make all open modals close when Escape is pressed, set the `closeOnEscapeTopOnly` prop to `false` on `ModalsProvider`:
+
+```tsx
+import { ModalsProvider } from '@mantine/modals';
+
+function Demo() {
+  return (
+    <ModalsProvider closeOnEscapeTopOnly={false} showAllModals>
+      {/* Your app here */}
+    </ModalsProvider>
+  );
+}
+```
+
+When `closeOnEscapeTopOnly` is set to `false`, pressing Escape will close all modals at once.
 
 ## Modal props
 

--- a/packages/@docs/demos/src/demos/modals/Modals.demo.showAllModals.tsx
+++ b/packages/@docs/demos/src/demos/modals/Modals.demo.showAllModals.tsx
@@ -1,0 +1,99 @@
+import { Button, Text } from '@mantine/core';
+import { ModalsProvider, useModals } from '@mantine/modals';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { Button, Text } from '@mantine/core';
+import { ModalsProvider, useModals } from '@mantine/modals';
+
+const DemoContent = () => {
+  const modals = useModals();
+
+  return (
+    <Button
+      onClick={() => {
+        modals.openModal({
+        title: 'Modal 1',
+        size: 'lg',
+        children: (
+          <div>
+            <Text>This is modal 1</Text>
+            <Button
+              fullWidth
+              mt="md"
+              onClick={() => {
+                modals.openModal({
+                  title: 'Modal 2',
+                  children: <div>This is modal 2</div>
+                });
+              }}
+            >
+              Open modal 2
+            </Button>
+          </div>
+        ),
+      });
+    }}
+    >
+      Open multiple modals
+    </Button>
+  );
+};
+
+function Demo() {
+  return (
+    <ModalsProvider showAllModals>
+      <DemoContent />
+    </ModalsProvider>
+  );
+}
+`;
+
+const DemoContent = () => {
+  const modals = useModals();
+
+  return (
+    <Button
+      onClick={() => {
+        modals.openModal({
+        title: 'Modal 1',
+        size: 'lg',
+        children: (
+          <div>
+            <Text>This is modal 1</Text>
+            <Button
+              fullWidth
+              mt="md"
+              onClick={() => {
+                modals.openModal({
+                  title: 'Modal 2',
+                  children: <div>This is modal 2</div>
+                });
+              }}
+            >
+              Open modal 2
+            </Button>
+          </div>
+        ),
+      });
+    }}
+    >
+      Open multiple modals
+    </Button>
+  );
+};
+
+function Demo() {
+  return (
+    <ModalsProvider showAllModals>
+      <DemoContent />
+    </ModalsProvider>
+  );
+}
+
+export const showAllModals: MantineDemo = {
+  type: 'code',
+  centered: true,
+  component: Demo,
+  code,
+}; 

--- a/packages/@docs/demos/src/demos/modals/Modals.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/modals/Modals.demos.story.tsx
@@ -23,6 +23,11 @@ export const Demo_multipleSteps = {
   render: renderDemo(demos.multipleSteps),
 };
 
+export const Demo_showAllModals = {
+  name: '⭐ Demo: showAllModals',
+  render: renderDemo(demos.showAllModals),
+};
+
 export const Demo_content = {
   name: '⭐ Demo: content',
   render: renderDemo(demos.content),

--- a/packages/@docs/demos/src/demos/modals/index.ts
+++ b/packages/@docs/demos/src/demos/modals/index.ts
@@ -6,3 +6,4 @@ export { content } from './Modals.demo.content';
 export { modalProps } from './Modals.demo.modalProps';
 export { updateModal } from './Modals.demo.updateModal';
 export { updateContextModal } from './Modals.demo.updateContextModal';
+export { showAllModals } from './Modals.demo.showAllModals';

--- a/packages/@mantine/modals/src/ModalsProvider.test.tsx
+++ b/packages/@mantine/modals/src/ModalsProvider.test.tsx
@@ -1,0 +1,154 @@
+import { useEffect, PropsWithChildren } from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { ModalsProvider } from './ModalsProvider';
+import { useModals } from './use-modals/use-modals';
+import { openModal } from './events';
+
+describe('@mantine/modals/ModalsProvider', () => {
+  const renderWithModals = ({
+    modalsCount,
+    showAllModals,
+    closeOnEscapeTopOnly,
+  }: {
+    modalsCount: number;
+    showAllModals?: boolean;
+    closeOnEscapeTopOnly?: boolean;
+  }) => {
+    const wrapper = ({ children }: PropsWithChildren<unknown>) => (
+      <MantineProvider>
+        <ModalsProvider showAllModals={showAllModals} closeOnEscapeTopOnly={closeOnEscapeTopOnly}>
+          {children}
+        </ModalsProvider>
+      </MantineProvider>
+    );
+  
+    const Component = () => {
+      const modals = useModals();
+  
+      useEffect(() => {
+        Array.from({ length: modalsCount }).forEach((_, index) => {
+          modals.openModal({
+            title: `Modal ${index + 1}`,
+            children: <div>Content {index + 1}</div>,
+            transitionProps: { duration: 0 },
+          });
+        });
+      }, []);
+  
+      return <div>Empty</div>;
+    };
+  
+    return render(<Component />, { wrapper });
+  };
+
+  describe('rendering', () => {
+    it('handles empty modals array correctly', () => {
+      const wrapper = ({ children }: PropsWithChildren<unknown>) => (
+        <MantineProvider>
+          <ModalsProvider>{children}</ModalsProvider>
+        </MantineProvider>
+      );
+
+      const Component = () => <div>Empty</div>;
+
+      render(<Component />, { wrapper });
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('only renders the last modal when showAllModals is not specified (defaults to false)', () => {
+      renderWithModals({ modalsCount: 3 });
+
+      const modals = screen.getAllByRole('dialog');
+      expect(screen.queryByText('Modal 1')).not.toBeInTheDocument();
+      expect(screen.queryByText('Content 1')).not.toBeInTheDocument();
+      expect(screen.queryByText('Modal 2')).not.toBeInTheDocument();
+      expect(screen.queryByText('Content 2')).not.toBeInTheDocument();
+      expect(screen.getByText('Modal 3')).toBeInTheDocument();
+      expect(screen.getByText('Content 3')).toBeInTheDocument();
+
+      expect(modals).toHaveLength(1);
+      expect(modals[0]).toHaveTextContent('Modal 3');
+      expect(modals[0]).toHaveTextContent('Content 3');
+
+      const closeButton = screen.getAllByRole('button').find(
+        (btn) => btn.className.includes('close')
+      );
+      if (closeButton) {
+        fireEvent.click(closeButton);
+        expect(screen.queryByText('Modal 3')).not.toBeInTheDocument();
+        expect(screen.getByText('Modal 2')).toBeInTheDocument();
+      }
+    });
+
+    it('renders multiple modals simultaneously with correct content', () => {
+      renderWithModals({ modalsCount: 2, showAllModals: true });
+      expect(screen.getByText('Modal 1')).toBeInTheDocument();
+      expect(screen.getByText('Modal 2')).toBeInTheDocument();
+      expect(screen.getByText('Content 1')).toBeInTheDocument();
+      expect(screen.getByText('Content 2')).toBeInTheDocument();
+    });
+
+    it('renders multiple modals in correct order based on opening sequence', () => {
+      renderWithModals({ modalsCount: 3, showAllModals: true });
+
+      const modals = screen.getAllByRole('dialog');
+      expect(modals[0]).toHaveTextContent('Modal 1');
+      expect(modals[1]).toHaveTextContent('Modal 2');
+      expect(modals[2]).toHaveTextContent('Modal 3');
+    });
+
+    it('maintains correct order when closing a modal in the middle', async () => {
+      renderWithModals({ modalsCount: 2, showAllModals: true });
+
+      const modals = screen.getAllByRole('dialog');
+      expect(screen.getByText('Modal 1')).toBeInTheDocument();
+      expect(screen.getByText('Content 1')).toBeInTheDocument();
+      expect(screen.getByText('Modal 2')).toBeInTheDocument();
+      expect(screen.getByText('Content 2')).toBeInTheDocument();
+    
+      fireEvent.keyDown(modals[1], { key: 'Escape' });
+
+      expect(screen.queryByText('Modal 2')).not.toBeInTheDocument();
+      expect(screen.queryByText('Content 2')).not.toBeInTheDocument();
+
+      openModal({
+        title: 'Modal 3',
+        children: 'Content 3',
+        transitionProps: { duration: 0 },
+      });
+
+      await waitFor(() => {
+        const modalsAfterOpen = screen.getAllByRole('dialog');
+        expect(modalsAfterOpen[0]).toHaveTextContent('Modal 1');
+        expect(modalsAfterOpen[1]).toHaveTextContent('Modal 3');
+      });
+    });
+  });
+
+  describe('escape key behavior', () => {
+    it('closes only the top modal when closeOnEscapeTopOnly is not specified (defaults to true)', () => {
+      renderWithModals({ modalsCount: 2, showAllModals: true });
+
+      const modals = screen.getAllByRole('dialog');
+      fireEvent.keyDown(modals[1], { key: 'Escape' });
+
+      expect(screen.getByText('Modal 1')).toBeInTheDocument();
+      expect(screen.getByText('Content 1')).toBeInTheDocument();
+      expect(screen.queryByText('Modal 2')).not.toBeInTheDocument();
+      expect(screen.queryByText('Content 2')).not.toBeInTheDocument();
+    });
+
+    it('closes all modals when closeOnEscapeTopOnly is false', () => {
+      renderWithModals({ modalsCount: 2, showAllModals: true, closeOnEscapeTopOnly: false });
+      
+      const modals = screen.getAllByRole('dialog');
+      fireEvent.keyDown(modals[1], { key: 'Escape' });
+      
+      expect(screen.queryByText('Modal 1')).not.toBeInTheDocument();
+      expect(screen.queryByText('Modal 2')).not.toBeInTheDocument();
+      expect(screen.queryByText('Content 1')).not.toBeInTheDocument();
+      expect(screen.queryByText('Content 2')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/@mantine/modals/src/ModalsProvider.tsx
+++ b/packages/@mantine/modals/src/ModalsProvider.tsx
@@ -68,15 +68,13 @@ function separateConfirmModalProps(props: OpenConfirmModal) {
 }
 
 export function ModalsProvider({ children, modalProps, labels, modals }: ModalsProviderProps) {
-  const [state, dispatch] = useReducer(modalsReducer, { modals: [], current: null });
-  const stateRef = useRef(state);
-  stateRef.current = state;
+  const [state, dispatch] = useReducer(modalsReducer, { modals: [] });
 
   const closeAll = useCallback(
     (canceled?: boolean) => {
       dispatch({ type: 'CLOSE_ALL', canceled });
     },
-    [stateRef, dispatch]
+    [dispatch]
   );
 
   const openModal = useCallback(
@@ -133,7 +131,7 @@ export function ModalsProvider({ children, modalProps, labels, modals }: ModalsP
     (id: string, canceled?: boolean) => {
       dispatch({ type: 'CLOSE', modalId: id, canceled });
     },
-    [stateRef, dispatch]
+    [dispatch]
   );
 
   const updateModal = useCallback(
@@ -178,16 +176,23 @@ export function ModalsProvider({ children, modalProps, labels, modals }: ModalsP
     updateContextModal,
   };
 
+  const currentModal = state.modals[state.modals.length - 1];
+
   const getCurrentModal = () => {
-    const currentModal = stateRef.current.current;
-    switch (currentModal?.type) {
+    if (!currentModal) {
+      return {
+        modalProps: {},
+        content: null,
+      };
+    }
+    switch (currentModal.type) {
       case 'context': {
         const { innerProps, ...rest } = currentModal.props;
-        const ContextModal = modals![currentModal.ctx];
+        const ContextModal = modals?.[currentModal.ctx];
 
         return {
           modalProps: rest,
-          content: <ContextModal innerProps={innerProps} context={ctx} id={currentModal.id} />,
+          content: ContextModal ? <ContextModal innerProps={innerProps} context={ctx} id={currentModal.id} /> : null,
         };
       }
       case 'confirm': {
@@ -231,7 +236,7 @@ export function ModalsProvider({ children, modalProps, labels, modals }: ModalsP
         {...modalProps}
         {...currentModalProps}
         opened={state.modals.length > 0}
-        onClose={() => closeModal(state.current?.id as any)}
+        onClose={() => closeModal(currentModal?.id)}
       >
         {content}
       </Modal>

--- a/packages/@mantine/modals/src/reducer.ts
+++ b/packages/@mantine/modals/src/reducer.ts
@@ -1,13 +1,14 @@
 import { ModalSettings, ModalState, OpenContextModal } from './context';
 
 interface ModalsState {
-  modals: ModalState[];
-
   /**
-   * Modal that is currently open or was the last open one.
-   * Keeping the last one is necessary for providing a clean exit transition.
+   * The stack of modals.
+   * The order of the array is from bottom to top.
+   * The last modal is the most recently opened and the one currently displayed.
+   *
+   * Note: The `current` property has been removed. Use modals[modals.length - 1] to get the current modal.
    */
-  current: ModalState | null;
+  modals: ModalState[];
 }
 
 interface OpenAction {
@@ -47,7 +48,6 @@ export function modalsReducer(
   switch (action.type) {
     case 'OPEN': {
       return {
-        current: action.modal,
         modals: [...state.modals, action.modal],
       };
     }
@@ -62,7 +62,6 @@ export function modalsReducer(
       const remainingModals = state.modals.filter((m) => m.id !== action.modalId);
 
       return {
-        current: remainingModals[remainingModals.length - 1] || state.current,
         modals: remainingModals,
       };
     }
@@ -80,7 +79,6 @@ export function modalsReducer(
         });
 
       return {
-        current: state.current,
         modals: [],
       };
     }
@@ -119,15 +117,8 @@ export function modalsReducer(
         return modal;
       });
 
-      const currentModal =
-        state.current?.id === modalId
-          ? updatedModals.find((modal) => modal.id === modalId) || state.current
-          : state.current;
-
       return {
-        ...state,
         modals: updatedModals,
-        current: currentModal,
       };
     }
     default: {


### PR DESCRIPTION
### This PR introduces two new features to the `ModalsProvider` component:

1. Support rendering multiple modals at once
    - Added the `showAllModals` prop to ModalsProvider, `false` by default.
    - When set to `true`, all opened modals are rendered in the order they were opened, with the most recently opened modal on top.

2. Fine-grained control over Escape key behavior
    - Added the `closeOnEscapeTopOnly` prop to ModalsProvider.
    - When set to `true` (default), only the topmost modal responds to the Escape key.
    - When set to `false`, pressing Escape will close all opened modals at once.

Additional changes:
- Refactored internal modal stack logic for clarity and maintainability.
- Added tests for the new `ModalsProvider` features and behaviors.
- Updated documentation to clearly explain the new props and behaviors.
- Added interactive demos for `showAllModals` to the documentation.

---

### Motivation

Our team encountered a real-world need for rendering and managing multiple modals simultaneously in our project. The current implementation of @mantine/modals only allows the most recently opened modal to be visible, which limits more advanced modal flows and user experiences.

Additionally, this feature request has been raised by other community members as well, as seen in [mantinedev discussions #4945. ](https://github.com/orgs/mantinedev/discussions/4945).

---

### Checklist
[x] Feature implementation
[x] Documentation updates
[x] Interactive demos

---

### Example

https://github.com/user-attachments/assets/ae3a90be-a388-44ea-968d-1474371976f1
