### PR TITLE
[@mantine.core] fix NumberInput big number issue

### DIFF
--- a/packages/@mantine/core/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/@mantine/core/src/components/NumberInput/NumberInput.test.tsx
@@ -204,4 +204,22 @@ describe('@mantine/core/NumberInput', () => {
     expect(onChangeSpy).toHaveBeenCalledTimes(0);
     expect(onBlurSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('sets value to very large min if input is less than min on blur', async () => {
+    const MIN = 5;
+    render(<NumberInput min={MIN} max={100} defaultValue={0} />);
+    focusInput();
+    await enterText('-90071992547409910');
+    blurInput();
+    expectValue(String(MIN));
+  });
+
+  it('sets value to very large max if input is greater than max on blur', async () => {
+    const MAX = 100;
+    render(<NumberInput min={5} max={MAX} defaultValue={0} />);
+    focusInput();
+    await enterText('90071992547409910');
+    blurInput();
+    expectValue(String(MAX));
+  });
 });

--- a/packages/@mantine/core/src/components/NumberInput/NumberInput.tsx
+++ b/packages/@mantine/core/src/components/NumberInput/NumberInput.tsx
@@ -196,6 +196,17 @@ const varsResolver = createVarsResolver<NumberInputFactory>((_, { size }) => ({
   },
 }));
 
+function clampAndSanitizeInput(sanitizedValue: string | number, max?: number, min?: number) {
+  const replaced = sanitizedValue.toString().replace(/^0+/, '');
+  const parsedValue = parseFloat(replaced);
+  if (Number.isNaN(parsedValue)) {
+    return replaced;
+  } else if (parsedValue > Number.MAX_SAFE_INTEGER) {
+    return max !== undefined ? String(max) : replaced;
+  }
+  return clamp(parsedValue, min, max);
+}
+
 export const NumberInput = factory<NumberInputFactory>((_props, ref) => {
   const props = useProps('NumberInput', defaultProps, _props);
   const {
@@ -386,8 +397,7 @@ export const NumberInput = factory<NumberInputFactory>((_props, ref) => {
     let sanitizedValue = _value;
 
     if (clampBehavior === 'blur' && typeof sanitizedValue === 'number') {
-      const clampedValue = clamp(sanitizedValue, min, max);
-      sanitizedValue = clampedValue;
+      sanitizedValue = clamp(sanitizedValue, min, max);
     }
 
     if (
@@ -395,12 +405,7 @@ export const NumberInput = factory<NumberInputFactory>((_props, ref) => {
       typeof sanitizedValue === 'string' &&
       getDecimalPlaces(sanitizedValue) < 15
     ) {
-      const replaced = sanitizedValue.toString().replace(/^0+/, '');
-      const parsedValue = parseFloat(replaced);
-      sanitizedValue =
-        Number.isNaN(parsedValue) || parsedValue > Number.MAX_SAFE_INTEGER
-          ? replaced
-          : clamp(parsedValue, min, max);
+      sanitizedValue = clampAndSanitizeInput(sanitizedValue, max, min);
     }
 
     if (_value !== sanitizedValue) {


### PR DESCRIPTION
fix: #7765

test(NumberInput): add onBlur min/max clamping and large value edge case tests

- Add tests to verify value is clamped to min or max on blur when input is out of bounds
- Ensure clamping works with both regular and very large min/max values