### PR TITLE
[@mantine/core] Badge: Fix circle prop with defaultProps.radius

### DIFF
--- a/packages/@mantine/core/src/components/Badge/Badge.tsx
+++ b/packages/@mantine/core/src/components/Badge/Badge.tsx
@@ -82,7 +82,7 @@ export type BadgeFactory = PolymorphicFactory<{
 }>;
 
 const varsResolver = createVarsResolver<BadgeFactory>(
-  (theme, { radius, color, gradient, variant, size, autoContrast }) => {
+  (theme, { radius, color, gradient, variant, size, autoContrast, circle }) => {
     const colors = theme.variantColorResolver({
       color: color || theme.primaryColor,
       theme,
@@ -96,7 +96,7 @@ const varsResolver = createVarsResolver<BadgeFactory>(
         '--badge-height': getSize(size, 'badge-height'),
         '--badge-padding-x': getSize(size, 'badge-padding-x'),
         '--badge-fz': getSize(size, 'badge-fz'),
-        '--badge-radius': radius === undefined ? undefined : getRadius(radius),
+        '--badge-radius': circle || radius === undefined ? undefined : getRadius(radius),
         '--badge-bg': color || variant ? colors.background : undefined,
         '--badge-color': color || variant ? colors.color : undefined,
         '--badge-bd': color || variant ? colors.border : undefined,


### PR DESCRIPTION
## What does this PR do?

Fixes #8465

## Problem

When the Badge component has `defaultProps.radius` set to a small value (e.g., "xs"), the `circle` prop doesn't create a perfect circle. Instead, it shows a rounded square.

## Solution

Modified `varsResolver` to check for the `circle` prop. When `circle` is true, `--badge-radius` returns `undefined`, allowing the CSS default value (1000px) to be used.

## Before & After

**Before:** Circle badge with defaultProps radius "xs" shows as rounded square
**After:** Circle badge displays as perfect circle regardless of defaultProps radius

## Testing

Manually tested with the reproduction code from the issue - all badges now display as perfect circles.