### PR TITLE
Add `domain` prop to Slider and RangeSlider for custom ranges

### DIFF
--- a/packages/@mantine/core/src/components/Slider/Slider.story.tsx
+++ b/packages/@mantine/core/src/components/Slider/Slider.story.tsx
@@ -61,6 +61,14 @@ export function SizeSlider() {
   );
 }
 
+export function DomainSlider() {
+  return (
+    <div style={{ padding: 40, maxWidth: 300 }}>
+      <Slider domain={[0, 100]} min={20} max={60} />
+    </div>
+  );
+}
+
 export function Range() {
   return (
     <div style={{ padding: 40, maxWidth: 400 }}>

--- a/packages/@mantine/core/src/components/Slider/Slider.story.tsx
+++ b/packages/@mantine/core/src/components/Slider/Slider.story.tsx
@@ -65,6 +65,7 @@ export function DomainSlider() {
   return (
     <div style={{ padding: 40, maxWidth: 300 }}>
       <Slider domain={[0, 100]} min={20} max={60} />
+      <RangeSlider domain={[0, 100]} min={20} max={60} />
     </div>
   );
 }

--- a/packages/@mantine/core/src/components/Slider/Slider/Slider.tsx
+++ b/packages/@mantine/core/src/components/Slider/Slider/Slider.tsx
@@ -55,6 +55,9 @@ export interface SliderProps
   /** Maximum possible value, `100` by default */
   max?: number;
 
+  /** Domain of the slider, defines the full range of possible values, `[min, max]` by default */
+  domain?: [number, number];
+
   /** Number by which value will be incremented/decremented with thumb drag and arrows, `1` by default */
   step?: number;
 
@@ -164,6 +167,7 @@ export const Slider = factory<SliderFactory>((_props, ref) => {
     size,
     min,
     max,
+    domain,
     step,
     precision: _precision,
     defaultValue,
@@ -219,7 +223,8 @@ export const Slider = factory<SliderFactory>((_props, ref) => {
 
   const root = useRef<HTMLDivElement>(null);
   const thumb = useRef<HTMLDivElement>(null);
-  const position = getPosition({ value: _value, min: min!, max: max! });
+  const [domainMin, domainMax] = domain || [min!, max!];
+  const position = getPosition({ value: _value, min: domainMin, max: domainMax });
   const scaledValue = scale!(_value);
   const _label = typeof label === 'function' ? label(scaledValue) : label;
   const precision = _precision ?? getPrecision(step!);
@@ -229,23 +234,24 @@ export const Slider = factory<SliderFactory>((_props, ref) => {
       if (!disabled) {
         const nextValue = getChangeValue({
           value: x,
-          min: min!,
-          max: max!,
+          min: domainMin,
+          max: domainMax,
           step: step!,
           precision,
         });
+        const clampedValue = clamp(nextValue, min!, max!);
         setValue(
           restrictToMarks && marks?.length
             ? findClosestNumber(
-                nextValue,
+                clampedValue,
                 marks.map((mark) => mark.value)
               )
-            : nextValue
+            : clampedValue
         );
-        valueRef.current = nextValue;
+        valueRef.current = clampedValue;
       }
     },
-    [disabled, min, max, step, precision, setValue, marks, restrictToMarks]
+    [disabled, min, max, domainMin, domainMax, step, precision, setValue, marks, restrictToMarks]
   );
 
   const handleScrubEnd = useCallback(() => {
@@ -409,8 +415,8 @@ export const Slider = factory<SliderFactory>((_props, ref) => {
           offset={0}
           filled={position}
           marks={marks}
-          min={min!}
-          max={max!}
+          min={domainMin}
+          max={domainMax}
           value={scaledValue}
           disabled={disabled}
           containerProps={{
@@ -420,8 +426,8 @@ export const Slider = factory<SliderFactory>((_props, ref) => {
           }}
         >
           <Thumb
-            max={max!}
-            min={min!}
+            max={domainMax}
+            min={domainMin}
             value={scaledValue}
             position={position}
             dragging={active}


### PR DESCRIPTION
### Description

This pull request introduces the `domain` prop to both `Slider` and `RangeSlider` components in the `@mantine/core` library. The `domain` prop allows for defining a complete range of possible values, independent of `min` and `max`, enabling more flexible and customizable value ranges.

### Changes
- Added `domain` prop to `Slider` and `RangeSlider` for handling custom value ranges.
- Updated internal calculations to use the `domain` prop while clamping values within `min` and `max`.
- Added a story named `DomainSlider` to demonstrate the `domain` prop usage.