### PR TITLE
Add 'offset' option to useScrollSpy hook

### DIFF
--- a/apps/mantine.dev/src/pages/hooks/use-scroll-spy.mdx
+++ b/apps/mantine.dev/src/pages/hooks/use-scroll-spy.mdx
@@ -20,6 +20,8 @@ and similar features.
 - `selector` - selector to get headings, by default it is `'h1, h2, h3, h4, h5, h6'`
 - `getDepth` - a function to retrieve depth of heading, by default depth is calculated based on tag name
 - `getValue` - a function to retrieve heading value, by default `element.textContent` is used
+- `scrollHost` - host element to attach scroll event listener, if not provided, `window` is used
+- `offset` - offset from the top of the viewport to use when determining the active heading, by default `0` is used
 
 Example of using custom options to get headings with `data-heading` attribute:
 
@@ -77,6 +79,9 @@ interface UseScrollSpyOptions {
 
   /** Host element to attach scroll event listener, if not provided, `window` is used */
   scrollHost?: HTMLElement;
+
+  /** Offset from the top of the viewport to use when determining the active heading, `0` by default */
+  offset?: number;
 }
 
 interface UseScrollSpyReturnType {

--- a/packages/@mantine/hooks/src/use-scroll-spy/use-scroll-spy.ts
+++ b/packages/@mantine/hooks/src/use-scroll-spy/use-scroll-spy.ts
@@ -126,7 +126,12 @@ export function useScrollSpy({
     headingsRef.current = headings;
     setInitialized(true);
     setData(headings);
-    setActive(getActiveElement(headings.map((d) => d.getNode().getBoundingClientRect()), offset));
+    setActive(
+      getActiveElement(
+        headings.map((d) => d.getNode().getBoundingClientRect()),
+        offset
+      )
+    );
   };
 
   useEffect(() => {

--- a/packages/@mantine/hooks/src/use-scroll-spy/use-scroll-spy.ts
+++ b/packages/@mantine/hooks/src/use-scroll-spy/use-scroll-spy.ts
@@ -78,7 +78,7 @@ export interface UseScrollSpyOptions {
   /** Host element to attach scroll event listener, if not provided, `window` is used */
   scrollHost?: HTMLElement;
 
-  /** Offset from the top of the viewport to consider when determining the active heading */
+  /** Offset from the top of the viewport to use when determining the active heading, `0` by default */
   offset?: number;
 }
 

--- a/packages/@mantine/hooks/src/use-scroll-spy/use-scroll-spy.ts
+++ b/packages/@mantine/hooks/src/use-scroll-spy/use-scroll-spy.ts
@@ -21,14 +21,14 @@ function getHeadingsData(
   return result;
 }
 
-function getActiveElement(rects: DOMRect[]) {
+function getActiveElement(rects: DOMRect[], offset: number = 0) {
   if (rects.length === 0) {
     return -1;
   }
 
   const closest = rects.reduce(
     (acc, item, index) => {
-      if (Math.abs(acc.position) < Math.abs(item.y)) {
+      if (Math.abs(acc.position - offset) < Math.abs(item.y - offset)) {
         return acc;
       }
 
@@ -77,6 +77,9 @@ export interface UseScrollSpyOptions {
 
   /** Host element to attach scroll event listener, if not provided, `window` is used */
   scrollHost?: HTMLElement;
+
+  /** Offset from the top of the viewport to consider when determining the active heading */
+  offset?: number;
 }
 
 export interface UseScrollSpyReturnType {
@@ -97,6 +100,7 @@ export function useScrollSpy({
   selector = 'h1, h2, h3, h4, h5, h6',
   getDepth = getDefaultDepth,
   getValue = getDefaultValue,
+  offset = 0,
   scrollHost,
 }: UseScrollSpyOptions = {}): UseScrollSpyReturnType {
   const [active, setActive] = useState(-1);
@@ -106,7 +110,10 @@ export function useScrollSpy({
 
   const handleScroll = () => {
     setActive(
-      getActiveElement(headingsRef.current.map((d) => d.getNode().getBoundingClientRect()))
+      getActiveElement(
+        headingsRef.current.map((d) => d.getNode().getBoundingClientRect()),
+        offset
+      )
     );
   };
 
@@ -119,7 +126,7 @@ export function useScrollSpy({
     headingsRef.current = headings;
     setInitialized(true);
     setData(headings);
-    setActive(getActiveElement(headings.map((d) => d.getNode().getBoundingClientRect())));
+    setActive(getActiveElement(headings.map((d) => d.getNode().getBoundingClientRect()), offset));
   };
 
   useEffect(() => {


### PR DESCRIPTION
This PR adds an 'offset' option to the useScrollSpy hook, used when calculating the active heading with respect to the top of the viewport.

- `offset` - offset from the top of the viewport to use when determining the active heading, by default `0` is used

This allows the hook to accommodate pages with floating headers or other elements that obscures the top of the viewport.

Example usage:
```tsx
function Demo() {
  return (
    <TableOfContents
      scrollSpyOptions={{
        offset: 70 // Offsets the "top of the viewport" used when calculating the active element
      }}
    />
  );
}
```

This fixes an issue where the Table of Contents may display an unexpected heading as active when using the AppShell header.
https://codesandbox.io/p/sandbox/mantine-react-template-forked-wlrnk8

### Without offset:
<img width="554" height="226" alt="image" src="https://github.com/user-attachments/assets/da5f6168-938f-490d-a942-7d106f3646fd" />

("Title 3" is the topmost visible title in the user's window, but TableOfContents shows "Title 2" as active)

### With offset:
<img width="554" height="238" alt="image" src="https://github.com/user-attachments/assets/64d55674-bb65-4b70-9408-c13185e06a79" />

TableOfContents shows the expected Title 3 as active, accommodating for the header.




