### PR TITLE
🐛 Fix input font-family to inherit

### DIFF
--- a/packages/@mantine/core/src/components/Input/Input.module.css
+++ b/packages/@mantine/core/src/components/Input/Input.module.css
@@ -144,7 +144,7 @@
   color: var(--input-color);
   border: rem(1px) solid var(--input-bd);
   background-color: var(--input-bg);
-  font-family: var(--input-font-family, var(--mantine-font-family));
+  font-family: var(--input-font-family, inherit);
   height: var(--input-size);
   min-height: var(--input-height);
   line-height: var(--input-line-height);


### PR DESCRIPTION
## What does this PR do?

Changes the fallback`font-family` for Input components from `var(--mantine-font-family)` to `inherit`.

Setting input `font-family` to `inherit` is also done in other frameworks.  
Here are some relevant code references:

- [Tailwind CSS](https://github.com/tailwindlabs/tailwindcss/blob/8165e045641b94de151798cd36d12e6a9886a3f3/packages/tailwindcss/preflight.css#L231-L244)
- [Bootstrap](https://github.com/twbs/bootstrap/blob/25aa8cc0b32f0d1a54be575347e6d84b70b1acd7/scss/_reboot.scss#L406-L412)

## Why was this change needed?

Ensure `<TextInput ff="monospace" />` is styled properly.