### PR TITLE
fix: Resolved the mql compatibility issue

### DIFF
--- a/packages/@mantine/core/src/core/MantineProvider/use-mantine-color-scheme/use-provider-color-scheme.ts
+++ b/packages/@mantine/core/src/core/MantineProvider/use-mantine-color-scheme/use-provider-color-scheme.ts
@@ -82,8 +82,20 @@ export function useProviderColorScheme({
       }
     };
 
-    media.current?.addEventListener('change', listener);
-    return () => media.current?.removeEventListener('change', listener);
+    if(typeof media.current?.addEventListener === 'function') {
+      media.current.addEventListener('change', listener);
+    } else {
+      media.current?.addListener?.(listener);
+    }
+
+    return () => {
+      if(typeof media.current?.removeEventListener === 'function') {
+        media.current.removeEventListener('change', listener);
+        return;
+      }
+
+      media.current?.removeListener?.(listener);
+    };
   }, [value, forceColorScheme]);
 
   return { colorScheme: colorSchemeValue, setColorScheme, clearColorScheme };


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/05391dad-23cc-4d81-995b-261763cef751)

In some browser versions, such as Safari, only the addListener method of MQL is supported, but this method is deprecated.

The current W3C standard only supports addEventListener of EventTarget.

Then, in some versions that don't support the new standard, the following error will be reported:

![image](https://github.com/user-attachments/assets/e68ccf95-35d2-4d6f-944c-445e863c3ef7)

So in order to support some intermediate versions, compatibility issues need to be addressed.



