### PR TITLE
[@mantine/core] Fix: add boolean to data attribute types

### DIFF
--- a/packages/@mantine/core/src/core/types.ts
+++ b/packages/@mantine/core/src/core/types.ts
@@ -1,3 +1,3 @@
 export interface DataAttributes {
-  [key: `data-${string}`]: string | number | undefined;
+  [key: `data-${string}`]: string | number | boolean | undefined;
 }


### PR DESCRIPTION
Allows data-* attributes to be boolean type.

For us, it's common to write data attributes like:

```tsx
  <Button
    data-disabled
    ...
  />
```

which just serializes like `data-disabled="true"`. I think there is no need to prevent that.