### PR TITLE
Fix Horizontal Scrollbars not updating when content  overflows

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.module.css
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.module.css
@@ -3,6 +3,10 @@
 
   position: relative;
   overflow: hidden;
+
+  &:where([data-autosize]) .content {
+    width: min-content;
+  }
 }
 
 .viewport {

--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.story.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.story.tsx
@@ -128,6 +128,30 @@ export function OverflowIssue() {
   );
 }
 
+export function AutoOverflowIssue() {
+  const [width, setWidth] = useState(150);
+  const [height, setHeight] = useState(150);
+
+  return (
+    <div style={{ padding: 40 }}>
+      <Box w={200}>
+        <ScrollArea.Autosize offsetScrollbars type="auto" mah={200} maw={170}>
+          <button onClick={() => setWidth((prev) => (prev === 150 ? 300 : 150))} style={{ width }}>
+            Horizontal
+          </button>
+
+          <button
+            onClick={() => setHeight((prev) => (prev === 150 ? 300 : 150))}
+            style={{ height }}
+          >
+            Vertical
+          </button>
+        </ScrollArea.Autosize>
+      </Box>
+    </div>
+  );
+}
+
 export function OnBottomReached() {
   const [scrollPosition, onScrollPositionChange] = useState({ x: 0, y: 0 });
   const [hasReachedBottom, setHasReachedBottom] = useState(false);

--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -331,7 +331,7 @@ export const ScrollAreaAutosize = factory<ScrollAreaAutosizeFactory>((props, ref
 
   return (
     <Box {...others} ref={ref} style={[{ display: 'flex', overflow: 'auto' }, style]}>
-      <Box style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+      <Box style={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
         <ScrollArea
           classNames={classNames}
           styles={styles}
@@ -349,6 +349,7 @@ export const ScrollAreaAutosize = factory<ScrollAreaAutosizeFactory>((props, ref
           scrollbars={scrollbars}
           onBottomReached={onBottomReached}
           onTopReached={onTopReached}
+          data-autosize="true"
         >
           {children}
         </ScrollArea>


### PR DESCRIPTION
Fixes #8075

The problem is that `display: block` by default lets its content overflow vertically, but only grows to 100% horizontally. This could be fixed in two ways

1. Make the content have `display: inline-block`
2. Make the content have a fixed width

I fixed the issue by giving the content container of `ScrollArea.Autosize` `width: min-content`. I think that's the least intrusive way of handling this issue that hopefully doesn't break anything else. This way the container resizes whenever the content changes its width.

I deliberately only applied the fix to `ScrollArea.Autosize` as applying it to `ScrollArea` messes up other components like `MultiSelect`.

If anyone has a better solution to this problem feel free to let me know. I kinda worry that applying these styles messes up other components relying on `ScrollArea.Autosize` down the line.