### PR TITLE
[@mantine/core] Add clearSearchOnChange back on MultiSelect

### DIFF
--- a/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
@@ -105,6 +105,9 @@ export interface MultiSelectProps
 
   /** Controls color of the default chevron */
   chevronColor?: MantineColor;
+
+  /** Clear search value when item is selected */
+  clearSearchOnChange?: boolean;
 }
 
 export type MultiSelectFactory = Factory<{
@@ -118,6 +121,7 @@ const defaultProps = {
   withCheckIcon: true,
   checkIconPosition: 'left',
   hiddenInputValuesDivider: ',',
+  clearSearchOnChange: true,
 } satisfies Partial<MultiSelectProps>;
 
 export const MultiSelect = factory<MultiSelectFactory>((_props, ref) => {
@@ -196,6 +200,7 @@ export const MultiSelect = factory<MultiSelectFactory>((_props, ref) => {
     scrollAreaProps,
     chevronColor,
     attributes,
+    clearSearchOnChange,
     ...others
   } = props;
 
@@ -316,7 +321,9 @@ export const MultiSelect = factory<MultiSelectFactory>((_props, ref) => {
         attributes={attributes}
         onOptionSubmit={(val) => {
           onOptionSubmit?.(val);
-          handleSearchChange('');
+          if (clearSearchOnChange) {
+            handleSearchChange('');
+          }
           combobox.updateSelectedOptionIndex('selected');
 
           if (_value.includes(optionsLockup[val].value)) {

--- a/packages/@mantine/core/src/components/MultiSelect/MutliSelect.story.tsx
+++ b/packages/@mantine/core/src/components/MultiSelect/MutliSelect.story.tsx
@@ -223,6 +223,20 @@ export function Searchable() {
   );
 }
 
+export function SearchableNoClearOnChange() {
+  return (
+    <div style={{ padding: 40 }}>
+      <MultiSelect
+        data={['React', 'Angular', 'Svelte']}
+        placeholder="MultiSelect something"
+        searchable
+        nothingFoundMessage="Nothing found..."
+        clearSearchOnChange={false}
+      />
+    </div>
+  );
+}
+
 export function NoDataProvidedMessage() {
   return (
     <div style={{ padding: 40 }}>


### PR DESCRIPTION
Adding back this prop that used to be part of v6
See https://v6.mantine.dev/core/multi-select/?t=props for reference