### PR TITLE
Fix use-list-state type

### DIFF
--- a/packages/@mantine/hooks/src/use-list-state/use-list-state.ts
+++ b/packages/@mantine/hooks/src/use-list-state/use-list-state.ts
@@ -22,7 +22,7 @@ export interface UseListStateHandlers<T> {
 
 export type UseListStateReturnValue<T> = [T[], UseListStateHandlers<T>];
 
-export function useListState<T>(initialValue: T[] = []): UseListStateReturnValue<T> {
+export function useListState<T>(initialValue: T[] | (() => T[]) = []): UseListStateReturnValue<T> {
   const [state, setState] = useState(initialValue);
 
   const append = (...items: T[]) => setState((current) => [...current, ...items]);


### PR DESCRIPTION
`useState` allows you to pass an initializer value. ([Reference](https://react.dev/reference/react/useState#avoiding-recreating-the-initial-state))
It would be convenient if useListState also supported initializers. Technically, we were passing values directly to useState, so we modified the type definitions accordingly.
