### PR TITLE
[@mantine/core] Added in descriptions to Select options

### DIFF
--- a/apps/mantine.dev/src/pages/core/select.mdx
+++ b/apps/mantine.dev/src/pages/core/select.mdx
@@ -71,6 +71,12 @@ By default, `allowDeselect` is `true`:
 
 <Demo data={SelectDemos.allowDeselect} />
 
+## With Description
+
+By using an array of objects and adding `description` to the data property, you can add descriptions to your select dropdown options.
+
+<Demo data={SelectDemos.withDescription} />
+
 ## Searchable
 
 Set `searchable` prop to allow filtering options by user input:

--- a/packages/@docs/demos/src/demos/core/Select/Select.demo.withDescription.tsx
+++ b/packages/@docs/demos/src/demos/core/Select/Select.demo.withDescription.tsx
@@ -1,0 +1,72 @@
+import { Select } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { Select } from '@mantine/core';
+
+function Demo() {
+  return (
+      <Select
+        label="Your favorite library"
+        placeholder="Pick value"
+        data={[
+          {
+            value: 'React',
+            label: 'React',
+            description:
+              'React is a JavaScript library for building fast, interactive user interfaces using a component-based architecture.',
+          },
+          {
+            value: 'Angular',
+            label: 'Angular',
+            description:
+              'Angular is a TypeScript-based web application framework for building large-scale, single-page applications with a structured, full-featured approach.',
+          },
+          {
+            value: 'Svelte',
+            label: 'Svelte',
+            description:
+              'Svelte is a modern JavaScript framework that compiles components into highly efficient vanilla JavaScript at build time, eliminating the need for a virtual DOM.',
+          }
+        ]}
+      />
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <Select
+      label="Your favorite library"
+      placeholder="Pick value"
+      data={[
+        {
+          value: 'React',
+          label: 'React',
+          description:
+            'React is a JavaScript library for building fast, interactive user interfaces using a component-based architecture.',
+        },
+        {
+          value: 'Angular',
+          label: 'Angular',
+          description:
+            'Angular is a TypeScript-based web application framework for building large-scale, single-page applications with a structured, full-featured approach.',
+        },
+        {
+          value: 'Svelte',
+          label: 'Svelte',
+          description:
+            'Svelte is a modern JavaScript framework that compiles components into highly efficient vanilla JavaScript at build time, eliminating the need for a virtual DOM.',
+        },
+      ]}
+    />
+  );
+}
+
+export const withDescription: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+  maxWidth: 340,
+  centered: true,
+};

--- a/packages/@docs/demos/src/demos/core/Select/Select.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/core/Select/Select.demos.story.tsx
@@ -58,6 +58,11 @@ export const Demo_readOnly = {
   render: renderDemo(demos.readOnly),
 };
 
+export const Demo_withDescription = {
+  name: '⭐ Demo: withDescription',
+  render: renderDemo(demos.withDescription),
+};
+
 export const Demo_scrollArea = {
   name: '⭐ Demo: scrollArea',
   render: renderDemo(demos.scrollArea),

--- a/packages/@docs/demos/src/demos/core/Select/index.ts
+++ b/packages/@docs/demos/src/demos/core/Select/index.ts
@@ -25,3 +25,4 @@ export { withinPopover } from './Select.demo.withinPopover';
 export { dropdownOffset } from './Select.demo.dropdownOffset';
 export { renderOption } from './Select.demo.renderOption';
 export { dropdownWidth } from './Select.demo.dropdownWidth';
+export { withDescription } from './Select.demo.withDescription';

--- a/packages/@mantine/core/src/components/Combobox/Combobox.module.css
+++ b/packages/@mantine/core/src/components/Combobox/Combobox.module.css
@@ -209,3 +209,9 @@
     opacity: 1;
   }
 }
+
+.optionsDropdownDescription {
+  font-size: var(--combobox-option-fz, var(--mantine-font-size-xs));
+  color: var(--mantine-color-placeholder);
+  font-weight: 500;
+}

--- a/packages/@mantine/core/src/components/Combobox/Combobox.types.ts
+++ b/packages/@mantine/core/src/components/Combobox/Combobox.types.ts
@@ -8,6 +8,7 @@ export interface ComboboxStringItem {
 
 export interface ComboboxItem extends ComboboxStringItem {
   label: string;
+  description?: string;
 }
 
 export interface ComboboxItemGroup<T = ComboboxItem | string> {

--- a/packages/@mantine/core/src/components/Combobox/OptionsDropdown/OptionsDropdown.tsx
+++ b/packages/@mantine/core/src/components/Combobox/OptionsDropdown/OptionsDropdown.tsx
@@ -48,7 +48,12 @@ function Option({
     const defaultContent = (
       <>
         {checkIconPosition === 'left' && check}
-        <span>{data.label}</span>
+        <div>
+          <div>{data.label}</div>
+          {data.description && (
+            <div className={classes.optionsDropdownDescription}>{data.description}</div>
+          )}
+        </div>
         {checkIconPosition === 'right' && check}
       </>
     );

--- a/packages/@mantine/core/src/components/Select/Select.story.tsx
+++ b/packages/@mantine/core/src/components/Select/Select.story.tsx
@@ -239,6 +239,36 @@ export function AllowDeselectFalse() {
   );
 }
 
+export function WithDescription() {
+  return (
+    <div style={{ padding: 40 }}>
+      <Select
+        placeholder="Select something"
+        data={[
+          {
+            value: 'React',
+            label: 'React',
+            description:
+              'React is a JavaScript library for building fast, interactive user interfaces using a component-based architecture.',
+          },
+          {
+            value: 'Angular',
+            label: 'Angular',
+            description:
+              'Angular is a TypeScript-based web application framework for building large-scale, single-page applications with a structured, full-featured approach.',
+          },
+          {
+            value: 'Svelte',
+            label: 'Svelte',
+            description:
+              'Svelte is a modern JavaScript framework that compiles components into highly efficient vanilla JavaScript at build time, eliminating the need for a virtual DOM.',
+          },
+        ]}
+      />
+    </div>
+  );
+}
+
 export function ReadOnly() {
   return (
     <div style={{ padding: 40 }}>


### PR DESCRIPTION
[Link to Feature Request](https://github.com/orgs/mantinedev/discussions/7876#discussion-8361362)
---
This PR adds the ability to add descriptions to select options. The code would look something like the following:
```ts
<Select
  label="Your favorite library"
  placeholder="Pick value"
  data={[
    {
      value: 'React',
      label: 'React',
      description:
        'React is a JavaScript library for building fast, interactive user interfaces using a component-based architecture.',
    },
    {
      value: 'Angular',
      label: 'Angular',
      description:
        'Angular is a TypeScript-based web application framework for building large-scale, single-page applications with a structured, full-featured approach.',
    },
    {
      value: 'Svelte',
      label: 'Svelte',
      description:
        'Svelte is a modern JavaScript framework that compiles components into highly efficient vanilla JavaScript at build time, eliminating the need for a virtual DOM.',
    },
  ]}
/>
```

and would look something like this:

<img width="553" alt="image" src="https://github.com/user-attachments/assets/63059aa0-4cd9-49ac-aa90-9d93c8680a8c" />
