### PR TITLE
V8 DateTimePicker and DatePickerInput lose responsive layout on narrow screens Bug Fix

### DIFF
--- a/packages/@mantine/dates/src/components/PickerInputBase/PickerInputBase.tsx
+++ b/packages/@mantine/dates/src/components/PickerInputBase/PickerInputBase.tsx
@@ -175,6 +175,7 @@ export const PickerInputBase = factory<PickerInputBaseFactory>((_props, ref) => 
               disabled={disabled}
               component="button"
               type="button"
+              multiline
               onClick={(event) => {
                 onClick?.(event);
                 dropdownHandlers.toggle();


### PR DESCRIPTION
Added multiline prop to wrap into two lines without overlapping the border