### PR TITLE
Typo in postcss-fns-inline.mdx

### DIFF
--- a/apps/help.mantine.dev/src/pages/q/postcss-fns-inline.mdx
+++ b/apps/help.mantine.dev/src/pages/q/postcss-fns-inline.mdx
@@ -26,7 +26,7 @@ mixins and other helpers to simplify working with Mantine styles. Example of usi
 
 // What you get after PostCSS processing
 [data-mantine-color-scheme='light'] .demo {
-  background: black;
+  background: white;
 }
 
 [data-mantine-color-scheme='dark'] .demo {


### PR DESCRIPTION
the example code had a typo