### PR TITLE
fix: apply conditional p/div rendering and add aria-live

### DIFF
--- a/packages/@mantine/core/src/components/Input/InputError/InputError.tsx
+++ b/packages/@mantine/core/src/components/Input/InputError/InputError.tsx
@@ -79,12 +79,15 @@ export const InputError = factory<InputErrorFactory>((_props, ref) => {
   const ctx = useInputWrapperContext();
   const getStyles = (__inheritStyles && ctx?.getStyles) || _getStyles;
 
+  const htmlTag = typeof others.children === 'string' ? 'p' : 'div';
+
   return (
     <Box
-      component="p"
+      component={htmlTag}
       ref={ref}
       variant={variant}
       size={size}
+      aria-live="polite"
       {...getStyles('error', ctx?.getStyles ? { className, style } : undefined)}
       {...others}
     />


### PR DESCRIPTION
fix https://github.com/mantinedev/mantine/issues/8188

- Render p when content is a plain string; use div for other types.
- Add aria-live to enhance accessibility for dynamic updates. [MDN Link](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-live)

Result
- string input
<img width="1471" height="462" alt="스크린샷 2025-08-25 오전 1 35 59" src="https://github.com/user-attachments/assets/76bc6c42-10b4-486b-9e8f-177159c77687" />

- React node input
<img width="1437" height="433" alt="스크린샷 2025-08-25 오전 1 40 13" src="https://github.com/user-attachments/assets/1028d23b-ae9d-4b0e-a2da-7c0620d05385" />



- Related content
https://github.com/facebook/react/issues/24519
https://github.com/vercel/next.js/pull/46677
