### PR TITLE
[@mantine/tiptap] Remove unused z-index to display bubble menu above toolbar

### DIFF
--- a/packages/@mantine/tiptap/src/RichTextEditor.module.css
+++ b/packages/@mantine/tiptap/src/RichTextEditor.module.css
@@ -309,7 +309,6 @@
   gap: var(--mantine-spacing-sm);
   top: var(--rte-sticky-offset, 0px);
   background-color: var(--mantine-color-body);
-  z-index: 1;
   border-start-end-radius: var(--mantine-radius-default);
   border-start-start-radius: var(--mantine-radius-default);
   border-bottom: 1px solid;


### PR DESCRIPTION
As proposed in #8415, simply remove the z-index definition to make the bubble menu appear above the toolbar. I don't think it's worth creating a new story for this, but please let me know if you think otherwise