### PR TITLE
[Documentation] Add a demo for 3 states color scheme toggle with an additional Auto state

### DIFF
--- a/apps/mantine.dev/src/pages/theming/color-schemes.mdx
+++ b/apps/mantine.dev/src/pages/theming/color-schemes.mdx
@@ -84,6 +84,10 @@ function Demo() {
 }
 ```
 
+Example: auto 3 state scheme toggle.
+
+<Demo data={ThemingDemos.colorSchemeSegmentedControl} />
+
 ## Transitions during color scheme change
 
 By default, transitions on all elements are disabled when color scheme changes to avoid

--- a/packages/@docs/demos/src/demos/theming/Theming.demo.colorSchemeSegmentedControl.module.css
+++ b/packages/@docs/demos/src/demos/theming/Theming.demo.colorSchemeSegmentedControl.module.css
@@ -1,0 +1,16 @@
+.rootBackground {
+  @mixin dark {
+    background-color: var(--mantine-color-dark-5);
+    border-color: var(--mantine-color-dark-5);
+  }
+}
+
+.indicatorBackground {
+  @mixin dark {
+    background-color: var(--mantine-color-dark-3);
+  }
+}
+
+.autoIconColor {
+  color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
+}

--- a/packages/@docs/demos/src/demos/theming/Theming.demo.colorSchemeSegmentedControl.tsx
+++ b/packages/@docs/demos/src/demos/theming/Theming.demo.colorSchemeSegmentedControl.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useLayoutEffect, useState } from 'react';
+import { IconMoonStars, IconSun, IconYinYangFilled } from '@tabler/icons-react';
+import {
+  Center,
+  SegmentedControl,
+  useMantineColorScheme,
+  useMantineTheme,
+  type MantineColorScheme,
+} from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+import classes from './Theming.demo.colorSchemeSegmentedControl.module.css';
+
+const code = `
+import { useEffect, useLayoutEffect, useState } from 'react';
+import { IconMoonStars, IconSun, IconYinYangFilled } from '@tabler/icons-react';
+import {
+  Center,
+  SegmentedControl,
+  useMantineColorScheme,
+  useMantineTheme,
+  type MantineColorScheme,
+} from '@mantine/core';
+import classes from './Demo.module.css';
+
+function Demo() {
+  const iconSize = 22;
+  const iconStroke = 2.5;
+  const transitionDuration = 200;
+  const theme = useMantineTheme();
+  const { colorScheme, setColorScheme } = useMantineColorScheme();
+  const [colorSchemeSegmentedControlValue, setColorSchemeSegmentedControlValue] =
+    useState<MantineColorScheme>('auto');
+
+  const lightIcon = <IconSun size={iconSize} stroke={iconStroke} color={theme.colors.yellow[6]} />;
+
+  const darkIcon = (
+    <IconMoonStars size={iconSize} stroke={iconStroke} color={theme.colors.blue[6]} />
+  );
+
+  const autoIcon = (
+    <IconYinYangFilled size={iconSize} stroke={iconStroke} className={classes.autoIconColor} />
+  );
+
+  useEffect(() => {
+    setColorSchemeSegmentedControlValue(colorScheme); // Avoid hydration error, meanwhile sync with other color scheme control if any
+  }, [colorScheme]);
+
+  useLayoutEffect(() => {
+    // Aollow SegmentedControl transition to finish before re-rendering the color scheme
+    const timeoutId = setTimeout(() => {
+      setColorScheme(colorSchemeSegmentedControlValue);
+    }, transitionDuration);
+    return () => clearTimeout(timeoutId);
+  }, [colorSchemeSegmentedControlValue, transitionDuration]);
+
+  return (
+    <SegmentedControl
+      classNames={{
+        root: classes.rootBackground,
+        indicator: classes.indicatorBackground,
+      }}
+      transitionDuration={transitionDuration}
+      value={colorSchemeSegmentedControlValue}
+      onChange={(value: string) => setColorSchemeSegmentedControlValue(value as MantineColorScheme)}
+      aria-label="Toggle color scheme"
+      data={[
+        {
+          value: 'light',
+          label: <Center>{lightIcon}</Center>,
+        },
+        {
+          value: 'auto',
+          label: <Center>{autoIcon}</Center>,
+        },
+        {
+          value: 'dark',
+          label: <Center>{darkIcon}</Center>,
+        },
+      ]}
+    />
+  );
+}
+`;
+
+const cssCode = `
+.rootBackground {
+  @mixin dark {
+    background-color: var(--mantine-color-dark-5);
+    border-color: var(--mantine-color-dark-5);
+  }
+}
+
+.indicatorBackground {
+  @mixin dark {
+    background-color: var(--mantine-color-dark-3);
+  }
+}
+
+.autoIconColor {
+  color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
+}
+`;
+
+function Demo() {
+  const iconSize = 22;
+  const iconStroke = 2.5;
+  const transitionDuration = 200;
+  const theme = useMantineTheme();
+  const { colorScheme, setColorScheme } = useMantineColorScheme();
+  const [colorSchemeSegmentedControlValue, setColorSchemeSegmentedControlValue] =
+    useState<MantineColorScheme>('auto');
+
+  const lightIcon = <IconSun size={iconSize} stroke={iconStroke} color={theme.colors.yellow[6]} />;
+
+  const darkIcon = (
+    <IconMoonStars size={iconSize} stroke={iconStroke} color={theme.colors.blue[6]} />
+  );
+
+  const autoIcon = (
+    <IconYinYangFilled size={iconSize} stroke={iconStroke} className={classes.autoIconColor} />
+  );
+
+  useEffect(() => {
+    setColorSchemeSegmentedControlValue(colorScheme); // Avoid hydration error, meanwhile sync with other color scheme control if any
+  }, [colorScheme]);
+
+  useLayoutEffect(() => {
+    // Aollow SegmentedControl transition to finish before re-rendering the color scheme
+    const timeoutId = setTimeout(() => {
+      setColorScheme(colorSchemeSegmentedControlValue);
+    }, transitionDuration);
+    return () => clearTimeout(timeoutId);
+  }, [colorSchemeSegmentedControlValue, transitionDuration]);
+
+  return (
+    <SegmentedControl
+      classNames={{
+        root: classes.rootBackground,
+        indicator: classes.indicatorBackground,
+      }}
+      transitionDuration={transitionDuration}
+      value={colorSchemeSegmentedControlValue}
+      onChange={(value: string) => setColorSchemeSegmentedControlValue(value as MantineColorScheme)}
+      aria-label="Toggle color scheme"
+      data={[
+        {
+          value: 'light',
+          label: <Center>{lightIcon}</Center>,
+        },
+        {
+          value: 'auto',
+          label: <Center>{autoIcon}</Center>,
+        },
+        {
+          value: 'dark',
+          label: <Center>{darkIcon}</Center>,
+        },
+      ]}
+    />
+  );
+}
+
+export const colorSchemeSegmentedControl: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  centered: true,
+  code: [
+    { fileName: 'Demo.tsx', language: 'tsx', code },
+    { fileName: 'Demo.module.css', language: 'scss', code: cssCode },
+  ],
+};

--- a/packages/@docs/demos/src/demos/theming/Theming.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/theming/Theming.demos.story.tsx
@@ -98,6 +98,11 @@ export const Demo_colorSchemeControl = {
   render: renderDemo(demos.colorSchemeControl),
 };
 
+export const Demo_colorSchemeSegmentedControl = {
+  name: '⭐ Demo: colorSchemeSegmentedControl',
+  render: renderDemo(demos.colorSchemeSegmentedControl),
+};
+
 export const Demo_defaultGradient = {
   name: '⭐ Demo: defaultGradient',
   render: renderDemo(demos.defaultGradient),

--- a/packages/@docs/demos/src/demos/theming/index.ts
+++ b/packages/@docs/demos/src/demos/theming/index.ts
@@ -17,6 +17,7 @@ export { headingsStyles } from './Theming.demo.headingsStyles';
 export { fontSizeConfigurator } from './Theming.demo.fontSizeConfigurator';
 export { colorScheme } from './Theming.demo.colorScheme';
 export { colorSchemeControl } from './Theming.demo.colorSchemeControl';
+export { colorSchemeSegmentedControl } from './Theming.demo.colorSchemeSegmentedControl';
 export { defaultGradient } from './Theming.demo.defaultGradient';
 export { cursorType } from './Theming.demo.cursorType';
 export { autoContrast } from './Theming.demo.autoContrast';


### PR DESCRIPTION
Closes: https://github.com/mantinedev/mantine/issues/8101
<img width="2940" height="1594" alt="glowing-guide-pj6xg995v47wc66g-7545 app github dev_theming_color-schemes_" src="https://github.com/user-attachments/assets/fa0f2520-d77f-4373-b5f1-26d18865ac5c" />
