### PR TITLE
[@mantine/core] Add `isDuplicate` prop to TagsInput for custom duplic…

### DIFF
--- a/packages/@mantine/core/src/components/TagsInput/TagsInput.test.tsx
+++ b/packages/@mantine/core/src/components/TagsInput/TagsInput.test.tsx
@@ -1,4 +1,6 @@
-import { inputDefaultProps, inputStylesApiSelectors, tests } from '@mantine-tests/core';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { inputDefaultProps, inputStylesApiSelectors, render, tests } from '@mantine-tests/core';
 import { TagsInput, TagsInputProps, TagsInputStylesNames } from './TagsInput';
 
 const defaultProps: TagsInputProps = {
@@ -46,5 +48,23 @@ describe('@mantine/core/TagsInput', () => {
     component: TagsInput,
     props: defaultProps,
     selector: 'input',
+  });
+
+  it('isDuplicate test', async () => {
+    const user = userEvent.setup();
+    render(
+      <TagsInput
+        role="combobox"
+        data={['test-1']}
+        isDuplicate={(value) => value.startsWith('test')}
+      />
+    );
+
+    const input = screen.getByRole('combobox');
+
+    await user.type(input, 'test-2');
+    await user.keyboard('{Enter}');
+
+    expect(screen.queryByText('test-2')).not.toBeInTheDocument();
   });
 });

--- a/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
+++ b/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
@@ -103,6 +103,9 @@ export interface TagsInputProps
 
   /** Determines whether the value typed in by the user but not submitted should be accepted when the input is blurred, `true` by default */
   acceptValueOnBlur?: boolean;
+
+  /** Custom function to determine if a tag is duplicate. Accepts tag value and array of current values. By default checks if tag exists case-insensitively. */
+  isDuplicate?: (value: string, currentValues: string[]) => boolean;
 }
 
 export type TagsInputFactory = Factory<{
@@ -192,6 +195,7 @@ export const TagsInput = factory<TagsInputFactory>((_props, ref) => {
     onClear,
     scrollAreaProps,
     acceptValueOnBlur,
+    isDuplicate,
     ...others
   } = props;
 
@@ -251,13 +255,15 @@ export const TagsInput = factory<TagsInputFactory>((_props, ref) => {
   });
 
   const handleValueSelect = (val: string) => {
-    const isDuplicate = _value.some((tag) => tag.toLowerCase() === val.toLowerCase());
+    const duplicateCheck = isDuplicate
+      ? isDuplicate(val, _value)
+      : _value.some((tag) => tag.toLowerCase() === val.toLowerCase());
 
-    if (isDuplicate) {
+    if (duplicateCheck) {
       onDuplicate?.(val);
     }
 
-    if ((!isDuplicate || (isDuplicate && allowDuplicates)) && _value.length < maxTags!) {
+    if ((!duplicateCheck || (duplicateCheck && allowDuplicates)) && _value.length < maxTags!) {
       onOptionSubmit?.(val);
       handleSearchChange('');
       if (val.length > 0) {


### PR DESCRIPTION
### Description

This pull request introduces a new `isDuplicate` prop to the `TagsInput` component in `@mantine/core`. This allows developers to provide custom logic for detecting duplicate tags.

- Implemented `isDuplicate` prop for flexible duplicate detection.
- Updated `handleValueSelect` to utilize the custom `isDuplicate` logic.
- Added unit tests to ensure the behavior works as expected.