### PR TITLE
Fix typo in mantine-provider-missing.mdx

### DIFF
--- a/apps/help.mantine.dev/src/pages/q/mantine-provider-missing.mdx
+++ b/apps/help.mantine.dev/src/pages/q/mantine-provider-missing.mdx
@@ -17,7 +17,7 @@ export default Layout(meta);
 
 The error above occurs in the following cases:
 
-- You are do not have `MantineProvider` in your app at all
+- You do not have `MantineProvider` in your app at all
 - You are rendering Mantine components outside of `MantineProvider` context
 - You have different versions of `@mantine/*` packages in your application.
   For example, you have `@mantine/core@7.0.0` and `@mantine/dates@7.1.0` installed.


### PR DESCRIPTION
This PR fixes a grammatical error in the help documentation. On line 20 of `apps/help.mantine.dev/src/pages/q/mantine-provider-missing.mdx`, the text "You are do not have" has been corrected to "You do not have" for better readability and proper grammar.