### PR TITLE
[@mantine/dates] TimePicker: Fix custom amPmLabels being truncated in…

### DIFF
--- a/packages/@mantine/dates/src/components/TimePicker/AmPmInput/AmPmInput.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/AmPmInput/AmPmInput.tsx
@@ -76,11 +76,15 @@ export const AmPmInput = forwardRef<HTMLSelectElement, AmPmInputProps>(
     };
 
     if (inputType === 'input') {
+      const displayValue = value || '--';
+      const inputSize = displayValue.length + 1;
+
       return (
         <input
           {...ctx.getStyles('field', { className, style })}
           ref={ref as any}
-          value={value || '--'}
+          value={displayValue}
+          size={inputSize}
           onChange={(event) => !readOnly && onChange(event.target.value || null)}
           onClick={((event: any) => event.stopPropagation()) as any}
           onKeyDown={handleKeyDown as any}

--- a/packages/@mantine/dates/src/components/TimePicker/TimePicker.module.css
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePicker.module.css
@@ -31,7 +31,8 @@
 
 .control {
   text-align: center;
-  width: 2.5em;
+  min-width: 2.5em;
+  width: max-content;
   height: 2em;
   border-radius: var(--mantine-radius-default);
   font-size: var(--control-font-size, var(--mantine-font-size-sm));
@@ -132,7 +133,7 @@
   appearance: none;
 
   &:where([data-am-pm]) {
-    width: calc(3ch + 0.3em);
+    width: auto;
   }
 
   &:where(:disabled) {


### PR DESCRIPTION
fixes #8253 

---

<img width="568" height="402" alt="스크린샷 2025-10-05 오후 9 08 49" src="https://github.com/user-attachments/assets/db770086-8ca4-48fe-b943-468b3693d5e8" />

## Changes

### Input Field (`AmPmInput.tsx`)
  - Added dynamic `size` attribute based on the current value length (`displayValue.length + 1`)
  - The input field now automatically adjusts its width to fit the actual AM/PM label text

### Dropdown Controls (`TimePicker.module.css`)
  - `.control`: Changed from fixed `width: 2.5em` to `min-width: 2.5em` + `width: max-content`
  - Allows AM/PM controls in dropdown to expand based on label length while maintaining minimum size for number controls
  - `.field[data-am-pm]`: Changed from fixed `width: calc(3ch + 0.3em)` to `width: auto`
  - Allows the input field to respect the dynamic `size` attribute