### PR TITLE
fix TagsInput: Backspace can remove tags even when readOnly is set

### DIFF
--- a/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
+++ b/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
@@ -313,7 +313,8 @@ export const TagsInput = factory<TagsInputFactory>((_props, ref) => {
       event.key === 'Backspace' &&
       length === 0 &&
       _value.length > 0 &&
-      !event.nativeEvent.isComposing
+      !event.nativeEvent.isComposing &&
+      !readOnly
     ) {
       onRemove?.(_value[_value.length - 1]);
       setValue(_value.slice(0, _value.length - 1));


### PR DESCRIPTION
fixed #8066 