### PR TITLE
feat(DatePicker): Add keyboard shortcuts for year navigation accessib…

### DIFF
--- a/docs/keyboard-navigation.md
+++ b/docs/keyboard-navigation.md
@@ -1,0 +1,42 @@
+# DatePicker Keyboard Navigation
+
+The DatePicker component now includes enhanced keyboard navigation features to improve accessibility and user experience.
+
+## Keyboard Shortcuts
+
+When the DatePicker is focused, you can use the following keyboard shortcuts:
+
+- **Ctrl/Cmd + Arrow Up**: Navigate one year back
+- **Ctrl/Cmd + Arrow Down**: Navigate one year forward
+- **Ctrl/Cmd + Shift + Arrow Up**: Navigate one decade (10 years) back
+- **Ctrl/Cmd + Shift + Arrow Down**: Navigate one decade (10 years) forward
+- **Y key**: Open year selection view (when in month view)
+
+## Usage
+
+The keyboard navigation is enabled by default. You can disable it by setting the `enableKeyboardNavigation` prop to `false`:
+
+```tsx
+import { DatePicker } from '@mantine/dates';
+
+function Demo() {
+  return (
+    <DatePicker 
+      label="Date picker with keyboard navigation"
+      enableKeyboardNavigation={true} // enabled by default
+    />
+  );
+}
+```
+
+## Accessibility
+
+The keyboard shortcuts follow common patterns used in desktop applications:
+- Modifier keys (Ctrl/Cmd) are used for larger time jumps
+- Shift modifier increases the jump size (year → decade)
+- Single letter shortcuts (Y) provide quick access to different views
+
+This feature is particularly useful for:
+- Users who prefer keyboard navigation
+- Quickly selecting dates far in the past (like birth dates)
+- Improving overall accessibility of date selection

--- a/packages/@docs/demos/src/demos/dates/DatePicker/DatePicker.demo.keyboardNavigation.tsx
+++ b/packages/@docs/demos/src/demos/dates/DatePicker/DatePicker.demo.keyboardNavigation.tsx
@@ -1,0 +1,33 @@
+import { DatePicker } from '@mantine/dates';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { DatePicker } from '@mantine/dates';
+
+function Demo() {
+  return (
+    <DatePicker 
+      label="Pick date with keyboard navigation"
+      placeholder="Use Ctrl/Cmd + Arrow keys"
+      enableKeyboardNavigation
+    />
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <DatePicker 
+      label="Pick date with keyboard navigation"
+      placeholder="Use Ctrl/Cmd + Arrow keys"
+      enableKeyboardNavigation
+    />
+  );
+}
+
+export const keyboardNavigation: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+  centered: true,
+};

--- a/packages/@docs/demos/src/demos/dates/DatePicker/index.ts
+++ b/packages/@docs/demos/src/demos/dates/DatePicker/index.ts
@@ -23,3 +23,4 @@ export { withWeekNumbers } from './DatePicker.demo.withWeekNumbers';
 export { presets } from './DatePicker.demo.presets';
 export { presetsRange } from './DatePicker.demo.presetsRange';
 export { headerControlsOrder } from './DatePicker.demo.headerControlsOrder';
+export { keyboardNavigation } from './DatePicker.demo.keyboardNavigation';

--- a/packages/@mantine/dates/src/components/Calendar/Calendar.keyboardNavigation.test.tsx
+++ b/packages/@mantine/dates/src/components/Calendar/Calendar.keyboardNavigation.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import dayjs from 'dayjs';
+import { Calendar } from './Calendar';
+
+describe('Calendar - Keyboard Navigation', () => {
+  it('should navigate by year with Ctrl+ArrowUp/Down', async () => {
+    const user = userEvent.setup();
+    const onDateChange = jest.fn();
+    
+    render(
+      <Calendar 
+        defaultDate="2024-06-15"
+        onDateChange={onDateChange}
+        enableKeyboardNavigation
+      />
+    );
+    
+    // Focus on the calendar
+    const calendar = screen.getByRole('region', { name: /calendar/i });
+    calendar.focus();
+    
+    // Navigate one year back with Ctrl+ArrowUp
+    await user.keyboard('{Control>}{ArrowUp}{/Control}');
+    expect(onDateChange).toHaveBeenCalledWith('2023-06-15');
+    
+    // Navigate one year forward with Ctrl+ArrowDown
+    await user.keyboard('{Control>}{ArrowDown}{/Control}');
+    expect(onDateChange).toHaveBeenCalledWith('2025-06-15');
+  });
+  
+  it('should navigate by decade with Ctrl+Shift+ArrowUp/Down', async () => {
+    const user = userEvent.setup();
+    const onDateChange = jest.fn();
+    
+    render(
+      <Calendar 
+        defaultDate="2024-06-15"
+        onDateChange={onDateChange}
+        enableKeyboardNavigation
+      />
+    );
+    
+    // Focus on the calendar
+    const calendar = screen.getByRole('region', { name: /calendar/i });
+    calendar.focus();
+    
+    // Navigate one decade back with Ctrl+Shift+ArrowUp
+    await user.keyboard('{Control>}{Shift>}{ArrowUp}{/Shift}{/Control}');
+    expect(onDateChange).toHaveBeenCalledWith('2014-06-15');
+    
+    // Navigate one decade forward with Ctrl+Shift+ArrowDown
+    await user.keyboard('{Control>}{Shift>}{ArrowDown}{/Shift}{/Control}');
+    expect(onDateChange).toHaveBeenCalledWith('2034-06-15');
+  });
+  
+  it('should open year view with Y key', async () => {
+    const user = userEvent.setup();
+    const onLevelChange = jest.fn();
+    
+    render(
+      <Calendar 
+        defaultDate="2024-06-15"
+        defaultLevel="month"
+        onLevelChange={onLevelChange}
+        enableKeyboardNavigation
+      />
+    );
+    
+    // Focus on the calendar
+    const calendar = screen.getByRole('region', { name: /calendar/i });
+    calendar.focus();
+    
+    // Press Y key to open year view
+    await user.keyboard('y');
+    expect(onLevelChange).toHaveBeenCalledWith('year');
+  });
+  
+  it('should not handle keyboard events when disabled', async () => {
+    const user = userEvent.setup();
+    const onDateChange = jest.fn();
+    const onLevelChange = jest.fn();
+    
+    render(
+      <Calendar 
+        defaultDate="2024-06-15"
+        onDateChange={onDateChange}
+        onLevelChange={onLevelChange}
+        enableKeyboardNavigation={false}
+      />
+    );
+    
+    // Focus on the calendar
+    const calendar = screen.getByRole('region', { name: /calendar/i });
+    calendar.focus();
+    
+    // Try keyboard navigation - should not work
+    await user.keyboard('{Control>}{ArrowUp}{/Control}');
+    await user.keyboard('y');
+    
+    expect(onDateChange).not.toHaveBeenCalled();
+    expect(onLevelChange).not.toHaveBeenCalled();
+  });
+  
+  it('should work with macOS Cmd key', async () => {
+    const user = userEvent.setup();
+    const onDateChange = jest.fn();
+    
+    render(
+      <Calendar 
+        defaultDate="2024-06-15"
+        onDateChange={onDateChange}
+        enableKeyboardNavigation
+      />
+    );
+    
+    // Focus on the calendar
+    const calendar = screen.getByRole('region', { name: /calendar/i });
+    calendar.focus();
+    
+    // Navigate with Cmd+ArrowUp (macOS)
+    await user.keyboard('{Meta>}{ArrowUp}{/Meta}');
+    expect(onDateChange).toHaveBeenCalledWith('2023-06-15');
+  });
+});

--- a/packages/@mantine/dates/src/components/Calendar/Calendar.tsx
+++ b/packages/@mantine/dates/src/components/Calendar/Calendar.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { useImperativeHandle } from 'react';
+import { useImperativeHandle, useEffect, useRef } from 'react';
 import {
   Box,
   BoxProps,
@@ -39,6 +39,10 @@ export interface CalendarAriaLabels {
 
   nextDecade?: string;
   previousDecade?: string;
+  
+  keyboardNavigationYear?: string;
+  keyboardNavigationDecade?: string;
+  keyboardOpenYearView?: string;
 }
 
 type OmittedSettings =
@@ -151,6 +155,9 @@ export interface CalendarProps
 
   /** Determines whether days should be static, static days can be used to display month if it is not expected that user will interact with the component in any way  */
   static?: boolean;
+  
+  /** Enable enhanced keyboard navigation (Ctrl/Cmd + Arrow keys for year navigation, Ctrl/Cmd + Shift + Arrow keys for decade navigation, Y key to open year view) */
+  enableKeyboardNavigation?: boolean;
 }
 
 export type CalendarFactory = Factory<{
@@ -164,6 +171,7 @@ const defaultProps = {
   minLevel: 'month',
   __updateDateOnYearSelect: true,
   __updateDateOnMonthSelect: true,
+  enableKeyboardNavigation: true,
 } satisfies Partial<CalendarProps>;
 
 export const Calendar = factory<CalendarFactory>((_props, ref) => {
@@ -241,6 +249,7 @@ export const Calendar = factory<CalendarFactory>((_props, ref) => {
     onNextMonth,
     onPreviousMonth,
     static: isStatic,
+    enableKeyboardNavigation,
     ...others
   } = props;
 
@@ -327,8 +336,74 @@ export const Calendar = factory<CalendarFactory>((_props, ref) => {
     setDate(nextDate);
   };
 
+  // Keyboard navigation
+  const calendarRef = useRef<HTMLDivElement>(null);
+  
+  useEffect(() => {
+    if (!enableKeyboardNavigation || isStatic) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Only handle keyboard events when focus is within the calendar
+      if (!calendarRef.current?.contains(document.activeElement)) return;
+      
+      const isCtrlOrCmd = event.ctrlKey || event.metaKey;
+      const isShift = event.shiftKey;
+      
+      switch (event.key) {
+        case 'ArrowUp':
+          if (isCtrlOrCmd && isShift) {
+            event.preventDefault();
+            // Navigate by decade (10 years back)
+            handlePreviousDecade();
+          } else if (isCtrlOrCmd) {
+            event.preventDefault();
+            // Navigate by year
+            handlePreviousYear();
+          }
+          break;
+          
+        case 'ArrowDown':
+          if (isCtrlOrCmd && isShift) {
+            event.preventDefault();
+            // Navigate by decade (10 years forward)
+            handleNextDecade();
+          } else if (isCtrlOrCmd) {
+            event.preventDefault();
+            // Navigate by year
+            handleNextYear();
+          }
+          break;
+          
+        case 'y':
+        case 'Y':
+          if (_level === 'month') {
+            event.preventDefault();
+            // Open year selection view
+            setLevel('year');
+          }
+          break;
+      }
+    };
+    
+    document.addEventListener('keydown', handleKeyDown);
+    
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [enableKeyboardNavigation, isStatic, _level, handleNextYear, handlePreviousYear, handleNextDecade, handlePreviousDecade]);
+
+  // Merge refs
+  const mergedRef = (node: HTMLDivElement) => {
+    calendarRef.current = node;
+    if (typeof ref === 'function') {
+      ref(node);
+    } else if (ref) {
+      ref.current = node;
+    }
+  };
+
   return (
-    <Box ref={ref} size={size} data-calendar {...others}>
+    <Box ref={mergedRef} size={size} data-calendar {...others}>
       {_level === 'month' && (
         <MonthLevelGroup
           month={currentDate}


### PR DESCRIPTION
This PR improves DatePicker accessibility by adding keyboard shortcuts for year navigation, addressing the need for better keyboard support when 
  selecting dates far in the past (like birth dates).

  ## New keyboard shortcuts:
  - Ctrl/Cmd + Arrow Up/Down: Navigate by year
  - Ctrl/Cmd + Shift + Arrow Up/Down: Navigate by decade
  - Y key: Open year selection view

  ## Changes:
  - Added enableKeyboardNavigation prop to Calendar component (enabled by default)
  - Implemented keyboard event handlers for year/decade navigation
  - Added comprehensive test coverage for keyboard navigation
  - Created demo showcasing the new feature
  - Added documentation for keyboard shortcuts

  Fixes #5444 and partially addresses #332