### PR TITLE
fix(inputs): Textarea, Combobox and JsonInput padding missing

### DIFF
--- a/packages/@mantine/core/src/components/Input/Input.tsx
+++ b/packages/@mantine/core/src/components/Input/Input.tsx
@@ -163,6 +163,7 @@ const defaultProps = {
   rightSectionPointerEvents: 'none',
   withAria: true,
   withErrorStyles: true,
+  size: 'sm',
 } satisfies Partial<InputProps>;
 
 const varsResolver = createVarsResolver<InputFactory>((_, props, ctx) => ({

--- a/packages/@mantine/core/src/components/InputBase/InputBase.tsx
+++ b/packages/@mantine/core/src/components/InputBase/InputBase.tsx
@@ -35,6 +35,7 @@ export type InputBaseFactory = PolymorphicFactory<{
 const defaultProps = {
   __staticSelector: 'InputBase',
   withAria: true,
+  size: 'sm',
 } satisfies Partial<InputBaseProps>;
 
 export const InputBase = polymorphicFactory<InputBaseFactory>((props, ref) => {

--- a/packages/@mantine/core/src/components/JsonInput/JsonInput.tsx
+++ b/packages/@mantine/core/src/components/JsonInput/JsonInput.tsx
@@ -38,6 +38,7 @@ export type JsonInputFactory = Factory<{
 const defaultProps = {
   serialize: JSON.stringify,
   deserialize: JSON.parse,
+  size: 'sm',
 } satisfies Partial<JsonInputProps>;
 
 export const JsonInput = factory<JsonInputFactory>((props, ref) => {

--- a/packages/@mantine/core/src/components/Textarea/Textarea.tsx
+++ b/packages/@mantine/core/src/components/Textarea/Textarea.tsx
@@ -37,10 +37,14 @@ export type TextareaFactory = Factory<{
   stylesNames: __InputStylesNames;
 }>;
 
+const defaultProps = {
+  size: 'sm',
+} satisfies Partial<TextareaProps>;
+
 export const Textarea = factory<TextareaFactory>((props, ref) => {
   const { autosize, maxRows, minRows, __staticSelector, resize, ...others } = useProps(
     'Textarea',
-    null,
+    defaultProps,
     props
   );
 


### PR DESCRIPTION
Fix the issue where textarea, Combobox and JSON input lose their vertical padding when the size prop is not provided... 🙏 

- resolved #8174 

- relate docs page:
  - https://mantine.dev/combobox/?e=SelectOptionComponent
  - https://mantine.dev/core/json-input/
  - https://mantine.dev/core/textarea/#enable-resize
