### PR TITLE
[@mantine/hooks] use-local-storage: Use microtask for dispatching update events

### DIFF
--- a/packages/@mantine/hooks/src/use-local-storage/create-storage.ts
+++ b/packages/@mantine/hooks/src/use-local-storage/create-storage.ts
@@ -115,9 +115,12 @@ export function createStorage<T>(type: StorageType, hookName: string) {
           setValue((current) => {
             const result = val(current);
             setItem(key, serialize(result));
-            window.dispatchEvent(
-              new CustomEvent(eventName, { detail: { key, value: val(current) } })
-            );
+            // Defer dispatching this event to avoid the handler being called during render.
+            queueMicrotask(() => {
+              window.dispatchEvent(
+                new CustomEvent(eventName, { detail: { key, value: val(current) } })
+              );
+            });
             return result;
           });
         } else {


### PR DESCRIPTION
When two components call `useLocalStorage` with the same key and one of them uses the setter in "updater" / "reducer" / "lambda" form instead of passing a plain value, a React error may occur:

```tsx
function ComponentA() {
  const [example] = useLocalStorage({ key: "example" });

  return <div>{example}</div>;
}

function ComponentB() {
  const [_, setExample] = useLocalStorage({ key: "example" });

  return (
    <>
      <ComponentA />
      <button onClick={() => { setExample(() => "something"); }}>
        update
      </button>
    </>
  );
}
```

This will lead to an error being emitted by React when clicking the button (at least in Chromium 135.0.7049.114):
"Cannot update a component (\`ComponentA\`) while rendering a different component (\`ComponentB\`)."

Currently, `window.dispatchEvent` is [called directly within the updater of `setValue`](https://github.com/mantinedev/mantine/blob/bcfcfd5670cfdc4d1179a5a843396b95f20c1a9b/packages/%40mantine/hooks/src/use-local-storage/create-storage.ts#L118) when a function is given.
Because dispatching happens synchronously, this may lead to the event handler (which contains another call to `setValue`) being called during render which causes the aforementioned error.

Using a microtask defers the dispatch until after the updater has completed and avoids this issue.

Using a non-micro task via `useTimeout` instead of `queueMicrotask` is also considerable but I think a microtask keeps the behavior closer to what it is now without getting into other event loop-related issues.

The non-function form when giving a value directly to the setter returned by `useLocalStorage` is not affected by this because then `window.dispatchEvent` is [called outside of `setValue`](https://github.com/mantinedev/mantine/blob/bcfcfd5670cfdc4d1179a5a843396b95f20c1a9b/packages/%40mantine/hooks/src/use-local-storage/create-storage.ts#L125).