### PR TITLE
Fix typo in DatePickerInput Styles API documentation

### DIFF
--- a/packages/@docs/styles-api/src/data/Dates.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/Dates.styles-api.ts
@@ -116,7 +116,7 @@ export const YearLevelGroupStylesApi: StylesApiData<YearLevelGroupFactory> = {
     levelsGroup: 'Group of years levels',
     monthsList: 'Months list table element',
     monthsListRow: 'Months list row element',
-    monthsListCell: 'Monthss list cell element',
+    monthsListCell: 'Months list cell element',
     monthsListControl: 'Button used to pick months and years',
   },
 


### PR DESCRIPTION
Fixed typo in description of `monthsListCell` selector.