### PR TITLE
Fix TimePicker scrolls page to top when withDropdown=true and defaultValue is set (#8237)

### DIFF
--- a/packages/@mantine/dates/src/components/TimePicker/TimeControlsList/TimeControlsList.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimeControlsList/TimeControlsList.tsx
@@ -58,10 +58,13 @@ export function TimeControlsList({
 
   useEffect(() => {
     if (value !== null) {
-      const target = ref.current?.querySelector<HTMLButtonElement>(`[data-value="${value}"]`);
-      if (!isElementVisibleInScrollContainer(target, ref.current)) {
-        target?.scrollIntoView({ block: 'nearest' });
-      }
+      const scrollToValue = () => {
+        const target = ref.current?.querySelector<HTMLButtonElement>(`[data-value="${value}"]`);
+        if (!isElementVisibleInScrollContainer(target, ref.current)) {
+          target?.scrollIntoView({ block: 'nearest' });
+        }
+      };
+      requestAnimationFrame(scrollToValue);
     }
   }, [value]);
 


### PR DESCRIPTION
## Description
Fixes issue where TimePicker scrolls page to top when , no presets, and  is set.

## Summary 
TimePicker dropdown scrolling to top when opened with defaultValue

## Problem
When using TimePicker with withDropdown={true} and a defaultValue, opening the dropdown would always scroll to the top of the time controls list instead of showing the currently selected value. This made it difficult for users to see and modify their current selection.

## Root Cause
The scroll-to-view logic in TimeControlsList was executing immediately when the component mounted, before the ScrollArea component and Popover dropdown were fully initialized and positioned. This timing issue caused the scroll operation to fail silently.

## Solution
Wrapped the scrollIntoView call in requestAnimationFrame to defer execution until the browser's next repaint cycle. This ensures all DOM elements are fully rendered and positioned before attempting to scroll.

Fixes #8237

## Testing
- [✅] Tested with TimePicker component with  and  set
- [✅] Verified page no longer scrolls to top on dropdown open
- [✅] Existing functionality remains intact