### PR TITLE
hooks and documentation for `use-selection`

### DIFF
--- a/apps/mantine.dev/src/mdx/data/mdx-hooks-data.ts
+++ b/apps/mantine.dev/src/mdx/data/mdx-hooks-data.ts
@@ -188,4 +188,5 @@ export const MDX_HOOKS_DATA: Record<string, Frontmatter> = {
     'Track scroll position and detect which heading is currently in the viewport, can be used for table of contents'
   ),
   useFileDialog: hDocs('useFileDialog', 'Capture one or more files from the user'),
+  useSelection: hDocs('useSelection', 'returns current selection'),
 };

--- a/apps/mantine.dev/src/mdx/mdx-nav-data.ts
+++ b/apps/mantine.dev/src/mdx/mdx-nav-data.ts
@@ -148,6 +148,7 @@ const HOOKS_PAGES_GROUP: MdxPagesCategory[] = sortCategoriesPages([
       MDX_DATA.useMutationObserver,
       MDX_DATA.useScrollIntoView,
       MDX_DATA.useScrollSpy,
+      MDX_DATA.useSelection,
       MDX_DATA.useViewportSize,
       MDX_DATA.useWindowEvent,
       MDX_DATA.useWindowScroll,

--- a/apps/mantine.dev/src/pages/hooks/use-selection.mdx
+++ b/apps/mantine.dev/src/pages/hooks/use-selection.mdx
@@ -1,0 +1,11 @@
+import { HooksDemos } from '@docs/demos';
+import { Layout } from '@/layout';
+import { MDX_DATA } from '@/mdx';
+
+export default Layout(MDX_DATA.useSelection);
+
+## Usage
+
+`use-selection` returns current selection:
+
+<Demo data={HooksDemos.useSelectionDemo} />

--- a/packages/@docs/demos/src/demos/hooks/Hooks.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/hooks/Hooks.demos.story.tsx
@@ -150,8 +150,8 @@ export const Demo_useLoggerDemo = {
 
 export const Demo_useSelectedDemo = {
   name: '⭐ Demo: useSelectedDemo',
-  render: renderDemo(demos.useSelectionUsage),
-}
+  render: renderDemo(demos.useSelectionDemo),
+};
 
 export const Demo_useMediaQueryDemo = {
   name: '⭐ Demo: useMediaQueryDemo',

--- a/packages/@docs/demos/src/demos/hooks/Hooks.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/hooks/Hooks.demos.story.tsx
@@ -148,6 +148,11 @@ export const Demo_useLoggerDemo = {
   render: renderDemo(demos.useLoggerDemo),
 };
 
+export const Demo_useSelectedDemo = {
+  name: '⭐ Demo: useSelectedDemo',
+  render: renderDemo(demos.useSelectionUsage),
+}
+
 export const Demo_useMediaQueryDemo = {
   name: '⭐ Demo: useMediaQueryDemo',
   render: renderDemo(demos.useMediaQueryDemo),

--- a/packages/@docs/demos/src/demos/hooks/index.ts
+++ b/packages/@docs/demos/src/demos/hooks/index.ts
@@ -68,5 +68,5 @@ export { useIsFirstRenderUsage } from './use-is-first-render.demo.usage';
 export { useRadialMoveUsage } from './use-radial-move.demo.usage';
 export { useScrollSpyUsage } from './use-scroll-spy.demo.usage';
 export { useScrollSpySelector } from './use-scroll-spy.demo.selector';
-export { usage as useSelectionUsage } from './use-selection.demo.usage';
+export { useSelectionUsage } from './use-selection.demo.usage';
 export { useFileDialogUsage } from './use-file-dialog.demo';

--- a/packages/@docs/demos/src/demos/hooks/index.ts
+++ b/packages/@docs/demos/src/demos/hooks/index.ts
@@ -68,4 +68,5 @@ export { useIsFirstRenderUsage } from './use-is-first-render.demo.usage';
 export { useRadialMoveUsage } from './use-radial-move.demo.usage';
 export { useScrollSpyUsage } from './use-scroll-spy.demo.usage';
 export { useScrollSpySelector } from './use-scroll-spy.demo.selector';
+export { usage as useSelectionUsage } from './use-selection.demo.usage';
 export { useFileDialogUsage } from './use-file-dialog.demo';

--- a/packages/@docs/demos/src/demos/hooks/index.ts
+++ b/packages/@docs/demos/src/demos/hooks/index.ts
@@ -68,5 +68,5 @@ export { useIsFirstRenderUsage } from './use-is-first-render.demo.usage';
 export { useRadialMoveUsage } from './use-radial-move.demo.usage';
 export { useScrollSpyUsage } from './use-scroll-spy.demo.usage';
 export { useScrollSpySelector } from './use-scroll-spy.demo.selector';
-export { useSelectionUsage } from './use-selection.demo.usage';
+export { useSelectionDemo } from './use-selection.demo.usage';
 export { useFileDialogUsage } from './use-file-dialog.demo';

--- a/packages/@docs/demos/src/demos/hooks/use-selection.demo.usage.tsx
+++ b/packages/@docs/demos/src/demos/hooks/use-selection.demo.usage.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { Table, Checkbox, Button, Group, Text } from '@mantine/core';
+import { useSelection } from '@mantine/hooks';
+
+// Assuming MantineDemo type is globally available or imported in other demos
+// For example: import type { MantineDemo } from '@mantine/ds';
+
+const elements = [
+  { id: '1', position: 6, mass: 12.011, symbol: 'C', name: 'Carbon' },
+  { id: '2', position: 7, mass: 14.007, symbol: 'N', name: 'Nitrogen' },
+  { id: '3', position: 39, mass: 88.906, symbol: 'Y', name: 'Yttrium' },
+  { id: '4', position: 56, mass: 137.33, symbol: 'Ba', name: 'Barium' },
+  { id: '5', position: 58, mass: 140.12, symbol: 'Ce', name: 'Cerium' },
+];
+
+function Demo() {
+  // Initialize with the first item selected as an example
+  const [selected, handlers] = useSelection(elements, [elements[0]]);
+
+  const allSelected = handlers.isAllSelected();
+  const someSelected = handlers.isSomeSelected();
+
+  const rows = elements.map((item) => {
+    // Check if item (by id) is in the selected array
+    const isSelected = selected.some((s) => s.id === item.id);
+    return (
+      <Table.Tr key={item.id} bg={isSelected ? 'var(--mantine-color-blue-light)' : undefined}>
+        <Table.Td>
+          <Checkbox
+            checked={isSelected}
+            onChange={() => handlers.toggle(item)}
+            aria-label={`Select row ${item.name}`}
+          />
+        </Table.Td>
+        <Table.Td>{item.position}</Table.Td>
+        <Table.Td>{item.name}</Table.Td>
+        <Table.Td>{item.symbol}</Table.Td>
+        <Table.Td>{item.mass}</Table.Td>
+      </Table.Tr>
+    );
+  });
+
+  const handleSelectAllToggle = () => {
+    if (allSelected) {
+      handlers.resetSelection();
+    } else {
+      handlers.setSelection(elements);
+    }
+  };
+
+  return (
+    <>
+      <Group mb="md">
+        <Button onClick={handleSelectAllToggle}>
+          {allSelected ? 'Deselect all' : 'Select all'}
+        </Button>
+        <Button onClick={() => handlers.setSelection([elements[1], elements[3]])} variant="light">
+          Select Nitrogen & Barium
+        </Button>
+        <Button onClick={handlers.resetSelection} variant="outline" color="red">
+          Reset selection
+        </Button>
+      </Group>
+
+      <Text mb="xs" size="sm">
+        Selected items: {selected.map(s => s.name).join(', ') || 'None'} (Total: {selected.length})
+      </Text>
+
+      <Table miw={700} verticalSpacing="sm">
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th style={{ width: '2rem' }}>
+              <Checkbox
+                checked={allSelected}
+                indeterminate={someSelected && !allSelected}
+                onChange={handleSelectAllToggle}
+                aria-label="Select all rows"
+              />
+            </Table.Th>
+            <Table.Th>Element position</Table.Th>
+            <Table.Th>Element name</Table.Th>
+            <Table.Th>Symbol</Table.Th>
+            <Table.Th>Atomic mass</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>{rows}</Table.Tbody>
+      </Table>
+    </>
+  );
+}
+
+export const usage: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code: "// Simplified code string for now. Will replace with actual component code later.\nconst MyDemo = () => { /* ... */ };",
+};

--- a/packages/@docs/demos/src/demos/hooks/use-selection.demo.usage.tsx
+++ b/packages/@docs/demos/src/demos/hooks/use-selection.demo.usage.tsx
@@ -1,9 +1,92 @@
 import React from 'react';
-import { Table, Checkbox, Button, Group, Text } from '@mantine/core';
+import { Button, Checkbox, Group, Table, Text } from '@mantine/core';
 import { useSelection } from '@mantine/hooks';
+import { MantineDemo } from '@mantinex/demo';
 
-// Assuming MantineDemo type is globally available or imported in other demos
-// For example: import type { MantineDemo } from '@mantine/ds';
+const code = `
+const elements = [
+  { id: '1', position: 6, mass: 12.011, symbol: 'C', name: 'Carbon' },
+  { id: '2', position: 7, mass: 14.007, symbol: 'N', name: 'Nitrogen' },
+  { id: '3', position: 39, mass: 88.906, symbol: 'Y', name: 'Yttrium' },
+  { id: '4', position: 56, mass: 137.33, symbol: 'Ba', name: 'Barium' },
+  { id: '5', position: 58, mass: 140.12, symbol: 'Ce', name: 'Cerium' },
+];
+
+function Demo() {
+  // Initialize with the first item selected as an example
+  const [selected, handlers] = useSelection(elements, [elements[0]]);
+
+  const allSelected = handlers.isAllSelected();
+  const someSelected = handlers.isSomeSelected();
+
+  const rows = elements.map((item) => {
+    // Check if item (by id) is in the selected array
+    const isSelected = selected.some((s) => s.id === item.id);
+    return (
+      <Table.Tr key={item.id} bg={isSelected ? 'var(--mantine-color-blue-light)' : undefined}>
+        <Table.Td>
+          <Checkbox
+            checked={isSelected}
+            onChange={() => handlers.toggle(item)}
+          />
+        </Table.Td>
+        <Table.Td>{item.position}</Table.Td>
+        <Table.Td>{item.name}</Table.Td>
+        <Table.Td>{item.symbol}</Table.Td>
+        <Table.Td>{item.mass}</Table.Td>
+      </Table.Tr>
+    );
+  });
+
+  const handleSelectAllToggle = () => {
+    if (allSelected) {
+      handlers.resetSelection();
+    } else {
+      handlers.setSelection(elements);
+    }
+  };
+
+  return (
+    <>
+      <Group mb="md">
+        <Button onClick={handleSelectAllToggle}>
+          {allSelected ? 'Deselect all' : 'Select all'}
+        </Button>
+        <Button onClick={() => handlers.setSelection([elements[1], elements[3]])} variant="light">
+          Select Nitrogen & Barium
+        </Button>
+        <Button onClick={handlers.resetSelection} variant="outline" color="red">
+          Reset selection
+        </Button>
+      </Group>
+
+      <Text mb="xs" size="sm">
+        Selected items: {selected.map(s => s.name).join(', ') || 'None'} (Total: {selected.length})
+      </Text>
+
+      <Table miw={700} verticalSpacing="sm">
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th style={{ width: '2rem' }}>
+              <Checkbox
+                checked={allSelected}
+                indeterminate={someSelected && !allSelected}
+                onChange={handleSelectAllToggle}
+                aria-label="Select all rows"
+              />
+            </Table.Th>
+            <Table.Th>Element position</Table.Th>
+            <Table.Th>Element name</Table.Th>
+            <Table.Th>Symbol</Table.Th>
+            <Table.Th>Atomic mass</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>{rows}</Table.Tbody>
+      </Table>
+    </>
+  );
+}
+`
 
 const elements = [
   { id: '1', position: 6, mass: 12.011, symbol: 'C', name: 'Carbon' },
@@ -89,8 +172,8 @@ function Demo() {
   );
 }
 
-export const usage: MantineDemo = {
+export const useSelectionUsage: MantineDemo = {
   type: 'code',
   component: Demo,
-  code: "// Simplified code string for now. Will replace with actual component code later.\nconst MyDemo = () => { /* ... */ };",
+  code,
 };

--- a/packages/@docs/demos/src/demos/hooks/use-selection.demo.usage.tsx
+++ b/packages/@docs/demos/src/demos/hooks/use-selection.demo.usage.tsx
@@ -4,6 +4,9 @@ import { useSelection } from '@mantine/hooks';
 import { MantineDemo } from '@mantinex/demo';
 
 const code = `
+import { Button, Checkbox, Group, Table, Text } from '@mantine/core';
+import { useSelection } from '@mantine/hooks';
+
 const elements = [
   { id: '1', position: 6, mass: 12.011, symbol: 'C', name: 'Carbon' },
   { id: '2', position: 7, mass: 14.007, symbol: 'N', name: 'Nitrogen' },
@@ -22,8 +25,9 @@ function Demo() {
   const rows = elements.map((item) => {
     // Check if item (by id) is in the selected array
     const isSelected = selected.some((s) => s.id === item.id);
+    const bg = isSelected ? 'var(--mantine-color-blue-light)' : undefined;
     return (
-      <Table.Tr key={item.id} bg={isSelected ? 'var(--mantine-color-blue-light)' : undefined}>
+      <Table.Tr key={item.id} bg={bg}>
         <Table.Td>
           <Checkbox
             checked={isSelected}
@@ -86,7 +90,7 @@ function Demo() {
     </>
   );
 }
-`
+`;
 
 const elements = [
   { id: '1', position: 6, mass: 12.011, symbol: 'C', name: 'Carbon' },
@@ -104,10 +108,13 @@ function Demo() {
   const someSelected = handlers.isSomeSelected();
 
   const rows = elements.map((item) => {
+    const bg = selected.some((s) => s.id === item.id)
+      ? 'var(--mantine-color-blue-light)'
+      : undefined;
     // Check if item (by id) is in the selected array
     const isSelected = selected.some((s) => s.id === item.id);
     return (
-      <Table.Tr key={item.id} bg={isSelected ? 'var(--mantine-color-blue-light)' : undefined}>
+      <Table.Tr key={item.id} bg={bg}>
         <Table.Td>
           <Checkbox
             checked={isSelected}
@@ -146,13 +153,14 @@ function Demo() {
       </Group>
 
       <Text mb="xs" size="sm">
-        Selected items: {selected.map(s => s.name).join(', ') || 'None'} (Total: {selected.length})
+        Selected items: {selected.map((s) => s.name).join(', ') || 'None'} (Total: {selected.length}
+        )
       </Text>
 
-      <Table miw={700} verticalSpacing="sm">
+      <Table miw="auto" verticalSpacing="sm">
         <Table.Thead>
           <Table.Tr>
-            <Table.Th style={{ width: '2rem' }}>
+            <Table.Th>
               <Checkbox
                 checked={allSelected}
                 indeterminate={someSelected && !allSelected}
@@ -172,7 +180,7 @@ function Demo() {
   );
 }
 
-export const useSelectionUsage: MantineDemo = {
+export const useSelectionDemo: MantineDemo = {
   type: 'code',
   component: Demo,
   code,

--- a/packages/@mantine/hooks/src/index.ts
+++ b/packages/@mantine/hooks/src/index.ts
@@ -75,6 +75,7 @@ export { useFetch } from './use-fetch/use-fetch';
 export { useRadialMove, normalizeRadialValue } from './use-radial-move/use-radial-move';
 export { useScrollSpy } from './use-scroll-spy/use-scroll-spy';
 export { useFileDialog } from './use-file-dialog/use-file-dialog';
+export { useSelection } from './use-selection/use-selection';
 
 export type { UseMovePosition } from './use-move/use-move';
 export type { OS } from './use-os/use-os';

--- a/packages/@mantine/hooks/src/use-selection/use-selection.test.ts
+++ b/packages/@mantine/hooks/src/use-selection/use-selection.test.ts
@@ -96,6 +96,15 @@ describe('@mantine/hooks/use-selection', () => {
     expect(result2.current[1].isAllSelected()).toBe(false);
   });
 
+  it('isSomeSelected returns false if data is empty', () => {
+    const { result } = renderHook(() => useSelection([]));
+    expect(result.current[1].isSomeSelected()).toBe(false);
+
+    // Also check if initialSelection is provided but data is empty
+    const { result: result2 } = renderHook(() => useSelection([], [1, 2]));
+    expect(result2.current[1].isSomeSelected()).toBe(false);
+  });
+
   it('checks if some items are selected', () => {
     const { result } = renderHook(() => useSelection(initialData));
     // Initially, no items are selected

--- a/packages/@mantine/hooks/src/use-selection/use-selection.test.ts
+++ b/packages/@mantine/hooks/src/use-selection/use-selection.test.ts
@@ -1,0 +1,184 @@
+import { act, renderHook } from '@testing-library/react';
+import { useSelection } from './use-selection';
+
+describe('@mantine/hooks/use-selection', () => {
+  const initialData = [1, 2, 3, 4, 5];
+  const objectData = [
+    { id: 1, value: 'a' },
+    { id: 2, value: 'b' },
+    { id: 3, value: 'c' },
+  ];
+
+  it('initializes with an empty selection', () => {
+    const { result } = renderHook(() => useSelection(initialData));
+    const [selected] = result.current;
+    expect(selected).toEqual([]);
+  });
+
+  it('selects an item', () => {
+    const { result } = renderHook(() => useSelection(initialData));
+    act(() => {
+      result.current[1].select(1);
+    });
+    expect(result.current[0]).toEqual([1]);
+    act(() => {
+      result.current[1].select(3);
+    });
+    expect(result.current[0]).toEqual([1, 3]);
+  });
+
+  it('deselects an item', () => {
+    const { result } = renderHook(() => useSelection(initialData));
+    act(() => {
+      result.current[1].select(1);
+      result.current[1].select(3);
+    });
+    expect(result.current[0]).toEqual([1, 3]);
+    act(() => {
+      result.current[1].deselect(1);
+    });
+    expect(result.current[0]).toEqual([3]);
+  });
+
+  it('toggles an item selection', () => {
+    const { result } = renderHook(() => useSelection(initialData));
+    act(() => {
+      result.current[1].toggle(1);
+    });
+    expect(result.current[0]).toEqual([1]);
+    act(() => {
+      result.current[1].toggle(1);
+    });
+    expect(result.current[0]).toEqual([]);
+    act(() => {
+      result.current[1].toggle(2);
+    });
+    expect(result.current[0]).toEqual([2]);
+  });
+
+  it('checks if all items are selected', () => {
+    const { result } = renderHook(() => useSelection(initialData));
+    expect(result.current[1].isAllSelected()).toBe(false);
+    act(() => {
+      initialData.forEach((item) => result.current[1].select(item));
+    });
+    expect(result.current[1].isAllSelected()).toBe(true);
+    act(() => {
+      result.current[1].deselect(1);
+    });
+    expect(result.current[1].isAllSelected()).toBe(false);
+  });
+
+  it('isAllSelected returns false if data is empty', () => {
+    const { result } = renderHook(() => useSelection([]));
+    expect(result.current[1].isAllSelected()).toBe(false);
+  });
+
+  it('checks if some items are selected', () => {
+    const { result } = renderHook(() => useSelection(initialData));
+    expect(result.current[1].isSomeSelected()).toBe(false);
+    act(() => {
+      result.current[1].select(1);
+    });
+    expect(result.current[1].isSomeSelected()).toBe(true);
+    act(() => {
+      initialData.forEach((item) => result.current[1].select(item));
+    });
+    expect(result.current[1].isSomeSelected()).toBe(true);
+    act(() => {
+      result.current[1].resetSelection();
+    });
+    expect(result.current[1].isSomeSelected()).toBe(false);
+  });
+
+  it('sets selection to a given list', () => {
+    const { result } = renderHook(() => useSelection(initialData));
+    act(() => {
+      result.current[1].setSelection([1, 2, 3]);
+    });
+    expect(result.current[0]).toEqual([1, 2, 3]);
+    expect(result.current[1].isSomeSelected()).toBe(true);
+    expect(result.current[1].isAllSelected()).toBe(false);
+  });
+
+  it('resets selection to an empty array', () => {
+    const { result } = renderHook(() => useSelection(initialData));
+    act(() => {
+      result.current[1].setSelection([1, 2, 3]);
+    });
+    expect(result.current[0]).toEqual([1, 2, 3]);
+    act(() => {
+      result.current[1].resetSelection();
+    });
+    expect(result.current[0]).toEqual([]);
+    expect(result.current[1].isSomeSelected()).toBe(false);
+    expect(result.current[1].isAllSelected()).toBe(false);
+  });
+
+  it('handles object data correctly', () => {
+    const { result } = renderHook(() => useSelection(objectData));
+    const item1 = objectData[0];
+    const item2 = objectData[1];
+
+    act(() => {
+      result.current[1].select(item1);
+    });
+    expect(result.current[0]).toEqual([item1]);
+
+    act(() => {
+      result.current[1].toggle(item2);
+    });
+    expect(result.current[0]).toEqual([item1, item2]);
+
+    act(() => {
+      result.current[1].deselect(item1);
+    });
+    expect(result.current[0]).toEqual([item2]);
+
+    expect(result.current[1].isSomeSelected()).toBe(true);
+    expect(result.current[1].isAllSelected()).toBe(false);
+
+    act(() => {
+      result.current[1].setSelection(objectData);
+    });
+    expect(result.current[1].isAllSelected()).toBe(true);
+  });
+
+  it('handlers maintain referential equality', () => {
+    const { result, rerender } = renderHook(() => useSelection(initialData));
+    const initialHandlers = result.current[1];
+
+    rerender();
+
+    const newHandlers = result.current[1];
+
+    expect(newHandlers.select).toBe(initialHandlers.select);
+    expect(newHandlers.deselect).toBe(initialHandlers.deselect);
+    expect(newHandlers.toggle).toBe(initialHandlers.toggle);
+    expect(newHandlers.isAllSelected).toBe(initialHandlers.isAllSelected); // This will fail if data or selected changes
+    expect(newHandlers.isSomeSelected).toBe(initialHandlers.isSomeSelected); // This will fail if data or selected changes
+    expect(newHandlers.setSelection).toBe(initialHandlers.setSelection);
+    expect(newHandlers.resetSelection).toBe(initialHandlers.resetSelection);
+  });
+
+  it('isAllSelected and isSomeSelected update when data prop changes', () => {
+    let currentData = [1, 2];
+    const { result, rerender } = renderHook(() => useSelection(currentData));
+
+    act(() => {
+      result.current[1].setSelection([1, 2]);
+    });
+    expect(result.current[1].isAllSelected()).toBe(true);
+
+    currentData = [1, 2, 3];
+    rerender(); // Rerender with new data prop
+
+    expect(result.current[1].isAllSelected()).toBe(false);
+    expect(result.current[1].isSomeSelected()).toBe(true); // Still true because [1,2] are selected
+
+    act(() => {
+      result.current[1].select(3);
+    });
+    expect(result.current[1].isAllSelected()).toBe(true);
+  });
+});

--- a/packages/@mantine/hooks/src/use-selection/use-selection.test.ts
+++ b/packages/@mantine/hooks/src/use-selection/use-selection.test.ts
@@ -9,35 +9,53 @@ describe('@mantine/hooks/use-selection', () => {
     { id: 3, value: 'c' },
   ];
 
-  it('initializes with an empty selection', () => {
+  it('initializes with an empty selection by default', () => {
     const { result } = renderHook(() => useSelection(initialData));
     const [selected] = result.current;
     expect(selected).toEqual([]);
   });
 
-  it('selects an item', () => {
+  it('initializes with provided initialSelection', () => {
+    const { result } = renderHook(() => useSelection(initialData, [1, 2]));
+    const [selected] = result.current;
+    expect(selected).toEqual([1, 2]);
+  });
+
+  it('selects an item and maintains selected array reference on no-op', () => {
     const { result } = renderHook(() => useSelection(initialData));
     act(() => {
       result.current[1].select(1);
     });
     expect(result.current[0]).toEqual([1]);
+    const selectedArrayRef = result.current[0];
+    act(() => {
+      result.current[1].select(1); // select already selected item
+    });
+    expect(result.current[0]).toEqual([1]);
+    expect(result.current[0]).toBe(selectedArrayRef); // Reference should not change
+
     act(() => {
       result.current[1].select(3);
     });
     expect(result.current[0]).toEqual([1, 3]);
+    expect(result.current[0]).not.toBe(selectedArrayRef); // Reference should change
   });
 
-  it('deselects an item', () => {
-    const { result } = renderHook(() => useSelection(initialData));
-    act(() => {
-      result.current[1].select(1);
-      result.current[1].select(3);
-    });
+  it('deselects an item and maintains selected array reference on no-op', () => {
+    const { result } = renderHook(() => useSelection(initialData, [1, 3]));
     expect(result.current[0]).toEqual([1, 3]);
+
     act(() => {
       result.current[1].deselect(1);
     });
     expect(result.current[0]).toEqual([3]);
+
+    const selectedArrayRef = result.current[0];
+    act(() => {
+      result.current[1].deselect(1); // deselect non-selected item
+    });
+    expect(result.current[0]).toEqual([3]);
+    expect(result.current[0]).toBe(selectedArrayRef); // Reference should not change
   });
 
   it('toggles an item selection', () => {
@@ -72,23 +90,41 @@ describe('@mantine/hooks/use-selection', () => {
   it('isAllSelected returns false if data is empty', () => {
     const { result } = renderHook(() => useSelection([]));
     expect(result.current[1].isAllSelected()).toBe(false);
+
+    // Also check if selection is also empty
+    const { result: result2 } = renderHook(() => useSelection([], []));
+    expect(result2.current[1].isAllSelected()).toBe(false);
   });
 
   it('checks if some items are selected', () => {
     const { result } = renderHook(() => useSelection(initialData));
+    // Initially, no items are selected
     expect(result.current[1].isSomeSelected()).toBe(false);
+
+    // Select one item
     act(() => {
       result.current[1].select(1);
     });
-    expect(result.current[1].isSomeSelected()).toBe(true);
+    expect(result.current[1].isSomeSelected()).toBe(true); // Some selected (1), not all
+
+    // Select all items
     act(() => {
       initialData.forEach((item) => result.current[1].select(item));
     });
+    expect(result.current[1].isAllSelected()).toBe(true);
+    expect(result.current[1].isSomeSelected()).toBe(false); // All selected, so not 'some'
+
+    // Deselect one item (some are selected again)
+    act(() => {
+      result.current[1].deselect(initialData[0]);
+    });
     expect(result.current[1].isSomeSelected()).toBe(true);
+
+    // Reset selection
     act(() => {
       result.current[1].resetSelection();
     });
-    expect(result.current[1].isSomeSelected()).toBe(false);
+    expect(result.current[1].isSomeSelected()).toBe(false); // None selected
   });
 
   it('sets selection to a given list', () => {
@@ -101,28 +137,30 @@ describe('@mantine/hooks/use-selection', () => {
     expect(result.current[1].isAllSelected()).toBe(false);
   });
 
-  it('resets selection to an empty array', () => {
-    const { result } = renderHook(() => useSelection(initialData));
-    act(() => {
-      result.current[1].setSelection([1, 2, 3]);
-    });
+  it('resets selection and maintains selected array reference on no-op', () => {
+    const { result } = renderHook(() => useSelection(initialData, [1, 2, 3]));
     expect(result.current[0]).toEqual([1, 2, 3]);
+
     act(() => {
       result.current[1].resetSelection();
     });
     expect(result.current[0]).toEqual([]);
     expect(result.current[1].isSomeSelected()).toBe(false);
     expect(result.current[1].isAllSelected()).toBe(false);
+
+    const selectedArrayRef = result.current[0];
+    act(() => {
+      result.current[1].resetSelection(); // reset already empty selection
+    });
+    expect(result.current[0]).toEqual([]);
+    expect(result.current[0]).toBe(selectedArrayRef); // Reference should not change
   });
 
   it('handles object data correctly', () => {
-    const { result } = renderHook(() => useSelection(objectData));
+    const { result } = renderHook(() => useSelection(objectData, [objectData[0]]));
     const item1 = objectData[0];
     const item2 = objectData[1];
 
-    act(() => {
-      result.current[1].select(item1);
-    });
     expect(result.current[0]).toEqual([item1]);
 
     act(() => {
@@ -142,43 +180,50 @@ describe('@mantine/hooks/use-selection', () => {
       result.current[1].setSelection(objectData);
     });
     expect(result.current[1].isAllSelected()).toBe(true);
+    expect(result.current[1].isSomeSelected()).toBe(false); // All selected, so not 'some'
   });
 
-  it('handlers maintain referential equality', () => {
+  it('handlers maintain referential equality when state does not change', () => {
     const { result, rerender } = renderHook(() => useSelection(initialData));
     const initialHandlers = result.current[1];
 
-    rerender();
+    rerender(); // Rerender without changing props or state that handlers depend on
 
     const newHandlers = result.current[1];
 
     expect(newHandlers.select).toBe(initialHandlers.select);
     expect(newHandlers.deselect).toBe(initialHandlers.deselect);
     expect(newHandlers.toggle).toBe(initialHandlers.toggle);
-    expect(newHandlers.isAllSelected).toBe(initialHandlers.isAllSelected); // This will fail if data or selected changes
-    expect(newHandlers.isSomeSelected).toBe(initialHandlers.isSomeSelected); // This will fail if data or selected changes
+    // isAllSelected and isSomeSelected depend on `data` and `selected` (Set instance)
+    // If data and selected Set instance haven't changed, these should be stable.
+    expect(newHandlers.isAllSelected).toBe(initialHandlers.isAllSelected);
+    expect(newHandlers.isSomeSelected).toBe(initialHandlers.isSomeSelected);
     expect(newHandlers.setSelection).toBe(initialHandlers.setSelection);
     expect(newHandlers.resetSelection).toBe(initialHandlers.resetSelection);
   });
 
   it('isAllSelected and isSomeSelected update when data prop changes', () => {
     let currentData = [1, 2];
-    const { result, rerender } = renderHook(() => useSelection(currentData));
+    const { result, rerender } = renderHook(({ data }) => useSelection(data), {
+      initialProps: { data: currentData },
+    });
 
     act(() => {
       result.current[1].setSelection([1, 2]);
     });
     expect(result.current[1].isAllSelected()).toBe(true);
+    expect(result.current[1].isSomeSelected()).toBe(false);
 
     currentData = [1, 2, 3];
-    rerender(); // Rerender with new data prop
+    rerender({ data: currentData }); // Rerender with new data prop
 
     expect(result.current[1].isAllSelected()).toBe(false);
-    expect(result.current[1].isSomeSelected()).toBe(true); // Still true because [1,2] are selected
+    expect(result.current[1].isSomeSelected()).toBe(true); // Still true because [1,2] are selected out of [1,2,3]
 
     act(() => {
       result.current[1].select(3);
     });
     expect(result.current[1].isAllSelected()).toBe(true);
+    expect(result.current[1].isSomeSelected()).toBe(false);
   });
 });

--- a/packages/@mantine/hooks/src/use-selection/use-selection.ts
+++ b/packages/@mantine/hooks/src/use-selection/use-selection.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-interface SelectionHandlers<T> {
+type SelectionHandlers<T> = {
   select: (item: T) => void;
   deselect: (item: T) => void;
   toggle: (item: T) => void;
@@ -8,17 +8,30 @@ interface SelectionHandlers<T> {
   isSomeSelected: () => boolean;
   setSelection: (items: T[]) => void;
   resetSelection: () => void;
-}
+};
 
-export const useSelection = <T>(data: T[]): [T[], SelectionHandlers<T>] => {
-  const [selected, setSelected] = useState<Set<T>>(new Set());
+export const useSelection = <T>(
+  data: T[],
+  initialSelection: T[] = [] // Added initialSelection
+): [T[], SelectionHandlers<T>] => {
+  const [selected, setSelected] = useState<Set<T>>(new Set(initialSelection)); // Use initialSelection
 
   const select = useCallback((item: T) => {
-    setSelected((prev) => new Set(prev).add(item));
+    setSelected((prev) => {
+      if (prev.has(item)) { // If item is already selected
+        return prev; // Return previous Set instance to avoid unnecessary re-render
+      }
+      const next = new Set(prev);
+      next.add(item);
+      return next;
+    });
   }, []);
 
   const deselect = useCallback((item: T) => {
     setSelected((prev) => {
+      if (!prev.has(item)) { // If item is not in the selection
+        return prev; // Return previous Set instance
+      }
       const next = new Set(prev);
       next.delete(item);
       return next;
@@ -28,7 +41,11 @@ export const useSelection = <T>(data: T[]): [T[], SelectionHandlers<T>] => {
   const toggle = useCallback((item: T) => {
     setSelected((prev) => {
       const next = new Set(prev);
-      next.has(item) ? next.delete(item) : next.add(item);
+      if (next.has(item)) {
+        next.delete(item);
+      } else {
+        next.add(item);
+      }
       return next;
     });
   }, []);
@@ -39,13 +56,22 @@ export const useSelection = <T>(data: T[]): [T[], SelectionHandlers<T>] => {
   );
 
   const isSomeSelected = useCallback(
-    () => data.some((item) => selected.has(item)),
-    [data, selected]
+    () => selected.size > 0 && !isAllSelected(), // Updated logic
+    [selected, isAllSelected] // isAllSelected is a dependency
   );
 
-  const setSelection = useCallback((items: T[]) => setSelected(new Set(items)), []);
+  const setSelection = useCallback((items: T[]) => {
+    setSelected(new Set(items));
+  }, []);
 
-  const resetSelection = useCallback(() => setSelected(new Set()), []);
+  const resetSelection = useCallback(() => {
+    setSelected((prev) => {
+      if (prev.size === 0) { // If already empty
+        return prev; // Return previous Set instance
+      }
+      return new Set();
+    });
+  }, []);
 
   return [
     Array.from(selected),

--- a/packages/@mantine/hooks/src/use-selection/use-selection.ts
+++ b/packages/@mantine/hooks/src/use-selection/use-selection.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from 'react';
 
-
 interface SelectionHandlers<T> {
   select: (item: T) => void;
   deselect: (item: T) => void;

--- a/packages/@mantine/hooks/src/use-selection/use-selection.ts
+++ b/packages/@mantine/hooks/src/use-selection/use-selection.ts
@@ -10,10 +10,7 @@ type SelectionHandlers<T> = {
   resetSelection: () => void;
 };
 
-export const useSelection = <T>(
-  data: T[],
-  initialSelection?: T[]
-): [T[], SelectionHandlers<T>] => {
+export const useSelection = <T>(data: T[], initialSelection?: T[]): [T[], SelectionHandlers<T>] => {
   const [selected, setSelected] = useState<Set<T>>(new Set(initialSelection || []));
 
   const select = useCallback((item: T) => {

--- a/packages/@mantine/hooks/src/use-selection/use-selection.ts
+++ b/packages/@mantine/hooks/src/use-selection/use-selection.ts
@@ -1,0 +1,63 @@
+import { useCallback, useState } from 'react';
+
+
+interface SelectionHandlers<T> {
+  select: (item: T) => void;
+  deselect: (item: T) => void;
+  toggle: (item: T) => void;
+  isAllSelected: () => boolean;
+  isSomeSelected: () => boolean;
+  setSelection: (items: T[]) => void;
+  resetSelection: () => void;
+}
+
+export const useSelection = <T>(data: T[]): [T[], SelectionHandlers<T>] => {
+  const [selected, setSelected] = useState<Set<T>>(new Set());
+
+  const select = useCallback((item: T) => {
+    setSelected((prev) => new Set(prev).add(item));
+  }, []);
+
+  const deselect = useCallback((item: T) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      next.delete(item);
+      return next;
+    });
+  }, []);
+
+  const toggle = useCallback((item: T) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      next.has(item) ? next.delete(item) : next.add(item);
+      return next;
+    });
+  }, []);
+
+  const isAllSelected = useCallback(
+    () => data.length > 0 && data.every((item) => selected.has(item)),
+    [data, selected]
+  );
+
+  const isSomeSelected = useCallback(
+    () => data.some((item) => selected.has(item)),
+    [data, selected]
+  );
+
+  const setSelection = useCallback((items: T[]) => setSelected(new Set(items)), []);
+
+  const resetSelection = useCallback(() => setSelected(new Set()), []);
+
+  return [
+    Array.from(selected),
+    {
+      select,
+      deselect,
+      toggle,
+      isAllSelected,
+      isSomeSelected,
+      setSelection,
+      resetSelection,
+    },
+  ];
+};

--- a/packages/@mantine/hooks/src/use-selection/use-selection.ts
+++ b/packages/@mantine/hooks/src/use-selection/use-selection.ts
@@ -12,9 +12,9 @@ type SelectionHandlers<T> = {
 
 export const useSelection = <T>(
   data: T[],
-  initialSelection: T[] = []
+  initialSelection?: T[]
 ): [T[], SelectionHandlers<T>] => {
-  const [selected, setSelected] = useState<Set<T>>(new Set(initialSelection));
+  const [selected, setSelected] = useState<Set<T>>(new Set(initialSelection || []));
 
   const select = useCallback((item: T) => {
     setSelected((prev) => {

--- a/packages/@mantine/hooks/src/use-selection/use-selection.ts
+++ b/packages/@mantine/hooks/src/use-selection/use-selection.ts
@@ -12,14 +12,14 @@ type SelectionHandlers<T> = {
 
 export const useSelection = <T>(
   data: T[],
-  initialSelection: T[] = [] // Added initialSelection
+  initialSelection: T[] = []
 ): [T[], SelectionHandlers<T>] => {
-  const [selected, setSelected] = useState<Set<T>>(new Set(initialSelection)); // Use initialSelection
+  const [selected, setSelected] = useState<Set<T>>(new Set(initialSelection));
 
   const select = useCallback((item: T) => {
     setSelected((prev) => {
-      if (prev.has(item)) { // If item is already selected
-        return prev; // Return previous Set instance to avoid unnecessary re-render
+      if (prev.has(item)) {
+        return prev;
       }
       const next = new Set(prev);
       next.add(item);
@@ -29,8 +29,8 @@ export const useSelection = <T>(
 
   const deselect = useCallback((item: T) => {
     setSelected((prev) => {
-      if (!prev.has(item)) { // If item is not in the selection
-        return prev; // Return previous Set instance
+      if (!prev.has(item)) {
+        return prev;
       }
       const next = new Set(prev);
       next.delete(item);
@@ -56,8 +56,8 @@ export const useSelection = <T>(
   );
 
   const isSomeSelected = useCallback(
-    () => selected.size > 0 && !isAllSelected(), // Updated logic
-    [selected, isAllSelected] // isAllSelected is a dependency
+    () => data.length > 0 && selected.size > 0 && !isAllSelected(),
+    [data, selected, isAllSelected]
   );
 
   const setSelection = useCallback((items: T[]) => {
@@ -66,8 +66,8 @@ export const useSelection = <T>(
 
   const resetSelection = useCallback(() => {
     setSelected((prev) => {
-      if (prev.size === 0) { // If already empty
-        return prev; // Return previous Set instance
+      if (prev.size === 0) {
+        return prev;
       }
       return new Set();
     });


### PR DESCRIPTION
## Description

### Changes
- Added `use-selection` custom hook implementation in `[@mantine/hooks]`.
- Fixed the `isSomeSelected` logic to handle empty data cases correctly and added related test cases.
- Introduced comprehensive tests for `use-selection` in `[@mantine/hooks]`.
- Improved documentation in `[@mantine/docs]`, including:
  - Storybook setup for showcasing components and hooks.
  - Initial version of demos for better usage reference.
- Updated `[@mantine/core]` to use `@mantine/hooks` for state management.
- Updated `[@mantine/dates]` to use `@mantine/hooks` for state management.