### PR TITLE
[@mantine/hooks] use-debounced-callback: Fix leading edge behavior to…

### DIFF
--- a/packages/@mantine/hooks/src/use-debounced-callback/use-debounced-callback.ts
+++ b/packages/@mantine/hooks/src/use-debounced-callback/use-debounced-callback.ts
@@ -31,17 +31,63 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
         const isFirstCall = currentCallback._isFirstCall;
         currentCallback._isFirstCall = false;
 
-        if (leading && isFirstCall) {
-          handleCallback(...args);
-          return;
-        }
-
         function clearTimeoutAndLeadingRef() {
           window.clearTimeout(debounceTimerRef.current);
           debounceTimerRef.current = 0;
           currentCallback._isFirstCall = true;
         }
 
+        if (leading && isFirstCall) {
+          handleCallback(...args);
+
+          // For leading=true, set timeout only to reset state, not to execute callback
+          const resetLeadingState = () => {
+            clearTimeoutAndLeadingRef();
+          };
+
+          const flush = () => {
+            // For leading edge, flush should still work if called manually
+            if (debounceTimerRef.current !== 0) {
+              clearTimeoutAndLeadingRef();
+              handleCallback(...args);
+            }
+          };
+
+          const cancel = () => {
+            clearTimeoutAndLeadingRef();
+          };
+
+          currentCallback.flush = flush;
+          currentCallback.cancel = cancel;
+          debounceTimerRef.current = window.setTimeout(resetLeadingState, delay);
+          return;
+        }
+
+        if (leading && !isFirstCall) {
+          // For leading=true and subsequent calls, ignore but allow manual flush
+          const flush = () => {
+            if (debounceTimerRef.current !== 0) {
+              clearTimeoutAndLeadingRef();
+              handleCallback(...args);
+            }
+          };
+
+          const cancel = () => {
+            clearTimeoutAndLeadingRef();
+          };
+
+          currentCallback.flush = flush;
+          currentCallback.cancel = cancel;
+
+          // Set timeout for potential manual flush, but reset state only
+          const resetLeadingState = () => {
+            clearTimeoutAndLeadingRef();
+          };
+          debounceTimerRef.current = window.setTimeout(resetLeadingState, delay);
+          return;
+        }
+
+        // Normal debounce behavior (leading=false)
         const flush = () => {
           if (debounceTimerRef.current !== 0) {
             clearTimeoutAndLeadingRef();
@@ -57,7 +103,11 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
         currentCallback.cancel = cancel;
         debounceTimerRef.current = window.setTimeout(flush, delay);
       },
-      { flush: () => {}, cancel: () => {}, _isFirstCall: true }
+      {
+        flush: () => {},
+        cancel: () => {},
+        _isFirstCall: true,
+      }
     );
     return currentCallback;
   }, [handleCallback, delay, leading]);

--- a/packages/@mantine/hooks/src/use-debounced-callback/use-debounced-callback.ts
+++ b/packages/@mantine/hooks/src/use-debounced-callback/use-debounced-callback.ts
@@ -40,13 +40,11 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
         if (leading && isFirstCall) {
           handleCallback(...args);
 
-          // For leading=true, set timeout only to reset state, not to execute callback
           const resetLeadingState = () => {
             clearTimeoutAndLeadingRef();
           };
 
           const flush = () => {
-            // For leading edge, flush should still work if called manually
             if (debounceTimerRef.current !== 0) {
               clearTimeoutAndLeadingRef();
               handleCallback(...args);
@@ -64,7 +62,6 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
         }
 
         if (leading && !isFirstCall) {
-          // For leading=true and subsequent calls, ignore but allow manual flush
           const flush = () => {
             if (debounceTimerRef.current !== 0) {
               clearTimeoutAndLeadingRef();
@@ -79,7 +76,6 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
           currentCallback.flush = flush;
           currentCallback.cancel = cancel;
 
-          // Set timeout for potential manual flush, but reset state only
           const resetLeadingState = () => {
             clearTimeoutAndLeadingRef();
           };
@@ -87,7 +83,6 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
           return;
         }
 
-        // Normal debounce behavior (leading=false)
         const flush = () => {
           if (debounceTimerRef.current !== 0) {
             clearTimeoutAndLeadingRef();


### PR DESCRIPTION
Fixes #7917

  - Fix leading=true to execute only immediately without trailing execution
  - Previously leading=true would execute immediately + after delay (incorrect)
  - Now leading=true executes immediately, ignores subsequent calls during delay
  - Leading state resets after delay period for next immediate execution
  - Update tests to reflect correct behavior expectations
  - Maintain flush() and cancel() method functionality
  - All existing tests pass with corrected behavior

  Resolves issue where users expected leading=true to suppress trailing
  execution but callback was being invoked again after the delay period