### PR TITLE
[@mantine/core] Alert: Allow custom role prop to override default alert role

### DIFF
--- a/packages/@mantine/core/src/components/Alert/Alert.tsx
+++ b/packages/@mantine/core/src/components/Alert/Alert.tsx
@@ -107,6 +107,7 @@ export const Alert = factory<AlertFactory>((_props, ref) => {
     closeButtonLabel,
     variant,
     autoContrast,
+    role,
     attributes,
     ...others
   } = props;
@@ -135,8 +136,8 @@ export const Alert = factory<AlertFactory>((_props, ref) => {
       {...getStyles('root', { variant })}
       variant={variant}
       ref={ref}
+      role={role || 'alert'}
       {...others}
-      role="alert"
       aria-describedby={children ? bodyId : undefined}
       aria-labelledby={title ? titleId : undefined}
     >


### PR DESCRIPTION
Added support for overriding the default `role` attribute in the `Alert` component, similar to the `Notification` component (https://github.com/mantinedev/mantine/blob/master/packages/%40mantine/core/src/components/Notification/Notification.tsx#L137-L138).
This allows setting less critical messages to `role="status"` or other roles to improve a11y.
