### PR TITLE
🐛Fix: nestedList overflow issue

### DIFF
--- a/packages/@mantine/core/src/components/List/List.module.css
+++ b/packages/@mantine/core/src/components/List/List.module.css
@@ -1,20 +1,22 @@
 .root {
   --list-fz: var(--mantine-font-size-md);
   --list-lh: var(--mantine-line-height-md);
+  --list-marker-gap: var(--mantine-spacing-lg);
 
-  list-style-position: inside;
+  list-style-position: outside;
   font-size: var(--list-fz);
   line-height: var(--list-lh);
   margin: 0;
   padding: 0;
+  padding-inline-start: var(--list-marker-gap);
 
   &:where([data-with-padding]) {
-    padding-inline-start: var(--mantine-spacing-md);
+    padding-inline-start: calc(var(--list-marker-gap) + var(--mantine-spacing-md));
   }
 }
 
 .item {
-  white-space: nowrap;
+  white-space: normal;
   line-height: var(--list-lh);
 
   &:where([data-with-icon]) {


### PR DESCRIPTION
Hello👋,
As a solution to issue #8165 , I changed `list-style-position: inside` to `list-style-position: outside`.

Issue #2778  also suggested using `outside`, and I believe this change is beneficial for preventing potential future bugs. Should I instead maintain `inside` and make modifications in other areas?

Additionally, after changing to `outside`, there's now a spacing difference between the marker and text, and for the "With Icons" case, padding-inline-start has been applied to secure the marker's position. To maintain the same appearance as before, additional adjustments would be needed.

If you could suggest an alternative approach, I'd be happy to implement it accordingly. Thank you.

# Before
<img width="894" height="521" alt="스크린샷 2025-09-15 오후 10 56 05" src="https://github.com/user-attachments/assets/bbbb3f3b-852a-4f39-8208-6289affea7d9" />
<img width="918" height="554" alt="스크린샷 2025-09-15 오후 10 57 28" src="https://github.com/user-attachments/assets/214fbc10-d172-4ab9-b091-213ce35faebf" />
<img width="827" height="501" alt="스크린샷 2025-09-15 오후 10 57 44" src="https://github.com/user-attachments/assets/79bd2912-0fa7-41d5-9300-6f47b3dbc475" />

# After
<img width="878" height="523" alt="스크린샷 2025-09-15 오후 10 56 29" src="https://github.com/user-attachments/assets/3d07dfc8-be0a-4167-8459-c149046d531e" />
<img width="866" height="555" alt="스크린샷 2025-09-15 오후 10 56 55" src="https://github.com/user-attachments/assets/661ac1b2-9af9-4105-b953-8ebf0a78bc33" />
<img width="839" height="183" alt="스크린샷 2025-09-15 오후 11 21 56" src="https://github.com/user-attachments/assets/2e9c7d20-9a08-4b40-95ea-ca967f3d8030" />
