### PR TITLE
feat(input): set default size to sm

### DIFF
--- a/packages/@mantine/core/src/components/Input/Input.tsx
+++ b/packages/@mantine/core/src/components/Input/Input.tsx
@@ -163,6 +163,7 @@ const defaultProps = {
   rightSectionPointerEvents: 'none',
   withAria: true,
   withErrorStyles: true,
+  size: 'sm',
 } satisfies Partial<InputProps>;
 
 const varsResolver = createVarsResolver<InputFactory>((_, props, ctx) => ({


### PR DESCRIPTION
<img width="361" height="174" alt="image" src="https://github.com/user-attachments/assets/e0ec06d9-ec55-4bd5-af1f-93aaf4c9655a" />

It should be able to fix the issue where the textarea padding falls back to 0, rather than being set explicitly.