### PR TITLE
[@mantine/form] Add Support for Cascading Form Updates

### DIFF
--- a/apps/mantine.dev/src/pages/form/values.mdx
+++ b/apps/mantine.dev/src/pages/form/values.mdx
@@ -203,6 +203,15 @@ function Demo() {
 }
 ```
 
+## form.watch cascade
+
+To loosely subscribe to changes, you can set `cascadeUpdates: true`.
+This allows for parent objects to be written to directly, while still having
+subscribers to nested keys updated. Additionally, writes to nested keys
+will bubble up triggering parent key subscriptions as well.
+
+<Demo data={FormDemos.cascadeUpdates} />
+
 ## Get values type
 
 ```tsx

--- a/packages/@docs/demos/src/demos/form/Form.demo.cascadeUpdates.tsx
+++ b/packages/@docs/demos/src/demos/form/Form.demo.cascadeUpdates.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import { Button, Code, Stack, TextInput } from '@mantine/core';
+import { createFormContext } from '@mantine/form';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { Button, Code, Stack, TextInput } from '@mantine/core';
+import { createFormContext } from '@mantine/form';
+import { useState } from 'react';
+
+const [Provider, usePersonFormContext, usePersonForm] = createFormContext<{ person: { name: string } }>();
+
+function Demo() {
+  const form = usePersonForm({
+    mode: 'uncontrolled',
+    cascadeUpdates: true,
+    initialValues: {
+      person: { name: "" }
+    }
+  })
+
+  return (
+    <Provider form={form}>
+      <Stack>
+        <TextInput
+          label="Name"
+          placeholder="Name"
+          key={form.key('person.name')}
+          {...form.getInputProps('person.name')}
+        />
+        <Button onClick={() => form.setFieldValue("person", { name: "Jane Doe" })}>Set 'person' object to \`{'{ name: "Jane Doe" }'}\`</Button>
+        <Watcher />
+      </Stack>
+    </Provider>
+  );
+}
+
+function Watcher() {
+  const form = usePersonFormContext();
+
+  const [person, setPerson] = useState<{ name: string }>();
+  const [name, setName] = useState<string>();
+
+  form.watch('person', ({ value }) => setPerson(value));
+  form.watch("person.name", ({ value }) => setName(value));
+
+  return <Code block>{JSON.stringify({ person, name }, null, 2)}</Code>
+}
+`;
+
+const [Provider, usePersonFormContext, usePersonForm] = createFormContext<{
+  person: { name: string };
+}>();
+
+function Demo() {
+  const form = usePersonForm({
+    mode: 'uncontrolled',
+    cascadeUpdates: true,
+    initialValues: {
+      person: { name: '' },
+    },
+  });
+
+  return (
+    <Provider form={form}>
+      <Stack>
+        <TextInput
+          label="Name"
+          placeholder="Name"
+          key={form.key('person.name')}
+          {...form.getInputProps('person.name')}
+        />
+        <Button onClick={() => form.setFieldValue('person', { name: 'Jane Doe' })}>
+          Set 'person' object to `{'{ name: "Jane Doe" }'}`
+        </Button>
+        <Watcher />
+      </Stack>
+    </Provider>
+  );
+}
+
+function Watcher() {
+  const form = usePersonFormContext();
+
+  const [person, setPerson] = useState<{ name: string }>();
+  const [name, setName] = useState<string>();
+
+  form.watch('person', ({ value }) => setPerson(value));
+  form.watch('person.name', ({ value }) => setName(value));
+
+  return <Code block>{JSON.stringify({ person, name }, null, 2)}</Code>;
+}
+
+export const cascadeUpdates: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+  centered: true,
+  maxWidth: 340,
+};

--- a/packages/@docs/demos/src/demos/form/Form.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/form/Form.demos.story.tsx
@@ -177,3 +177,8 @@ export const Demo_rootRuleArray = {
   name: '⭐ Demo: rootRuleArray',
   render: renderDemo(demos.rootRuleArray),
 };
+
+export const Demo_cascadeUpdates = {
+  name: '⭐ Demo: cascadeUpdates',
+  render: renderDemo(demos.cascadeUpdates),
+};

--- a/packages/@docs/demos/src/demos/form/index.ts
+++ b/packages/@docs/demos/src/demos/form/index.ts
@@ -33,3 +33,4 @@ export { focusError } from './Form.demo.focusError';
 export { submitting } from './Form.demo.submitting';
 export { rootRuleObject } from './Form.demo.rootRuleObject';
 export { rootRuleArray } from './Form.demo.rootRuleArray';
+export { cascadeUpdates } from './Form.demo.cascadeUpdates';

--- a/packages/@mantine/form/src/hooks/use-form-watch/use-form-watch.ts
+++ b/packages/@mantine/form/src/hooks/use-form-watch/use-form-watch.ts
@@ -7,10 +7,12 @@ import { SetValuesSubscriberPayload } from '../use-form-values/use-form-values';
 
 interface UseFormWatchInput<Values extends Record<string, any>> {
   $status: $FormStatus<Values>;
+  cascadeUpdates?: boolean;
 }
 
 export function useFormWatch<Values extends Record<string, any>>({
   $status,
+  cascadeUpdates,
 }: UseFormWatchInput<Values>) {
   const subscribers = useRef<Record<LooseKeys<Values>, FormFieldSubscriber<Values, any>[]>>(
     {} as any
@@ -28,19 +30,36 @@ export function useFormWatch<Values extends Record<string, any>>({
   }, []);
 
   const getFieldSubscribers = useCallback((path: LooseKeys<Values>) => {
-    if (!subscribers.current[path]) {
-      return [];
+    const result: ((input: SetValuesSubscriberPayload<Values>) => void)[] =
+      subscribers.current[path]?.map(
+        (callback) => (input: SetValuesSubscriberPayload<Values>) =>
+          callback({
+            previousValue: getPath(path, input.previousValues) as any,
+            value: getPath(path, input.updatedValues) as any,
+            touched: $status.isTouched(path),
+            dirty: $status.isDirty(path),
+          })
+      ) ?? [];
+
+    if (cascadeUpdates) {
+      for (const subscriptionKey in subscribers.current) {
+        if (subscriptionKey.startsWith(`${path}.`) || path.startsWith(`${subscriptionKey}.`)) {
+          result.push(
+            ...subscribers.current[subscriptionKey].map(
+              (cb) => (input: SetValuesSubscriberPayload<Values>) =>
+                cb({
+                  previousValue: getPath(subscriptionKey, input.previousValues) as any,
+                  value: getPath(subscriptionKey, input.updatedValues) as any,
+                  touched: $status.isTouched(subscriptionKey),
+                  dirty: $status.isDirty(subscriptionKey),
+                })
+            )
+          );
+        }
+      }
     }
 
-    return subscribers.current[path].map(
-      (callback) => (input: SetValuesSubscriberPayload<Values>) =>
-        callback({
-          previousValue: getPath(path, input.previousValues) as any,
-          value: getPath(path, input.updatedValues) as any,
-          touched: $status.isTouched(path),
-          dirty: $status.isDirty(path),
-        })
-    );
+    return result;
   }, []);
 
   return {

--- a/packages/@mantine/form/src/types.ts
+++ b/packages/@mantine/form/src/types.ts
@@ -207,6 +207,7 @@ export interface UseFormInput<
   }) => Record<string, any> | undefined | void;
   onSubmitPreventDefault?: 'always' | 'never' | 'validation-failed';
   touchTrigger?: 'focus' | 'change';
+  cascadeUpdates?: boolean;
 }
 
 export interface UseFormReturnType<

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -46,12 +46,13 @@ export function useForm<
   validate: rules,
   onSubmitPreventDefault = 'always',
   touchTrigger = 'change',
+  cascadeUpdates = false,
 }: UseFormInput<Values, TransformValues> = {}): UseFormReturnType<Values, TransformValues> {
   const $errors = useFormErrors<Values>(initialErrors);
   const $values = useFormValues<Values>({ initialValues, onValuesChange, mode });
   const $status = useFormStatus<Values>({ initialDirty, initialTouched, $values, mode });
   const $list = useFormList<Values>({ $values, $errors, $status });
-  const $watch = useFormWatch<Values>({ $status });
+  const $watch = useFormWatch<Values>({ $status, cascadeUpdates });
   const [formKey, setFormKey] = useState(0);
   const [fieldKeys, setFieldKeys] = useState<Record<string, number>>({});
   const [submitting, setSubmitting] = useState(false);


### PR DESCRIPTION
## Description

Fixes an issue where changes to parent objects did not trigger updates for subscribers of nested keys, and where subscribers of parent keys were not notified when a nested key of that parent object changed.

To avoid introducing unexpected behavior for existing users, this new behavior is gated behind an opt-in flag: `cascadeUpdates?: boolean`.

---

closes #8024 