### PR TITLE
[@mantine/charts] Add cellProps to PieChart and DonutChart

### DIFF
--- a/packages/@mantine/charts/src/DonutChart/DonutChart.tsx
+++ b/packages/@mantine/charts/src/DonutChart/DonutChart.tsx
@@ -1,5 +1,6 @@
 import {
   Cell,
+  CellProps,
   Pie,
   PieLabel,
   PieProps,
@@ -104,6 +105,11 @@ export interface DonutChartProps
 
   /** A function to format values inside the tooltip */
   valueFormatter?: (value: number) => string;
+
+  /** Props passed down to recharts `Cell` component */
+  cellProps?:
+    | ((series: DonutChartCell) => Partial<Omit<CellProps, 'ref'>>)
+    | Partial<Omit<CellProps, 'ref'>>;
 }
 
 export type DonutChartFactory = Factory<{
@@ -200,6 +206,7 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
     strokeColor,
     labelsType,
     attributes,
+    cellProps,
     ...others
   } = props;
 
@@ -231,6 +238,7 @@ export const DonutChart = factory<DonutChartFactory>((_props, ref) => {
       fill={getThemeColor(item.color, theme)}
       stroke="var(--chart-stroke-color, var(--mantine-color-body))"
       strokeWidth={strokeWidth}
+      {...(typeof cellProps === 'function' ? cellProps(item) : cellProps)}
     />
   ));
 

--- a/packages/@mantine/charts/src/PieChart/PieChart.tsx
+++ b/packages/@mantine/charts/src/PieChart/PieChart.tsx
@@ -1,5 +1,6 @@
 import {
   Cell,
+  CellProps,
   Pie,
   PieLabel,
   PieProps,
@@ -102,6 +103,11 @@ export interface PieChartProps
 
   /** A function to format values inside the tooltip */
   valueFormatter?: (value: number) => string;
+
+  /** Props passed down to recharts `Cell` component */
+  cellProps?:
+    | ((series: PieChartCell) => Partial<Omit<CellProps, 'ref'>>)
+    | Partial<Omit<CellProps, 'ref'>>;
 }
 
 export type PieChartFactory = Factory<{
@@ -218,6 +224,7 @@ export const PieChart = factory<PieChartFactory>((_props, ref) => {
     labelsType,
     strokeColor,
     attributes,
+    cellProps,
     ...others
   } = props;
 
@@ -249,6 +256,7 @@ export const PieChart = factory<PieChartFactory>((_props, ref) => {
       fill={getThemeColor(item.color, theme)}
       stroke="var(--chart-stroke-color, var(--mantine-color-body))"
       strokeWidth={strokeWidth}
+      {...(typeof cellProps === 'function' ? cellProps(item) : cellProps)}
     />
   ));
 


### PR DESCRIPTION
Similar to `barProps` in `BarChart`, allow passing `cellProps` for more granular control over Pie segments