### PR TITLE
docs: add usage example for useDisclosure with Modal

### DIFF
--- a/example
+++ b/example
@@ -1,0 +1,16 @@
+import { useDisclosure } from '@mantine/hooks';
+import { Button, Modal } from '@mantine/core';
+
+export function Demo() {
+  const [opened, { open, close }] = useDisclosure(false);
+
+  return (
+    <>
+      <Modal opened={opened} onClose={close} title="Mantine Modal Example">
+        Modal content goes here 🚀
+      </Modal>
+
+      <Button onClick={open}>Open Modal</Button>
+    </>
+  );
+}


### PR DESCRIPTION
This pull request adds a new usage example for the useDisclosure hook with the Modal component.
It shows how to open and close a modal using the hook, making the documentation more practical and beginner-friendly.