### PR TITLE
[mantine.dev] Add env option to HeadlessMantineProvider  (#7836)

### DIFF
--- a/packages/@mantine/core/src/core/MantineProvider/MantineProvider.tsx
+++ b/packages/@mantine/core/src/core/MantineProvider/MantineProvider.tsx
@@ -129,9 +129,12 @@ export interface HeadlessMantineProviderProps {
 
   /** Your application */
   children?: React.ReactNode;
+
+  /** Environment at which the provider is used, `'test'` environment disables all transitions and portals */
+  env?: 'default' | 'test';
 }
 
-export function HeadlessMantineProvider({ children, theme }: HeadlessMantineProviderProps) {
+export function HeadlessMantineProvider({ children, theme, env }: HeadlessMantineProviderProps) {
   return (
     <MantineContext.Provider
       value={{
@@ -143,6 +146,7 @@ export function HeadlessMantineProvider({ children, theme }: HeadlessMantineProv
         cssVariablesSelector: ':root',
         withStaticClasses: false,
         headless: true,
+        env,
       }}
     >
       <MantineThemeProvider theme={theme}>{children}</MantineThemeProvider>


### PR DESCRIPTION
Adding an env prop to the `HeadlessMantineProvider` since it can be used instead of `MantineProvider` for a custom render function.

This is my first PR for the mantine project. Please let me know if I am doing something incorrectly.