### PR TITLE
Fix carret no longer displaying on password inputs

### DIFF
--- a/packages/@mantine/core/src/components/Input/Input.module.css
+++ b/packages/@mantine/core/src/components/Input/Input.module.css
@@ -212,7 +212,7 @@
     color: var(--input-disabled-color);
   }
 
-  &:read-only {
+  &[readonly] {
     caret-color: transparent;
   }
 }


### PR DESCRIPTION
PasswordInput carret was invisivle because of Pull Request #8063.

Tested both Select component and PasswordInput on Chrome, Edge and FireFox as the original pull request said it was broken in FireFox.