### PR TITLE
[@mantine/core] Fix: MenuSub prop defaults not being overridden

### DIFF
--- a/packages/@mantine/core/src/components/Menu/MenuSub/MenuSub.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuSub/MenuSub.tsx
@@ -25,7 +25,7 @@ const defaultProps: Partial<MenuSubProps> = {
 };
 
 export function MenuSub(_props: MenuSubProps) {
-  const { children, closeDelay, ...others } = useProps('MenuSub', _props, defaultProps);
+  const { children, closeDelay, ...others } = useProps('MenuSub', defaultProps, _props);
   const id = useId();
   const [opened, { open, close }] = useDisclosure(false);
   const ctx = useSubMenuContext();


### PR DESCRIPTION
Currently, it doesn't work to pass in `offset`, `position`, or `transitionProps` to `Menu.Sub`:

```typescript
<Menu.Sub
  position="right"
  offset={20}
  transitionProps={{ duration: 150, transition: "fade" }}
> // These props have no effect
```

It appears this is because the `props` and `defaultProps` parameters that are passed into `useProps` are the wrong way round which means the props the user is passing in are getting set as the default and then overridden by the props that are intended to be the default.

```typescript
// packages/@mantine/core/src/components/Menu/MenuSub/MenuSub.tsx

const defaultProps: Partial<MenuSubProps> = {
  offset: 0,
  position: 'right-start',
  transitionProps: { duration: 0 },
};

export function MenuSub(_props: MenuSubProps) {
  const { children, closeDelay, ...others } = useProps('MenuSub', _props, defaultProps);
  ...
}
```

```typescript
// packages/@mantine/core/src/core/MantineProvider/use-props/use-props.ts

export function useProps<T extends Record<string, any>, U extends Partial<T> = {}>(
  component: string,
  defaultProps: U,
  props: T
)
```