### PR TITLE
fix: Change modal property from 'modal' to 'modalKey' in docs

### DIFF
--- a/apps/mantine.dev/src/pages/x/modals.mdx
+++ b/apps/mantine.dev/src/pages/x/modals.mdx
@@ -142,7 +142,7 @@ Typesafe context modals will force you to use the correct types for `openContext
 import { closeModal, openContextModal } from '@mantine/modals';
 
 openContextModal({
-  modal: 'demonstration',
+  modalKey: 'demonstration',
   title: 'Test modal from context',
   innerProps: {
     modalBody:


### PR DESCRIPTION
When migrating from an older version to v8.3.8 my linter caught this change. Requesting this change to keep the docs consistent. Thanks 