### PR TITLE
[@mantine/cone] Fix focus loss on tab navigation when Combobox has withinPortal=false

### DIFF
--- a/packages/@mantine/core/src/components/Combobox/OptionsDropdown/OptionsDropdown.tsx
+++ b/packages/@mantine/core/src/components/Combobox/OptionsDropdown/OptionsDropdown.tsx
@@ -1,4 +1,5 @@
 import cx from 'clsx';
+import { deepMerge } from '../../../core';
 import { CheckIcon } from '../../Checkbox';
 import { ScrollArea, ScrollAreaProps } from '../../ScrollArea/ScrollArea';
 import { Combobox } from '../Combobox';
@@ -106,6 +107,12 @@ export interface OptionsDropdownProps {
   scrollAreaProps: ScrollAreaProps | undefined;
 }
 
+const defaultScrollAreaProps: Partial<ScrollAreaProps> = {
+  viewportProps: {
+    tabIndex: -1,
+  },
+};
+
 export function OptionsDropdown({
   data,
   hidden,
@@ -150,6 +157,7 @@ export function OptionsDropdown({
     />
   ));
 
+  const _scrollAreaProps = deepMerge(defaultScrollAreaProps, scrollAreaProps);
   return (
     <Combobox.Dropdown hidden={hidden || (hiddenWhenEmpty && isEmpty)} data-composed>
       <Combobox.Options labelledBy={labelId} aria-label={ariaLabel}>
@@ -159,7 +167,7 @@ export function OptionsDropdown({
             type="scroll"
             scrollbarSize="var(--combobox-padding)"
             offsetScrollbars="y"
-            {...scrollAreaProps}
+            {..._scrollAreaProps}
           >
             {options}
           </ScrollArea.Autosize>


### PR DESCRIPTION
When `withPortal` is set to false on components using Combobox (e.g., Select), tab navigation causes focus to be lost. This happens because, during tabbing, focus moves to the scroll area of the Combobox options only for a moment, but the options immediately close, resulting in focus loss.
In my opinion, since Combobox already supports keyboard navigation with arrow keys, tab focus on the options is unnecessary.
To address this, the default `viewportProps` for options now includes `tabIndex: -1`, preventing the scroll area from receiving focus during tab navigation.

## Before

1. Set `comboboxProps={{ withinPortal: false }}` on the Select component.
2. Focus the Select component, then press the Tab key.
3. Ideally, focus should move to the Button next to the Select, but instead, focus is lost.

https://github.com/user-attachments/assets/e3b3d6f0-e358-4deb-9114-159a6f7472c2

## After

https://github.com/user-attachments/assets/063868be-3d55-4d2a-b6cb-457a9e1f8d83

