### PR TITLE
[@mantine/core] stop scaling explicit rem units in rem function

### DIFF
--- a/apps/mantine.dev/src/pages/styles/rem.mdx
+++ b/apps/mantine.dev/src/pages/styles/rem.mdx
@@ -93,7 +93,7 @@ em(32); // -> 2em
 rem('16px'); // -> calc(1rem * var(--mantine-scale))
 em('16px'); // -> 1em
 
-rem('2rem'); // -> calc(2rem * var(--mantine-scale))
+rem('2rem'); // -> 2rem
 em('2rem'); // -> 2rem
 
 rem('50%'); // -> 50%
@@ -103,7 +103,7 @@ rem('5vh'); // -> 5vh
 em('5vh'); // -> 5vh
 
 // mixed values are converted to rem
-rem('16px 2rem'); // -> calc(1rem * var(--mantine-scale)) calc(2rem * var(--mantine-scale))
+rem('16px 2rem'); // -> calc(1rem * var(--mantine-scale)) 2rem
 ```
 
 ## Convert rem to px

--- a/packages/@mantine/core/src/core/Box/style-props/parse-style-props/parse-style-props.test.ts
+++ b/packages/@mantine/core/src/core/Box/style-props/parse-style-props/parse-style-props.test.ts
@@ -13,7 +13,7 @@ describe('@mantine/core/Box/parse-style-props', () => {
     ).toStrictEqual({
       hasResponsiveStyles: false,
       inlineStyles: {
-        padding: 'calc(1.5rem * var(--mantine-scale))',
+        padding: '1.5rem',
         marginInline: 'calc(2rem * var(--mantine-scale))',
         color: 'var(--mantine-color-red-5)',
         opacity: 0.65,
@@ -39,7 +39,7 @@ describe('@mantine/core/Box/parse-style-props', () => {
       hasResponsiveStyles: true,
       inlineStyles: {},
       styles: {
-        padding: 'calc(1.5rem * var(--mantine-scale))',
+        padding: '1.5rem',
         marginInline: 'calc(2rem * var(--mantine-scale))',
         color: 'var(--mantine-color-red-5)',
         opacity: 0.65,
@@ -48,7 +48,7 @@ describe('@mantine/core/Box/parse-style-props', () => {
         {
           query: `(min-width: ${DEFAULT_THEME.breakpoints.xs})`,
           styles: {
-            padding: 'calc(2rem * var(--mantine-scale))',
+            padding: '2rem',
             marginInline: 'calc(4rem * var(--mantine-scale))',
             color: 'var(--mantine-color-red-6)',
             opacity: 0.85,
@@ -63,7 +63,7 @@ describe('@mantine/core/Box/parse-style-props', () => {
       parseStyleProps({
         data: STYlE_PROPS_DATA,
         styleProps: {
-          p: { base: '1.5rem', xs: '2rem' },
+          p: { base: 24, xs: 32 },
           mx: 64,
           c: 'red.6',
           opacity: { base: 0.65, xs: 0.85 },
@@ -108,7 +108,7 @@ describe('@mantine/core/Box/parse-style-props', () => {
       hasResponsiveStyles: true,
       inlineStyles: {},
       styles: {
-        padding: 'calc(1.5rem * var(--mantine-scale))',
+        padding: '1.5rem',
         marginInline: 'calc(2rem * var(--mantine-scale))',
         color: 'var(--mantine-color-red-5)',
         opacity: 0.65,
@@ -117,7 +117,7 @@ describe('@mantine/core/Box/parse-style-props', () => {
         {
           query: `(min-width: ${DEFAULT_THEME.breakpoints.xs})`,
           styles: {
-            padding: 'calc(2rem * var(--mantine-scale))',
+            padding: '2rem',
             marginInline: 'calc(4rem * var(--mantine-scale))',
             color: 'var(--mantine-color-red-6)',
             opacity: 0.85,
@@ -126,7 +126,7 @@ describe('@mantine/core/Box/parse-style-props', () => {
         {
           query: `(min-width: ${DEFAULT_THEME.breakpoints.md})`,
           styles: {
-            padding: 'calc(3rem * var(--mantine-scale))',
+            padding: '3rem',
             marginInline: 'calc(8rem * var(--mantine-scale))',
             color: 'var(--mantine-color-red-7)',
             opacity: 1,

--- a/packages/@mantine/core/src/core/utils/get-size/get-size.test.ts
+++ b/packages/@mantine/core/src/core/utils/get-size/get-size.test.ts
@@ -5,7 +5,7 @@ describe('@mantine/core/get-size', () => {
     expect(getSize(10)).toBe('calc(0.625rem * var(--mantine-scale))');
     expect(getSize('10')).toBe('calc(0.625rem * var(--mantine-scale))');
     expect(getSize('10px')).toBe('calc(0.625rem * var(--mantine-scale))');
-    expect(getSize('10rem')).toBe('calc(10rem * var(--mantine-scale))');
+    expect(getSize('10rem')).toBe('10rem');
     expect(getSize('10%')).toBe('10%');
     expect(getSize('10vh')).toBe('10vh');
     expect(getSize('10cqw')).toBe('10cqw');
@@ -30,7 +30,7 @@ describe('@mantine/core/get-spacing', () => {
     expect(getSpacing(0)).toBe('0rem');
     expect(getSpacing('10')).toBe('calc(0.625rem * var(--mantine-scale))');
     expect(getSpacing('10px')).toBe('calc(0.625rem * var(--mantine-scale))');
-    expect(getSpacing('10rem')).toBe('calc(10rem * var(--mantine-scale))');
+    expect(getSpacing('10rem')).toBe('10rem');
     expect(getSpacing('10%')).toBe('10%');
     expect(getSpacing('xs')).toBe('var(--mantine-spacing-xs)');
     expect(getSpacing('md')).toBe('var(--mantine-spacing-md)');
@@ -43,7 +43,7 @@ describe('@mantine/core/get-radius', () => {
     expect(getRadius(0)).toBe('0rem');
     expect(getRadius('10')).toBe('calc(0.625rem * var(--mantine-scale))');
     expect(getRadius('10px')).toBe('calc(0.625rem * var(--mantine-scale))');
-    expect(getRadius('10rem')).toBe('calc(10rem * var(--mantine-scale))');
+    expect(getRadius('10rem')).toBe('10rem');
     expect(getRadius('10%')).toBe('10%');
     expect(getRadius('xs')).toBe('var(--mantine-radius-xs)');
     expect(getRadius('md')).toBe('var(--mantine-radius-md)');
@@ -60,7 +60,7 @@ describe('@mantine/core/get-font-size', () => {
     expect(getFontSize(0)).toBe('0rem');
     expect(getFontSize('10')).toBe('calc(0.625rem * var(--mantine-scale))');
     expect(getFontSize('10px')).toBe('calc(0.625rem * var(--mantine-scale))');
-    expect(getFontSize('10rem')).toBe('calc(10rem * var(--mantine-scale))');
+    expect(getFontSize('10rem')).toBe('10rem');
     expect(getFontSize('10%')).toBe('10%');
     expect(getFontSize('xs')).toBe('var(--mantine-font-size-xs)');
     expect(getFontSize('md')).toBe('var(--mantine-font-size-md)');

--- a/packages/@mantine/core/src/core/utils/units-converters/rem.test.ts
+++ b/packages/@mantine/core/src/core/utils/units-converters/rem.test.ts
@@ -19,8 +19,8 @@ describe('@mantine/units-converters/rem', () => {
     expect(rem('32px')).toBe('calc(2rem * var(--mantine-scale))');
   });
 
-  it('scales rem values', () => {
-    expect(rem('2rem')).toBe('calc(2rem * var(--mantine-scale))');
+  it('does not scale rem values', () => {
+    expect(rem('2rem')).toBe('2rem');
   });
 
   it('does not modify other values', () => {
@@ -43,9 +43,7 @@ describe('@mantine/units-converters/rem', () => {
       'calc(0.625rem * var(--mantine-scale)) calc(0.3125rem * var(--mantine-scale))'
     );
 
-    expect(rem('1rem 0.5rem')).toBe(
-      'calc(1rem * var(--mantine-scale)) calc(0.5rem * var(--mantine-scale))'
-    );
+    expect(rem('16px 0.5rem')).toBe('calc(1rem * var(--mantine-scale)) 0.5rem');
 
     expect(rem('16px solid var(--mantine-color-primary)')).toBe(
       'calc(1rem * var(--mantine-scale)) solid var(--mantine-color-primary)'
@@ -54,7 +52,7 @@ describe('@mantine/units-converters/rem', () => {
 
   it('converts all values in space separated string and leaves non px values untouched', () => {
     expect(rem('10px 5px 1rem 2em')).toBe(
-      'calc(0.625rem * var(--mantine-scale)) calc(0.3125rem * var(--mantine-scale)) calc(1rem * var(--mantine-scale)) 2em'
+      'calc(0.625rem * var(--mantine-scale)) calc(0.3125rem * var(--mantine-scale)) 1rem 2em'
     );
 
     expect(rem('1px solid red')).toBe('calc(0.0625rem * var(--mantine-scale)) solid red');

--- a/packages/@mantine/core/src/core/utils/units-converters/rem.ts
+++ b/packages/@mantine/core/src/core/utils/units-converters/rem.ts
@@ -41,10 +41,6 @@ function createConverter(units: string, { shouldScale = false } = {}) {
           .join(' ');
       }
 
-      if (value.includes(units)) {
-        return shouldScale ? scaleRem(value) : value;
-      }
-
       const replaced = value.replace('px', '');
       if (!Number.isNaN(Number(replaced))) {
         const val = `${Number(replaced) / 16}${units}`;


### PR DESCRIPTION
As discussed on Discord, this MR changes the logic of the `rem` function to only scale px values, not rem values.

This impacts a few test files, I tried to change things to relevant values for what each test was testing.