### PR TITLE
Select checking for searchControlled

### DIFF
--- a/packages/@mantine/core/src/components/Select/Select.tsx
+++ b/packages/@mantine/core/src/components/Select/Select.tsx
@@ -177,7 +177,7 @@ export const Select = factory<SelectFactory>((_props, ref) => {
   const selectedOption = typeof _value === 'string' ? optionsLockup[_value] : undefined;
   const previousSelectedOption = usePrevious(selectedOption);
 
-  const [search, setSearch] = useUncontrolled({
+  const [search, setSearch, searchControlled] = useUncontrolled({
     value: searchValue,
     defaultValue: defaultSearchValue,
     finalValue: selectedOption ? selectedOption.label : '',
@@ -230,7 +230,7 @@ export const Select = factory<SelectFactory>((_props, ref) => {
   }, [value, selectedOption]);
 
   useEffect(() => {
-    if (!controlled) {
+    if (!controlled && !searchControlled) {
       handleSearchChange(typeof _value === 'string' ? optionsLockup[_value]?.label || '' : '');
     }
   }, [data, _value]);


### PR DESCRIPTION
If the value is not controlled, and you mutate the data prop, the onSearchChange will call causing problems.
From what I can tell the issue was introduced with https://github.com/mantinedev/mantine/commit/b22de41c6dfe68720ef031e3cd98b3efa2de0ab9 

Relates to https://github.com/mantinedev/mantine/issues/7801  