### PR TITLE
[docs] Add missing links for hooks and core in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
 
 ## Packages
 
-- `@mantine/hooks` – collection of 50+ hooks for state and UI management
-- `@mantine/core` – core components library – 100+ components
+- [`@mantine/hooks`](https://mantine.dev/hooks/package/) – collection of 50+ hooks for state and UI management
+- [`@mantine/core`](https://mantine.dev/core/package/) – core components library – 100+ components
 - [`@mantine/form`](https://mantine.dev/form/use-form) – forms management library
 - [`@mantine/charts`](https://mantine.dev/charts/getting-started/) – recharts based charts library
 - [`@mantine/notifications`](https://mantine.dev/x/notifications) – a fully featured notifications system


### PR DESCRIPTION
In the README, all packages had links to their corresponding documentation pages except for core and hooks.
This PR adds the missing links, ensuring consistency across the section and making it easier to jump directly to the relevant documentation.