### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm_test.yml
+++ b/.github/workflows/npm_test.yml
@@ -1,4 +1,6 @@
 name: Pull request workflow
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/mantinedev/mantine/security/code-scanning/1](https://github.com/mantinedev/mantine/security/code-scanning/1)

To fix this issue, add an explicit `permissions` block at the workflow (root) level, immediately after the `name:` (and before `on:`), specifying the minimal required permissions for this workflow. Since the workflow only checks out code and runs tests (no steps that need to write to repository contents, pull requests, or issues), set `contents: read`. If you later add jobs interacting with PRs/issues, you can scope them as granularly as needed.  
Edit `.github/workflows/npm_test.yml`, insert the following block after `name: Pull request workflow`:

```yaml
permissions:
  contents: read
```

No imports or additional code changes are required; just add this block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
