### PR TITLE
[@mantine/form] export FormArrayElement type

### DIFF
--- a/packages/@mantine/form/src/index.ts
+++ b/packages/@mantine/form/src/index.ts
@@ -14,3 +14,4 @@ export { joiResolver } from './resolvers/joi-resolver/joi-resolver';
 
 export type * from './types';
 export type { UseFieldInput, UseFieldReturnType } from './use-field';
+export type { FormArrayElement } from './paths.types.js';


### PR DESCRIPTION
I have custom components which insert and remove list items. They need `FormArrayElement` to be typed correctly.