### PR TITLE
[@mantine.hook] feat parse-hotkey add normalization for special keys

### DIFF
--- a/packages/@mantine/hooks/src/use-hotkeys/parse-hotkey.ts
+++ b/packages/@mantine/hooks/src/use-hotkeys/parse-hotkey.ts
@@ -13,6 +13,34 @@ export type Hotkey = KeyboardModifiers & {
 
 type CheckHotkeyMatch = (event: KeyboardEvent) => boolean;
 
+const keyNameMap: Record<string, string> = {
+  ' ': 'space',
+  ArrowLeft: 'arrowleft',
+  ArrowRight: 'arrowright',
+  ArrowUp: 'arrowup',
+  ArrowDown: 'arrowdown',
+  Escape: 'esc',
+  Esc: 'esc',
+  Enter: 'enter',
+  Tab: 'tab',
+  Backspace: 'backspace',
+  Delete: 'delete',
+  Insert: 'insert',
+  Home: 'home',
+  End: 'end',
+  PageUp: 'pageup',
+  PageDown: 'pagedown',
+  '+': 'plus',
+  '-': 'minus',
+  '*': 'asterisk',
+  '/': 'slash',
+};
+
+function normalizeKey(key: string): string {
+  const lowerKey = key.replace('Key', '').toLowerCase();
+  return keyNameMap[key] || lowerKey;
+}
+
 export function parseHotkey(hotkey: string): Hotkey {
   const keys = hotkey
     .toLowerCase()
@@ -64,8 +92,9 @@ function isExactHotkey(hotkey: Hotkey, event: KeyboardEvent, usePhysicalKeys?: b
 
   if (
     key &&
-    ((!usePhysicalKeys && pressedKey.toLowerCase() === key.toLowerCase()) ||
-      pressedCode.replace('Key', '').toLowerCase() === key.toLowerCase())
+    (usePhysicalKeys
+      ? normalizeKey(pressedCode) === normalizeKey(key)
+      : normalizeKey(pressedKey ?? pressedCode) === normalizeKey(key))
   ) {
     return true;
   }

--- a/packages/@mantine/hooks/src/use-hotkeys/use-hotkeys.test.tsx
+++ b/packages/@mantine/hooks/src/use-hotkeys/use-hotkeys.test.tsx
@@ -28,6 +28,13 @@ describe('@mantine/hooks/use-hotkey', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  it('correctly handles space key', () => {
+    const handler = jest.fn();
+    renderHook(() => useHotkeys([['shift+space', handler]]));
+    dispatchEvent({ shiftKey: true, key: 'space' });
+    expect(handler).toHaveBeenCalled();
+  });
+
   it('correctly handles [plus] key', () => {
     const handler = jest.fn();
     renderHook(() => useHotkeys([['shift+[plus]', handler]]));


### PR DESCRIPTION
fix: #7743

### Summary

- Enhanced the `parse-hotkey` utility to normalize special keys.
- Improved consistency and reliability when handling hotkey parsing.
- Added and updated related tests to cover normalization logic.

### Details

- Modified `parse-hotkey.ts` to include normalization logic for special keys.
- Updated `use-hotkeys.test.tsx` to ensure correct handling and coverage of new normalization behavior.