### PR TITLE
fix: SubMenu overflows on small screen widths

### DIFF
--- a/packages/@mantine/core/src/components/Menu/MenuSub/MenuSub.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuSub/MenuSub.tsx
@@ -32,6 +32,12 @@ const defaultProps = {
   offset: 0,
   position: 'right-start',
   transitionProps: { duration: 0 },
+  middlewares: {
+    shift: {
+      // Enable crossAxis shift to keep submenu dropdown within viewport bounds when positioned horizontally
+      crossAxis: true,
+    },
+  },
 } satisfies Partial<MenuSubProps>;
 
 export function MenuSub(_props: MenuSubProps) {


### PR DESCRIPTION
# Submenu Positioning with Floating UI

## Overview of Floating UI
**flip()**: Adjusts placement (e.g., `top` to `bottom`) to prevent overflow.
**shift()**: Moves the floating element along the x or y axis to stay within the viewport. By default, only [`mainAxis=true`.](https://floating-ui.com/docs/shift#crossaxis)

## Problem Description
Since the submenu is set to `position=right-start`, the `mainAxis` changes to the y-axis in this horizontal placement. By default, `shift()` only adjusts the `mainAxis`, which may lead to inconsistent behavior due to Floating UI's handling.

## Solution
Enable `crossAxis: true` in `shift()` to allow x-axis adjustments, aligning the submenu to the viewport's right boundary. As `shift()` precedes `flip()` in the [`usePopover` middleware order](https://github.com/mantinedev/mantine/blob/master/packages/%40mantine/core/src/components/Popover/use-popover.ts#L74-L90), `flip()` does not trigger horizontal placement changes. The current middleware order in `usePopover` is sufficient, ensuring a visually consistent right-aligned submenu.

## Visual Results
<img width="456" height="311" alt="image" src="https://github.com/user-attachments/assets/2ad81322-808d-46a5-908b-73f504d70c10" />

<img width="473" height="365" alt="image" src="https://github.com/user-attachments/assets/82c14a53-8acf-4907-a80c-a53b5455c50e" />

<img width="347" height="342" alt="image" src="https://github.com/user-attachments/assets/6b8a7651-b54f-443a-ab48-6f9a92aa0bc4" />

[Per Floating UI docs: "Enabling this can lead to the floating element **overlapping** the reference element, which may not be desired and is often replaced by the flip() middleware."](<https://floating-ui.com/docs/shift#crossaxis:~:text=Enabling%20this%20can%20lead%20to%20the%20floating%20element%20overlapping%20the%20reference%20element%2C%20which%20may%20not%20be%20desired%20and%20is%20often%20replaced%20by%20the%20flip()%20middleware.>)
However, this approach is effective for our use case.

## Alternative Approach
Updating the [middleware order](https://github.com/mantinedev/mantine/blob/master/packages/%40mantine/core/src/components/Popover/use-popover.ts#L74-L90) to `[flip(), shift()]` would flip the submenu to `left-start` on overflow before shifting. The results would appear as follows:
<img width="639" height="424" alt="image" src="https://github.com/user-attachments/assets/b14697fb-431c-4531-baf6-55697e185240" />

<img width="387" height="353" alt="image" src="https://github.com/user-attachments/assets/7e4d9547-9aaf-457a-94c3-0b84c2bcdb51" />


## Conclusion
Both solutions are effective. I opted for the minimal code change by enabling `crossAxis: true` in `shift()` for the align-right approach. Users can modify position and middleware but should be familiar with Floating UI middleware to understand the implications of their changes.