### PR TITLE
[@mantine/hooks] Check the last entry in useInViewport observer

### DIFF
--- a/packages/@mantine/hooks/src/use-in-viewport/use-in-viewport.ts
+++ b/packages/@mantine/hooks/src/use-in-viewport/use-in-viewport.ts
@@ -12,9 +12,11 @@ export function useInViewport<T extends HTMLElement = any>(): UseInViewportRetur
   const ref: React.RefCallback<T | null> = useCallback((node) => {
     if (typeof IntersectionObserver !== 'undefined') {
       if (node && !observer.current) {
-        observer.current = new IntersectionObserver((entries) =>
-          setInViewport(entries.some((entry) => entry.isIntersecting))
-        );
+        observer.current = new IntersectionObserver((entries) => {
+          // Entries might be batched (e.g. when scrolling very fast), so we need to use the last entry to get the most recent state
+          const lastEntry = entries[entries.length - 1];
+          setInViewport(lastEntry.isIntersecting);
+        });
       } else {
         observer.current?.disconnect();
       }


### PR DESCRIPTION
From [MDN](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver):
> You should not assume the number of entries, because multiple threshold-crossing events may be reported in a single callback invocation. The entries are dispatched using a queue, so they should be ordered by the time they were generated, but you should preferably use [IntersectionObserverEntry.time](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry/time) to correctly order them.

However, in practice, explicit ordering is unnecessary and may produce side effects, since `entry.time` is clamped to 100 microseconds in Chrome and 1 millisecond in Safari, so two entries might have the same `time` (at least in theory). 

The issue is reproduceable by creating a very long scroll view with multiple observed elements in Chrome. When dragging the scrollbar manually and very fast, some entities are kept with `inViewport = true`. This happens when intersection observer callback is called with two or more entries, e.g. first with positive `isIntersecting` and second with the negative value.

Follow-up for https://github.com/mantinedev/mantine/pull/7359