### PR TITLE
fix: Prevent combobox popover position flip when opened twice

### DIFF
--- a/packages/@mantine/core/src/components/Combobox/Combobox.story.tsx
+++ b/packages/@mantine/core/src/components/Combobox/Combobox.story.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { Anchor } from '../Anchor';
 import { Button } from '../Button';
+import { Input } from '../Input';
+import { InputBase } from '../InputBase';
 import { Popover } from '../Popover';
 import { ScrollArea } from '../ScrollArea';
 import { Text } from '../Text';
@@ -466,5 +468,111 @@ export function SearchWithScrollArea() {
         </Combobox.Options>
       </Combobox.Dropdown>
     </Combobox>
+  );
+}
+
+export function BottomRightAbsolute() {
+  const combobox = useCombobox({
+    onDropdownClose: () => combobox.resetSelectedOption(),
+  });
+
+  const [value, setValue] = useState<string | null>(null);
+
+  const options = groceries.slice(0, 5).map((item) => (
+    <Combobox.Option value={item} key={item}>
+      {item}
+    </Combobox.Option>
+  ));
+
+  return (
+    <>
+      <div style={{ height: '100vh', position: 'relative' }}>
+        <h2 style={{ padding: 20 }}>Test: Combobox at bottom-right corner</h2>
+        <p style={{ padding: '0 20px' }}>
+          Click the dropdown at the bottom-right corner twice. It should consistently flip to top
+          when there's no space at bottom.
+        </p>
+
+        <div style={{ position: 'absolute', right: 10, bottom: 10 }}>
+          <Combobox
+            store={combobox}
+            onOptionSubmit={(val) => {
+              setValue(val);
+              combobox.closeDropdown();
+            }}
+          >
+            <Combobox.Target>
+              <InputBase
+                component="button"
+                type="button"
+                pointer
+                rightSection={<Combobox.Chevron />}
+                rightSectionPointerEvents="none"
+                onClick={() => combobox.toggleDropdown()}
+              >
+                {value || <Input.Placeholder>Pick value (bottom-right)</Input.Placeholder>}
+              </InputBase>
+            </Combobox.Target>
+
+            <Combobox.Dropdown>
+              <Combobox.Options>{options}</Combobox.Options>
+            </Combobox.Dropdown>
+          </Combobox>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function BottomLeftAbsolute() {
+  const combobox = useCombobox({
+    onDropdownClose: () => combobox.resetSelectedOption(),
+  });
+
+  const [value, setValue] = useState<string | null>(null);
+
+  const options = groceries.slice(0, 5).map((item) => (
+    <Combobox.Option value={item} key={item}>
+      {item}
+    </Combobox.Option>
+  ));
+
+  return (
+    <>
+      <div style={{ height: '100vh', position: 'relative' }}>
+        <h2 style={{ padding: 20 }}>Test: Combobox at bottom-left corner</h2>
+        <p style={{ padding: '0 20px' }}>
+          Click the dropdown at the bottom-left corner twice. It should consistently flip to top
+          when there's no space at bottom.
+        </p>
+
+        <div style={{ position: 'absolute', left: 10, bottom: 10 }}>
+          <Combobox
+            store={combobox}
+            onOptionSubmit={(val) => {
+              setValue(val);
+              combobox.closeDropdown();
+            }}
+          >
+            <Combobox.Target>
+              <InputBase
+                component="button"
+                type="button"
+                pointer
+                rightSection={<Combobox.Chevron />}
+                rightSectionPointerEvents="none"
+                onClick={() => combobox.toggleDropdown()}
+              >
+                {value || <Input.Placeholder>Pick value (bottom-left)</Input.Placeholder>}
+              </InputBase>
+            </Combobox.Target>
+
+            <Combobox.Dropdown>
+              <Combobox.Options>{options}</Combobox.Options>
+            </Combobox.Dropdown>
+          </Combobox>
+        </div>
+      </div>
+    </>
   );
 }

--- a/packages/@mantine/core/src/components/Popover/Popover.tsx
+++ b/packages/@mantine/core/src/components/Popover/Popover.tsx
@@ -336,8 +336,12 @@ export function Popover(_props: PopoverProps) {
     transitionProps?.onExited?.();
     onExitTransitionEnd?.();
     setDropdownVisible(false);
-    positionRef.current = position;
-  }, [transitionProps?.onExited, onExitTransitionEnd]);
+    // Only reset position if preventPositionChangeWhenVisible is false
+    // to maintain the flipped position on subsequent opens
+    if (!preventPositionChangeWhenVisible) {
+      positionRef.current = position;
+    }
+  }, [transitionProps?.onExited, onExitTransitionEnd, preventPositionChangeWhenVisible, position]);
 
   const onEntered = useCallback(() => {
     transitionProps?.onEntered?.();


### PR DESCRIPTION
fixes https://github.com/mantinedev/mantine/issues/8253

## Cause
The issue was caused by an interaction between the `preventPositionChangeWhenVisible` property and position reset logic in the Popover component.

1. First click: Floating UI detects insufficient space at bottom and flips to top, storing the flipped position
2. On close: The `onExited` callback unconditionally resets position back to original (`bottom`)
3. Second click: Uses the reset position (`bottom`) with flip middleware disabled, causing overflow

## Changes
- In `onExited` in `Popover.tsx`, keep previous position when `preventPositionChangeWhenVisible` is true
- Added two Combobox stories to verify behavior when positioned at the bottom-left and bottom-right corners

## issue
https://github.com/mantinedev/mantine/issues/8253