### PR TITLE
fix(CodeHighlight): add aria-label to copy button for accessibility

### DIFF
--- a/packages/@mantine/code-highlight/src/CodeHighlight/CopyCodeButton/CopyCodeButton.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlight/CopyCodeButton/CopyCodeButton.tsx
@@ -20,6 +20,7 @@ export function CopyCodeButton({
       onClick={() => clipboard.copy(code.trim())}
       variant="none"
       tooltipLabel={clipboard.copied ? copiedLabel : copyLabel}
+      aria-label={clipboard.copied ? copiedLabel : `${copyLabel} code`}
     >
       <CopyIcon copied={clipboard.copied} />
     </CodeHighlightControl>


### PR DESCRIPTION
## Description

This PR adds an `aria-label` attribute to the CodeHighlight copy button to improve accessibility for screen reader users.

## Problem

Currently, the copy button in CodeHighlight component doesn't have an accessible name, which causes:
- Screen readers announce it as just "button" without context
- Accessibility test failures (e.g., in PageSpeed Insights)
- Poor experience for users relying on assistive technologies

## Solution

Added `aria-label` attribute to the `CodeHighlightControl` component in `CopyCodeButton`:
- When not copied: `"Copy code"`
- When copied: `"Copied"`

This follows the same pattern used in other Mantine components like Burger.

## Changes

- Added `aria-label` prop to `CodeHighlightControl` in `CopyCodeButton` component
- The label dynamically changes based on the clipboard state

## Testing

- [x] Tested manually in Storybook
- [x] Verified the button now has proper accessible name in browser DevTools
- [ ] No existing tests for CopyCodeButton component to update

## Note

This is a minimal accessibility fix that only adds the `aria-label` prop. No breaking changes or new features introduced.

## Checklist

- [x] I've followed the project's contribution guidelines
- [x] The code follows the existing code style
- [x] The change is backward compatible
- [x] This is a small accessibility fix that doesn't require prior discussion