### PR TITLE
[@mantine/core] optimize Popover autoUpdate for keepMounted elements

### DIFF
--- a/packages/@mantine/core/src/components/Popover/Popover.tsx
+++ b/packages/@mantine/core/src/components/Popover/Popover.tsx
@@ -300,6 +300,7 @@ export function Popover(_props: PopoverProps) {
     positionRef,
     disabled,
     preventPositionChangeWhenVisible,
+    keepMounted,
   });
 
   useClickOutside(


### PR DESCRIPTION
- Conditionally apply whileElementsMounted based on keepMounted prop
- Use manual autoUpdate control when keepMounted=true to avoid unnecessary updates on CSS-hidden elements
- Add keepMounted prop to usePopover options interface

Fixes performance issue where autoUpdate ran continuously on hidden popover dropdowns