### PR TITLE
[@mantine/core] Add keepMounted prop to Collapse component

### DIFF
--- a/packages/@mantine/core/src/components/Collapse/Collapse.story.tsx
+++ b/packages/@mantine/core/src/components/Collapse/Collapse.story.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { Box } from '../../core';
 import { Button } from '../Button';
 import { SegmentedControl } from '../SegmentedControl';
+import { Stack } from '../Stack';
+import { Text } from '../Text';
 import { Collapse } from './Collapse';
 
 export default { title: 'Collapse' };
@@ -11,18 +13,37 @@ export function NestedCollapseWithControl() {
   const [value, setValue] = useState('a');
 
   useEffect(() => {
-    setTimeout(() => setValue('b'));
+    setValue('b');
   }, []);
 
   return (
     <Box maw={400} mx="auto" mt={100}>
-      <Button onClick={() => setShow(!show)}>Toggle</Button>
-      <Collapse in={show}>
+      <Button onClick={() => setShow((pre) => !pre)}>Toggle</Button>
+      <Collapse in={show} keepMounted>
         <SegmentedControl value={value} onChange={setValue} data={['a', 'b']} />
         <Collapse in={value === 'b'}>
           1<br />2<br />3<br />4<br />5<br />
         </Collapse>
       </Collapse>
+    </Box>
+  );
+}
+
+export function StackedCollapse() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Box maw={400} mx="auto" mt={100}>
+      <Stack bg="gray" m="lg">
+        <Button onClick={() => setIsOpen((o) => !o)}>Toggle</Button>
+        <Collapse in={isOpen}>
+          <Text>Text</Text>
+        </Collapse>
+      </Stack>
+      <Text>
+        See that the grey box extends below the button even when the collapse is closed. Previously
+        there would be no stack gap above closed collapses.
+      </Text>
     </Box>
   );
 }

--- a/packages/@mantine/core/src/components/Collapse/Collapse.tsx
+++ b/packages/@mantine/core/src/components/Collapse/Collapse.tsx
@@ -27,6 +27,9 @@ export interface CollapseProps
 
   /** Determines whether opacity should be animated, `true` by default */
   animateOpacity?: boolean;
+
+  /** Keep element in DOM when collapsed, useful for nested collapses */
+  keepMounted?: boolean;
 }
 
 export type CollapseFactory = Factory<{
@@ -49,6 +52,7 @@ export const Collapse = factory<CollapseFactory>((props, ref) => {
     style,
     onTransitionEnd,
     animateOpacity,
+    keepMounted,
     ...others
   } = useProps('Collapse', defaultProps, props);
 
@@ -62,6 +66,7 @@ export const Collapse = factory<CollapseFactory>((props, ref) => {
     transitionDuration: duration,
     transitionTimingFunction,
     onTransitionEnd,
+    keepMounted,
   });
 
   if (duration === 0) {

--- a/packages/@mantine/core/src/components/Collapse/use-collapse.ts
+++ b/packages/@mantine/core/src/components/Collapse/use-collapse.ts
@@ -24,28 +24,34 @@ interface UseCollapse {
   transitionDuration?: number;
   transitionTimingFunction?: string;
   onTransitionEnd?: () => void;
+  keepMounted?: boolean;
 }
 
 interface GetCollapseProps {
   [key: string]: unknown;
+
   style?: CSSProperties;
   onTransitionEnd?: (e: TransitionEvent) => void;
   refKey?: string;
   ref?: React.ForwardedRef<HTMLDivElement>;
 }
 
+const collapsedHeight = 0;
+const getCollapsedStyles = (keepMounted: boolean): CSSProperties => ({
+  height: 0,
+  overflow: 'hidden',
+  ...(keepMounted ? {} : { display: 'none' }),
+});
+
 export function useCollapse({
   transitionDuration,
   transitionTimingFunction = 'ease',
   onTransitionEnd = () => {},
   opened,
+  keepMounted = false,
 }: UseCollapse): (props: GetCollapseProps) => Record<string, any> {
   const el = useRef<HTMLElement | null>(null);
-  const collapsedHeight = 0;
-  const collapsedStyles = {
-    height: 0,
-    overflow: 'hidden',
-  };
+  const collapsedStyles = getCollapsedStyles(keepMounted);
   const [styles, setStylesRaw] = useState<CSSProperties>(opened ? {} : collapsedStyles);
   const setStyles = (newStyles: {} | ((oldStyles: {}) => {})): void => {
     flushSync(() => setStylesRaw(newStyles));


### PR DESCRIPTION
  Fixes #7951

  Problem

  The Collapse component had two conflicting requirements that couldn't be satisfied
  simultaneously:

  1. Stack layout issue: When a Collapse is closed inside a Stack, it should not
  contribute to the Stack's gap spacing
  2. Nested animation issue: When Collapses are nested, the parent must remain in the
  DOM for child animations to work properly

  Root Cause

  The core issue was the use of display: 'none' in collapsed state:
  - ✅ With display: 'none': Stack gap issue is resolved, but nested animations break
  - ✅ Without display: 'none': Nested animations work, but Stack gap issue occurs

  Solution

  Added a keepMounted prop to the Collapse component that allows explicit control over
  this behavior:

  Default behavior (most common case)

```tsx
  <Stack>
    <Button>Toggle</Button>
    <Collapse in={isOpen}>  {/* keepMounted defaults to false */}
      <Text>Content</Text>
    </Collapse>
  </Stack>
```
  - Uses display: 'none' when collapsed
  - Collapsed element doesn't contribute to Stack spacing
  - ✅ Fixes the Stack gap issue

  Special case (nested animations)

```tsx
  <Collapse in={show} keepMounted>  {/* keepMounted={true} */}
    <SegmentedControl />
    <Collapse in={value === 'b'}>
      Content
    </Collapse>
  </Collapse>
```
  - Doesn't use display: 'none' when collapsed
  - Parent remains in DOM for child height calculations
  - ✅ Enables proper nested animations

  Implementation Details

  - Added keepMounted?: boolean prop to CollapseProps interface
  - Modified useCollapse hook to conditionally apply display: 'none'
  - Updated NestedCollapseWithControl story to demonstrate the fix