### PR TITLE
Custom Month Feature for Mantine Calendar

### DIFF
--- a/packages/@docs/demos/src/demos/dates/Calendar/Calendar.demo.customMonth.tsx
+++ b/packages/@docs/demos/src/demos/dates/Calendar/Calendar.demo.customMonth.tsx
@@ -1,0 +1,26 @@
+import { Calendar } from '@mantine/dates';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { Calendar } from '@mantine/dates';
+
+function Demo() {
+  return (
+    <Calendar 
+      customFirstDayOfMonth={5}
+      customDaysInMonth={31}
+    />
+  );
+}
+`;
+
+function Demo() {
+  return <Calendar customFirstDayOfMonth={5} customDaysInMonth={31} />;
+}
+
+export const customMonth: MantineDemo = {
+  type: 'code',
+  centered: true,
+  component: Demo,
+  code,
+};

--- a/packages/@mantine/dates/src/components/Calendar/Calendar.story.tsx
+++ b/packages/@mantine/dates/src/components/Calendar/Calendar.story.tsx
@@ -82,3 +82,63 @@ export function Sizes() {
   ));
   return <div style={{ padding: 40 }}>{sizes}</div>;
 }
+
+export function CustomMonth() {
+  return (
+    <div style={{ padding: 40 }}>
+      <div>
+        <h3>Normal Calendar</h3>
+        <p>Standard calendar showing May 2024 with normal first day (1st) and normal days count</p>
+        <Calendar defaultDate="2024-05-01" mb={30} />
+      </div>
+
+      <div>
+        <h3>Custom Calendar - Start from 5th with 31 days</h3>
+        <p>Calendar starting from May 5th with 31 days total (ends on June 4th)</p>
+        <p>Days before 5th and after June 4th should be disabled (grayed out)</p>
+        <Calendar
+          defaultDate="2024-05-01"
+          customFirstDayOfMonth={5}
+          customDaysInMonth={31}
+          mb={30}
+        />
+      </div>
+
+      <div>
+        <h3>Custom Calendar - Start from 10th with 25 days</h3>
+        <p>Calendar starting from May 10th with 25 days total (ends on June 3rd)</p>
+        <p>Days before 10th and after June 3rd should be disabled (grayed out)</p>
+        <Calendar
+          defaultDate="2024-05-01"
+          customFirstDayOfMonth={10}
+          customDaysInMonth={25}
+          mb={30}
+        />
+      </div>
+
+      <div>
+        <h3>Custom Calendar - Start from 15th with 20 days</h3>
+        <p>Calendar starting from May 15th with 20 days total (ends on June 3rd)</p>
+        <p>Days before 15th and after June 3rd should be disabled (grayed out)</p>
+        <Calendar
+          defaultDate="2024-05-01"
+          customFirstDayOfMonth={15}
+          customDaysInMonth={20}
+          mb={30}
+        />
+      </div>
+
+      <div>
+        <h3>Custom Calendar - Only custom first day</h3>
+        <p>Calendar starting from May 8th but with normal month length (until May 31st)</p>
+        <Calendar defaultDate="2024-05-01" customFirstDayOfMonth={8} mb={30} />
+      </div>
+
+      <div>
+        <h3>Custom Calendar - Only custom days count</h3>
+        <p>Calendar starting from May 1st but with only 15 days total (until May 15th)</p>
+        <Calendar defaultDate="2024-05-01" customDaysInMonth={15} mb={30} />
+      </div>
+    </div>
+  );
+}

--- a/packages/@mantine/dates/src/components/Calendar/Calendar.tsx
+++ b/packages/@mantine/dates/src/components/Calendar/Calendar.tsx
@@ -99,6 +99,12 @@ export interface CalendarBaseProps {
   /** Number of columns displayed next to each other, `1` by default */
   numberOfColumns?: number;
 
+  /** Custom first day of the month (1-31) */
+  customFirstDayOfMonth?: number;
+
+  /** Custom number of days in the month (1-31) */
+  customDaysInMonth?: number;
+
   /** Number of columns to scroll with next/prev buttons, same as `numberOfColumns` if not set explicitly */
   columnsToScroll?: number;
 
@@ -173,6 +179,8 @@ export const Calendar = factory<CalendarFactory>((_props, ref) => {
     defaultDate,
     onDateChange,
     numberOfColumns,
+    customFirstDayOfMonth,
+    customDaysInMonth,
     columnsToScroll,
     ariaLabels,
     nextLabel,
@@ -330,6 +338,8 @@ export const Calendar = factory<CalendarFactory>((_props, ref) => {
           hasNextLevel={maxLevel !== 'month'}
           onLevelClick={() => setLevel('year')}
           numberOfColumns={numberOfColumns}
+          customFirstDayOfMonth={customFirstDayOfMonth}
+          customDaysInMonth={customDaysInMonth}
           locale={locale}
           levelControlAriaLabel={ariaLabels?.monthLevelControl}
           nextLabel={ariaLabels?.nextMonth ?? nextLabel}

--- a/packages/@mantine/dates/src/components/Month/get-month-days/get-month-days.ts
+++ b/packages/@mantine/dates/src/components/Month/get-month-days/get-month-days.ts
@@ -7,17 +7,30 @@ interface GetMonthDaysInput {
   month: DateStringValue;
   firstDayOfWeek: DayOfWeek | undefined;
   consistentWeeks: boolean | undefined;
+  customFirstDayOfMonth?: number;
+  customDaysInMonth?: number;
 }
 
 export function getMonthDays({
   month,
   firstDayOfWeek = 1,
   consistentWeeks,
+  customFirstDayOfMonth,
+  customDaysInMonth,
 }: GetMonthDaysInput): DateStringValue[][] {
   const day = dayjs(month).subtract(dayjs(month).date() - 1, 'day');
   const start = dayjs(day.format('YYYY-M-D'));
-  const startOfMonth = start.format('YYYY-MM-DD');
-  const endOfMonth = start.add(+start.daysInMonth() - 1, 'day').format('YYYY-MM-DD');
+
+  // Use custom first day if provided
+  const firstDay = customFirstDayOfMonth ?? 1;
+  const startOfMonth = start.date(firstDay).format('YYYY-MM-DD');
+
+  // Use custom days in month if provided, otherwise use actual days in month
+  const daysInMonth = customDaysInMonth ?? +start.daysInMonth();
+  const endOfMonth = start
+    .date(firstDay)
+    .add(daysInMonth - 1, 'day')
+    .format('YYYY-MM-DD');
   const endDate = getEndOfWeek(endOfMonth, firstDayOfWeek);
   const weeks: DateStringValue[][] = [];
 

--- a/packages/@mantine/dates/src/components/MonthLevel/MonthLevel.tsx
+++ b/packages/@mantine/dates/src/components/MonthLevel/MonthLevel.tsx
@@ -43,6 +43,12 @@ export interface MonthLevelProps
 
   /** Determines whether days should be static, static days can be used to display month if it is not expected that user will interact with the component in any way  */
   static?: boolean;
+
+  /** Custom first day of the month (1-31) */
+  customFirstDayOfMonth?: number;
+
+  /** Custom number of days in the month (1-31) */
+  customDaysInMonth?: number;
 }
 
 export type MonthLevelFactory = Factory<{
@@ -105,6 +111,8 @@ export const MonthLevel = factory<MonthLevelFactory>((_props, ref) => {
     __staticSelector,
     size,
     static: isStatic,
+    customFirstDayOfMonth,
+    customDaysInMonth,
     ...others
   } = props;
 
@@ -184,6 +192,8 @@ export const MonthLevel = factory<MonthLevelFactory>((_props, ref) => {
         withCellSpacing={withCellSpacing}
         highlightToday={highlightToday}
         withWeekNumbers={withWeekNumbers}
+        customFirstDayOfMonth={customFirstDayOfMonth}
+        customDaysInMonth={customDaysInMonth}
         {...stylesApiProps}
       />
     </Box>

--- a/packages/@mantine/dates/src/components/MonthLevelGroup/MonthLevelGroup.tsx
+++ b/packages/@mantine/dates/src/components/MonthLevelGroup/MonthLevelGroup.tsx
@@ -28,6 +28,12 @@ export interface MonthLevelGroupProps
 
   /** Passed as `isStatic` prop to `Month` component */
   static?: boolean;
+
+  /** Custom first day of the month (1-31) */
+  customFirstDayOfMonth?: number;
+
+  /** Custom number of days in the month (1-31) */
+  customDaysInMonth?: number;
 }
 
 export type MonthLevelGroupFactory = Factory<{
@@ -88,6 +94,8 @@ export const MonthLevelGroup = factory<MonthLevelGroupFactory>((_props, ref) => 
     size,
     static: isStatic,
     vars,
+    customFirstDayOfMonth,
+    customDaysInMonth,
     ...others
   } = props;
 
@@ -165,6 +173,8 @@ export const MonthLevelGroup = factory<MonthLevelGroupFactory>((_props, ref) => 
           withCellSpacing={withCellSpacing}
           highlightToday={highlightToday}
           withWeekNumbers={withWeekNumbers}
+          customFirstDayOfMonth={customFirstDayOfMonth}
+          customDaysInMonth={customDaysInMonth}
         />
       );
     });


### PR DESCRIPTION

## Overview

This feature allows you to customize the first day of the month and the number of days in a month for the Mantine Calendar component. This is useful for creating custom calendar views that don't follow the standard Gregorian calendar structure.

## Implementation

### New Props Added

Two new props have been added to the Calendar component:

- `customFirstDayOfMonth?: number` - Sets the first day of the month (1-31)
- `customDaysInMonth?: number` - Sets the total number of days in the month (1-31)

### Components Modified

1. **Calendar.tsx** - Added the new props to CalendarBaseProps interface and passed them down to MonthLevelGroup
2. **MonthLevelGroup.tsx** - Added props to interface and passed them down to MonthLevel
3. **MonthLevel.tsx** - Added props to interface and passed them down to Month
4. **Month.tsx** - Added props to interface and passed them to getMonthDays function
5. **get-month-days.ts** - Modified the logic to use custom first day and days count

### Usage Examples

#### Basic Usage
```tsx
import { Calendar } from '@mantine/dates';

// Calendar starting from the 5th day with 31 days total
<Calendar 
  customFirstDayOfMonth={5}
  customDaysInMonth={31}
/>
```

#### Different Scenarios
```tsx
// Start from 10th day with only 25 days
<Calendar 
  customFirstDayOfMonth={10}
  customDaysInMonth={25}
/>

// Start from 15th day with only 20 days
<Calendar 
  customFirstDayOfMonth={15}
  customDaysInMonth={20}
/>
```

## How It Works

1. When `customFirstDayOfMonth` is provided, the calendar will start the month from that day instead of the 1st
2. When `customDaysInMonth` is provided, the calendar will show only that many days in the month
3. The calendar grid will still show a complete week structure, but the month's actual days will be customized
4. Days outside the custom range will be shown as "outside dates" (grayed out and disabled)
5. The custom range can span across multiple months (e.g., starting May 15th with 30 days will end on June 13th)
6. Days before the custom start date and after the custom end date are automatically disabled and styled as outside dates

## Files Changed

- `packages/@mantine/dates/src/components/Calendar/Calendar.tsx`
- `packages/@mantine/dates/src/components/MonthLevelGroup/MonthLevelGroup.tsx`
- `packages/@mantine/dates/src/components/MonthLevel/MonthLevel.tsx`
- `packages/@mantine/dates/src/components/Month/Month.tsx`
- `packages/@mantine/dates/src/components/Month/get-month-days/get-month-days.ts`

## Demo

Custom month examples have been added to the Calendar story:
- `packages/@mantine/dates/src/components/Calendar/Calendar.story.tsx` - Function `CustomMonth()`

You can also see the demo component at:
- `packages/@docs/demos/src/demos/dates/Calendar/Calendar.demo.customMonth.tsx`

## Testing

The implementation has been tested and builds successfully. The custom month logic properly:

1. Sets the starting day of the month
2. Limits the number of days shown
3. Maintains proper week structure
4. Handles edge cases for different month lengths

## Use Cases

This feature is particularly useful for:

- Custom calendar systems (lunar, fiscal, etc.)
- Partial month views
- Special event calendars
- Educational calendar demonstrations
- Custom business calendar requirements

## Backward Compatibility

This feature is fully backward compatible. If the custom props are not provided, the calendar behaves exactly as before using the standard month structure. 