### PR TITLE
[@mantine/core] Fix NaN handling in shallowEqual and useShallowEffect

### DIFF
--- a/packages/@mantine/hooks/src/utils/shallow-equal/shallow-equal.ts
+++ b/packages/@mantine/hooks/src/utils/shallow-equal/shallow-equal.ts
@@ -3,6 +3,10 @@ export function shallowEqual(a: any, b: any) {
     return true;
   }
 
+  if (Number.isNaN(a) && Number.isNaN(b)) {
+    return true;
+  }
+
   if (!(a instanceof Object) || !(b instanceof Object)) {
     return false;
   }
@@ -21,7 +25,7 @@ export function shallowEqual(a: any, b: any) {
       return false;
     }
 
-    if (a[key] !== b[key]) {
+    if (a[key] !== b[key] && !(Number.isNaN(a[key]) && Number.isNaN(b[key]))) {
       return false;
     }
   }


### PR DESCRIPTION
**Description**

This pull request addresses an issue where `useShallowEffect` would incorrectly re-trigger when a dependency was `NaN` in both the previous and current renders. React's native `useEffect` hook treats `NaN` as equal to `NaN` for dependency comparison (following `Object.is` semantics), meaning the effect does not re-run in such cases. This change brings `useShallowEffect`'s behavior in line with `useEffect` for `NaN` values.

The root cause was the `shallowEqual` utility function, which previously treated `NaN` as not equal to itself (`NaN !== NaN` is `true` under strict equality).

**Changes Made**

The primary modifications were made to the `shallowEqual` function to ensure `NaN` values are considered equal:

1.  **Top-Level NaN Argument Handling:**
    * Added a check at the beginning of `shallowEqual` to return `true` if both top-level arguments `a` and `b` are `NaN`.
        ```typescript
        // After: if (a === b) { return true; }
        if (Number.isNaN(a) && Number.isNaN(b)) {
          return true;
        }
        ```
    * This ensures that `shallowEqual(NaN, NaN)` now correctly evaluates to `true`.

2.  **Property Value NaN Handling:**
    * Modified the comparison logic for object property values. If two property values `a[key]` and `b[key]` are not strictly equal (`a[key] !== b[key]`), an additional check is performed. If *both* are `NaN`, they are now considered equal for the purposes of `shallowEqual`.
        ```typescript
        // Inside the loop for comparing object properties:
        if (a[key] !== b[key]) {
          // If not strictly equal, check if it's because both are NaN
          if (!(Number.isNaN(a[key]) && Number.isNaN(b[key]))) {
            return false; // Return false only if they are different and not both NaN
          }
        }
        ```
    * This ensures that objects like `{ value: NaN }` and `{ value: NaN }` are considered shallowly equal if their other properties also match.

These changes specifically target `NaN` comparison using `Number.isNaN()` and preserve the existing `===` strict equality behavior for all other value comparisons (e.g., `0` and `-0` remain equal, as per original behavior). This approach avoids unintended side effects that a broader switch to `Object.is()` for all comparisons might introduce.

**Impact**

* **`useShallowEffect` and `useShallowCompare`:** These hooks now correctly handle `NaN` values in dependency arrays. An effect managed by `useShallowEffect` will no longer re-run unnecessarily if a dependency changes from `NaN` to `NaN`.
* **Consistency with React:** Aligns the behavior of `useShallowEffect` more closely with React's native `useEffect` concerning `NaN` dependencies.

This fix ensures more predictable and correct behavior for shallow comparison involving `NaN` values.