### PR TITLE
[mantine.dev] Update Table demo to use docs dynamic sticky header offset

### DIFF
--- a/packages/@docs/demos/src/demos/core/Table/Table.demo.stickyHeader.tsx
+++ b/packages/@docs/demos/src/demos/core/Table/Table.demo.stickyHeader.tsx
@@ -51,7 +51,7 @@ export function Demo() {
   ));
 
   return (
-    <Table stickyHeader stickyHeaderOffset={60}>
+    <Table stickyHeader style={{ '--table-sticky-header-offset': 'var(--docs-header-height)' }}>
       <Table.Thead>
         <Table.Tr>
           <Table.Th>Element position</Table.Th>


### PR DESCRIPTION
After updating to 8.x.x the new docs header is `100px` for desktop and `56px` for mobile instead of the old `60px` one. We can't see the sticky header of the demo table because it will go under the blurry header.

Remove the demo table's sticky header offset `60` and use the value of the CSS style variable `--docs-header-height` as `--table-sticky-header-offset` . So the we can see the behavior of the sticky header.