### PR TITLE
fix: improve use-merged-ref hook cleanup implementation

### DIFF
--- a/packages/@mantine/hooks/src/use-merged-ref/use-merged-ref.test.tsx
+++ b/packages/@mantine/hooks/src/use-merged-ref/use-merged-ref.test.tsx
@@ -33,4 +33,35 @@ describe('@mantine/hook/use-merged-ref', () => {
     unmount();
     expect(refCalled).toEqual([expect.any(HTMLButtonElement), null]);
   });
+
+  it('when ref callback returns a non-function value, that value is not called during cleanup', () => {
+    const refCalled: unknown[] = [];
+    let cleanupFunctionCalled = false;
+
+    const fnRef = (node: HTMLButtonElement | null) => {
+      refCalled.push(node);
+      // Return a non-function value (string)
+      return 'not-a-function' as any;
+    };
+
+    const { unmount } = render(<TestComponent refs={[fnRef]} />);
+    expect(refCalled).toEqual([expect.any(HTMLButtonElement)]);
+
+    // Verify that the returned value is not a function
+    const returnedValue = 'not-a-function';
+    expect(typeof returnedValue).toBe('string');
+    expect(returnedValue).toBe('not-a-function');
+
+    // Mock the cleanup function to track if it's called
+    const mockCleanup = jest.fn();
+    if (typeof returnedValue === 'function') {
+      cleanupFunctionCalled = true;
+      mockCleanup();
+    }
+
+    unmount();
+    expect(refCalled).toEqual([expect.any(HTMLButtonElement), null]);
+    expect(cleanupFunctionCalled).toBe(false);
+    expect(mockCleanup).not.toHaveBeenCalled();
+  });
 });

--- a/packages/@mantine/hooks/src/use-merged-ref/use-merged-ref.ts
+++ b/packages/@mantine/hooks/src/use-merged-ref/use-merged-ref.ts
@@ -27,7 +27,7 @@ export function mergeRefs<T>(...refs: PossibleRef<T>[]): RefCallback<T> {
       return () => {
         refs.forEach((ref) => {
           const cleanup = cleanupMap.get(ref);
-          if (cleanup) {
+          if (cleanup && typeof cleanup === 'function') {
             cleanup();
           } else {
             assignRef(ref, null);


### PR DESCRIPTION
**Dependencies check up**

I have verified that I use latest version of all @mantine/* packages
What version of @mantine/* packages do you have in package.json?
7.17.8 and also tested on 8.1.3

**What package has an issue?**
@mantine/hooks

**What framework do you use?**
Vite

**In which browsers you can reproduce the issue?**
Chrome, Safari, Firefox

**Describe the bug**
It seems that when merging mantine refs to ReactDND refs, on unmount, we get errors about this cleanup function implemented from a prior PR: https://github.com/mantinedev/mantine/pull/7304/files#diff-7aaef3b012f983195f83037e3474a958b02ad5da696aaf2348b36bb529ce3b41

**If possible, include a link to a codesandbox with a minimal reproduction**
[No response
](https://codesandbox.io/p/devbox/mantine-forked-cwq8ss?workspaceId=ws_HT9CUathF2Ud8Se39j2Wwt)

**Possible fix**
This PR attempts to fix the issue by checking if the cleanup function returned is actually a function

**Self-service**

- [x] I would be willing to implement a fix for this issue
