### PR TITLE
Fix: Date-related test failures due to UTC/local timezone mismatch Issue

### DIFF
--- a/packages/@mantine/dates/src/components/Day/Day.test.tsx
+++ b/packages/@mantine/dates/src/components/Day/Day.test.tsx
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import lodash from 'lodash';
 import { render, screen, tests } from '@mantine-tests/core';
 import { Day, DayProps, DayStylesNames } from './Day';
@@ -98,7 +99,7 @@ describe('@mantine/dates/Day', () => {
     const { rerender } = render(<Day {...defaultProps} date="2021-11-01" />);
     expect(screen.getByRole('button')).not.toHaveAttribute('data-today');
 
-    rerender(<Day {...defaultProps} date={new Date().toISOString().split('T')[0]} />);
+    rerender(<Day {...defaultProps} date={dayjs().format('YYYY-MM-DD')} />);
     expect(screen.getByRole('button')).toHaveAttribute('data-today');
   });
 });

--- a/packages/@mantine/dates/src/components/Month/get-date-in-tab-order/get-date-in-tab-order.test.ts
+++ b/packages/@mantine/dates/src/components/Month/get-date-in-tab-order/get-date-in-tab-order.test.ts
@@ -33,10 +33,13 @@ describe('@mantine/dates/get-date-in-tab-order', () => {
   });
 
   it('returns current day', () => {
+    const localToday = dayjs().format('YYYY-MM-DD');
+    const localMonth = dayjs().format('YYYY-MM');
+
     expect(
       getDateInTabOrder({
         dates: getMonthDays({
-          month: new Date().toISOString().split('T')[0],
+          month: localToday,
           firstDayOfWeek: 1,
           consistentWeeks: false,
         }),
@@ -45,9 +48,9 @@ describe('@mantine/dates/get-date-in-tab-order', () => {
         getDayProps: defaultControlProps,
         excludeDate: defaultExcludeDate,
         hideOutsideDates: defaultHideOutsideDates,
-        month: defaultMonth,
+        month: localMonth,
       })
-    ).toStrictEqual(new Date().toISOString().split('T')[0]);
+    ).toStrictEqual(localToday);
   });
 
   it('returns first non-disabled day in month', () => {


### PR DESCRIPTION
## Issue

Two test files were failing due to timezone-related issues:

1. `packages/@mantine/dates/src/components/Month/get-date-in-tab-order/get-date-in-tab-order.test.ts`
   - Test case: `returns current day`
   - Expected: `"2025-05-22"` (UTC)
   - Received: `"2025-05-23"` (local KST)

2. `packages/@mantine/dates/src/components/Day/Day.test.tsx`
   - Test case: `adds data-today attribute if date is the same as today`
   - Failed to find expected `data-today` attribute

## Root Cause

The tests were using `new Date().toISOString().split('T')[0]` which returns dates in UTC. This caused failures when the local date (e.g., KST, UTC+9) was different from the UTC date. For example, when it's May 23 in KST, it's still May 22 in UTC.

## Solution

1. **In `get-date-in-tab-order.test.ts`**:
   - Updated the `returns current day` test to use `dayjs().format('YYYY-MM-DD')` for getting the current local date
   - Aligned the `month` parameter with the local date

2. **In `Day.test.tsx`**:
   - Added `dayjs` import
   - Updated the test to use `dayjs().format('YYYY-MM-DD')` when passing the `date` prop to the `Day` component

3. **Code Style**:
   - Ran Prettier to maintain consistent code formatting

## Testing

- All tests in both files now pass successfully
- The components now correctly handle local dates in tests

## Additional Notes

When writing tests that involve dates, it's important to be explicit about timezones. Using `dayjs()` without parameters ensures we're working with the local timezone, which is typically what we want for date component tests.