### PR TITLE
typo

### DIFF
--- a/changelog/7.2.0.md
+++ b/changelog/7.2.0.md
@@ -98,7 +98,7 @@ from given data:
 import { Table, TableData } from '@mantine/core';
 
 const tableData: TableData = {
-  caption: 'Some elements from periodic table',
+  caption: 'Some elements from the periodic table',
   head: ['Element position', 'Atomic mass', 'Symbol', 'Element name'],
   body: [
     [6, 12.011, 'C', 'Carbon'],

--- a/packages/@docs/demos/src/demos/core/Table/Table.demo.captions.tsx
+++ b/packages/@docs/demos/src/demos/core/Table/Table.demo.captions.tsx
@@ -56,7 +56,7 @@ export function Demo() {
 
   return (
     <Table captionSide="bottom">
-      <Table.Caption>Some elements from periodic table</Table.Caption>
+      <Table.Caption>Some elements from the periodic table</Table.Caption>
       <Table.Thead>{ths}</Table.Thead>
       <Table.Tbody>{rows}</Table.Tbody>
       <Table.Tfoot>{ths}</Table.Tfoot>

--- a/packages/@docs/demos/src/demos/core/Table/Table.demo.data.tsx
+++ b/packages/@docs/demos/src/demos/core/Table/Table.demo.data.tsx
@@ -22,7 +22,7 @@ function Demo() {
 `;
 
 const tableData: TableData = {
-  caption: 'Some elements from periodic table',
+  caption: 'Some elements from the periodic table',
   head: ['Element position', 'Atomic mass', 'Symbol', 'Element name'],
   body: [
     [6, 12.011, 'C', 'Carbon'],


### PR DESCRIPTION
before:
`Some elements from periodic table`
after:
`Some elements from the periodic table`