### PR TITLE
fix(hooks): make cancel a stable reference

### DIFF
--- a/packages/@mantine/hooks/src/use-debounced-value/use-debounced-value.ts
+++ b/packages/@mantine/hooks/src/use-debounced-value/use-debounced-value.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface UseDebouncedValueOptions {
   leading?: boolean;
@@ -16,7 +16,7 @@ export function useDebouncedValue<T = any>(
   const timeoutRef = useRef<number | null>(null);
   const cooldownRef = useRef(false);
 
-  const cancel = () => window.clearTimeout(timeoutRef.current!);
+  const cancel = useCallback(() => window.clearTimeout(timeoutRef.current!), []);
 
   useEffect(() => {
     if (mountedRef.current) {


### PR DESCRIPTION
When using useDebouncedValue cancel in useEffect we need to either biome-ignore or eslint-ignore to avoid accidental cancels.