### PR TITLE
[@mantine/dates] prevent endless loop in getEndOfWeek

### DIFF
--- a/packages/@mantine/dates/src/components/Month/get-end-of-week/get-end-of-week.ts
+++ b/packages/@mantine/dates/src/components/Month/get-end-of-week/get-end-of-week.ts
@@ -4,6 +4,10 @@ import type { DateStringValue, DayOfWeek } from '../../../types';
 export function getEndOfWeek(date: DateStringValue, firstDayOfWeek: DayOfWeek = 1) {
   let value = dayjs(date);
 
+  if (!value.isValid()) {
+    return value;
+  }
+
   const lastDayOfWeek = firstDayOfWeek === 0 ? 6 : firstDayOfWeek - 1;
   while (value.day() !== lastDayOfWeek) {
     value = value.add(1, 'day');


### PR DESCRIPTION
Calling `getEndOfWeek` with an invalid date now causes an endless loop (`getEndOfWeek("", "")` for instance).
See https://codesandbox.io/p/sandbox/priceless-flower-8v9mhl?file=%2Fsrc%2FApp.js%3A7%2C5-7%2C17

This function is at least also called from `DateInput`. Simply setting an invalid value there also causes the loop after clicking the input:
```
<DateInput value={'invalid'} />
```