### PR TITLE
[@Mantine/core] Fix: detached DOM causing memory leak in Tree component

### DIFF
--- a/packages/@mantine/core/src/components/Tree/TreeNode.tsx
+++ b/packages/@mantine/core/src/components/Tree/TreeNode.tsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { findElementAncestor, GetStylesApi } from '../../core';
+import { Box, findElementAncestor, GetStylesApi } from '../../core';
 import type { RenderNode, TreeFactory, TreeNodeData } from './Tree';
 import type { TreeController } from './use-tree';
 
@@ -196,9 +196,9 @@ export function TreeNode({
       )}
 
       {controller.expandedState[node.value] && nested.length > 0 && (
-        <ul role="group" {...getStyles('subtree')} data-level={level}>
+        <Box component="ul" role="group" {...getStyles('subtree')} data-level={level}>
           {nested}
-        </ul>
+        </Box>
       )}
     </li>
   );


### PR DESCRIPTION
fixed #7677 

A few changes in `TreeNode` nested tree nodes, it worked
as-is : `<ul role="group" ... >`
to-be: `<Box component="ul" role="group">`

https://github.com/user-attachments/assets/78853a04-6c7c-4f51-a8c2-d234dd94a507

But I'm still not sure exactly *why* it works, and what differences between them making these results?
If anyone has any insight on this, I'd love to hear it.