### PR TITLE
Add `onOverflowChange` callback to `ScrollArea.Autosize`

### DIFF
--- a/apps/mantine.dev/src/pages/core/scroll-area.mdx
+++ b/apps/mantine.dev/src/pages/core/scroll-area.mdx
@@ -59,7 +59,10 @@ get viewport element ref with `viewportRef` prop and call `scrollTo` method:
 
 ## ScrollArea.Autosize
 
-`ScrollArea.Autosize` component allows to create scrollable containers when given max-height is reached:
+`ScrollArea.Autosize` component allows to create scrollable containers when given max-height is reached.
+It also supports a callback for detecting when vertical overflow occurs:
+
+- onOverflowChange – triggered when content exceeds max-height, making the container scrollable or not
 
 <Demo data={ScrollAreaDemos.maxHeight} />
 

--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -290,8 +290,8 @@ export const ScrollAreaAutosize = factory<ScrollAreaAutosizeFactory>((props, ref
   // Overflow detection (Autosize-only)
   const [resizeObserverRef, rect] = useResizeObserver<HTMLDivElement>();
   const combinedViewportRef = useMergeRefs([viewportRef, resizeObserverRef]);
-  const didMountRef = useRef(false);
-  const lastOverflowRef = useRef(false);
+  const [overflowing, setOverflowing] = useState(false);
+  const didMount = useRef(false);
 
   useEffect(() => {
     if (!onOverflowChange) {
@@ -306,17 +306,18 @@ export const ScrollAreaAutosize = factory<ScrollAreaAutosizeFactory>((props, ref
 
     const isOverflowing = el.scrollHeight > el.clientHeight;
 
-    if (!didMountRef.current) {
-      didMountRef.current = true;
-      if (isOverflowing) {
-        onOverflowChange(true);
-        lastOverflowRef.current = true;
+    if (isOverflowing !== overflowing) {
+      if (didMount.current) {
+        onOverflowChange(isOverflowing);
+      } else {
+        didMount.current = true;
+        if (isOverflowing) {
+          onOverflowChange(true);
+        }
       }
-    } else if (isOverflowing !== lastOverflowRef.current) {
-      onOverflowChange(isOverflowing);
-      lastOverflowRef.current = isOverflowing;
+      setOverflowing(isOverflowing);
     }
-  }, [rect.height, onOverflowChange]);
+  }, [rect.height, onOverflowChange, overflowing]);
 
   return (
     <Box {...others} ref={ref} style={[{ display: 'flex', overflow: 'auto' }, style]}>

--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useMergeRefs } from '@floating-ui/react';
+import { useResizeObserver } from '@mantine/hooks';
 import {
   Box,
   BoxProps,
@@ -287,40 +288,36 @@ export const ScrollAreaAutosize = factory<ScrollAreaAutosizeFactory>((props, ref
   } = useProps('ScrollAreaAutosize', defaultProps, props as ScrollAreaAutosizeProps);
 
   // Overflow detection (Autosize-only)
-  const viewportObserverRef = useRef<HTMLDivElement>(null);
-  const combinedViewportRef = useMergeRefs([viewportRef, viewportObserverRef]);
-
+  const [resizeObserverRef, rect] = useResizeObserver<HTMLDivElement>();
+  const combinedViewportRef = useMergeRefs([viewportRef, resizeObserverRef]);
   const [overflowing, setOverflowing] = useState(false);
   const didMount = useRef(false);
 
   useEffect(() => {
-    const el = viewportObserverRef.current;
+    if (!onOverflowChange) {
+      return;
+    }
+
+    const el = resizeObserverRef.current;
+
     if (!el) {
       return;
     }
 
-    const update = () => {
-      const isOverflowing = el.scrollHeight > el.clientHeight;
+    const isOverflowing = el.scrollHeight > el.clientHeight;
 
-      if (isOverflowing !== overflowing) {
-        if (didMount.current) {
-          onOverflowChange?.(isOverflowing);
-        } else {
-          didMount.current = true;
-          if (isOverflowing) {
-            onOverflowChange?.(true);
-          }
+    if (isOverflowing !== overflowing) {
+      if (didMount.current) {
+        onOverflowChange(isOverflowing);
+      } else {
+        didMount.current = true;
+        if (isOverflowing) {
+          onOverflowChange(true);
         }
-
-        setOverflowing(isOverflowing);
       }
-    };
-
-    update();
-    const ro = new ResizeObserver(update);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [onOverflowChange, overflowing]);
+      setOverflowing(isOverflowing);
+    }
+  }, [rect.height, onOverflowChange, overflowing]);
 
   return (
     <Box {...others} ref={ref} style={[{ display: 'flex', overflow: 'auto' }, style]}>

--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -294,7 +294,12 @@ export const ScrollAreaAutosize = factory<ScrollAreaAutosizeFactory>((props, ref
   const didMount = useRef(false);
 
   useEffect(() => {
+    if (!onOverflowChange) {
+      return;
+    }
+
     const el = viewportObserverRef.current;
+
     if (!el) {
       return;
     }

--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -72,6 +72,12 @@ export interface ScrollAreaProps
   /** Called when scrollarea is scrolled all the way to the top */
   onTopReached?: () => void;
 
+  /** Called when vertical scrollbar thumb visibility changes */
+  onVerticalThumbVisibilityChange?: (visible: boolean) => void;
+
+  /** Called when horizontal scrollbar thumb visibility changes */
+  onHorizontalThumbVisibilityChange?: (visible: boolean) => void;
+
   /** Defines `overscroll-behavior` of the viewport */
   overscrollBehavior?: React.CSSProperties['overscrollBehavior'];
 }
@@ -123,6 +129,8 @@ export const ScrollArea = factory<ScrollAreaFactory>((_props, ref) => {
     scrollbars,
     onBottomReached,
     onTopReached,
+    onVerticalThumbVisibilityChange,
+    onHorizontalThumbVisibilityChange,
     overscrollBehavior,
     ...others
   } = props;
@@ -130,6 +138,40 @@ export const ScrollArea = factory<ScrollAreaFactory>((_props, ref) => {
   const [scrollbarHovered, setScrollbarHovered] = useState(false);
   const [verticalThumbVisible, setVerticalThumbVisible] = useState(false);
   const [horizontalThumbVisible, setHorizontalThumbVisible] = useState(false);
+  const verticalDidMount = useRef(false);
+  const horizontalDidMount = useRef(false);
+
+  const verticalCallbackRef = useRef(onVerticalThumbVisibilityChange);
+  useEffect(() => {
+    verticalCallbackRef.current = onVerticalThumbVisibilityChange;
+  }, [onVerticalThumbVisibilityChange]);
+
+  const horizontalCallbackRef = useRef(onHorizontalThumbVisibilityChange);
+  useEffect(() => {
+    horizontalCallbackRef.current = onHorizontalThumbVisibilityChange;
+  }, [onHorizontalThumbVisibilityChange]);
+
+  useEffect(() => {
+    if (verticalDidMount.current) {
+      verticalCallbackRef.current?.(verticalThumbVisible);
+    } else {
+      verticalDidMount.current = true;
+      if (verticalThumbVisible) {
+        verticalCallbackRef.current?.(verticalThumbVisible);
+      }
+    }
+  }, [verticalThumbVisible]);
+
+  useEffect(() => {
+    if (horizontalDidMount.current) {
+      horizontalCallbackRef.current?.(horizontalThumbVisible);
+    } else {
+      horizontalDidMount.current = true;
+      if (horizontalThumbVisible) {
+        horizontalCallbackRef.current?.(horizontalThumbVisible);
+      }
+    }
+  }, [horizontalThumbVisible]);
 
   const getStyles = useStyles<ScrollAreaFactory>({
     name: 'ScrollArea',
@@ -272,6 +314,8 @@ export const ScrollAreaAutosize = factory<ScrollAreaFactory>((props, ref) => {
     vars,
     onBottomReached,
     onTopReached,
+    onVerticalThumbVisibilityChange,
+    onHorizontalThumbVisibilityChange,
     ...others
   } = useProps('ScrollAreaAutosize', defaultProps, props);
 
@@ -295,6 +339,8 @@ export const ScrollAreaAutosize = factory<ScrollAreaFactory>((props, ref) => {
           scrollbars={scrollbars}
           onBottomReached={onBottomReached}
           onTopReached={onTopReached}
+          onVerticalThumbVisibilityChange={onVerticalThumbVisibilityChange}
+          onHorizontalThumbVisibilityChange={onHorizontalThumbVisibilityChange}
         >
           {children}
         </ScrollArea>

--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -290,8 +290,8 @@ export const ScrollAreaAutosize = factory<ScrollAreaAutosizeFactory>((props, ref
   // Overflow detection (Autosize-only)
   const [resizeObserverRef, rect] = useResizeObserver<HTMLDivElement>();
   const combinedViewportRef = useMergeRefs([viewportRef, resizeObserverRef]);
-  const [overflowing, setOverflowing] = useState(false);
-  const didMount = useRef(false);
+  const didMountRef = useRef(false);
+  const lastOverflowRef = useRef(false);
 
   useEffect(() => {
     if (!onOverflowChange) {
@@ -306,18 +306,17 @@ export const ScrollAreaAutosize = factory<ScrollAreaAutosizeFactory>((props, ref
 
     const isOverflowing = el.scrollHeight > el.clientHeight;
 
-    if (isOverflowing !== overflowing) {
-      if (didMount.current) {
-        onOverflowChange(isOverflowing);
-      } else {
-        didMount.current = true;
-        if (isOverflowing) {
-          onOverflowChange(true);
-        }
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      if (isOverflowing) {
+        onOverflowChange(true);
+        lastOverflowRef.current = true;
       }
-      setOverflowing(isOverflowing);
+    } else if (isOverflowing !== lastOverflowRef.current) {
+      onOverflowChange(isOverflowing);
+      lastOverflowRef.current = isOverflowing;
     }
-  }, [rect.height, onOverflowChange, overflowing]);
+  }, [rect.height, onOverflowChange]);
 
   return (
     <Box {...others} ref={ref} style={[{ display: 'flex', overflow: 'auto' }, style]}>


### PR DESCRIPTION
This PR adds a new `onOverflowChange?: (overflowing: boolean) => void` prop to ScrollArea.Autosize.

It fires when content starts or stops exceeding max-height, enabling consumers to react when the container becomes scrollable.

https://github.com/user-attachments/assets/e43d5e79-934f-4907-9326-40c816c5bb46