### PR TITLE
fix(hooks): Safari iframe matchMedia crash

### DIFF
--- a/packages/@mantine/hooks/src/use-media-query/use-media-query.ts
+++ b/packages/@mantine/hooks/src/use-media-query/use-media-query.ts
@@ -46,14 +46,14 @@ export function useMediaQuery(
   );
   useEffect(() => {
     try {
-        const mediaQuery = window.matchMedia(query);
-        setMatches(mediaQuery.matches);
-        return attachMediaListener(mediaQuery, (event) => setMatches(event.matches));
-      } catch (e) {
-        // Safari iframe compatibility issue
-        console.warn('MediaQuery not available:', e);
-        return undefined;
-      }
+      const mediaQuery = window.matchMedia(query);
+      setMatches(mediaQuery.matches);
+      return attachMediaListener(mediaQuery, (event) => setMatches(event.matches));
+    } catch (e) {
+      // Safari iframe compatibility issue
+      console.warn('MediaQuery not available:', e);
+      return undefined;
+    }
   }, [query]);
 
   return matches || false;

--- a/packages/@mantine/hooks/src/use-media-query/use-media-query.ts
+++ b/packages/@mantine/hooks/src/use-media-query/use-media-query.ts
@@ -44,16 +44,16 @@ export function useMediaQuery(
   const [matches, setMatches] = useState(
     getInitialValueInEffect ? initialValue : getInitialValue(query)
   );
-  const queryRef = useRef<MediaQueryList>(null);
-
   useEffect(() => {
-    if ('matchMedia' in window) {
-      queryRef.current = window.matchMedia(query);
-      setMatches(queryRef.current.matches);
-      return attachMediaListener(queryRef.current, (event) => setMatches(event.matches));
-    }
-
-    return undefined;
+    try {
+        const mediaQuery = window.matchMedia(query);
+        setMatches(mediaQuery.matches);
+        return attachMediaListener(mediaQuery, (event) => setMatches(event.matches));
+      } catch (e) {
+        // Safari iframe compatibility issue
+        console.warn('MediaQuery not available:', e);
+        return undefined;
+      }
   }, [query]);
 
   return matches || false;

--- a/packages/@mantine/hooks/src/use-media-query/use-media-query.ts
+++ b/packages/@mantine/hooks/src/use-media-query/use-media-query.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export interface UseMediaQueryOptions {
   getInitialValueInEffect: boolean;
@@ -51,7 +51,6 @@ export function useMediaQuery(
       return attachMediaListener(mediaQuery, (event) => setMatches(event.matches));
     } catch (e) {
       // Safari iframe compatibility issue
-      console.warn('MediaQuery not available:', e);
       return undefined;
     }
   }, [query]);


### PR DESCRIPTION
This fixes an issue with Mantine in an iframe context in Safari. Original issue can be found [here](https://github.com/metabase/metabase/issues/62302).

The original bug happens when switching tabs in an interactive embedded Metabase. It actually comes from the way Safari implements MediaQueryList event handling. It seems that events are triggered while an iframe is being removed, leading to an RTE. The crash only happening in Safari and also crashing the dev tools prevents from having a look at the error, but a git bisect shows that the issue was introduced in https://github.com/metabase/metabase/pull/53447.

Unfortunately there's no way of deterministically knowing when the error will be thrown, hence the `try {...} catch()`.

Also removed the unnecessary `useRef` usage.

Temporary patch in our repo is [here](https://github.com/metabase/metabase/pull/62407).

