### PR TITLE
🐛fix(popover): prevent horizontal ghost scrolling

### DIFF
--- a/packages/@mantine/core/src/components/Popover/use-popover.ts
+++ b/packages/@mantine/core/src/components/Popover/use-popover.ts
@@ -75,8 +75,8 @@ function getPopoverMiddlewares(
     middlewares.push(
       shift(
         typeof middlewaresOptions.shift === 'boolean'
-          ? { limiter: limitShift(), padding: 5 }
-          : { limiter: limitShift(), padding: 5, ...middlewaresOptions.shift }
+          ? { limiter: limitShift(), padding: 0 }
+          : { limiter: limitShift(), padding: 0, ...middlewaresOptions.shift }
       )
     );
   }


### PR DESCRIPTION
Fixes #8321 

Hello :D ,
I've resolved the infinite scrolling issue in the Select component.

### Changes:
Modified the shift padding value from `5` to `0` in `use-popover.ts`

### Issue Details:
The Combobox renders through a portal, which made this issue a bit tricky to track down. 😅
To reproduce this issue, you can easily observe it by removing the padding from the Combobox's parent div in the Demo.

### Root Cause:
The problem occurred when the Combobox had left padding. Since the shift middleware is enabled by default in the popover's defaultProps, the component would get pushed by `5px` padding and then pulled back by the shift, creating a loop that resulted in infinite scrolling.

### Solution:
I've set the default padding value of the shift middleware to `0` in `use-popover.ts.`

### Side Effects:
This change may affect the Popover Arrow component. If you'd like to modify only the Combobox without impacting other components, you can configure the Combobox props with `shift: { padding: 0 }` instead.

```jsx
<Combobox 
  middlewares={{ 
    shift: { padding: 0 }
  }}
>
  {/* ... */}
</Combobox>
```


If you could suggest an alternative approach, I'd be happy to implement it accordingly. Thank you.

## Before
### Normal
<img width="668" height="348" alt="스크린샷 2025-10-11 오전 1 10 02" src="https://github.com/user-attachments/assets/5f78d0fd-755a-424f-ad04-5b4e98de7a69" /> 
 
### Bug
<img width="817" height="339" alt="스크린샷 2025-10-11 오전 1 09 55" src="https://github.com/user-attachments/assets/03ed5c5e-b046-43de-afe5-a53ceac78bd6" />

https://github.com/user-attachments/assets/94baf595-4362-44b1-8ef8-3f3fa8ae2437

## After
<img width="336" height="324" alt="스크린샷 2025-10-11 오전 2 10 14" src="https://github.com/user-attachments/assets/2e7a0a42-8015-4c95-84e0-b10281c93572" />


https://github.com/user-attachments/assets/23ca0190-35f3-40c7-878a-b0dc8583d99f

