### PR TITLE
🐛 Fix DateTimePicker onDropdownClose callback

### DIFF
--- a/packages/@mantine/dates/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/packages/@mantine/dates/src/components/DateTimePicker/DateTimePicker.tsx
@@ -118,6 +118,7 @@ export const DateTimePicker = factory<DateTimePickerFactory>((_props, ref) => {
     defaultTimeValue,
     presets,
     attributes,
+    onDropdownClose,
     ...rest
   } = props;
 
@@ -212,6 +213,7 @@ export const DateTimePicker = factory<DateTimePickerFactory>((_props, ref) => {
     if (_value && _value !== clamped) {
       setValue(clampDate(minDate, maxDate, _value));
     }
+    onDropdownClose?.();
   };
 
   return (


### PR DESCRIPTION
Fix DateTimePicker onDropdownClose callback implementation.

- Properly implement the `onDropdownClose` prop that was missing in the component
logic
- The callback is now correctly triggered when the dropdown closes