### PR TITLE
enhance HoverCard component with group delay logic

### DIFF
--- a/apps/mantine.dev/src/pages/core/hover-card.mdx
+++ b/apps/mantine.dev/src/pages/core/hover-card.mdx
@@ -14,6 +14,12 @@ Set open and close delays in ms with `openDelay` and `closeDelay` props:
 
 <Demo data={HoverCardDemos.delay} />
 
+## HoverCard delay group
+
+`HoverCard.Group` component can be used to sync open and close delays for multiple hover cards:
+
+<Demo data={HoverCardDemos.group} />
+
 ## With interactive elements
 
 `HoverCard` is displayed only when the mouse is over the target element or dropdown,

--- a/packages/@docs/demos/src/demos/core/HoverCard/HoverCard.demo.group.tsx
+++ b/packages/@docs/demos/src/demos/core/HoverCard/HoverCard.demo.group.tsx
@@ -42,7 +42,7 @@ function Demo() {
 
 function Demo() {
   return (
-    <HoverCard.Group openDelay={500} closeDelay={100}>
+    <HoverCard.Group openDelay={2000} closeDelay={100}>
       <Group justify="center">
         <HoverCard shadow="md">
           <HoverCard.Target>
@@ -79,4 +79,4 @@ export const group: MantineDemo = {
   type: 'code',
   component: Demo,
   code,
-}; 
+};

--- a/packages/@docs/demos/src/demos/core/HoverCard/HoverCard.demo.group.tsx
+++ b/packages/@docs/demos/src/demos/core/HoverCard/HoverCard.demo.group.tsx
@@ -1,0 +1,82 @@
+import { Button, Group, HoverCard, Text } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { HoverCard, Button, Text, Group } from '@mantine/core';
+
+function Demo() {
+  return (
+    <HoverCard.Group openDelay={500} closeDelay={100}>
+      <Group justify="center">
+        <HoverCard shadow="md">
+          <HoverCard.Target>
+            <Button>HoverCard 1</Button>
+          </HoverCard.Target>
+          <HoverCard.Dropdown>
+            <Text size="sm">First hover card content</Text>
+          </HoverCard.Dropdown>
+        </HoverCard>
+
+        <HoverCard shadow="md">
+          <HoverCard.Target>
+            <Button>HoverCard 2</Button>
+          </HoverCard.Target>
+          <HoverCard.Dropdown>
+            <Text size="sm">Second hover card content</Text>
+          </HoverCard.Dropdown>
+        </HoverCard>
+
+        <HoverCard shadow="md">
+          <HoverCard.Target>
+            <Button>HoverCard 3</Button>
+          </HoverCard.Target>
+          <HoverCard.Dropdown>
+            <Text size="sm">Third hover card content</Text>
+          </HoverCard.Dropdown>
+        </HoverCard>
+      </Group>
+    </HoverCard.Group>
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <HoverCard.Group openDelay={500} closeDelay={100}>
+      <Group justify="center">
+        <HoverCard shadow="md">
+          <HoverCard.Target>
+            <Button>HoverCard 1</Button>
+          </HoverCard.Target>
+          <HoverCard.Dropdown>
+            <Text size="sm">First hover card content</Text>
+          </HoverCard.Dropdown>
+        </HoverCard>
+
+        <HoverCard shadow="md">
+          <HoverCard.Target>
+            <Button>HoverCard 2</Button>
+          </HoverCard.Target>
+          <HoverCard.Dropdown>
+            <Text size="sm">Second hover card content</Text>
+          </HoverCard.Dropdown>
+        </HoverCard>
+
+        <HoverCard shadow="md">
+          <HoverCard.Target>
+            <Button>HoverCard 3</Button>
+          </HoverCard.Target>
+          <HoverCard.Dropdown>
+            <Text size="sm">Third hover card content</Text>
+          </HoverCard.Dropdown>
+        </HoverCard>
+      </Group>
+    </HoverCard.Group>
+  );
+}
+
+export const group: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+}; 

--- a/packages/@docs/demos/src/demos/core/HoverCard/HoverCard.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/core/HoverCard/HoverCard.demos.story.tsx
@@ -17,3 +17,8 @@ export const Demo_delay = {
   name: '⭐ Demo: delay',
   render: renderDemo(demos.delay),
 };
+
+export const Demo_group = {
+  name: '⭐ Demo: group',
+  render: renderDemo(demos.group),
+};

--- a/packages/@docs/demos/src/demos/core/HoverCard/index.ts
+++ b/packages/@docs/demos/src/demos/core/HoverCard/index.ts
@@ -1,3 +1,4 @@
 export { usage } from './HoverCard.demo.usage';
 export { profile } from './HoverCard.demo.profile';
 export { delay } from './HoverCard.demo.delay';
+export { group } from './HoverCard.demo.group';

--- a/packages/@mantine/core/src/components/HoverCard/HoverCard.context.ts
+++ b/packages/@mantine/core/src/components/HoverCard/HoverCard.context.ts
@@ -3,6 +3,10 @@ import { createSafeContext } from '../../core';
 interface HoverCardContext {
   openDropdown: () => void;
   closeDropdown: () => void;
+  getReferenceProps?: () => any;
+  getFloatingProps?: () => any;
+  reference?: (node: HTMLElement | null) => void;
+  floating?: (node: HTMLElement | null) => void;
 }
 
 export const [HoverCardContextProvider, useHoverCardContext] = createSafeContext<HoverCardContext>(

--- a/packages/@mantine/core/src/components/HoverCard/HoverCard.story.tsx
+++ b/packages/@mantine/core/src/components/HoverCard/HoverCard.story.tsx
@@ -76,3 +76,40 @@ export function WithSwitch() {
     </div>
   );
 }
+
+export function Group() {
+  return (
+    <div style={{ padding: 40 }}>
+      <HoverCard.Group openDelay={500} closeDelay={100}>
+        <div style={{ display: 'flex', gap: 16, justifyContent: 'center' }}>
+          <HoverCard shadow="md">
+            <HoverCard.Target>
+              <Button>HoverCard 1</Button>
+            </HoverCard.Target>
+            <HoverCard.Dropdown>
+              <p>First hover card content with group delay</p>
+            </HoverCard.Dropdown>
+          </HoverCard>
+
+          <HoverCard shadow="md">
+            <HoverCard.Target>
+              <Button>HoverCard 2</Button>
+            </HoverCard.Target>
+            <HoverCard.Dropdown>
+              <p>Second hover card content with group delay</p>
+            </HoverCard.Dropdown>
+          </HoverCard>
+
+          <HoverCard shadow="md">
+            <HoverCard.Target>
+              <Button>HoverCard 3</Button>
+            </HoverCard.Target>
+            <HoverCard.Dropdown>
+              <p>Third hover card content with group delay</p>
+            </HoverCard.Dropdown>
+          </HoverCard>
+        </div>
+      </HoverCard.Group>
+    </div>
+  );
+}

--- a/packages/@mantine/core/src/components/HoverCard/HoverCard.tsx
+++ b/packages/@mantine/core/src/components/HoverCard/HoverCard.tsx
@@ -1,14 +1,11 @@
-import { useDisclosure } from '@mantine/hooks';
 import { ExtendComponent, Factory, useProps } from '../../core';
-import { useDelayedHover } from '../Floating';
 import { Popover, PopoverProps, PopoverStylesNames } from '../Popover';
 import { PopoverCssVariables } from '../Popover/Popover';
 import { HoverCardContextProvider } from './HoverCard.context';
 import { HoverCardDropdown } from './HoverCardDropdown/HoverCardDropdown';
-import { HoverCardTarget } from './HoverCardTarget/HoverCardTarget';
 import { HoverCardGroup } from './HoverCardGroup/HoverCardGroup';
+import { HoverCardTarget } from './HoverCardTarget/HoverCardTarget';
 import { useHoverCard } from './use-hover-card';
-import { useHoverCardGroupContext } from './HoverCardGroup/HoverCardGroup.context';
 
 export interface HoverCardProps extends Omit<PopoverProps, 'opened' | 'onChange'> {
   variant?: string;
@@ -48,45 +45,26 @@ export function HoverCard(props: HoverCardProps) {
     props
   );
 
-  const withinGroup = useHoverCardGroupContext();
+  const hoverCard = useHoverCard({
+    openDelay,
+    closeDelay,
+    defaultOpened: initiallyOpened,
+    onOpen,
+    onClose,
+  });
 
-  // Use the new hook if within a group, otherwise use the legacy implementation
-  if (withinGroup) {
-    const hoverCard = useHoverCard({
-      openDelay,
-      closeDelay,
-      defaultOpened: initiallyOpened,
-      onOpen,
-      onClose,
-    });
-
-    // For group mode, we don't need the legacy delayed hover since the group handles delays
-    const openDropdown = () => { };
-    const closeDropdown = () => { };
-
-    return (
-      <HoverCardContextProvider value={{
-        openDropdown,
-        closeDropdown,
+  return (
+    <HoverCardContextProvider
+      value={{
+        openDropdown: hoverCard.openDropdown,
+        closeDropdown: hoverCard.closeDropdown,
         getReferenceProps: hoverCard.getReferenceProps,
         getFloatingProps: hoverCard.getFloatingProps,
         reference: hoverCard.reference,
         floating: hoverCard.floating,
-      }}>
-        <Popover {...others} opened={hoverCard.opened} __staticSelector="HoverCard">
-          {children}
-        </Popover>
-      </HoverCardContextProvider>
-    );
-  }
-
-  // Legacy implementation for backward compatibility
-  const [opened, { open, close }] = useDisclosure(initiallyOpened, { onClose, onOpen });
-  const { openDropdown, closeDropdown } = useDelayedHover({ open, close, openDelay, closeDelay });
-
-  return (
-    <HoverCardContextProvider value={{ openDropdown, closeDropdown }}>
-      <Popover {...others} opened={opened} __staticSelector="HoverCard">
+      }}
+    >
+      <Popover {...others} opened={hoverCard.opened} __staticSelector="HoverCard">
         {children}
       </Popover>
     </HoverCardContextProvider>

--- a/packages/@mantine/core/src/components/HoverCard/HoverCardDropdown/HoverCardDropdown.tsx
+++ b/packages/@mantine/core/src/components/HoverCard/HoverCardDropdown/HoverCardDropdown.tsx
@@ -20,7 +20,6 @@ export function HoverCardDropdown(props: HoverCardDropdownProps) {
   const ctx = useHoverCardContext();
   const withinGroup = useHoverCardGroupContext();
 
-  // Use group-aware event handlers if within a group
   if (withinGroup && ctx.getFloatingProps && ctx.floating) {
     const floatingProps = ctx.getFloatingProps();
 
@@ -37,7 +36,6 @@ export function HoverCardDropdown(props: HoverCardDropdownProps) {
     );
   }
 
-  // Legacy implementation
   const handleMouseEnter = createEventHandler<any>(onMouseEnter, ctx.openDropdown);
   const handleMouseLeave = createEventHandler<any>(onMouseLeave!, ctx.closeDropdown);
 

--- a/packages/@mantine/core/src/components/HoverCard/HoverCardDropdown/HoverCardDropdown.tsx
+++ b/packages/@mantine/core/src/components/HoverCard/HoverCardDropdown/HoverCardDropdown.tsx
@@ -1,6 +1,7 @@
 import { createEventHandler, useProps } from '../../../core';
 import { Popover, PopoverDropdownProps } from '../../Popover';
 import { useHoverCardContext } from '../HoverCard.context';
+import { useHoverCardGroupContext } from '../HoverCardGroup/HoverCardGroup.context';
 
 export interface HoverCardDropdownProps extends PopoverDropdownProps {
   /** Dropdown content */
@@ -17,7 +18,26 @@ export function HoverCardDropdown(props: HoverCardDropdownProps) {
   );
 
   const ctx = useHoverCardContext();
+  const withinGroup = useHoverCardGroupContext();
 
+  // Use group-aware event handlers if within a group
+  if (withinGroup && ctx.getFloatingProps && ctx.floating) {
+    const floatingProps = ctx.getFloatingProps();
+
+    return (
+      <Popover.Dropdown
+        ref={ctx.floating}
+        {...floatingProps}
+        onMouseEnter={createEventHandler<any>(onMouseEnter, floatingProps.onMouseEnter)}
+        onMouseLeave={createEventHandler<any>(onMouseLeave, floatingProps.onMouseLeave)}
+        {...others}
+      >
+        {children}
+      </Popover.Dropdown>
+    );
+  }
+
+  // Legacy implementation
   const handleMouseEnter = createEventHandler<any>(onMouseEnter, ctx.openDropdown);
   const handleMouseLeave = createEventHandler<any>(onMouseLeave!, ctx.closeDropdown);
 

--- a/packages/@mantine/core/src/components/HoverCard/HoverCardGroup/HoverCardGroup.context.ts
+++ b/packages/@mantine/core/src/components/HoverCard/HoverCardGroup/HoverCardGroup.context.ts
@@ -3,4 +3,4 @@ import { createContext, useContext } from 'react';
 const HoverCardGroupContext = createContext(false);
 
 export const HoverCardGroupProvider = HoverCardGroupContext.Provider;
-export const useHoverCardGroupContext = () => useContext(HoverCardGroupContext); 
+export const useHoverCardGroupContext = () => useContext(HoverCardGroupContext);

--- a/packages/@mantine/core/src/components/HoverCard/HoverCardGroup/HoverCardGroup.context.ts
+++ b/packages/@mantine/core/src/components/HoverCard/HoverCardGroup/HoverCardGroup.context.ts
@@ -1,0 +1,6 @@
+import { createContext, useContext } from 'react';
+
+const HoverCardGroupContext = createContext(false);
+
+export const HoverCardGroupProvider = HoverCardGroupContext.Provider;
+export const useHoverCardGroupContext = () => useContext(HoverCardGroupContext); 

--- a/packages/@mantine/core/src/components/HoverCard/HoverCardGroup/HoverCardGroup.tsx
+++ b/packages/@mantine/core/src/components/HoverCard/HoverCardGroup/HoverCardGroup.tsx
@@ -1,0 +1,38 @@
+import { FloatingDelayGroup } from '@floating-ui/react';
+import { ExtendComponent, Factory, MantineThemeComponent, useProps } from '../../../core';
+import { HoverCardGroupProvider } from './HoverCardGroup.context';
+
+export interface HoverCardGroupProps {
+  /** <HoverCard /> components */
+  children: React.ReactNode;
+
+  /** Open delay in ms */
+  openDelay?: number;
+
+  /** Close delay in ms */
+  closeDelay?: number;
+}
+
+const defaultProps: Partial<HoverCardGroupProps> = {
+  openDelay: 0,
+  closeDelay: 0,
+};
+
+export function HoverCardGroup(props: HoverCardGroupProps) {
+  const { openDelay, closeDelay, children } = useProps('HoverCardGroup', defaultProps, props);
+
+  return (
+    <HoverCardGroupProvider value>
+      <FloatingDelayGroup delay={{ open: openDelay, close: closeDelay }}>
+        {children}
+      </FloatingDelayGroup>
+    </HoverCardGroupProvider>
+  );
+}
+
+export type HoverCardGroupFactory = Factory<{
+  props: HoverCardGroupProps;
+}>;
+
+HoverCardGroup.displayName = '@mantine/core/HoverCardGroup';
+HoverCardGroup.extend = (c: ExtendComponent<HoverCardGroupFactory>): MantineThemeComponent => c; 

--- a/packages/@mantine/core/src/components/HoverCard/HoverCardGroup/HoverCardGroup.tsx
+++ b/packages/@mantine/core/src/components/HoverCard/HoverCardGroup/HoverCardGroup.tsx
@@ -35,4 +35,4 @@ export type HoverCardGroupFactory = Factory<{
 }>;
 
 HoverCardGroup.displayName = '@mantine/core/HoverCardGroup';
-HoverCardGroup.extend = (c: ExtendComponent<HoverCardGroupFactory>): MantineThemeComponent => c; 
+HoverCardGroup.extend = (c: ExtendComponent<HoverCardGroupFactory>): MantineThemeComponent => c;

--- a/packages/@mantine/core/src/components/HoverCard/HoverCardTarget/HoverCardTarget.tsx
+++ b/packages/@mantine/core/src/components/HoverCard/HoverCardTarget/HoverCardTarget.tsx
@@ -2,6 +2,7 @@ import { cloneElement, forwardRef } from 'react';
 import { createEventHandler, isElement, useProps } from '../../../core';
 import { Popover, PopoverTargetProps } from '../../Popover';
 import { useHoverCardContext } from '../HoverCard.context';
+import { useHoverCardGroupContext } from '../HoverCardGroup/HoverCardGroup.context';
 
 export interface HoverCardTargetProps extends PopoverTargetProps {
   /** Key of the prop that is used to pass event listeners, by default event listeners are passed directly to component */
@@ -26,6 +27,25 @@ export const HoverCardTarget = forwardRef<HTMLElement, HoverCardTargetProps>((pr
   }
 
   const ctx = useHoverCardContext();
+  const withinGroup = useHoverCardGroupContext();
+
+  // Use group-aware event handlers if within a group
+  if (withinGroup && ctx.getReferenceProps && ctx.reference) {
+    const referenceProps = ctx.getReferenceProps();
+
+    return (
+      <Popover.Target refProp={refProp} ref={ref} {...others}>
+        {cloneElement(
+          children as React.ReactElement,
+          eventPropsWrapperName
+            ? { [eventPropsWrapperName]: { ...referenceProps, ref: ctx.reference } }
+            : { ...referenceProps, ref: ctx.reference }
+        )}
+      </Popover.Target>
+    );
+  }
+
+  // Legacy implementation
   const onMouseEnter = createEventHandler((children.props as any).onMouseEnter, ctx.openDropdown);
   const onMouseLeave = createEventHandler((children.props as any).onMouseLeave, ctx.closeDropdown);
 

--- a/packages/@mantine/core/src/components/HoverCard/HoverCardTarget/HoverCardTarget.tsx
+++ b/packages/@mantine/core/src/components/HoverCard/HoverCardTarget/HoverCardTarget.tsx
@@ -29,7 +29,6 @@ export const HoverCardTarget = forwardRef<HTMLElement, HoverCardTargetProps>((pr
   const ctx = useHoverCardContext();
   const withinGroup = useHoverCardGroupContext();
 
-  // Use group-aware event handlers if within a group
   if (withinGroup && ctx.getReferenceProps && ctx.reference) {
     const referenceProps = ctx.getReferenceProps();
 
@@ -45,7 +44,6 @@ export const HoverCardTarget = forwardRef<HTMLElement, HoverCardTargetProps>((pr
     );
   }
 
-  // Legacy implementation
   const onMouseEnter = createEventHandler((children.props as any).onMouseEnter, ctx.openDropdown);
   const onMouseLeave = createEventHandler((children.props as any).onMouseLeave, ctx.closeDropdown);
 

--- a/packages/@mantine/core/src/components/HoverCard/index.ts
+++ b/packages/@mantine/core/src/components/HoverCard/index.ts
@@ -1,7 +1,9 @@
 export { HoverCard } from './HoverCard';
 export { HoverCardDropdown } from './HoverCardDropdown/HoverCardDropdown';
 export { HoverCardTarget } from './HoverCardTarget/HoverCardTarget';
+export { HoverCardGroup } from './HoverCardGroup/HoverCardGroup';
 
 export type { HoverCardProps } from './HoverCard';
 export type { HoverCardDropdownProps } from './HoverCardDropdown/HoverCardDropdown';
 export type { HoverCardTargetProps } from './HoverCardTarget/HoverCardTarget';
+export type { HoverCardGroupProps } from './HoverCardGroup/HoverCardGroup';

--- a/packages/@mantine/core/src/components/HoverCard/use-hover-card.ts
+++ b/packages/@mantine/core/src/components/HoverCard/use-hover-card.ts
@@ -1,0 +1,66 @@
+import { useCallback, useState } from 'react';
+import {
+  useDelayGroup,
+  useFloating,
+  useHover,
+  useInteractions,
+  useRole,
+  useDismiss,
+} from '@floating-ui/react';
+import { useId } from '@mantine/hooks';
+import { useHoverCardGroupContext } from './HoverCardGroup/HoverCardGroup.context';
+
+interface UseHoverCard {
+  openDelay?: number;
+  closeDelay?: number;
+  opened?: boolean;
+  defaultOpened?: boolean;
+  onOpen?: () => void;
+  onClose?: () => void;
+}
+
+export function useHoverCard(settings: UseHoverCard) {
+  const [uncontrolledOpened, setUncontrolledOpened] = useState(settings.defaultOpened);
+  const controlled = typeof settings.opened === 'boolean';
+  const opened = controlled ? settings.opened : uncontrolledOpened;
+  const withinGroup = useHoverCardGroupContext();
+  const uid = useId();
+
+  const onChange = useCallback(
+    (_opened: boolean) => {
+      setUncontrolledOpened(_opened);
+
+      if (_opened) {
+        setCurrentId(uid);
+        settings.onOpen?.();
+      } else {
+        settings.onClose?.();
+      }
+    },
+    [uid, settings.onOpen, settings.onClose]
+  );
+
+  const { context, refs } = useFloating({
+    open: opened,
+    onOpenChange: onChange,
+  });
+
+  const { delay: groupDelay, setCurrentId } = useDelayGroup(context, { id: uid });
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    useHover(context, {
+      enabled: true,
+      delay: withinGroup ? groupDelay : { open: settings.openDelay, close: settings.closeDelay },
+    }),
+    useRole(context, { role: 'dialog' }),
+    useDismiss(context, { enabled: typeof settings.opened === 'undefined' }),
+  ]);
+
+  return {
+    opened,
+    reference: refs.setReference,
+    floating: refs.setFloating,
+    getReferenceProps,
+    getFloatingProps,
+  };
+} 

--- a/packages/@mantine/core/src/components/HoverCard/use-hover-card.ts
+++ b/packages/@mantine/core/src/components/HoverCard/use-hover-card.ts
@@ -90,7 +90,7 @@ export function useHoverCard(settings: UseHoverCard) {
     }
   }, [withinGroup, clearTimeouts, settings.closeDelay, onChange]);
 
-  useEffect(() => clearTimeouts, [clearTimeouts]);
+  useEffect(() => () => clearTimeouts(), [clearTimeouts]);
 
   return {
     opened,


### PR DESCRIPTION
### Summary

This pull request introduces improvements to the `HoverCard` component:

- Refactored `HoverCard` to simplify group handling and centralize delay logic using the `use-hover-card` hook.
- Added `HoverCard.Group` to synchronize open/close delays across multiple `HoverCard` components.
- Updated demo examples to showcase the new group functionality and delay timing.
- Performed minor cleanups, including import consistency, removal of unused code, and compliance with formatting standards.