### PR TITLE
[@mantine/date] fix TimePicker disabled or readOnly not work #8008

### DIFF
--- a/packages/@mantine/dates/src/components/TimePicker/TimePicker.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePicker.tsx
@@ -322,6 +322,7 @@ export const TimePicker = factory<TimePickerFactory>((_props, ref) => {
         transitionProps={{ duration: 0 }}
         position="bottom-start"
         withRoles={false}
+        disabled={disabled || readOnly}
         {...popoverProps}
       >
         <Popover.Target>


### PR DESCRIPTION
This pull request addresses an issue in the `TimePicker` component where the `disabled` and `readOnly` props were not functioning as expected. The fix ensures that these props now behave correctly, improving component reliability.

fixed #8008