### PR TITLE
[@mantine/dates] fix: treat empty string as null to-date-string

### DIFF
--- a/packages/@mantine/dates/src/utils/to-date-string/to-date-string.ts
+++ b/packages/@mantine/dates/src/utils/to-date-string/to-date-string.ts
@@ -4,11 +4,11 @@ import { DateStringValue } from '../../types';
 export function toDateString(
   value: string | number | Date | Dayjs | undefined | null
 ): DateStringValue | undefined | null {
-  return value == null ? value : dayjs(value).format('YYYY-MM-DD');
+  return value == null || value === '' ? null : dayjs(value).format('YYYY-MM-DD');
 }
 
 export function toDateTimeString(
   value: string | number | Date | Dayjs | undefined | null
 ): DateStringValue | undefined | null {
-  return value == null ? value : dayjs(value).format('YYYY-MM-DD HH:mm:ss');
+  return value == null || value === '' ? null : dayjs(value).format('YYYY-MM-DD HH:mm:ss');
 }


### PR DESCRIPTION
fixes memory leak https://github.com/mantinedev/mantine/issues/7779