### PR TITLE
Implement responsive size properties for Mantine components

### DIFF
--- a/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,3 +1,4 @@
+import { render } from '@testing-library/react';
 import { tests } from '@mantine-tests/core';
 import {
   SegmentedControl,
@@ -30,5 +31,41 @@ describe('@mantine/core/SegmentedControl', () => {
     refType: HTMLDivElement,
     displayName: '@mantine/core/SegmentedControl',
     stylesApiSelectors: ['root', 'label', 'input', 'control', 'indicator'],
+  });
+
+  it('supports responsive size properties', () => {
+    const { container } = render(
+      <SegmentedControl 
+        {...defaultProps} 
+        size={{ base: 'sm', md: 'lg' }}
+      />
+    );
+    
+    // Check that base size is applied
+    const root = container.querySelector('[role="radiogroup"]');
+    expect(root).toHaveStyle('--sc-padding: var(--sc-padding-sm)');
+    expect(root).toHaveStyle('--sc-font-size: var(--mantine-font-size-sm)');
+    
+    // Check that responsive styles are injected
+    const styleElement = container.querySelector('style[data-mantine-styles="inline"]');
+    expect(styleElement).toBeInTheDocument();
+    expect(styleElement?.innerHTML).toContain('@media');
+  });
+
+  it('works with regular size values', () => {
+    const { container } = render(
+      <SegmentedControl 
+        {...defaultProps} 
+        size="md"
+      />
+    );
+    
+    const root = container.querySelector('[role="radiogroup"]');
+    expect(root).toHaveStyle('--sc-padding: var(--sc-padding-md)');
+    expect(root).toHaveStyle('--sc-font-size: var(--mantine-font-size-md)');
+    
+    // Should not have responsive styles
+    const styleElement = container.querySelector('style[data-mantine-styles="inline"]');
+    expect(styleElement).not.toBeInTheDocument();
   });
 });

--- a/packages/@mantine/core/src/core/types.ts
+++ b/packages/@mantine/core/src/core/types.ts
@@ -1,3 +1,12 @@
+import type { MantineSize } from './MantineProvider';
+import type { StyleProp } from './Box';
+
 export interface DataAttributes {
   [key: `data-${string}`]: string | number | boolean | undefined;
 }
+
+/** Responsive size prop that supports breakpoint-based values */
+export type ResponsiveStyleProp<T> = StyleProp<T>;
+
+/** Responsive MantineSize that supports breakpoint-based values */
+export type MantineResponsiveSize = ResponsiveStyleProp<MantineSize | (string & {})>;

--- a/packages/@mantine/core/src/core/utils/create-responsive-size-variables/create-responsive-size-variables.test.ts
+++ b/packages/@mantine/core/src/core/utils/create-responsive-size-variables/create-responsive-size-variables.test.ts
@@ -1,0 +1,116 @@
+import { createResponsiveSizeVariables } from './create-responsive-size-variables';
+import { getSize } from '../get-size/get-size';
+
+const mockTheme = {
+  breakpoints: {
+    xs: '36em',
+    sm: '48em',
+    md: '62em',
+    lg: '75em',
+    xl: '88em',
+  },
+};
+
+describe('@mantine/core/createResponsiveSizeVariables', () => {
+  it('handles non-responsive values', () => {
+    const result = createResponsiveSizeVariables({
+      size: 'md',
+      property: '--test-size',
+      getter: getSize,
+      theme: mockTheme,
+    });
+
+    expect(result.base).toEqual({ '--test-size': 'var(--size-md)' });
+    expect(result.media).toEqual([]);
+  });
+
+  it('handles responsive objects with base value', () => {
+    const result = createResponsiveSizeVariables({
+      size: { base: 'sm', md: 'lg' },
+      property: '--test-size',
+      getter: getSize,
+      theme: mockTheme,
+    });
+
+    expect(result.base).toEqual({ '--test-size': 'var(--size-sm)' });
+    expect(result.media).toHaveLength(1);
+    expect(result.media[0]).toEqual({
+      query: '(min-width: 62em)',
+      styles: { '--test-size': 'var(--size-lg)' },
+    });
+  });
+
+  it('handles responsive objects without base value', () => {
+    const result = createResponsiveSizeVariables({
+      size: { sm: 'md', lg: 'xl' },
+      property: '--test-size',
+      getter: getSize,
+      theme: mockTheme,
+    });
+
+    expect(result.base).toEqual({ '--test-size': 'var(--size-undefined)' });
+    expect(result.media).toHaveLength(2);
+    expect(result.media[0]).toEqual({
+      query: '(min-width: 48em)',
+      styles: { '--test-size': 'var(--size-md)' },
+    });
+    expect(result.media[1]).toEqual({
+      query: '(min-width: 75em)',
+      styles: { '--test-size': 'var(--size-xl)' },
+    });
+  });
+
+  it('handles multiple breakpoints', () => {
+    const result = createResponsiveSizeVariables({
+      size: { base: 'xs', sm: 'sm', md: 'md', lg: 'lg', xl: 'xl' },
+      property: '--test-size',
+      getter: getSize,
+      theme: mockTheme,
+    });
+
+    expect(result.base).toEqual({ '--test-size': 'var(--size-xs)' });
+    expect(result.media).toHaveLength(4);
+    
+    // Check that breakpoints are sorted correctly
+    expect(result.media[0].query).toBe('(min-width: 48em)'); // sm
+    expect(result.media[1].query).toBe('(min-width: 62em)'); // md
+    expect(result.media[2].query).toBe('(min-width: 75em)'); // lg
+    expect(result.media[3].query).toBe('(min-width: 88em)'); // xl
+  });
+
+  it('handles null and undefined values', () => {
+    const nullResult = createResponsiveSizeVariables({
+      size: null,
+      property: '--test-size',
+      getter: getSize,
+      theme: mockTheme,
+    });
+
+    expect(nullResult.base).toEqual({ '--test-size': undefined });
+    expect(nullResult.media).toEqual([]);
+
+    const undefinedResult = createResponsiveSizeVariables({
+      size: undefined,
+      property: '--test-size',
+      getter: getSize,
+      theme: mockTheme,
+    });
+
+    expect(undefinedResult.base).toEqual({ '--test-size': undefined });
+    expect(undefinedResult.media).toEqual([]);
+  });
+
+  it('uses custom getter function', () => {
+    const customGetter = (size: unknown) => `custom-${size}`;
+    
+    const result = createResponsiveSizeVariables({
+      size: { base: 'sm', md: 'lg' },
+      property: '--custom-size',
+      getter: customGetter,
+      theme: mockTheme,
+    });
+
+    expect(result.base).toEqual({ '--custom-size': 'custom-sm' });
+    expect(result.media[0].styles).toEqual({ '--custom-size': 'custom-lg' });
+  });
+});

--- a/packages/@mantine/core/src/core/utils/create-responsive-size-variables/create-responsive-size-variables.ts
+++ b/packages/@mantine/core/src/core/utils/create-responsive-size-variables/create-responsive-size-variables.ts
@@ -1,0 +1,71 @@
+import type { MantineTheme } from '../../MantineProvider';
+import type { StyleProp } from '../../Box';
+import { keys } from '../keys/keys';
+import { getSortedBreakpoints } from '../get-sorted-breakpoints/get-sorted-breakpoints';
+import { getSize, getFontSize, getSpacing, getRadius, getShadow, getLineHeight } from '../get-size/get-size';
+import { getBaseValue } from '../get-base-value/get-base-value';
+
+type SizeGetter = (size: unknown) => string | undefined;
+
+interface ResponsiveSizeOptions {
+  size: StyleProp<any>;
+  property: string;
+  getter?: SizeGetter;
+  theme: MantineTheme;
+}
+
+/**
+ * Creates CSS variables for responsive size properties
+ */
+export function createResponsiveSizeVariables({
+  size,
+  property,
+  getter = getSize,
+  theme,
+}: ResponsiveSizeOptions) {
+  // If not a responsive object, return simple base variable
+  if (typeof size !== 'object' || size === null) {
+    return {
+      base: { [property]: getter(size) },
+      media: [],
+    };
+  }
+
+  const baseValue = getBaseValue(size);
+  const breakpointKeys = keys(size).filter((key) => key !== 'base');
+
+  if (breakpointKeys.length === 0) {
+    return {
+      base: { [property]: getter(baseValue) },
+      media: [],
+    };
+  }
+
+  const base = { [property]: getter(baseValue) };
+  const sortedBreakpoints = getSortedBreakpoints(breakpointKeys, theme.breakpoints);
+
+  const media = sortedBreakpoints.map(({ value }) => ({
+    query: `(min-width: ${getBreakpointValue(value, theme.breakpoints)}em)`,
+    styles: {
+      [property]: getter(size[value as keyof typeof size]),
+    },
+  }));
+
+  return { base, media };
+}
+
+function getBreakpointValue(breakpoint: string, breakpoints: Record<string, string>): string {
+  return breakpoints[breakpoint] || breakpoint;
+}
+
+/**
+ * Convenience functions for common size properties
+ */
+export const createResponsiveFontSizeVariables = (size: StyleProp<any>, property: string, theme: MantineTheme) =>
+  createResponsiveSizeVariables({ size, property, getter: getFontSize, theme });
+
+export const createResponsiveSpacingVariables = (size: StyleProp<any>, property: string, theme: MantineTheme) =>
+  createResponsiveSizeVariables({ size, property, getter: getSpacing, theme });
+
+export const createResponsiveRadiusVariables = (size: StyleProp<any>, property: string, theme: MantineTheme) =>
+  createResponsiveSizeVariables({ size, property, getter: getRadius, theme });

--- a/packages/@mantine/core/src/core/utils/get-size/get-size.test.ts
+++ b/packages/@mantine/core/src/core/utils/get-size/get-size.test.ts
@@ -1,4 +1,4 @@
-import { getFontSize, getLineHeight, getRadius, getShadow, getSize, getSpacing } from './get-size';
+import { getFontSize, getLineHeight, getRadius, getShadow, getSize, getSpacing, isResponsiveSize } from './get-size';
 
 describe('@mantine/core/get-size', () => {
   it('returns correct size for numbers and number like values', () => {
@@ -22,6 +22,13 @@ describe('@mantine/core/get-size', () => {
     expect(getSize('xs')).toBe('var(--size-xs)');
     expect(getSize('md')).toBe('var(--size-md)');
   });
+
+  it('handles responsive size objects by extracting base value', () => {
+    expect(getSize({ base: 'sm', md: 'lg' })).toBe('var(--size-sm)');
+    expect(getSize({ base: 10, md: 20 })).toBe('calc(0.625rem * var(--mantine-scale))');
+    expect(getSize({ sm: 'md', lg: 'xl' })).toBe('var(--size-undefined)');
+  });
+});
 });
 
 describe('@mantine/core/get-spacing', () => {
@@ -84,5 +91,17 @@ describe('@mantine/core/get-shadow', () => {
     expect(getShadow('5px 5px 10px red')).toBe('5px 5px 10px red');
     expect(getShadow('xs')).toBe('var(--mantine-shadow-xs)');
     expect(getShadow('md')).toBe('var(--mantine-shadow-md)');
+  });
+});
+
+describe('@mantine/core/isResponsiveSize', () => {
+  it('correctly identifies responsive size objects', () => {
+    expect(isResponsiveSize({ base: 'sm', md: 'lg' })).toBe(true);
+    expect(isResponsiveSize({ sm: 'md', lg: 'xl' })).toBe(true);
+    expect(isResponsiveSize({ base: 'sm' })).toBe(false);
+    expect(isResponsiveSize('sm')).toBe(false);
+    expect(isResponsiveSize(null)).toBe(false);
+    expect(isResponsiveSize(undefined)).toBe(false);
+    expect(isResponsiveSize({})).toBe(false);
   });
 });

--- a/packages/@mantine/core/src/core/utils/get-size/get-size.ts
+++ b/packages/@mantine/core/src/core/utils/get-size/get-size.ts
@@ -1,16 +1,21 @@
 import { isNumberLike } from '../is-number-like/is-number-like';
 import { rem } from '../units-converters';
+import { getBaseValue } from '../get-base-value/get-base-value';
+import type { StyleProp } from '../../Box';
 
 export function getSize(size: unknown, prefix = 'size', convertToRem = true): string | undefined {
   if (size === undefined) {
     return undefined;
   }
 
-  return isNumberLike(size)
+  // Handle responsive size objects by extracting the base value
+  const baseSize = getBaseValue(size);
+
+  return isNumberLike(baseSize)
     ? convertToRem
-      ? rem(size)
-      : (size as string)
-    : `var(--${prefix}-${size})`;
+      ? rem(baseSize)
+      : (baseSize as string)
+    : `var(--${prefix}-${baseSize})`;
 }
 
 export function getSpacing(size: unknown) {
@@ -39,4 +44,20 @@ export function getShadow(size: unknown) {
   }
 
   return getSize(size, 'mantine-shadow', false);
+}
+
+/**
+ * Check if a value is a responsive size object (has breakpoints other than 'base')
+ */
+export function isResponsiveSize(size: unknown): size is StyleProp<unknown> {
+  if (typeof size !== 'object' || size === null) {
+    return false;
+  }
+  
+  const keys = Object.keys(size);
+  if (keys.length === 1 && keys[0] === 'base') {
+    return false;
+  }
+  
+  return keys.length > 1 || (keys.length === 1 && keys[0] !== 'base');
 }

--- a/packages/@mantine/core/src/core/utils/index.ts
+++ b/packages/@mantine/core/src/core/utils/index.ts
@@ -39,3 +39,4 @@ export {
   createResponsiveSpacingVariables, 
   createResponsiveRadiusVariables 
 } from './create-responsive-size-variables/create-responsive-size-variables';
+export { useResponsiveSize, createResponsiveSizeHelpers } from './use-responsive-size/use-responsive-size';

--- a/packages/@mantine/core/src/core/utils/index.ts
+++ b/packages/@mantine/core/src/core/utils/index.ts
@@ -20,6 +20,7 @@ export {
   getRadius,
   getFontSize,
   getLineHeight,
+  isResponsiveSize,
 } from './get-size/get-size';
 export { createEventHandler } from './create-event-handler/create-event-handler';
 export { getBreakpointValue } from './get-breakpoint-value/get-breakpoint-value';
@@ -32,3 +33,9 @@ export { getEnv } from './get-env/get-env';
 export { memoize } from './memoize/memoize';
 export { findClosestNumber } from './find-closest-number/find-closest-number';
 export { getRefProp } from './get-ref-prop/get-ref-prop';
+export { 
+  createResponsiveSizeVariables, 
+  createResponsiveFontSizeVariables, 
+  createResponsiveSpacingVariables, 
+  createResponsiveRadiusVariables 
+} from './create-responsive-size-variables/create-responsive-size-variables';

--- a/packages/@mantine/core/src/core/utils/use-responsive-size/use-responsive-size.ts
+++ b/packages/@mantine/core/src/core/utils/use-responsive-size/use-responsive-size.ts
@@ -1,0 +1,61 @@
+import { useMantineTheme } from '../../MantineProvider';
+import type { StyleProp } from '../../Box';
+import { isResponsiveSize } from '../get-size/get-size';
+import { createResponsiveSizeVariables } from '../create-responsive-size-variables/create-responsive-size-variables';
+
+type SizeGetter = (size: unknown) => string | undefined;
+
+interface UseResponsiveSizeOptions {
+  size: StyleProp<any> | undefined;
+  property: string;
+  getter?: SizeGetter;
+}
+
+/**
+ * Hook to handle responsive size properties
+ * Returns base CSS variables and media queries for responsive sizes
+ */
+export function useResponsiveSize({ size, property, getter }: UseResponsiveSizeOptions) {
+  const theme = useMantineTheme();
+
+  if (!isResponsiveSize(size)) {
+    return {
+      baseVars: {},
+      media: [],
+    };
+  }
+
+  const result = createResponsiveSizeVariables({
+    size,
+    property,
+    getter,
+    theme,
+  });
+
+  return {
+    baseVars: result.base,
+    media: result.media,
+  };
+}
+
+/**
+ * Helper to create responsive size variables for common properties
+ */
+export function createResponsiveSizeHelpers(size: StyleProp<any> | undefined, theme: any) {
+  return {
+    padding: (property: string, getter: SizeGetter) => 
+      isResponsiveSize(size) 
+        ? createResponsiveSizeVariables({ size, property, getter, theme })
+        : { base: {}, media: [] },
+    
+    fontSize: (property: string, getter: SizeGetter) => 
+      isResponsiveSize(size) 
+        ? createResponsiveSizeVariables({ size, property, getter, theme })
+        : { base: {}, media: [] },
+        
+    generic: (property: string, getter: SizeGetter) => 
+      isResponsiveSize(size) 
+        ? createResponsiveSizeVariables({ size, property, getter, theme })
+        : { base: {}, media: [] },
+  };
+}


### PR DESCRIPTION
I am not very familiar with the codebase of this project, which is why I used the Copilot agent. Even if it does not fully meet your requirements, it might still give you (or someone else) an idea of how to implement it.

Please let me know if you think something should be changed. This PR addresses one of the most requested missing features: a responsive size property.

Instead of suggesting the use of https://mantine.dev/styles/responsive/#component-size-based-on-media-query
, this PR provides a cleaner solution.

The original PR: https://github.com/sovetski/mantine/pull/1

Some related links:

- https://github.com/orgs/mantinedev/discussions/7674
- https://github.com/orgs/mantinedev/discussions/8304
- https://github.com/orgs/mantinedev/discussions/6246
- https://github.com/orgs/mantinedev/discussions/7137
- https://github.com/orgs/mantinedev/discussions/5135
- https://github.com/orgs/mantinedev/discussions/2953
- https://github.com/orgs/mantinedev/discussions/4067