### PR TITLE
Update schema-validation.mdx on zod4 validation

### DIFF
--- a/apps/mantine.dev/src/pages/form/schema-validation.mdx
+++ b/apps/mantine.dev/src/pages/form/schema-validation.mdx
@@ -139,9 +139,9 @@ import { z } from 'zod/v4';
 import { zod4Resolver } from 'mantine-form-zod-resolver';
 
 const schema = z.object({
-  name: z.string().min(2, { message: 'Name should have at least 2 letters' }),
-  email: z.email({ message: 'Invalid email' }),
-  age: z.number().min(18, { message: 'You must be at least 18 to create an account' }),
+  name: z.string().min(2, { error: 'Name should have at least 2 letters' }),
+  email: z.email({ error: 'Invalid email' }),
+  age: z.number().min(18, { error: 'You must be at least 18 to create an account' }),
 });
 
 const form = useForm({


### PR DESCRIPTION
In Zod v4, the `message` key has been deprecated in favor of `error`.

Reference: https://zod.dev/v4/changelog?id=deprecates-message