### PR TITLE
[@mantine/charts]: Pass labelFormatter prop provided by Recharts into default ChartTooltip

### DIFF
--- a/packages/@mantine/charts/src/AreaChart/AreaChart.tsx
+++ b/packages/@mantine/charts/src/AreaChart/AreaChart.tsx
@@ -472,9 +472,9 @@ export const AreaChart = factory<AreaChartFactory>((_props, ref) => {
                 strokeWidth: 1,
                 strokeDasharray,
               }}
-              content={({ label, payload }) => (
+              content={({ label, payload, labelFormatter }) => (
                 <ChartTooltip
-                  label={label}
+                  label={labelFormatter && payload ? labelFormatter(label, payload) : label}
                   payload={payload}
                   unit={unit}
                   classNames={resolvedClassNames}

--- a/packages/@mantine/charts/src/BarChart/BarChart.tsx
+++ b/packages/@mantine/charts/src/BarChart/BarChart.tsx
@@ -459,9 +459,9 @@ export const BarChart = factory<BarChartFactory>((_props, ref) => {
                 strokeDasharray,
                 fill: 'var(--chart-cursor-fill)',
               }}
-              content={({ label, payload }) => (
+              content={({ label, payload, labelFormatter }) => (
                 <ChartTooltip
-                  label={label}
+                  label={labelFormatter && payload ? labelFormatter(label, payload) : label}
                   payload={payload}
                   type={type === 'waterfall' ? 'scatter' : undefined}
                   unit={unit}

--- a/packages/@mantine/charts/src/CompositeChart/CompositeChart.tsx
+++ b/packages/@mantine/charts/src/CompositeChart/CompositeChart.tsx
@@ -515,9 +515,9 @@ export const CompositeChart = factory<CompositeChartFactory>((_props, ref) => {
                 strokeWidth: 1,
                 strokeDasharray,
               }}
-              content={({ label, payload }) => (
+              content={({ label, payload, labelFormatter }) => (
                 <ChartTooltip
-                  label={label}
+                  label={labelFormatter && payload ? labelFormatter(label, payload) : label}
                   payload={payload}
                   unit={unit}
                   classNames={resolvedClassNames}

--- a/packages/@mantine/charts/src/LineChart/LineChart.tsx
+++ b/packages/@mantine/charts/src/LineChart/LineChart.tsx
@@ -458,9 +458,9 @@ export const LineChart = factory<LineChartFactory>((_props, ref) => {
                 strokeWidth: 1,
                 strokeDasharray,
               }}
-              content={({ label, payload }) => (
+              content={({ label, payload, labelFormatter }) => (
                 <ChartTooltip
-                  label={label}
+                  label={labelFormatter && payload ? labelFormatter(label, payload) : label}
                   payload={payload}
                   unit={unit}
                   classNames={resolvedClassNames}

--- a/packages/@mantine/charts/src/RadarChart/RadarChart.tsx
+++ b/packages/@mantine/charts/src/RadarChart/RadarChart.tsx
@@ -265,9 +265,9 @@ export const RadarChart = factory<RadarChartFactory>((_props, ref) => {
                 stroke: 'var(--chart-grid-color)',
                 strokeWidth: 1,
               }}
-              content={({ label, payload }) => (
+              content={({ label, payload, labelFormatter }) => (
                 <ChartTooltip
-                  label={label}
+                  label={labelFormatter && payload ? labelFormatter(label, payload) : label}
                   payload={payload}
                   classNames={resolvedClassNames}
                   styles={resolvedStyles}

--- a/packages/@mantine/charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/@mantine/charts/src/ScatterChart/ScatterChart.tsx
@@ -312,10 +312,10 @@ export const ScatterChart = factory<ScatterChartFactory>((_props, ref) => {
                 strokeWidth: 1,
                 strokeDasharray,
               }}
-              content={({ label, payload }) => (
+              content={({ label, payload, labelFormatter }) => (
                 <ChartTooltip
                   type="scatter"
-                  label={label}
+                  label={labelFormatter && payload ? labelFormatter(label, payload) : label}
                   payload={
                     labels
                       ? payload?.map((item) => ({


### PR DESCRIPTION
This PR proxies the `labelFormatter` prop provided by the Recharts `Tooltip` component into the default `ChartTooltip` component.

The formatter function can be passed in via the `tooltipProps` on applicable charts