### PR TITLE
Fix/reset field rerender (#8017)

### DIFF
--- a/packages/@mantine/form/src/hooks/use-form-values/use-form-values.ts
+++ b/packages/@mantine/form/src/hooks/use-form-values/use-form-values.ts
@@ -14,7 +14,7 @@ export interface $FormValues<Values extends Record<PropertyKey, any>> {
   initialize: (values: Values, onInitialize: () => void) => void;
   getValues: () => Values;
   getValuesSnapshot: () => Values;
-  resetField: (path: PropertyKey) => void;
+  resetField: (path: PropertyKey, subscribers?: (SetFieldValueSubscriber<Values> | null | undefined)[]) => void;
 }
 
 export interface SetValuesSubscriberPayload<Values> {
@@ -131,7 +131,7 @@ export function useFormValues<Values extends Record<PropertyKey, any>>({
   const getValuesSnapshot = useCallback(() => valuesSnapshot.current, []);
 
   const resetField = useCallback(
-    (path: PropertyKey) => {
+    (path: PropertyKey, subscribers?: (SetFieldValueSubscriber<Values> | null | undefined)[]) => {
       const snapshotValue = getPath(path, valuesSnapshot.current);
       if (typeof snapshotValue === 'undefined') {
         return;
@@ -139,7 +139,8 @@ export function useFormValues<Values extends Record<PropertyKey, any>>({
       setFieldValue({
         path,
         value: snapshotValue,
-        updateState: mode === 'uncontrolled' || undefined,
+        updateState: mode === 'controlled',
+        subscribers,
       });
     },
     [setFieldValue, mode]

--- a/packages/@mantine/form/src/hooks/use-form-values/use-form-values.ts
+++ b/packages/@mantine/form/src/hooks/use-form-values/use-form-values.ts
@@ -14,7 +14,10 @@ export interface $FormValues<Values extends Record<PropertyKey, any>> {
   initialize: (values: Values, onInitialize: () => void) => void;
   getValues: () => Values;
   getValuesSnapshot: () => Values;
-  resetField: (path: PropertyKey, subscribers?: (SetFieldValueSubscriber<Values> | null | undefined)[]) => void;
+  resetField: (
+    path: PropertyKey,
+    subscribers?: (SetFieldValueSubscriber<Values> | null | undefined)[]
+  ) => void;
 }
 
 export interface SetValuesSubscriberPayload<Values> {

--- a/packages/@mantine/form/src/stories/Form.rendering.story.tsx
+++ b/packages/@mantine/form/src/stories/Form.rendering.story.tsx
@@ -1,3 +1,4 @@
+import { Button, TextInput } from '@mantine/core';
 import { useForm } from '../use-form';
 import { FormBase } from './_base';
 
@@ -17,6 +18,23 @@ export function Rendering() {
       <Input {...form.getInputProps('a')} name="a" />
       <Input {...form.getInputProps('b')} name="b" />
       <Input {...form.getInputProps('c')} name="c" />
+    </FormBase>
+  );
+}
+
+export function UncontrolledResetField() {
+  const form = useForm({
+    mode: 'uncontrolled',
+    initialValues: {
+      foo: 'foo',
+    },
+  });
+
+  return (
+    <FormBase form={form}>
+      <TextInput {...form.getInputProps('foo')} key={form.key('foo')} />
+      <Button onClick={() => form.resetField('foo')}>Reset Field</Button>
+      <Button onClick={() => form.setFieldValue('foo', 'foo')}>Set Field</Button>
     </FormBase>
   );
 }

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -247,12 +247,26 @@ export function useForm<
     [rules]
   );
 
-  const key: Key<Values> = (path) =>
-    `${formKey}-${path as string}-${fieldKeys[path as string] || 0}`;
+  const key: Key<Values> = (path) => `${formKey}-${String(path)}-${fieldKeys[String(path)] || 0}`;
 
   const getInputNode: GetInputNode<Values> = useCallback(
     (path) => document.querySelector(`[data-path="${getDataPath(name, path)}"]`),
     []
+  );
+
+  const resetField = useCallback(
+    (path: PropertyKey) => {
+      $values.resetField(path, [
+        mode !== 'controlled'
+          ? () =>
+              setFieldKeys((keys) => ({
+                ...keys,
+                [path as string]: (keys[path as string] || 0) + 1,
+              }))
+          : null,
+      ]);
+    },
+    [$values.resetField, mode, setFieldKeys]
   );
 
   const form: UseFormReturnType<Values, TransformValues> = {
@@ -263,7 +277,7 @@ export function useForm<
     getValues: $values.getValues,
     getInitialValues: $values.getValuesSnapshot,
     setInitialValues: $values.setValuesSnapshot,
-    resetField: $values.resetField,
+    resetField,
     initialize,
     setValues,
     setFieldValue,


### PR DESCRIPTION
Fixes #8050

This pull request introduces updates to the `resetField` function and provides an example to demonstrate its usage in uncontrolled form scenarios:

- Added a new story, `UncontrolledResetField`, to illustrate the `resetField` functionality with clear interactions like resetting and managing field values.
- Enhanced the `resetField` implementation to include support for an optional `subscribers` parameter, improving integration with value updates and ensuring compatibility across controlled and uncontrolled modes.