### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/packages/@mantine/spotlight/src/SpotlightActionsGroup.tsx
+++ b/packages/@mantine/spotlight/src/SpotlightActionsGroup.tsx
@@ -44,7 +44,11 @@ export const SpotlightActionsGroup = factory<SpotlightActionsGroupFactory>((prop
       {...ctx.getStyles('actionsGroup', { className, style, classNames, styles })}
       ref={ref}
       {...others}
-      __vars={{ '--spotlight-label': `'${label?.replace(/'/g, "\\'")}'` }}
+      __vars={{
+        '--spotlight-label': `'${label
+          ?.replace(/\\/g, '\\\\')
+          .replace(/'/g, "\\'")}'`
+      }}
     >
       {children}
     </Box>

--- a/packages/@mantine/spotlight/src/SpotlightActionsGroup.tsx
+++ b/packages/@mantine/spotlight/src/SpotlightActionsGroup.tsx
@@ -45,9 +45,7 @@ export const SpotlightActionsGroup = factory<SpotlightActionsGroupFactory>((prop
       ref={ref}
       {...others}
       __vars={{
-        '--spotlight-label': `'${label
-          ?.replace(/\\/g, '\\\\')
-          .replace(/'/g, "\\'")}'`
+        '--spotlight-label': `'${label?.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`,
       }}
     >
       {children}


### PR DESCRIPTION
Potential fix for [https://github.com/mantinedev/mantine/security/code-scanning/2](https://github.com/mantinedev/mantine/security/code-scanning/2)

To fully escape dangerous characters in the CSS variable interpolation, we must escape both single quotes and backslashes within the `label` string. The best approach is to first escape all backslashes (`\`), then escape single quotes (`'`), since newly-added backslashes could interfere with subsequent escaping if done out of order. Both should use the global regex flag to capture all instances in the string.

Edit only line 47, within `packages/@mantine/spotlight/src/SpotlightActionsGroup.tsx`, to ensure `label` is properly escaped. No additional dependencies are required because JavaScript's built-in string replace with regular expressions suffices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
