### PR TITLE
fix(Button): RTL directionality in a Button by swapping left and right sections

### DIFF
--- a/packages/@mantine/core/src/components/Button/Button.tsx
+++ b/packages/@mantine/core/src/components/Button/Button.tsx
@@ -13,6 +13,7 @@ import {
   PolymorphicFactory,
   rem,
   StylesApiProps,
+  useDirection,
   useProps,
   useStyles,
 } from '../../core';
@@ -167,6 +168,7 @@ export const Button = polymorphicFactory<ButtonFactory>((_props, ref) => {
     ...others
   } = props;
 
+  const { dir } = useDirection();
   const getStyles = useStyles<ButtonFactory>({
     name: 'Button',
     props,
@@ -183,6 +185,11 @@ export const Button = polymorphicFactory<ButtonFactory>((_props, ref) => {
 
   const hasLeftSection = !!leftSection;
   const hasRightSection = !!rightSection;
+
+  // In RTL, swap the sections visually
+  const shouldSwapSections = dir === 'rtl';
+  const startSection = shouldSwapSections ? rightSection : leftSection;
+  const endSection = shouldSwapSections ? leftSection : rightSection;
 
   return (
     <UnstyledButton
@@ -218,9 +225,9 @@ export const Button = polymorphicFactory<ButtonFactory>((_props, ref) => {
       )}
 
       <span {...getStyles('inner')}>
-        {leftSection && (
+        {startSection && (
           <Box component="span" {...getStyles('section')} mod={{ position: 'left' }}>
-            {leftSection}
+            {startSection}
           </Box>
         )}
 
@@ -228,9 +235,9 @@ export const Button = polymorphicFactory<ButtonFactory>((_props, ref) => {
           {children}
         </Box>
 
-        {rightSection && (
+        {endSection && (
           <Box component="span" {...getStyles('section')} mod={{ position: 'right' }}>
-            {rightSection}
+            {endSection}
           </Box>
         )}
       </span>


### PR DESCRIPTION
  Issue #8427

  ## 📝 Description

  Fixed RTL (Right-to-Left) directionality support in the Button component. Previously, `leftSection` and `rightSection` did not swap their visual positions in RTL layouts, causing icons and sections to appear on the incorrect
  side for Arabic, Hebrew, Persian, and other RTL languages.

  ## ⛳️ Current behavior (updates)

  In RTL layouts, when using `rightSection` prop on a Button component:
  - The section appears on the **left** side visually (incorrect)
  - `leftSection` appears on the **right** side visually (incorrect)
  - The DOM order remains `[leftSection][label][rightSection]` regardless of direction

  This breaks the user experience for RTL languages where visual reading direction is right-to-left.

  ## 🚀 New behavior

  With this fix:
  - In **LTR** mode: `rightSection` appears on the right (unchanged)
  - In **RTL** mode: `rightSection` appears on the right side *visually* (DOM order swapped to `[rightSection][label][leftSection]`)
  - The component automatically detects direction using `useDirection()` hook and swaps section rendering order
  - Maintains semantic meaning: `rightSection` always means "right side" regardless of text direction

  **Changes:**
  - Added `useDirection()` hook to detect current direction context
  - Implemented conditional section swapping: `startSection` and `endSection` variables swap based on `dir`

<img width="1126" height="404" alt="スクリーンショット 2025-11-11 17 11 27" src="https://github.com/user-attachments/assets/b20bcde8-d169-4c8c-bafa-e4f0662c2525" />


  ## 💣 Is this a breaking change (Yes/No):

  **No**

  This is a bug fix that improves existing functionality. The API remains unchanged - developers still use `leftSection` and `rightSection` props as before. The fix only affects visual rendering in RTL contexts, making the
  component work as expected.

  ## 📝 Additional Information

  - Tested with `DirectionProvider` in both LTR and RTL modes
  - The fix follows the same pattern used in other Mantine components that support RTL (e.g., `TabsTab`)
  - No performance impact as direction detection happens via React context