### PR TITLE
Add `.js` for nodenext module resolution

### DIFF
--- a/packages/@mantine/carousel/src/index.ts
+++ b/packages/@mantine/carousel/src/index.ts
@@ -1,5 +1,5 @@
-export { Carousel } from './Carousel';
-export { CarouselSlide } from './CarouselSlide/CarouselSlide';
+export { Carousel } from './Carousel.js';
+export { CarouselSlide } from './CarouselSlide/CarouselSlide.js';
 export type {
   CarouselProps,
   CarouselCssVariables,

--- a/packages/@mantine/code-highlight/src/index.ts
+++ b/packages/@mantine/code-highlight/src/index.ts
@@ -1,19 +1,19 @@
-export { CodeHighlight } from './CodeHighlight/CodeHighlight';
-export { InlineCodeHighlight } from './CodeHighlight/InlineCodeHighlight';
-export { CodeHighlightTabs } from './CodeHighlightTabs/CodeHighlightTabs';
-export { CodeHighlightControl } from './CodeHighlight/CodeHighlightControl/CodeHighlightControl';
+export { CodeHighlight } from './CodeHighlight/CodeHighlight.js';
+export { InlineCodeHighlight } from './CodeHighlight/InlineCodeHighlight.js';
+export { CodeHighlightTabs } from './CodeHighlightTabs/CodeHighlightTabs.js';
+export { CodeHighlightControl } from './CodeHighlight/CodeHighlightControl/CodeHighlightControl.js';
 
 export {
   CodeHighlightAdapterProvider,
   useHighlight,
-} from './CodeHighlightProvider/CodeHighlightProvider';
+} from './CodeHighlightProvider/CodeHighlightProvider.js';
 
-export { createHighlightJsAdapter } from './CodeHighlightProvider/adapters/highlight-js-adapter';
+export { createHighlightJsAdapter } from './CodeHighlightProvider/adapters/highlight-js-adapter.js';
 export {
   createShikiAdapter,
   stripShikiCodeBlocks,
-} from './CodeHighlightProvider/adapters/shiki-adapter';
-export { plainTextAdapter } from './CodeHighlightProvider/adapters/plain-text-adapter';
+} from './CodeHighlightProvider/adapters/shiki-adapter.js';
+export { plainTextAdapter } from './CodeHighlightProvider/adapters/plain-text-adapter.js';
 
 export type {
   CodeHighlightFactory,

--- a/packages/@mantine/dropzone/src/index.ts
+++ b/packages/@mantine/dropzone/src/index.ts
@@ -1,12 +1,12 @@
-import { Dropzone as _Dropzone } from './Dropzone';
-import { DropzoneFullScreen } from './DropzoneFullScreen';
+import { Dropzone as _Dropzone } from './Dropzone.js';
+import { DropzoneFullScreen } from './DropzoneFullScreen.js';
 
 _Dropzone.FullScreen = DropzoneFullScreen;
 export const Dropzone = _Dropzone;
 
 export { DropzoneFullScreen };
-export { DropzoneAccept, DropzoneIdle, DropzoneReject } from './DropzoneStatus';
-export * from './mime-types';
+export { DropzoneAccept, DropzoneIdle, DropzoneReject } from './DropzoneStatus.js';
+export * from './mime-types.js';
 
 export type {
   DropzoneStylesNames,

--- a/packages/@mantine/modals/src/index.ts
+++ b/packages/@mantine/modals/src/index.ts
@@ -1,5 +1,5 @@
-export { ModalsProvider } from './ModalsProvider';
-export { useModals } from './use-modals/use-modals';
+export { ModalsProvider } from './ModalsProvider.js';
+export { useModals } from './use-modals/use-modals.js';
 export {
   openModal,
   closeModal,

--- a/packages/@mantine/notifications/src/index.ts
+++ b/packages/@mantine/notifications/src/index.ts
@@ -9,8 +9,8 @@ export {
   createNotificationsStore,
   notificationsStore,
   useNotifications,
-} from './notifications.store';
-export { Notifications } from './Notifications';
+} from './notifications.store.js';
+export { Notifications } from './Notifications.js';
 
 export type {
   NotificationData,

--- a/packages/@mantine/nprogress/src/index.ts
+++ b/packages/@mantine/nprogress/src/index.ts
@@ -1,4 +1,4 @@
-export { NavigationProgress } from './NavigationProgress';
-export * from './nprogress.store';
+export { NavigationProgress } from './NavigationProgress.js';
+export * from './nprogress.store.js';
 
 export type { NavigationProgressProps } from './NavigationProgress';

--- a/packages/@mantine/spotlight/src/index.ts
+++ b/packages/@mantine/spotlight/src/index.ts
@@ -6,19 +6,19 @@ export {
   openSpotlight,
   closeSpotlight,
   toggleSpotlight,
-} from './spotlight.store';
-export type { SpotlightState, SpotlightStore } from './spotlight.store';
+} from './spotlight.store.js';
+export type { SpotlightState, SpotlightStore } from './spotlight.store.js';
 
-export { isActionsGroup } from './is-actions-group';
+export { isActionsGroup } from './is-actions-group.js';
 
-export { Spotlight } from './Spotlight';
-export { SpotlightRoot } from './SpotlightRoot';
-export { SpotlightAction } from './SpotlightAction';
-export { SpotlightActionsGroup } from './SpotlightActionsGroup';
-export { SpotlightActionsList } from './SpotlightActionsList';
-export { SpotlightEmpty } from './SpotlightEmpty';
-export { SpotlightFooter } from './SpotlightFooter';
-export { SpotlightSearch } from './SpotlightSearch';
+export { Spotlight } from './Spotlight.js';
+export { SpotlightRoot } from './SpotlightRoot.js';
+export { SpotlightAction } from './SpotlightAction.js';
+export { SpotlightActionsGroup } from './SpotlightActionsGroup.js';
+export { SpotlightActionsList } from './SpotlightActionsList.js';
+export { SpotlightEmpty } from './SpotlightEmpty.js';
+export { SpotlightFooter } from './SpotlightFooter.js';
+export { SpotlightSearch } from './SpotlightSearch.js';
 
 export type {
   SpotlightFactory,

--- a/packages/@mantine/tiptap/src/index.ts
+++ b/packages/@mantine/tiptap/src/index.ts
@@ -1,12 +1,12 @@
 export * from './extensions/index.js';
-export { RichTextEditor } from './RichTextEditor';
-export { useRichTextEditorContext } from './RichTextEditor.context';
-export { DEFAULT_LABELS } from './labels';
+export { RichTextEditor } from './RichTextEditor.js';
+export { useRichTextEditorContext } from './RichTextEditor.context.js';
+export { DEFAULT_LABELS } from './labels.js';
 
 export * from './RichTextEditorControl/index.js';
-export { RichTextEditorControlsGroup } from './RichTextEditorControlsGroup/RichTextEditorControlsGroup';
-export { RichTextEditorControl } from './RichTextEditorControl/RichTextEditorControl';
-export { RichTextEditorContent } from './RichTextEditorContent/RichTextEditorContent';
+export { RichTextEditorControlsGroup } from './RichTextEditorControlsGroup/RichTextEditorControlsGroup.js';
+export { RichTextEditorControl } from './RichTextEditorControl/RichTextEditorControl.js';
+export { RichTextEditorContent } from './RichTextEditorContent/RichTextEditorContent.js';
 
 export type {
   RichTextEditorProps,


### PR DESCRIPTION
This PR applies the same thing in https://github.com/mantinedev/mantine/pull/8211 to other packages. The way to reproduce the issue is identical to [the comment](https://github.com/mantinedev/mantine/pull/8211#issuecomment-3237159318).
