### PR TITLE
[@mantine/core] fix useCollapse remove  collapsedStyles  display: 'none'

### DIFF
--- a/packages/@mantine/core/src/components/Collapse/Collapse.story.tsx
+++ b/packages/@mantine/core/src/components/Collapse/Collapse.story.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { Box } from '../../core';
+import { Button } from '../Button';
+import { SegmentedControl } from '../SegmentedControl';
+import { Collapse } from './Collapse';
+
+export default { title: 'Collapse' };
+
+export function NestedCollapseWithControl() {
+  const [show, setShow] = useState(false);
+  const [value, setValue] = useState('a');
+
+  useEffect(() => {
+    setTimeout(() => setValue('b'));
+  }, []);
+
+  return (
+    <Box maw={400} mx="auto" mt={100}>
+      <Button onClick={() => setShow(!show)}>Toggle</Button>
+      <Collapse in={show}>
+        <SegmentedControl value={value} onChange={setValue} data={['a', 'b']} />
+        <Collapse in={value === 'b'}>
+          1<br />2<br />3<br />4<br />5<br />
+        </Collapse>
+      </Collapse>
+    </Box>
+  );
+}

--- a/packages/@mantine/core/src/components/Collapse/use-collapse.ts
+++ b/packages/@mantine/core/src/components/Collapse/use-collapse.ts
@@ -43,7 +43,6 @@ export function useCollapse({
   const el = useRef<HTMLElement | null>(null);
   const collapsedHeight = 0;
   const collapsedStyles = {
-    display: 'none',
     height: 0,
     overflow: 'hidden',
   };

--- a/packages/@mantine/core/src/components/Collapse/use-collapse.ts
+++ b/packages/@mantine/core/src/components/Collapse/use-collapse.ts
@@ -109,6 +109,7 @@ export function useCollapse({
     const theirRef: any = rest[refKey];
     return {
       'aria-hidden': !opened,
+      inert: !opened,
       ...rest,
       [refKey]: mergeRefs(el, theirRef),
       onTransitionEnd: handleTransitionEnd,


### PR DESCRIPTION
## Question: Is it safe to remove `display: none` from Collapse hidden styles?

### Context

I am considering removing `display: none` from the hidden styles in the Collapse component, and relying only on `height: 0` and `overflow: hidden` to hide content when collapsed.

### Why consider this change?

- Using `display: none` causes issues with nested Collapses and prevents child animations from triggering correctly when the parent is reopened.
- Removing `display: none` allows for smoother transitions, better support for nested Collapses, and more consistent state updates for children.

### Accessibility Considerations

- With `display: none`, content is removed from the accessibility tree, which is sometimes desirable, but it also prevents focus management and dynamic content updates.
- Using `height: 0` and `overflow: hidden` keeps the content in the DOM and accessibility tree. To address focus issues, we can blur any focused element inside a collapsed Collapse and use `aria-hidden` or `tabIndex` for additional control.

### My Question

**Are there any strong reasons or edge cases where we should keep `display: none` in Collapse, rather than just using `height: 0` and `overflow: hidden`?**

- Are there known accessibility or performance issues with this approach?
- Do you see any downsides to removing `display: none` for the sake of animation and nested Collapse support?

I would appreciate any feedback or concerns before proceeding with this change.
---
fix: #6447
@rtivital
If there are any concerns about accessibility or specific use-cases that require `display: none`, please let me know!