### PR TITLE
[@mantine/dates] DatePicker: add missing `multiple` type for `DatePickerPreset`

### DIFF
--- a/packages/@mantine/dates/src/components/DatePicker/DatePicker.tsx
+++ b/packages/@mantine/dates/src/components/DatePicker/DatePicker.tsx
@@ -40,7 +40,9 @@ import classes from './DatePicker.module.css';
 export interface DatePickerPreset<Type extends DatePickerType> {
   value: Type extends 'range'
     ? [DateStringValue | null, DateStringValue | null]
-    : DateStringValue | null;
+    : Type extends 'multiple'
+      ? DateStringValue[]
+      : DateStringValue | null;
   label: React.ReactNode;
 }
 


### PR DESCRIPTION
Fixes #8338 

This PR resolves a type issue in the `DatePickerPreset` interface.

The `value` property was incorrectly typed for the `'multiple'` selection mode. I've updated the conditional type to ensure that when `Type` is `'multiple'`, the `value` is correctly defined as `DateStringValue[]`. This fixes the type mismatch and ensures proper type safety.