### PR TITLE
fix typo in the link to the page extension code-highlight

### DIFF
--- a/apps/mantine.dev/src/pages/x/extensions.mdx
+++ b/apps/mantine.dev/src/pages/x/extensions.mdx
@@ -19,7 +19,7 @@ Official extensions list:
 - [@mantine/dates](/dates/getting-started) – date and time pickers, calendars, other date-related components
 - [@mantine/charts](/charts/getting-started) – charts and data visualization components based on recharts
 - [@mantine/notifications](/x/notifications) – notifications system
-- [@mantine/code-highlight](/x/code-highilight) – code highlight component used on Mantine websites
+- [@mantine/code-highlight](/x/code-highlight) – code highlight component used on Mantine websites
 - [@mantine/spotlight](/x/spotlight) – control center (`Ctrl + K` search bar), can be used for search
 - [@mantine/carousel](/x/carousel) – carousel component based on embla-carousel
 - [@mantine/dropzone](/x/dropzone) – captures files with drag and drop, based on react-dropzone


### PR DESCRIPTION
fixed #7918

fix typo in the link to the page extension code-highlight