### PR TITLE
[@mantine/core] Fix: MenuSub defaultProps docs

### DIFF
--- a/packages/@mantine/core/src/components/Menu/MenuSub/MenuSub.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuSub/MenuSub.tsx
@@ -1,7 +1,8 @@
 import { useDisclosure, useId } from '@mantine/hooks';
 import { ExtendComponent, Factory, useProps } from '../../../core';
-import { useDelayedHover } from '../../Floating';
+import { FloatingAxesOffsets, FloatingPosition, useDelayedHover } from '../../Floating';
 import { __PopoverProps, Popover } from '../../Popover';
+import { TransitionOverride } from '../../Transition';
 import { MenuSubDropdown } from '../MenuSubDropdown/MenuSubDropdown';
 import { MenuSubItem } from '../MenuSubItem/MenuSubItem';
 import { MenuSubTarget } from '../MenuSubTarget/MenuSubTarget';
@@ -16,6 +17,15 @@ interface MenuSubProps extends __PopoverProps {
 
   /** Close delay in ms */
   closeDelay?: number;
+
+  /** Dropdown position relative to the target element, `'right-start'` by default */
+  position?: FloatingPosition;
+
+  /** Offset of the dropdown element, `0` by default */
+  offset?: number | FloatingAxesOffsets;
+
+  /** Props passed down to the `Transition` component that used to animate dropdown presence, use to configure duration and animation type, `{ duration: 150, transition: 'fade' }` by default */
+  transitionProps?: TransitionOverride;
 }
 
 const defaultProps: Partial<MenuSubProps> = {


### PR DESCRIPTION
`Menu.Sub` has the following default props:

```tsx
// packages/@mantine/core/src/components/Menu/MenuSub/MenuSub.tsx

const defaultProps: Partial<MenuSubProps> = {
  offset: 0,
  position: 'right-start',
  transitionProps: { duration: 0 },
};
```

But the documentation(for props) currently looks like(see *Menu.Sub component props* https://mantine.dev/core/menu/?t=props):

![image](https://github.com/user-attachments/assets/80fed67a-d132-4e47-9cbc-b7008051b69d)

![image](https://github.com/user-attachments/assets/a4bd035f-ebd6-41ec-8a1f-5a34e2468362)

![image](https://github.com/user-attachments/assets/28c009c0-37cb-4b9e-8aea-221797cedf3c)

While implementing the Menu.Sub component with Popover, it seemed that the documentation had not been updated, so we updated it.

After:

![image](https://github.com/user-attachments/assets/73343bea-d562-4d59-8535-f769c0b23432)

![image](https://github.com/user-attachments/assets/29b45c67-46bd-4ca9-8225-82522a15e241)

![image](https://github.com/user-attachments/assets/d4e8c63c-dbca-4179-bd77-aabb4bc63cb6)
