### PR TITLE
[@matine/form] Add onValidationFailure & async onSubmit Typescript support to Form

### DIFF
--- a/packages/@mantine/form/src/Form/Form.tsx
+++ b/packages/@mantine/form/src/Form/Form.tsx
@@ -4,7 +4,9 @@ import { TransformedValues, UseFormReturnType } from '../types';
 export interface FormProps<Form extends UseFormReturnType<any>>
   extends React.ComponentPropsWithRef<'form'> {
   form: Form;
-  onSubmit?: (values: TransformedValues<Form>) => void;
+  onSubmit?: Parameters<Form['onSubmit']>[0]
+  onValidationFailure?: Parameters<Form['onSubmit']>[1]
+  onReset?: React.FormEventHandler<HTMLFormElement>
 }
 
 export type FormComponent = (<Form extends UseFormReturnType<any>>(
@@ -13,12 +15,17 @@ export type FormComponent = (<Form extends UseFormReturnType<any>>(
 
 export const Form: FormComponent = forwardRef(
   <Form extends UseFormReturnType<any>>(
-    { form, onSubmit, onReset, ...others }: FormProps<Form>,
+    { form, onSubmit, onReset, onValidationFailure, ...others }: FormProps<Form>,
     ref: React.ForwardedRef<HTMLFormElement>
   ) => (
     <form
       {...others}
-      onSubmit={form.onSubmit(typeof onSubmit === 'function' ? onSubmit : () => {})}
+      onSubmit={
+        form.onSubmit(
+          typeof onSubmit === 'function' ? onSubmit : () => {},
+          onValidationFailure
+        )
+      }
       onReset={(event) => {
         onReset?.(event);
         form.onReset(event);


### PR DESCRIPTION
For Form component exposed by `@mantine/form`.
- `onSubmit` prop did not allow for async actions/handlers
- `onValidationFailure` prop added for feature support.