### PR TITLE
[@mantine/core] Table: Fix missing border when rowspan is present

### DIFF
--- a/packages/@mantine/core/src/components/Table/Table.module.css
+++ b/packages/@mantine/core/src/components/Table/Table.module.css
@@ -68,6 +68,10 @@
 .th {
   padding: var(--table-vertical-spacing) var(--table-horizontal-spacing, var(--mantine-spacing-xs));
 
+  &:where([data-with-column-border]:not(:first-child)) {
+    border-inline-start: rem(1px) solid var(--table-border-color);
+  }
+
   &:where([data-with-column-border]:not(:last-child)) {
     border-inline-end: rem(1px) solid var(--table-border-color);
   }


### PR DESCRIPTION
# Description
When using `withColumnBorders` along with rowSpan cells, some borders do not appear (#8088).
<img width="1779" height="242" alt="imagen" src="https://github.com/user-attachments/assets/c3d39950-56af-4b22-8e0a-ca2911da55a5" />

# Why
Table styles define that borders are given at the end pof each cell that is not last child. The issue is that when rowspan is used, even it seems like a cell is not the last one, for the DOM it is.

# Solution
In order to fix this via CSS I decided to add another rule that places a border at the start of every cell if it is not the first one. This fixes the cases where rowspan is used.
<img width="1140" height="246" alt="imagen" src="https://github.com/user-attachments/assets/16f591b9-5803-4223-beac-210838ec66ba" />

I choose this solution as I did not found any other way to fix this without requiring the developer to provide manually a "lastCell" indicator.