### PR TITLE
[@mantine/hooks] use-document-visibility: Set initial document visibility state

### DIFF
--- a/packages/@mantine/hooks/src/use-document-visibility/use-document-visibility.ts
+++ b/packages/@mantine/hooks/src/use-document-visibility/use-document-visibility.ts
@@ -4,6 +4,7 @@ export function useDocumentVisibility(): DocumentVisibilityState {
   const [documentVisibility, setDocumentVisibility] = useState<DocumentVisibilityState>('visible');
 
   useEffect(() => {
+    setDocumentVisibility(document.visibilityState);
     const listener = () => setDocumentVisibility(document.visibilityState);
     document.addEventListener('visibilitychange', listener);
     return () => document.removeEventListener('visibilitychange', listener);


### PR DESCRIPTION
The initial document visibility state maybe 'hidden', should set it when useEffect runs.