### PR TITLE
[build] Speed up test pipeline with parallel pre-checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "release:patch": "npm run release patch && npm run docs:deploy",
     "release:minor": "npm run release minor && npm run docs:deploy",
     "release:major": "npm run release major && npm run docs:deploy",
-    "test": "npm run prettier:test && npm run syncpack && npm run typecheck && npm run lint && npm run jest",
+    "test": "node scripts/tests/run-quality-checks.mjs && npm run jest",
     "test:exports": "tsx scripts/tests/exports",
     "test:conflicts": "tsx scripts/tests/conflicts",
     "test:validate-package-json": "tsx scripts/tests/validate-package-json",

--- a/scripts/tests/run-quality-checks.mjs
+++ b/scripts/tests/run-quality-checks.mjs
@@ -1,0 +1,83 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..', '..');
+const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+const tasks = [
+  { name: 'prettier', script: 'prettier:test' },
+  { name: 'syncpack', script: 'syncpack' },
+  { name: 'typecheck', script: 'typecheck' },
+  { name: 'lint', script: 'lint' },
+];
+
+const running = new Map();
+
+function log(message) {
+  // eslint-disable-next-line no-console
+  console.log(`[test:parallel] ${message}`);
+}
+
+function terminateOthers(failedTask) {
+  running.forEach((child, name) => {
+    if (name === failedTask) {
+      return;
+    }
+
+    if (!child.killed) {
+      child.kill('SIGTERM');
+    }
+  });
+}
+
+function runTask(task) {
+  return new Promise((resolve, reject) => {
+    log(`Starting ${task.name}`);
+
+    const child = spawn(npmCmd, ['run', task.script], {
+      cwd: repoRoot,
+      stdio: 'inherit',
+      env: process.env,
+    });
+
+    running.set(task.name, child);
+
+    const handleExit = (code, signal) => {
+      running.delete(task.name);
+
+      if (code === 0) {
+        log(`Finished ${task.name}`);
+        resolve();
+      } else {
+        const reason =
+          code !== null ? `exit code ${code}` : signal ? `signal ${signal}` : 'unknown error';
+        const error = new Error(`[${task.name}] failed with ${reason}`);
+        error.taskName = task.name;
+        reject(error);
+      }
+    };
+
+    child.on('exit', handleExit);
+    child.on('error', (error) => {
+      running.delete(task.name);
+      error.taskName = task.name;
+      reject(error);
+    });
+  });
+}
+
+async function main() {
+  try {
+    await Promise.all(tasks.map((task) => runTask(task)));
+    log('All checks completed successfully');
+  } catch (error) {
+    terminateOthers(error?.taskName);
+    log(error?.message ?? error);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
  - Added scripts/tests/run-quality-checks.mjs to run prettier, syncpack, typecheck, and lint in parallel, terminating the remaining tasks if any of them fail so the fast fail signal is preserved.

before
<img width="1403" height="86" alt="image" src="https://github.com/user-attachments/assets/e969df41-e665-4337-bea9-6672418a9646" />

<img width="990" height="46" alt="image" src="https://github.com/user-attachments/assets/e09bca22-547d-4729-aa6d-6e9fb2c9ba09" />

after
<img width="1399" height="53" alt="image" src="https://github.com/user-attachments/assets/2bdf6bf7-7035-4880-b32e-089b4869d195" />

<img width="999" height="71" alt="image" src="https://github.com/user-attachments/assets/ed9c09d7-c9ef-4255-8bd5-288d43dc7650" />
