### PR TITLE
[mantine.dev] Make the demo and actual code consistent

### DIFF
--- a/packages/@docs/demos/src/demos/core/MultiSelect/MultiSelect.demo.renderOption.tsx
+++ b/packages/@docs/demos/src/demos/core/MultiSelect/MultiSelect.demo.renderOption.tsx
@@ -47,6 +47,8 @@ function Demo() {
       maxDropdownHeight={300}
       label="Employees of the month"
       placeholder="Search for employee"
+      hidePickedOptions
+      searchable
     />
   );
 }


### PR DESCRIPTION
I noticed that the code attached as a demo on this page ( https://github.com/mantinedev/mantine/blob/39360296221bced9adaf098135ff676f214c5022/packages/%40docs/demos/src/demos/core/MultiSelect/MultiSelect.demo.renderOption.tsx ) differs from the actual working implementation. To avoid confusion, the demo should reflect the exact same code as the one that is actually being executed.