### PR TITLE
[@mantine/hooks] Enhance useClickOutside to propagate event to handler

### DIFF
--- a/packages/@mantine/hooks/src/use-click-outside/use-click-outside.test.tsx
+++ b/packages/@mantine/hooks/src/use-click-outside/use-click-outside.test.tsx
@@ -98,4 +98,26 @@ describe('@mantine/hooks/use-click-outside', () => {
     await userEvent.click(target);
     expect(handler).toHaveBeenCalledTimes(1);
   });
+
+  it('propagates event to handler', async () => {
+    const handler = jest.fn();
+
+    render(
+      <>
+        <Target handler={handler} />
+        <div data-testid="outside-target" />
+      </>
+    );
+
+    const outsideTarget = screen.getByTestId('outside-target');
+
+    await userEvent.click(outsideTarget);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(expect.any(MouseEvent));
+
+    const event = handler.mock.calls[0][0];
+    expect(event).toHaveProperty('type', 'mousedown');
+    expect(event).toHaveProperty('target', outsideTarget);
+  });
 });

--- a/packages/@mantine/hooks/src/use-click-outside/use-click-outside.ts
+++ b/packages/@mantine/hooks/src/use-click-outside/use-click-outside.ts
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from 'react';
 
+type EventType = MouseEvent | TouchEvent;
+
 const DEFAULT_EVENTS = ['mousedown', 'touchstart'];
 
 export function useClickOutside<T extends HTMLElement = any>(
-  callback: () => void,
+  callback: (event: EventType) => void,
   events?: string[] | null,
   nodes?: (HTMLElement | null)[]
 ) {
@@ -11,14 +13,15 @@ export function useClickOutside<T extends HTMLElement = any>(
   const eventsList = events || DEFAULT_EVENTS;
 
   useEffect(() => {
-    const listener = (event: any) => {
+    const listener = (event: Event) => {
       const { target } = event ?? {};
       if (Array.isArray(nodes)) {
-        const shouldIgnore = !document.body.contains(target) && target.tagName !== 'HTML';
+        const shouldIgnore =
+          !document.body.contains(target as Node) && (target as Element)?.tagName !== 'HTML';
         const shouldTrigger = nodes.every((node) => !!node && !event.composedPath().includes(node));
-        shouldTrigger && !shouldIgnore && callback();
-      } else if (ref.current && !ref.current.contains(target)) {
-        callback();
+        shouldTrigger && !shouldIgnore && callback(event as EventType);
+      } else if (ref.current && !ref.current.contains(target as Node)) {
+        callback(event as EventType);
       }
     };
 


### PR DESCRIPTION
This PR extends the use-click-outside hook so that the callback receives the triggering event object as its first argument. This gives developers more flexibility when handling outside clicks without introducing breaking changes.

**Details**

- Updated the internal event listener to forward the event to the callback.
- Type definitions updated to reflect the new callback signature.
- Existing behavior remains unchanged for callbacks that don’t use arguments.

Linked feature request : https://github.com/orgs/mantinedev/discussions/8281