### PR TITLE
[@mantine/core] CheckboxIndicator: Update icon color to use CSS variable  #8271

### DIFF
--- a/packages/@mantine/core/src/components/Checkbox/CheckboxIndicator/CheckboxIndicator.module.css
+++ b/packages/@mantine/core/src/components/Checkbox/CheckboxIndicator/CheckboxIndicator.module.css
@@ -81,7 +81,7 @@
 .icon {
   display: block;
   width: 60%;
-  color: transparent;
+  color: var(--checkbox-icon-color);
   pointer-events: none;
   transform: translateY(rem(5px)) scale(0.5);
   opacity: 1;


### PR DESCRIPTION
Fixes #8271
Will fix the Checkbox iconColor prop ignored due to the usage of the wrong CSS variable #8271