### PR TITLE
[@mantine/tiptap] Prevent custom onClick handler overriding editor control

### DIFF
--- a/packages/@mantine/tiptap/src/RichTextEditorControl/RichTextEditorControl.tsx
+++ b/packages/@mantine/tiptap/src/RichTextEditorControl/RichTextEditorControl.tsx
@@ -121,10 +121,10 @@ export function createControl({
         title={_label}
         active={isActive?.name ? editor?.isActive(isActive.name, isActive.attributes) : false}
         ref={ref}
-        onClick={() => (editor as any)?.chain().focus()[operation.name](operation.attributes).run()}
         icon={props.icon || icon}
         disabled={isDisabled?.(editor) || false}
         {...props}
+        onClick={() => (editor as any)?.chain().focus()[operation.name](operation.attributes).run()}
       />
     );
   });


### PR DESCRIPTION
Partially reverts #8148. The onClick handler of a rich text editor control shouldn't be overridden by a custom implementation.
Fixes Controls no longer working in menus https://codesandbox.io/p/sandbox/rte-control-menu-w3p8h3

Ref: https://discordapp.com/channels/854810300876062770/1434681144913170595