### PR TITLE
[mantine.dev] Homepage: Fix navbar not showing on mobile (#8164)

### DIFF
--- a/apps/mantine.dev/src/components/Shell/Shell.tsx
+++ b/apps/mantine.dev/src/components/Shell/Shell.tsx
@@ -43,10 +43,10 @@ export function Shell({
     >
       <div>
         <DocsHeader headerControlsProps={headerControlsProps} withNav={withNav} />
+        {withMobileNavbar && mobileNavbarOpened && <DocsMobileNavbar />}
         {withNavbar ? (
           <Container size={1440} fluid={fluid} px={fluid ? 0 : undefined}>
             <div className={classes.inner}>
-              {withMobileNavbar && mobileNavbarOpened && <DocsMobileNavbar />}
               <DocsNavbar />
               <main className={classes.content}>{children}</main>
             </div>


### PR DESCRIPTION
The home page does not display the navbar on mobile because the subnav is not displayed on mobile. 

Fix: subnav and navbar should be separated

<img width="852" height="877" alt="image" src="https://github.com/user-attachments/assets/b273c931-0a8a-4e89-8bea-5a28fd4fb4e7" />


This does not affect the Combobox page (which also uses Shell) because that one has its own sidebar implementation (strange)