### PR TITLE
[@mantine/core] Improve type inference of onToggle

### DIFF
--- a/packages/@mantine/core/src/components/Popover/use-popover.ts
+++ b/packages/@mantine/core/src/components/Popover/use-popover.ts
@@ -144,7 +144,11 @@ export function usePopover(options: UsePopoverOptions) {
     }
   };
 
-  const onToggle = () => !options.disabled && setOpened(!_opened);
+  const onToggle = () => {
+    if (!options.disabled) {
+      setOpened(!_opened);
+    }
+  };
 
   const floating: UseFloatingReturn<Element> = useFloating({
     strategy: options.strategy,


### PR DESCRIPTION
Fixes https://github.com/mantinedev/mantine/issues/7954

This pull request includes a really simple change to the `usePopover` function in the `Popover` component. 
The change improves type inference of the `onToggle` function to be properly inferred as `() => void`.
