### PR TITLE
fix: properly configure rollup replace plugin for env variable replac…

### DIFF
--- a/scripts/build/rollup/create-package-config.ts
+++ b/scripts/build/rollup/create-package-config.ts
@@ -26,7 +26,11 @@ export function createPackageConfig(packagePath: string): RollupOptions {
       tsconfig: getPath('tsconfig.json'),
     }),
     alias({ entries: aliasEntries }),
-    replace({ preventAssignment: true }),
+   replace({
+  preventAssignment: true,
+  'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'production'),
+}),
+
     postcss({
       extract: true,
       modules: { generateScopedName },


### PR DESCRIPTION
### Fix: Properly configure Rollup replace plugin

Replaced the ineffective `replace({ preventAssignment: true })` with a working setup to inject `process.env.NODE_ENV`.  
This enables environment-specific optimizations and reduces bundle size in production builds.
