### PR TITLE
[@mantine/core]  Add Modal.Footer and Drawer.Footer components

### DIFF
--- a/apps/mantine.dev/src/pages/core/drawer.mdx
+++ b/apps/mantine.dev/src/pages/core/drawer.mdx
@@ -141,6 +141,7 @@ You can use the following compound components to have full control over the `Dra
 - `Drawer.Title` – `h2` element, `aria-labelledby` of `Drawer.Content` is pointing to this element, usually is rendered inside `Drawer.Header`
 - `Drawer.CloseButton` – close button, usually rendered inside `Drawer.Header`
 - `Drawer.Body` – a place for main content, `aria-describedby` of `Drawer.Content` is pointing to this element
+- `Drawer.Footer` - a place for extra content. It's always sticky to prevent scrolling drawer content to footer content
 
 <Demo data={DrawerDemos.composition} />
 

--- a/apps/mantine.dev/src/pages/core/modal.mdx
+++ b/apps/mantine.dev/src/pages/core/modal.mdx
@@ -142,6 +142,7 @@ You can use the following compound components to have full control over the `Mod
 - `Modal.Title` – `h2` element, `aria-labelledby` of `Modal.Content` is pointing to this element, usually is rendered inside `Modal.Header`
 - `Modal.CloseButton` – close button, usually rendered inside `Modal.Header`
 - `Modal.Body` – a place for main content, `aria-describedby` of `Modal.Content` is pointing to this element
+- `Modal.Footer` - a place for extra content. It's always sticky to prevent scrolling modal content to footer content
 
 <Demo data={ModalDemos.composition} />
 

--- a/packages/@docs/demos/src/demos/core/Drawer/Drawer.demo.composition.tsx
+++ b/packages/@docs/demos/src/demos/core/Drawer/Drawer.demo.composition.tsx
@@ -19,6 +19,10 @@ function Demo() {
             <Drawer.CloseButton />
           </Drawer.Header>
           <Drawer.Body>Drawer content</Drawer.Body>
+          <Drawer.Footer>
+            <Button onClick={close}>Close</Button>
+            <Button>Confirm</Button>
+          </Drawer.Footer>
         </Drawer.Content>
       </Drawer.Root>
 
@@ -33,6 +37,10 @@ function Demo() {
 function Demo() {
   const [opened, { open, close }] = useDisclosure(false);
 
+  const content = Array(100)
+    .fill(0)
+    .map((_, index) => <p key={index}>Drawer content</p>);
+
   return (
     <>
       <Drawer.Root opened={opened} onClose={close}>
@@ -42,7 +50,11 @@ function Demo() {
             <Drawer.Title>Drawer title</Drawer.Title>
             <Drawer.CloseButton />
           </Drawer.Header>
-          <Drawer.Body>Drawer content</Drawer.Body>
+          <Drawer.Body>{content}</Drawer.Body>
+          <Drawer.Footer>
+            <Button onClick={close}>Close</Button>
+            <Button>Confirm</Button>
+          </Drawer.Footer>
         </Drawer.Content>
       </Drawer.Root>
 

--- a/packages/@docs/demos/src/demos/core/Modal/Modal.demo.composition.tsx
+++ b/packages/@docs/demos/src/demos/core/Modal/Modal.demo.composition.tsx
@@ -19,6 +19,10 @@ function Demo() {
             <Modal.CloseButton />
           </Modal.Header>
           <Modal.Body>Modal content</Modal.Body>
+           <Modal.Footer>
+            <Button onClick={close}>Close</Button>
+            <Button>Confirm</Button>
+          </Modal.Footer>
         </Modal.Content>
       </Modal.Root>
 
@@ -33,6 +37,10 @@ function Demo() {
 function Demo() {
   const [opened, { open, close }] = useDisclosure(false);
 
+  const content = Array(100)
+    .fill(0)
+    .map((_, index) => <p key={index}>Modal content</p>);
+
   return (
     <>
       <Modal.Root opened={opened} onClose={close}>
@@ -42,7 +50,11 @@ function Demo() {
             <Modal.Title>Modal title</Modal.Title>
             <Modal.CloseButton />
           </Modal.Header>
-          <Modal.Body>Modal content</Modal.Body>
+          <Modal.Body>{content}</Modal.Body>
+          <Modal.Footer>
+            <Button onClick={close}>Close</Button>
+            <Button>Confirm</Button>
+          </Modal.Footer>
         </Modal.Content>
       </Modal.Root>
 

--- a/packages/@docs/styles-api/src/data/Drawer.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/Drawer.styles-api.ts
@@ -11,6 +11,7 @@ export const DrawerStylesApi: StylesApiData<DrawerFactory> = {
     title: 'Drawer title (h2 tag), displayed in the header',
     body: 'Drawer body, displayed after header',
     close: 'Close button',
+    footer: 'Drawer footer',
   },
 
   vars: {

--- a/packages/@docs/styles-api/src/data/Modal.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/Modal.styles-api.ts
@@ -11,6 +11,7 @@ export const ModalStylesApi: StylesApiData<ModalFactory> = {
     title: 'Modal title (h2 tag), displayed in the header',
     body: 'Modal body, displayed after header',
     close: 'Close button',
+    footer: 'Modal footer',
   },
 
   vars: {

--- a/packages/@mantine/core/src/components/Drawer/Drawer.module.css
+++ b/packages/@mantine/core/src/components/Drawer/Drawer.module.css
@@ -12,6 +12,10 @@
   z-index: 1000;
 }
 
+.footer {
+  z-index: 1000;
+}
+
 .content {
   flex: var(--drawer-flex, 0 0 var(--drawer-size));
   height: var(--drawer-height, calc(100% - var(--drawer-offset) * 2));

--- a/packages/@mantine/core/src/components/Drawer/Drawer.tsx
+++ b/packages/@mantine/core/src/components/Drawer/Drawer.tsx
@@ -4,6 +4,7 @@ import { ModalBaseCloseButtonProps, ModalBaseOverlayProps } from '../ModalBase';
 import { DrawerBody } from './DrawerBody';
 import { DrawerCloseButton } from './DrawerCloseButton';
 import { DrawerContent } from './DrawerContent';
+import { DrawerFooter } from './DrawerFooter';
 import { DrawerHeader } from './DrawerHeader';
 import { DrawerOverlay } from './DrawerOverlay';
 import {
@@ -52,6 +53,7 @@ export type DrawerFactory = Factory<{
     Overlay: typeof DrawerOverlay;
     Content: typeof DrawerContent;
     Body: typeof DrawerBody;
+    Footer: typeof DrawerFooter;
     Header: typeof DrawerHeader;
     Title: typeof DrawerTitle;
     CloseButton: typeof DrawerCloseButton;
@@ -143,6 +145,7 @@ Drawer.Root = DrawerRoot;
 Drawer.Overlay = DrawerOverlay;
 Drawer.Content = DrawerContent;
 Drawer.Body = DrawerBody;
+Drawer.Footer = DrawerFooter;
 Drawer.Header = DrawerHeader;
 Drawer.Title = DrawerTitle;
 Drawer.CloseButton = DrawerCloseButton;

--- a/packages/@mantine/core/src/components/Drawer/DrawerFooter.tsx
+++ b/packages/@mantine/core/src/components/Drawer/DrawerFooter.tsx
@@ -1,0 +1,35 @@
+import { CompoundStylesApiProps, factory, Factory, useProps } from '../../core';
+import { ModalBaseFooter, ModalBaseFooterProps } from '../ModalBase';
+import { useDrawerContext } from './Drawer.context';
+import classes from './Drawer.module.css';
+
+export type DrawerFooterStylesNames = 'footer';
+
+export interface DrawerFooterProps
+  extends ModalBaseFooterProps,
+    CompoundStylesApiProps<DrawerFooterFactory> {}
+
+export type DrawerFooterFactory = Factory<{
+  props: DrawerFooterProps;
+  ref: HTMLElement;
+  stylesNames: DrawerFooterStylesNames;
+  compound: true;
+}>;
+
+export const DrawerFooter = factory<DrawerFooterFactory>((_props, ref) => {
+  const props = useProps('DrawerFooter', null, _props);
+  const { classNames, className, style, styles, vars, ...others } = props;
+
+  const ctx = useDrawerContext();
+
+  return (
+    <ModalBaseFooter
+      ref={ref}
+      {...ctx.getStyles('footer', { classNames, style, styles, className })}
+      {...others}
+    />
+  );
+});
+
+DrawerFooter.classes = classes;
+DrawerFooter.displayName = '@mantine/core/DrawerFooter';

--- a/packages/@mantine/core/src/components/Modal/Modal.module.css
+++ b/packages/@mantine/core/src/components/Modal/Modal.module.css
@@ -36,6 +36,11 @@
   border-start-end-radius: var(--modal-radius, var(--mantine-radius-default));
 }
 
+.footer {
+  border-end-start-radius: var(--modal-radius, var(--mantine-radius-default));
+  border-end-end-radius: var(--modal-radius, var(--mantine-radius-default));
+}
+
 .content {
   flex: var(--modal-content-flex, 0 0 var(--modal-size));
   max-width: 100%;

--- a/packages/@mantine/core/src/components/Modal/Modal.story.tsx
+++ b/packages/@mantine/core/src/components/Modal/Modal.story.tsx
@@ -1,6 +1,7 @@
 import { useDisclosure } from '@mantine/hooks';
 import { Button } from '../Button';
 import { Card } from '../Card';
+import { Group } from '../Group';
 import { Menu } from '../Menu';
 import { ScrollArea } from '../ScrollArea';
 import { Select } from '../Select';
@@ -323,3 +324,32 @@ export function WithScrollArea() {
     </>
   );
 }
+
+export const Compound = () => {
+  const [opened, { open, close }] = useDisclosure(false);
+
+  return (
+    <>
+      <Button onClick={open}>Open modal</Button>
+
+      <Modal.Root opened={opened} onClose={close}>
+        <Modal.Overlay />
+        <Modal.Content>
+          <Modal.Header>
+            <Modal.Title>Modal title</Modal.Title>
+            <Modal.CloseButton />
+          </Modal.Header>
+          <Modal.Body>{content}</Modal.Body>
+          <Modal.Footer>
+            <Group>
+              <Button variant="transparent" onClick={close}>
+                Close
+              </Button>
+              <Button>Button</Button>
+            </Group>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal.Root>
+    </>
+  );
+};

--- a/packages/@mantine/core/src/components/Modal/Modal.tsx
+++ b/packages/@mantine/core/src/components/Modal/Modal.tsx
@@ -4,6 +4,7 @@ import { ModalBaseCloseButtonProps, ModalBaseOverlayProps } from '../ModalBase';
 import { ModalBody } from './ModalBody';
 import { ModalCloseButton } from './ModalCloseButton';
 import { ModalContent } from './ModalContent';
+import { ModalFooter } from './ModalFooter';
 import { ModalHeader } from './ModalHeader';
 import { ModalOverlay } from './ModalOverlay';
 import {
@@ -55,6 +56,7 @@ export type ModalFactory = Factory<{
     Content: typeof ModalContent;
     Body: typeof ModalBody;
     Header: typeof ModalHeader;
+    Footer: typeof ModalFooter;
     Title: typeof ModalTitle;
     CloseButton: typeof ModalCloseButton;
     Stack: typeof ModalStack;
@@ -151,6 +153,7 @@ Modal.Overlay = ModalOverlay;
 Modal.Content = ModalContent;
 Modal.Body = ModalBody;
 Modal.Header = ModalHeader;
+Modal.Footer = ModalFooter;
 Modal.Title = ModalTitle;
 Modal.CloseButton = ModalCloseButton;
 Modal.Stack = ModalStack;

--- a/packages/@mantine/core/src/components/Modal/ModalFooter.tsx
+++ b/packages/@mantine/core/src/components/Modal/ModalFooter.tsx
@@ -1,0 +1,35 @@
+import { CompoundStylesApiProps, factory, Factory, useProps } from '../../core';
+import { ModalBaseFooter, ModalBaseFooterProps } from '../ModalBase';
+import { useModalContext } from './Modal.context';
+import classes from './Modal.module.css';
+
+export type ModalFooterStylesNames = 'footer';
+
+export interface ModalFooterProps
+  extends ModalBaseFooterProps,
+    CompoundStylesApiProps<ModalFooterFactory> {}
+
+export type ModalFooterFactory = Factory<{
+  props: ModalFooterProps;
+  ref: HTMLElement;
+  stylesNames: ModalFooterStylesNames;
+  compound: true;
+}>;
+
+export const ModalFooter = factory<ModalFooterFactory>((_props, ref) => {
+  const props = useProps('ModalFooter', null, _props);
+  const { classNames, className, style, styles, vars, ...others } = props;
+
+  const ctx = useModalContext();
+
+  return (
+    <ModalBaseFooter
+      ref={ref}
+      {...ctx.getStyles('footer', { classNames, style, styles, className })}
+      {...others}
+    />
+  );
+});
+
+ModalFooter.classes = classes;
+ModalFooter.displayName = '@mantine/core/ModalFooter';

--- a/packages/@mantine/core/src/components/ModalBase/ModalBase.module.css
+++ b/packages/@mantine/core/src/components/ModalBase/ModalBase.module.css
@@ -20,6 +20,20 @@
   transition: padding-inline-end 100ms;
 }
 
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--mb-padding, var(--mantine-spacing-md));
+  padding-inline-end: calc(var(--mb-padding, var(--mantine-spacing-md)) - rem(5px));
+  position: sticky;
+  bottom: 0;
+  background-color: var(--mantine-color-body);
+  z-index: 1000;
+  min-height: 60px;
+  transition: padding-inline-end 100ms;
+}
+
 .inner {
   position: fixed;
   width: 100%;

--- a/packages/@mantine/core/src/components/ModalBase/ModalBaseFooter.tsx
+++ b/packages/@mantine/core/src/components/ModalBase/ModalBaseFooter.tsx
@@ -1,0 +1,23 @@
+import { forwardRef } from 'react';
+import cx from 'clsx';
+import { Box, BoxProps, ElementProps } from '../../core';
+import { useModalBaseContext } from './ModalBase.context';
+import classes from './ModalBase.module.css';
+
+export interface ModalBaseFooterProps extends BoxProps, ElementProps<'footer'> {}
+
+export const ModalBaseFooter = forwardRef<HTMLElement, ModalBaseFooterProps>(
+  ({ className, ...others }, ref) => {
+    const ctx = useModalBaseContext();
+    return (
+      <Box
+        component="footer"
+        ref={ref}
+        className={cx({ [classes.footer]: !ctx.unstyled }, className)}
+        {...others}
+      />
+    );
+  }
+);
+
+ModalBaseFooter.displayName = '@mantine/core/ModalBaseFooter';

--- a/packages/@mantine/core/src/components/ModalBase/index.ts
+++ b/packages/@mantine/core/src/components/ModalBase/index.ts
@@ -5,6 +5,7 @@ export { ModalBaseContent } from './ModalBaseContent';
 export { ModalBaseHeader } from './ModalBaseHeader';
 export { ModalBaseOverlay } from './ModalBaseOverlay';
 export { ModalBaseTitle } from './ModalBaseTitle';
+export { ModalBaseFooter } from './ModalBaseFooter';
 export { NativeScrollArea } from './NativeScrollArea';
 
 export type { ModalBaseProps } from './ModalBase';
@@ -14,6 +15,7 @@ export type { ModalBaseContentProps } from './ModalBaseContent';
 export type { ModalBaseHeaderProps } from './ModalBaseHeader';
 export type { ModalBaseOverlayProps } from './ModalBaseOverlay';
 export type { ModalBaseTitleProps } from './ModalBaseTitle';
+export type { ModalBaseFooterProps } from './ModalBaseFooter.tsx';
 
 export type ModalBaseStylesNames =
   | 'body'
@@ -23,4 +25,5 @@ export type ModalBaseStylesNames =
   | 'root'
   | 'content'
   | 'close'
-  | 'inner';
+  | 'inner'
+  | 'footer';


### PR DESCRIPTION
This component is useful when we want to make the modal footer sticky so that it can be seen regardless of the scroll position, when there is a lot of content in the ModalBody