### PR TITLE
[@mantine/core] Stepper: fix separator color

### DIFF
--- a/packages/@mantine/core/src/components/Stepper/Stepper.module.css
+++ b/packages/@mantine/core/src/components/Stepper/Stepper.module.css
@@ -11,6 +11,15 @@
   --stepper-spacing: var(--mantine-spacing-md);
   --stepper-radius: 1000px;
   --stepper-fz: var(--mantine-font-size-md);
+  --stepper-outline-thickness: 2px;
+
+  @mixin light {
+    --stepper-outline-color: var(--mantine-color-gray-2);
+  }
+
+  @mixin dark {
+    --stepper-outline-color: var(--mantine-color-dark-5);
+  }
 }
 
 .steps {
@@ -41,40 +50,14 @@
 }
 
 .separator {
-  --separator-offset: calc(var(--stepper-icon-size) / 2 - rem(1px));
-
   transition: background-color 150ms ease;
   flex: 1;
-
-  @mixin where-light {
-    background-color: var(--mantine-color-gray-2);
-  }
-
-  @mixin where-dark {
-    background-color: var(--mantine-color-dark-2);
-  }
+  height: var(--stepper-outline-thickness);
+  margin-inline: var(--mantine-spacing-md);
+  background-color: var(--stepper-outline-color);
 
   &:where([data-active]) {
     background-color: var(--stepper-color);
-  }
-
-  &:where([data-orientation='horizontal']) {
-    height: 2px;
-    margin-inline: var(--mantine-spacing-md);
-  }
-
-  &:where([data-orientation='vertical']) {
-    width: 2px;
-    margin-top: calc(var(--mantine-spacing-xs) / 2);
-    margin-bottom: calc(var(--mantine-spacing-xs) - rem(2px));
-
-    &:where([data-icon-position='left']) {
-      margin-inline-start: var(--separator-offset);
-    }
-
-    &:where([data-icon-position='right']) {
-      margin-inline-end: var(--separator-offset);
-    }
   }
 }
 
@@ -131,15 +114,7 @@
   inset-inline-start: calc(var(--stepper-icon-size) / 2);
   height: 100vh;
   position: absolute;
-  border-inline-start: 2px solid;
-
-  @mixin where-light {
-    border-color: var(--mantine-color-gray-1);
-  }
-
-  @mixin where-dark {
-    border-color: var(--mantine-color-dark-5);
-  }
+  border-inline-start: var(--stepper-outline-thickness) solid var(--stepper-outline-color);
 
   &:where([data-active]) {
     border-color: var(--stepper-color);
@@ -161,17 +136,14 @@
   transition:
     background-color 150ms ease,
     border-color 150ms ease;
-  border: 2px solid;
+  border: var(--stepper-outline-thickness) solid var(--stepper-outline-color);
+  background-color: var(--stepper-outline-color);
 
   @mixin where-light {
-    background-color: var(--mantine-color-gray-1);
-    border-color: var(--mantine-color-gray-1);
     color: var(--mantine-color-gray-7);
   }
 
   @mixin where-dark {
-    background-color: var(--mantine-color-dark-5);
-    border-color: var(--mantine-color-dark-5);
     color: var(--mantine-color-dark-1);
   }
 


### PR DESCRIPTION
Hello 👋 I noticed that the Stepper separator had a different color between horizontal and vertical orientations. For instance you can see this on the docs website:

| Vertical | Horizontal |
| --- | --- |
|![image](https://github.com/user-attachments/assets/d8c8467e-641b-4006-9eec-db59332aed99)|![image](https://github.com/user-attachments/assets/c1328c63-d8ef-421b-8559-25ef890e6577)|
| `mantine-color-gray-1` | `mantine-color-gray-2` |

While looking at the code I saw some dead code so I figured I would open a PR with a small cleanup. Here's a summary of what I did:

- `getStyles('separator')` is only every applied when `orientation === 'horizontal'` so the whole rule for `.separator &:where([data-orientation='vertical'])` can be deleted.
- defined `--stepper-outline-color` variable to make sure both orientations use the same color for the separator. 
  - I chose the one that was previously applied for horizontal orientation (gray 2), let me know if that works for you. 
  - I also apply this color to the non completed step background since it was the same for vertical, but I am unsure if it is ok (looks okay to me, but can revert if needed).
- defined a `--stepper-outline-thickness` variable for ease of customization

Here is a before and after
| Before | After |
| --- | --- | 
|![image](https://github.com/user-attachments/assets/d1ca085e-336d-4869-b0c0-d7179dd22c41)|![image](https://github.com/user-attachments/assets/07241554-6ff6-4c44-b809-b89d717dab7f)|
|![image](https://github.com/user-attachments/assets/b18b2ba6-0689-4e14-8742-ac486cf5e682)|![image](https://github.com/user-attachments/assets/f906622d-5074-4e34-8de4-451c1b5c5988)|
|![image](https://github.com/user-attachments/assets/45d5003e-e807-4aa2-a273-ccc4cd9dc3d0)|![image](https://github.com/user-attachments/assets/9d532563-aeff-4602-8dce-60a30ff9d901)|
|![image](https://github.com/user-attachments/assets/1494740b-f054-4a10-8e5e-ab5bfd2d881e)|![image](https://github.com/user-attachments/assets/74aaf0b0-2ab0-44e1-b22c-238374380594)|

