### PR TITLE
fix(Collapse): Fix inert attribute handling for React 18 compatibility

### DIFF
--- a/packages/@mantine/core/src/components/Collapse/use-collapse.ts
+++ b/packages/@mantine/core/src/components/Collapse/use-collapse.ts
@@ -107,16 +107,23 @@ export function useCollapse({
 
   function getCollapseProps({ style = {}, refKey = 'ref', ...rest }: GetCollapseProps = {}) {
     const theirRef: any = rest[refKey];
-    const props = {
+    const props: any = {
       'aria-hidden': !opened,
-      inert: !opened,
       ...rest,
       [refKey]: mergeRefs(el, theirRef),
       onTransitionEnd: handleTransitionEnd,
       style: { boxSizing: 'border-box', ...style, ...styles },
     };
 
-    if (!React.version.startsWith('18')) {
+    // Handle inert attribute based on React version
+    if (React.version.startsWith('18')) {
+      // React 18: Use empty string for inert=true, undefined for inert=false
+      if (!opened) {
+        props.inert = '';
+      }
+      // Don't set inert property when opened=true (leave it undefined)
+    } else {
+      // React 19+: Use boolean values
       props.inert = !opened;
     }
 


### PR DESCRIPTION
## What
Fixes incorrect `inert` attribute handling in the Collapse component for React 18 compatibility.

## Problem
The current implementation has backwards logic for React version detection and always sets the `inert` attribute as a boolean, which causes warnings in React 18:

`Warning: Received false for a non-boolean attribute inert.`


## Solution
- **React 18**: Use empty string `''` for `inert=true`, `undefined` for `inert=false`
- **React 19+**: Use boolean values (`true`/`false`)
- Fixed the backwards conditional logic that was checking `!React.version.startsWith('18')`

## Changes
- Updated `getCollapseProps` function in `use-collapse.ts` to properly handle `inert` attribute based on React version
- Added proper TypeScript handling with `any` type for props object to allow dynamic property assignment

## Testing
- All existing Collapse component tests pass
- Verified TypeScript compilation succeeds for the core component
- Manual testing confirms proper `inert` attribute behavior in both React versions