### PR TITLE
[@mantine/core] HoverCard: Fix dropdown closing when clicked

### DIFF
--- a/packages/@mantine/core/src/components/HoverCard/use-hover-card.ts
+++ b/packages/@mantine/core/src/components/HoverCard/use-hover-card.ts
@@ -61,7 +61,7 @@ export function useHoverCard(settings: UseHoverCard) {
       delay: withinGroup ? groupDelay : { open: settings.openDelay, close: settings.closeDelay },
     }),
     useRole(context, { role: 'dialog' }),
-    useDismiss(context, { enabled: typeof settings.opened === 'undefined' }),
+    useDismiss(context, { enabled: withinGroup }),
   ]);
 
   const openDropdown = useCallback(() => {


### PR DESCRIPTION
# HoverCard Dropdown Issue and Proposed Fix

## Issue Description
The HoverCard dropdown closes unexpectedly when clicked, disrupting the user experience as it should remain open during interaction.

## Root Cause
The issue occurs because `floating-ui`'s `useDismiss` hook incorrectly triggers an outside click event, calling `onChange(false)` to close the dropdown. The `useHoverCard` hook's inner `useFloating` is only intended for `withinGroup` contexts, so `useDismiss` should only be active when `withinGroup` is enabled. However, `useDismiss` is triggered regardless of this state. Additionally,[ `useDismiss` checks if the dropdown is open before registering events internally,](https://github.com/floating-ui/floating-ui/blob/master/packages/react/src/hooks/useDismiss.ts#L363) but the condition `enabled: typeof settings.opened === 'undefined'` maybe incorrect, leading to improper event registration.

## Proposed Fix
A small update is needed to ensure `useDismiss` is only active when `withinGroup` is enabled, preventing the dropdown from closing unexpectedly outside this context, and works like before. Additionally, the `enabled` check in `useDismiss` should be corrected to properly handle click-outside events, ensuring events are only registered when the dropdown is open and within the `withinGroup` context.