### PR TITLE
[@mantine/dates] Allow for custom placeholders in <TimePicker />

### DIFF
--- a/packages/@docs/demos/src/demos/dates/TimePicker/TimePicker.demo.withPlaceholders.tsx
+++ b/packages/@docs/demos/src/demos/dates/TimePicker/TimePicker.demo.withPlaceholders.tsx
@@ -1,0 +1,32 @@
+import { TimePicker } from '@mantine/dates';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { TimePicker } from '@mantine/dates';
+
+function Demo() {
+  return (
+    <TimePicker label="Enter time" withSeconds hoursPlaceholder="09" minutesPlaceholder="50" secondsPlaceholder="11" />
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <TimePicker
+      label="Enter time"
+      withSeconds
+      hoursPlaceholder="09"
+      minutesPlaceholder="50"
+      secondsPlaceholder="11"
+    />
+  );
+}
+
+export const withPlaceholders: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+  centered: true,
+  maxWidth: 340,
+};

--- a/packages/@docs/demos/src/demos/dates/TimePicker/TimePicker.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/dates/TimePicker/TimePicker.demos.story.tsx
@@ -92,3 +92,8 @@ export const Demo_dropdownWidth = {
   name: '⭐ Demo: dropdownWidth',
   render: renderDemo(demos.dropdownWidth),
 };
+
+export const Demo_withPlaceholders = {
+  name: '⭐ Demo: withPlaceholders',
+  render: renderDemo(demos.withPlaceholders),
+};

--- a/packages/@docs/demos/src/demos/dates/TimePicker/index.ts
+++ b/packages/@docs/demos/src/demos/dates/TimePicker/index.ts
@@ -16,3 +16,4 @@ export { presetsGroups } from './TimePicker.demo.presetsGroups';
 export { presetsRange } from './TimePicker.demo.presetsRange';
 export { dropdownPosition } from './TimePicker.demo.dropdownPosition';
 export { dropdownWidth } from './TimePicker.demo.dropdownWidth';
+export { withPlaceholders } from './TimePicker.demo.withPlaceholders';

--- a/packages/@mantine/dates/src/components/SpinInput/SpinInput.tsx
+++ b/packages/@mantine/dates/src/components/SpinInput/SpinInput.tsx
@@ -13,6 +13,7 @@ interface SpinInputProps
   onNextInput?: () => void;
   onPreviousInput?: () => void;
   allowTemporaryZero?: boolean;
+  placeholder?: string;
 }
 
 const getMaxDigit = (max: number) => Number(max.toFixed(0)[0]);
@@ -31,6 +32,7 @@ export const SpinInput = forwardRef<HTMLInputElement, SpinInputProps>(
       onFocus,
       readOnly,
       allowTemporaryZero = false,
+      placeholder = '--',
       ...others
     },
     ref
@@ -122,7 +124,7 @@ export const SpinInput = forwardRef<HTMLInputElement, SpinInputProps>(
         aria-valuenow={value === null ? 0 : value}
         data-empty={value === null || undefined}
         inputMode="numeric"
-        placeholder="--"
+        placeholder={placeholder}
         value={value === null ? '' : padTime(value)}
         onChange={(event) => handleChange(event.currentTarget.value)}
         onKeyDown={handleKeyDown}

--- a/packages/@mantine/dates/src/components/TimePicker/TimePicker.story.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePicker.story.tsx
@@ -250,3 +250,20 @@ export function ControlledEmptyString() {
     </div>
   );
 }
+
+export function WithPlaceholders() {
+  return (
+    <div style={{ padding: 40 }}>
+      <TimePicker
+        label="Enter time"
+        withSeconds
+        minutesStep={5}
+        secondsStep={5}
+        withDropdown
+        hoursPlaceholder="09"
+        minutesPlaceholder="50"
+        secondsPlaceholder="11"
+      />
+    </div>
+  );
+}

--- a/packages/@mantine/dates/src/components/TimePicker/TimePicker.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePicker.tsx
@@ -180,6 +180,15 @@ export interface TimePickerProps
 
   /** If set, the time controls list are reversed, @default `false` */
   reverseTimeControlsList?: boolean;
+
+  /** Hours input placeholder, @default `--` */
+  hoursPlaceholder?: string;
+
+  /** Minutes input placeholder, @default `--` */
+  minutesPlaceholder?: string;
+
+  /** Seconds input placeholder, @default `--` */
+  secondsPlaceholder?: string;
 }
 
 export type TimePickerFactory = Factory<{
@@ -198,6 +207,9 @@ const defaultProps = {
   amPmLabels: { am: 'AM', pm: 'PM' },
   pasteSplit: getParsedTime,
   maxDropdownContentHeight: 200,
+  hoursPlaceholder: '--',
+  minutesPlaceholder: '--',
+  secondsPlaceholder: '--',
 } satisfies Partial<TimePickerProps>;
 
 const varsResolver = createVarsResolver<TimePickerFactory>((_theme, { size }) => ({
@@ -262,6 +274,9 @@ export const TimePicker = factory<TimePickerFactory>((_props, ref) => {
     scrollAreaProps,
     attributes,
     reverseTimeControlsList,
+    hoursPlaceholder,
+    minutesPlaceholder,
+    secondsPlaceholder,
     ...others
   } = props;
 
@@ -430,6 +445,7 @@ export const TimePicker = factory<TimePickerFactory>((_props, ref) => {
                     }
                     hoursInputProps?.onBlur?.(event);
                   }}
+                  placeholder={hoursPlaceholder}
                 />
                 <span>:</span>
                 <SpinInput
@@ -458,6 +474,7 @@ export const TimePicker = factory<TimePickerFactory>((_props, ref) => {
                     handleFocus(event);
                     minutesInputProps?.onFocus?.(event);
                   }}
+                  placeholder={minutesPlaceholder}
                 />
 
                 {withSeconds && (
@@ -487,6 +504,7 @@ export const TimePicker = factory<TimePickerFactory>((_props, ref) => {
                         handleFocus(event);
                         secondsInputProps?.onFocus?.(event);
                       }}
+                      placeholder={secondsPlaceholder}
                     />
                   </>
                 )}


### PR DESCRIPTION
Resolves https://github.com/orgs/mantinedev/discussions/8386.

Added three new optional props to `<TimePicker />`:

- `hoursPlaceholder`
- `minutesPlaceholder`
- `secondsPlaceholder`

Added one new optional prop to `<SpinInput />`:

- `placeholder`

Now the users can set up custom input placeholders for every type of input separately.
Did not change any of the styling due to the concern of implementing a breaking change.