### PR TITLE
[@mantine/hooks] Fix focus capture timing to useFocusReturn hook 

### DIFF
--- a/packages/@mantine/hooks/src/use-focus-return/use-focus-return.ts
+++ b/packages/@mantine/hooks/src/use-focus-return/use-focus-return.ts
@@ -12,14 +12,17 @@ export function useFocusReturn({
   opened,
   shouldReturnFocus = true,
 }: UseFocusReturnOptions): UseFocusReturnReturnValue {
-  const lastActiveElement = useRef<HTMLElement>(null);
+  const lastActiveElement = useRef<HTMLElement>(
+    typeof document !== 'undefined' ? (document.activeElement as HTMLElement) : null
+  );
+
   const returnFocus = () => {
     if (
       lastActiveElement.current &&
       'focus' in lastActiveElement.current &&
       typeof lastActiveElement.current.focus === 'function'
     ) {
-      lastActiveElement.current?.focus({ preventScroll: true });
+      lastActiveElement.current.focus({ preventScroll: true });
     }
   };
 
@@ -34,12 +37,9 @@ export function useFocusReturn({
 
     document.addEventListener('keydown', clearFocusTimeout);
 
-    if (opened) {
-      lastActiveElement.current = document.activeElement as HTMLElement;
-    } else if (shouldReturnFocus) {
+    if (!opened && shouldReturnFocus) {
       timeout = window.setTimeout(returnFocus, 10);
     }
-
     return () => {
       window.clearTimeout(timeout);
       document.removeEventListener('keydown', clearFocusTimeout);


### PR DESCRIPTION
## Description  
  
This PR fixes the focus capture timing issue in the `useFocusReturn` hook and adds SSR safety.  
  
### Problem  
  
The current implementation captures `document.activeElement` after the modal opens using `useDidUpdate`, which means it often captures the modal's internal elements instead of the button that opened the modal. This breaks the intended behavior of returning focus to the original trigger element.  
  
### Solution  
  
1. **Fixed timing issue**: Capture `document.activeElement` during hook initialization instead of in `useDidUpdate` when `opened` becomes `true`  
2. **Added SSR safety**: Added `typeof document !== "undefined"` check to prevent errors during server-side rendering  
3. **Simplified logic**: Removed the `opened` condition from `useDidUpdate` since we only need to handle the closing case  

### Changes  
  
- Move focus capture from `useDidUpdate` to hook initialization  
- Add SSR safety check for `document.activeElement`  
- Remove unnecessary `opened` condition in `useDidUpdate`  
- **Remove redundant optional chaining in `returnFocus` function**: Changed `lastActiveElement.current?.focus()` to `lastActiveElement.current.focus()` since the if condition already guarantees the element exists and has a focus method  
- Maintain backward compatibility with existing API  