### PR TITLE
Fix for #7968: ScrollArea extends horizontally even with scrollbars="y" set

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.story.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.story.tsx
@@ -1,9 +1,12 @@
 import { createRef, useEffect, useState } from 'react';
 import { Box } from '../../core';
+import { Button } from '../Button';
 import { Code } from '../Code';
+import { InputBase } from '../InputBase';
 import { MultiSelect } from '../MultiSelect';
 import { NumberInput } from '../NumberInput';
 import { Paper } from '../Paper';
+import { Pill, PillGroup } from '../Pill';
 import { Stack } from '../Stack';
 import { ScrollArea } from './ScrollArea';
 
@@ -184,6 +187,41 @@ export function OnBottomReached() {
       <div>
         Custom Has Reached Bottom: <Code>{`{ ${customReachedBottom} }`}</Code>
       </div>
+    </Stack>
+  );
+}
+
+export function PillGroupIssue() {
+  const [pills, setPills] = useState<string[]>([]);
+
+  const handleAdd = () => {
+    const index = pills.length + 1;
+    setPills((prev) => [...prev, 'Pill '.repeat(index).trim()]);
+  };
+
+  const handleClear = () => {
+    setPills([]);
+  };
+
+  const handleRemove = (id: string) => {
+    setPills((prev) => prev.filter((item) => item !== id));
+  };
+
+  return (
+    <Stack p="md" w={250}>
+      <Button onClick={handleAdd}>Add Pill</Button>
+      <Button onClick={handleClear}>Clear</Button>
+      <InputBase component="div" multiline>
+        <ScrollArea.Autosize mah={120} scrollbars="y" type="always">
+          <PillGroup>
+            {pills.map((datumId) => (
+              <Pill key={datumId} withRemoveButton onRemove={() => handleRemove(datumId)}>
+                {datumId}
+              </Pill>
+            ))}
+          </PillGroup>
+        </ScrollArea.Autosize>
+      </InputBase>
     </Stack>
   );
 }

--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -330,8 +330,28 @@ export const ScrollAreaAutosize = factory<ScrollAreaAutosizeFactory>((props, ref
   }, [onOverflowChange, overflowing]);
 
   return (
-    <Box {...others} ref={ref} style={[{ display: 'flex', overflow: 'auto' }, style]}>
-      <Box style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+    <Box
+      {...others}
+      ref={ref}
+      style={[
+        {
+          display: 'flex',
+          overflow: 'hidden',
+        },
+        style,
+      ]}
+    >
+      <Box
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+          ...(scrollbars === 'y' && { minWidth: 0 }),
+          ...(scrollbars === 'x' && { minHeight: 0 }),
+          ...(scrollbars === 'xy' && { minWidth: 0, minHeight: 0 }),
+          ...(scrollbars === false && { minWidth: 0, minHeight: 0 }),
+        }}
+      >
         <ScrollArea
           classNames={classNames}
           styles={styles}


### PR DESCRIPTION
Fixes #7968 

Fixed horizontal expansion issue in ScrollArea.Autosize when scrollbars="y" is set. The container was growing beyond parent width limits and showing native scrollbars instead of custom ones.

- Modified ScrollArea.Autosize wrapper to use `overflow: 'hidden'` instead of `overflow: 'auto'`
- Added flex constraints to prevent horizontal expansion when scrollbars="y"
- Added story test case to verify the fix

Tested with PillGroup component and long content scenarios.
The PillGroup component used for testing has been added to Storybook.

<img width="601" height="1012" alt="스크린샷 2025-08-12 오전 1 29 00" src="https://github.com/user-attachments/assets/79bef75a-c270-4d7d-9d34-7c7ed334fa40" />


