### PR TITLE
[@mantine/core] Checkbox: Fix checked state not displaying when transitioning from indeterminate to all selected

### DIFF
--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
@@ -228,7 +228,7 @@ export const Checkbox = factory<CheckboxFactory>((_props, forwardedRef) => {
           component="input"
           id={uuid}
           ref={ref}
-          mod={{ error: !!error, indeterminate }}
+          mod={{ error: !!error }}
           {...getStyles('input', { focusable: true, variant })}
           {...rest}
           {...withContextProps}


### PR DESCRIPTION
## What does this PR do?

  Fixes a visual bug where the checkbox doesn't display a check mark when transitioning from indeterminate state to fully checked (all selected) state.

  ## Problem

  When a checkbox group transitions from indeterminate state (some items selected) to all items selected, the check icon fails to appear even though the checkbox is functionally checked.

  ### Root Cause
  The `mod={{ indeterminate }}` prop was creating styling conflicts during state transitions because:
  - Both `mod` prop and `useEffect` were managing the `data-indeterminate` attribute
  - The redundant attribute caused the checkbox to remain styled as indeterminate even after the state changed to checked
  - The `useEffect` cleanup wasn't being reflected in the component's visual state

  ## Solution

  Remove `indeterminate` from the `mod` prop to eliminate redundancy and conflicts.

  **Before:**
  ```typescript
  mod={{ error: !!error, indeterminate }}
```

  **After:**
  ```typescript
  mod={{ error: !!error }}
```


##  Related Issues

  Fixes the indeterminate → checked visual transition bug reported in the checkbox component.
   - Introduced in: 608df1d24a (Add `disabled` prop for Radio.Group, Checkbox.Group and Switch.Group)
   - https://github.com/mantinedev/mantine/commit/608df1d24ae8a0052c5ff4a5a2fc34a0e0c7f636#diff-0201478ccc3ddf52937be3a9319cb3aba7e4f3afb6b5b96922a7543a9216d448


  Expected Behavior:
  - Indeterminate state: Shows dash icon
  - All selected state: Shows check mark (this was broken before)
  - Deselect some: Returns to indeterminate state

  **Before:** Select all checkbox stuck in indeterminate state

  Indeterminate → All Selected: ❌ No check mark appears

  https://github.com/user-attachments/assets/802358cb-35ed-4040-a745-be0c3e2dde6b

  **After:** Select all checkbox correctly shows checked state

  Indeterminate → All Selected: ✅ Check mark displays correctly

https://github.com/user-attachments/assets/fd54f3fd-9d5b-40fa-b0fb-a2f0ad638bac
