### PR TITLE
[@mantine/hooks] Simplify useDidUpdate by removing unnecessary cleanup

### DIFF
--- a/packages/@mantine/hooks/src/use-did-update/use-did-update.ts
+++ b/packages/@mantine/hooks/src/use-did-update/use-did-update.ts
@@ -3,19 +3,11 @@ import { DependencyList, EffectCallback, useEffect, useRef } from 'react';
 export function useDidUpdate(fn: EffectCallback, dependencies?: DependencyList) {
   const mounted = useRef(false);
 
-  useEffect(
-    () => () => {
-      mounted.current = false;
-    },
-    []
-  );
-
   useEffect(() => {
     if (mounted.current) {
       return fn();
     }
 
     mounted.current = true;
-    return undefined;
   }, dependencies);
 }


### PR DESCRIPTION
### Summary
This PR simplifies the implementation of `useDidUpdate` by removing the unnecessary cleanup logic that reset `mounted.current` to `false`.

### Details
Previously, `useDidUpdate` contained an initial `useEffect` with a cleanup function setting `mounted.current = false` on component unmount. However, this value reset is never consumed after unmount, because the hook itself does not run again once the component is unmounted. The presence of this cleanup could introduce confusion without providing any real benefit.

By removing this redundant cleanup effect:
- The hook implementation becomes easier to read and maintain.
- There is no risk of unexpected state resets during a component’s lifecycle.
- The hook’s behavior remains identical, since `mounted.current` serves only as an initialization guard.

### Motivation
This change improves code clarity and reduces unnecessary operations while preserving the intended behavior of the hook.