### PR TITLE
Allow useDebouncedCallback to be fired immediately

### DIFF
--- a/packages/@mantine/hooks/src/use-debounced-callback/use-debounced-callback.ts
+++ b/packages/@mantine/hooks/src/use-debounced-callback/use-debounced-callback.ts
@@ -3,29 +3,42 @@ import { useCallbackRef } from '../use-callback-ref/use-callback-ref';
 
 export function useDebouncedCallback<T extends (...args: any[]) => any>(
   callback: T,
-  options: number | { delay: number; flushOnUnmount?: boolean }
+  options: number | { delay: number; flushOnUnmount?: boolean; leading?: boolean }
 ) {
   const delay = typeof options === 'number' ? options : options.delay;
   const flushOnUnmount = typeof options === 'number' ? false : options.flushOnUnmount;
+  const leading = typeof options === 'number' ? false : options.leading;
+
   const handleCallback = useCallbackRef(callback);
   const debounceTimerRef = useRef(0);
   const flushRef = useRef(() => {});
+  const leadingRef = useRef(leading);
 
   const lastCallback = Object.assign(
     useCallback(
       (...args: Parameters<T>) => {
         window.clearTimeout(debounceTimerRef.current);
+
+        if (leading && leadingRef.current) {
+          leadingRef.current = false;
+          handleCallback(...args);
+          return;
+        }
+
         const flush = () => {
           if (debounceTimerRef.current !== 0) {
             debounceTimerRef.current = 0;
+            leadingRef.current = true;
             handleCallback(...args);
           }
         };
+
         flushRef.current = flush;
         lastCallback.flush = flush;
         debounceTimerRef.current = window.setTimeout(flush, delay);
+        leadingRef.current = false;
       },
-      [handleCallback, delay]
+      [handleCallback, delay, leading]
     ),
     { flush: flushRef.current }
   );


### PR DESCRIPTION
This follows the same pattern as `useDebouncedState` to allow the caller to choose whether the callback should be fired immediately, or whether to wait until the delay duration passes.