### PR TITLE
fix: too narrow dropdown with preset props in TimePicker because of ScrollArea.AutoSize

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.module.css
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.module.css
@@ -5,7 +5,7 @@
   overflow: hidden;
 
   &:where([data-autosize]) .content {
-    width: min-content;
+    min-width: min-content;
   }
 }
 

--- a/packages/@mantine/dates/src/components/TimePicker/TimePresets/TimePresets.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePresets/TimePresets.tsx
@@ -47,7 +47,7 @@ export function TimePresets({
     ));
 
     return (
-      <ScrollArea.Autosize
+      <ScrollArea
         mah={ctx.maxDropdownContentHeight}
         type="never"
         {...ctx.getStyles('scrollarea')}
@@ -58,7 +58,7 @@ export function TimePresets({
             {items}
           </SimpleGrid>
         </div>
-      </ScrollArea.Autosize>
+      </ScrollArea>
     );
   }
 
@@ -75,14 +75,14 @@ export function TimePresets({
   ));
 
   return (
-    <ScrollArea.Autosize
+    <ScrollArea
       mah={ctx.maxDropdownContentHeight}
       type="never"
       {...ctx.getStyles('scrollarea')}
       {...ctx.scrollAreaProps}
     >
       <div {...ctx.getStyles('presetsRoot')}>{groups}</div>
-    </ScrollArea.Autosize>
+    </ScrollArea>
   );
 }
 

--- a/packages/@mantine/dates/src/components/TimePicker/TimePresets/TimePresets.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePresets/TimePresets.tsx
@@ -49,7 +49,6 @@ export function TimePresets({
     return (
       <ScrollArea.Autosize
         mah={ctx.maxDropdownContentHeight}
-
         type="never"
         {...ctx.getStyles('scrollarea')}
         {...ctx.scrollAreaProps}

--- a/packages/@mantine/dates/src/components/TimePicker/TimePresets/TimePresets.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePresets/TimePresets.tsx
@@ -47,8 +47,9 @@ export function TimePresets({
     ));
 
     return (
-      <ScrollArea
+      <ScrollArea.Autosize
         mah={ctx.maxDropdownContentHeight}
+
         type="never"
         {...ctx.getStyles('scrollarea')}
         {...ctx.scrollAreaProps}
@@ -58,7 +59,7 @@ export function TimePresets({
             {items}
           </SimpleGrid>
         </div>
-      </ScrollArea>
+      </ScrollArea.Autosize>
     );
   }
 
@@ -75,14 +76,14 @@ export function TimePresets({
   ));
 
   return (
-    <ScrollArea
+    <ScrollArea.Autosize
       mah={ctx.maxDropdownContentHeight}
       type="never"
       {...ctx.getStyles('scrollarea')}
       {...ctx.scrollAreaProps}
     >
       <div {...ctx.getStyles('presetsRoot')}>{groups}</div>
-    </ScrollArea>
+    </ScrollArea.Autosize>
   );
 }
 


### PR DESCRIPTION
fixes #8178

Because of [`min-content` in `ScrollArea.AutoSize`](https://github.com/mantinedev/mantine/pull/8160), when using `ScrollArea.AutoSize`, the width becomes too narrow.

So, fix the style of `ScrollArea.AutoSize`. The data coming into presets is likely to be dynamic, so AutoSize should be used.
 

result
- presets
<img width="435" height="175" alt="스크린샷 2025-08-24 오후 11 26 55" src="https://github.com/user-attachments/assets/b451da34-eb19-4665-aa6a-29d5d5a3446d" />

- presetsGroups
<img width="407" height="265" alt="스크린샷 2025-08-24 오후 11 27 01" src="https://github.com/user-attachments/assets/7781a277-ce08-480d-bc19-5c176fcdf1b8" />

- presetsRange
<img width="406" height="222" alt="스크린샷 2025-08-24 오후 11 27 09" src="https://github.com/user-attachments/assets/29eef003-d9ca-4e00-a4fc-46570921dbc3" />

This fix doesn't harm #8075.
![화면 기록 2025-08-25 오후 4 21 09](https://github.com/user-attachments/assets/8e6faa7a-79f0-4bdc-be9e-7739dc4c7e63)
