### PR TITLE
[@mantine/dates] TimePicker: 00 in dropdown is reachable with arrow keys when it was outside of scroll

### DIFF
--- a/packages/@mantine/dates/src/components/TimePicker/TimeControlsList/TimeControlsList.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimeControlsList/TimeControlsList.tsx
@@ -49,7 +49,7 @@ export function TimeControlsList({ min, max, step, value, onSelect }: TimeContro
   ));
 
   useEffect(() => {
-    if (value) {
+    if (value !== null) {
       const target = ref.current?.querySelector<HTMLButtonElement>(`[data-value="${value}"]`);
       if (!isElementVisibleInScrollContainer(target, ref.current)) {
         target?.scrollIntoView({ block: 'nearest' });


### PR DESCRIPTION
fixes #7787