### PR TITLE
[@mantine/core] NavLink: fix onClick/onKeyDown blocking expand/collapse

### DIFF
--- a/packages/@mantine/core/src/components/NavLink/NavLink.test.tsx
+++ b/packages/@mantine/core/src/components/NavLink/NavLink.test.tsx
@@ -51,6 +51,17 @@ describe('@mantine/core/NavLink', () => {
     expect(screen.getByRole('link')).toHaveAttribute('data-expanded');
   });
 
+  it('sets correct data-expanded attribute on link (uncontrolled) when onClick is provided', async () => {
+    render(
+      <NavLink {...defaultProps} onClick={() => {}}>
+        <div>test-dropdown</div>
+      </NavLink>
+    );
+    expect(screen.getByRole('link')).not.toHaveAttribute('data-expanded');
+    await userEvent.click(screen.getByRole('link'));
+    expect(screen.getByRole('link')).toHaveAttribute('data-expanded');
+  });
+
   it('sets correct data-expanded attribute on link based on defaultOpened prop (uncontrolled)', async () => {
     render(
       <NavLink {...defaultProps} defaultOpened>

--- a/packages/@mantine/core/src/components/NavLink/NavLink.tsx
+++ b/packages/@mantine/core/src/components/NavLink/NavLink.tsx
@@ -77,6 +77,12 @@ export interface NavLinkProps extends BoxProps, StylesApiProps<NavLinkFactory> {
 
   /** If set, adjusts text color based on background color for `filled` variant */
   autoContrast?: boolean;
+
+  /** Called when the root element is clicked */
+  onClick?: React.MouseEventHandler<HTMLElement>;
+
+  /** Called on keydown of the root element */
+  onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
 }
 
 export type NavLinkFactory = PolymorphicFactory<{
@@ -136,6 +142,8 @@ export const NavLink = polymorphicFactory<NavLinkFactory>((_props, ref) => {
     autoContrast,
     mod,
     attributes,
+    onClick,
+    onKeyDown,
     ...others
   } = props;
 
@@ -163,7 +171,7 @@ export const NavLink = polymorphicFactory<NavLinkFactory>((_props, ref) => {
   const withChildren = !!children;
 
   const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    (others as any).onClick?.(event);
+    onClick?.(event);
 
     if (withChildren) {
       event.preventDefault();
@@ -179,7 +187,7 @@ export const NavLink = polymorphicFactory<NavLinkFactory>((_props, ref) => {
         ref={ref}
         onClick={handleClick}
         onKeyDown={(event) => {
-          (others as any).onKeyDown?.(event);
+          onKeyDown?.(event);
 
           if (event.nativeEvent.code === 'Space' && withChildren) {
             event.preventDefault();


### PR DESCRIPTION
### Issue
In an uncontrolled parent NavLink with children, passing a custom `onClick` or `onKeyDown` prevents the link from expanding/collapsing.
- Clicking the parent does not toggle expansion when `onClick` is supplied.
- Pressing Space does not toggle expansion when `onKeyDown` is supplied.

This regression was introduced at dbf319e, where `{...others}` began overriding the internal handlers.
### Fix
- This fix extracts `onClick`/`onKeyDown` from props and composes them with internal handlers to ensure they are not overridden by `{...others}`. 
- The extracted handlers are typed against `<HTMLElement>` rather than `<HTMLAnchorElement>` to align with the polymorphic design of NavLink.
- A test was also added to confirm that expansion works when a custom `onClick` is provided.
- Fixes #8293