### PR TITLE
Update link to "getting started" page in submit-template.mdx

### DIFF
--- a/apps/help.mantine.dev/src/pages/q/submit-template.mdx
+++ b/apps/help.mantine.dev/src/pages/q/submit-template.mdx
@@ -47,4 +47,4 @@ Template examples:
 - Go to repository settings and enable the "Template repository" option
 - Make sure that your template has all the properties listed above
 - Submit your template by creating [an issue on Github](https://github.com/mantinedev/mantine/issues/new/choose)
-- After your template is reviewed, it will be added to the [getting started](/getting-started/) page
+- After your template is reviewed, it will be added to the [getting started](https://mantine.dev/getting-started/) page


### PR DESCRIPTION
### Description
This PR fixes a broken link in the `submit-template.mdx` file.

The previous link to the "getting started" page was incorrectly formatted or missing a valid URL.  
I've updated it to point directly to the correct page:  
[https://mantine.dev/getting-started/](https://mantine.dev/getting-started/)

### Changes
- Replaced broken `[getting started]` link with a valid one.

This should help users find the correct documentation after submitting their template.