### PR TITLE
[@mantine/core] Checkbox: Set data-indeterminate attribute value to 'true'

### DIFF
--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
@@ -195,7 +195,7 @@ export const Checkbox = factory<CheckboxFactory>((_props, forwardedRef) => {
       ref.current.indeterminate = indeterminate || false;
 
       if (indeterminate) {
-        ref.current.setAttribute('data-indeterminate', '');
+        ref.current.setAttribute('data-indeterminate', 'true');
       } else {
         ref.current.removeAttribute('data-indeterminate');
       }


### PR DESCRIPTION
 ## Description

  Follow-up to #8363 - Sets `data-indeterminate` attribute value to `'true'` instead of empty string to maintain backward compatibility with CSS selectors.

  ## Problem

  The previous fix used `setAttribute('data-indeterminate', '')` which produces:
  ```html
  <input data-indeterminate="" />

  However, the original implementation using mod={{ indeterminate }} produced:
  <input data-indeterminate="true" />
```

  This is a subtle breaking change for users with CSS selectors like [data-indeterminate="true"].

  Solution

  Changed to setAttribute('data-indeterminate', 'true') to match the original behavior.

  CSS Compatibility

  Both selectors now work correctly:
  - ✅ [data-indeterminate] - checks for attribute presence
  - ✅ [data-indeterminate="true"] - checks for specific value

  Related

  - Follow-up to #8363
  - Addresses review comment from @predrag-nikolic-kombinat-dev

  Type of Change

  - Bug fix (non-breaking change which fixes an issue)

