### PR TITLE
📜docs(select): add horizontal infinite scroll workaround

### DIFF
--- a/apps/mantine.dev/src/pages/core/select.mdx
+++ b/apps/mantine.dev/src/pages/core/select.mdx
@@ -201,6 +201,27 @@ To change dropdown offset, set `offset` prop in `comboboxProps`:
 
 <Demo data={SelectDemos.dropdownOffset} />
 
+## Prevent horizontal infinite scrolling
+
+If you experience horizontal infinite scrolling in the dropdown, set the `shift` middleware `padding` to `0`:
+
+```tsx
+import { Select } from '@mantine/core';
+
+function Demo() {
+  return (
+    <Select
+      data={['React', 'Angular', 'Vue']}
+      comboboxProps={{
+        middlewares: {
+          shift: { padding: 0 }
+        }
+      }}
+    />
+  );
+}
+```
+
 ## Dropdown animation
 
 By default, dropdown animations are disabled. To enable them, you can set `transitionProps`,


### PR DESCRIPTION
Fixes #8321 

Hello😆!

Following your feedback from PR #8350 , I've updated the Select component documentation instead of changing the library code.

I added the workaround section after "Dropdown offset" – I hope the placement makes sense! 
Please let me know if you'd prefer it in a different location or if any other changes are needed.

I've tested the workaround and confirmed it resolves the horizontal infinite scrolling issue.

Thanks :>

## After
<img width="972" height="482" alt="스크린샷 2025-10-11 오후 6 41 24" src="https://github.com/user-attachments/assets/77fe17e7-559e-4f2f-b9c5-02b41d710411" />
