### PR TITLE
[@mantine/core] Fix SSR-related errors in Tooltip, Popover.Target etc

### DIFF
--- a/packages/@mantine/core/src/components/Combobox/ComboboxEventsTarget/ComboboxEventsTarget.tsx
+++ b/packages/@mantine/core/src/components/Combobox/ComboboxEventsTarget/ComboboxEventsTarget.tsx
@@ -1,6 +1,6 @@
-import { Children, cloneElement } from 'react';
+import { cloneElement } from 'react';
 import { useMergedRef } from '@mantine/hooks';
-import { factory, Factory, getRefProp, isElement, useProps } from '../../../core';
+import { factory, Factory, getRefProp, getSingleElementChild, useProps } from '../../../core';
 import { useComboboxContext } from '../Combobox.context';
 import { useComboboxTargetProps } from '../use-combobox-target-props/use-combobox-target-props';
 
@@ -57,8 +57,8 @@ export const ComboboxEventsTarget = factory<ComboboxEventsTargetFactory>((props,
     ...others
   } = useProps('ComboboxEventsTarget', defaultProps, props);
 
-  const _children = Children.toArray(children);
-  if (_children.length !== 1 || !isElement(_children[0])) {
+  const child = getSingleElementChild(children);
+  if (!child) {
     throw new Error(
       'Combobox.EventsTarget component children should be an element or a component that accepts ref. Fragments, strings, numbers and other primitive values are not supported'
     );
@@ -70,14 +70,14 @@ export const ComboboxEventsTarget = factory<ComboboxEventsTargetFactory>((props,
     withAriaAttributes,
     withKeyboardNavigation,
     withExpandedAttribute,
-    onKeyDown: (_children[0].props as any).onKeyDown,
+    onKeyDown: (child.props as any).onKeyDown,
     autoComplete,
   });
 
-  return cloneElement(_children[0], {
+  return cloneElement(child, {
     ...targetProps,
     ...others,
-    [refProp]: useMergedRef(ref, ctx.store.targetRef, getRefProp(_children[0])),
+    [refProp]: useMergedRef(ref, ctx.store.targetRef, getRefProp(child)),
   });
 });
 

--- a/packages/@mantine/core/src/components/Combobox/ComboboxTarget/ComboboxTarget.tsx
+++ b/packages/@mantine/core/src/components/Combobox/ComboboxTarget/ComboboxTarget.tsx
@@ -1,6 +1,6 @@
-import { Children, cloneElement } from 'react';
+import { cloneElement } from 'react';
 import { useMergedRef } from '@mantine/hooks';
-import { factory, Factory, isElement, useProps } from '../../../core';
+import { factory, Factory, getSingleElementChild, useProps } from '../../../core';
 import { Popover } from '../../Popover';
 import { useComboboxContext } from '../Combobox.context';
 import { useComboboxTargetProps } from '../use-combobox-target-props/use-combobox-target-props';
@@ -58,8 +58,8 @@ export const ComboboxTarget = factory<ComboboxTargetFactory>((props, ref) => {
     ...others
   } = useProps('ComboboxTarget', defaultProps, props);
 
-  const _children = Children.toArray(children);
-  if (_children.length !== 1 || !isElement(_children[0])) {
+  const child = getSingleElementChild(children);
+  if (!child) {
     throw new Error(
       'Combobox.Target component children should be an element or a component that accepts ref. Fragments, strings, numbers and other primitive values are not supported'
     );
@@ -72,11 +72,11 @@ export const ComboboxTarget = factory<ComboboxTargetFactory>((props, ref) => {
     withAriaAttributes,
     withKeyboardNavigation,
     withExpandedAttribute,
-    onKeyDown: (_children[0].props as any).onKeyDown,
+    onKeyDown: (child.props as any).onKeyDown,
     autoComplete,
   });
 
-  const clonedElement = cloneElement(_children[0], {
+  const clonedElement = cloneElement(child, {
     ...targetProps,
     ...others,
   });

--- a/packages/@mantine/core/src/components/FocusTrap/FocusTrap.tsx
+++ b/packages/@mantine/core/src/components/FocusTrap/FocusTrap.tsx
@@ -1,6 +1,6 @@
-import { Children, cloneElement } from 'react';
+import { cloneElement } from 'react';
 import { useFocusTrap, useMergedRef } from '@mantine/hooks';
-import { isElement } from '../../core';
+import { getSingleElementChild } from '../../core';
 import { VisuallyHidden } from '../VisuallyHidden';
 
 export interface FocusTrapProps {
@@ -26,12 +26,12 @@ export function FocusTrap({
   const focusTrapRef = useFocusTrap(active);
   const ref = useMergedRef(focusTrapRef, innerRef);
 
-  const _children = Children.toArray(children);
-  if (_children.length !== 1 || !isElement(_children[0])) {
+  const child = getSingleElementChild(children);
+  if (!child) {
     return children;
   }
 
-  return cloneElement(_children[0], { [refProp]: ref });
+  return cloneElement(child, { [refProp]: ref });
 }
 
 export function FocusTrapInitialFocus(props: React.ComponentPropsWithoutRef<'span'>) {

--- a/packages/@mantine/core/src/components/HoverCard/HoverCardTarget/HoverCardTarget.tsx
+++ b/packages/@mantine/core/src/components/HoverCard/HoverCardTarget/HoverCardTarget.tsx
@@ -1,5 +1,5 @@
-import { Children, cloneElement, forwardRef } from 'react';
-import { createEventHandler, isElement, useProps } from '../../../core';
+import { cloneElement, forwardRef } from 'react';
+import { createEventHandler, getSingleElementChild, useProps } from '../../../core';
 import { Popover, PopoverTargetProps } from '../../Popover';
 import { useHoverCardContext } from '../HoverCard.context';
 import { useHoverCardGroupContext } from '../HoverCardGroup/HoverCardGroup.context';
@@ -20,8 +20,8 @@ export const HoverCardTarget = forwardRef<HTMLElement, HoverCardTargetProps>((pr
     props
   );
 
-  const _children = Children.toArray(children);
-  if (_children.length !== 1 || !isElement(_children[0])) {
+  const child = getSingleElementChild(children);
+  if (!child) {
     throw new Error(
       'HoverCard.Target component children should be an element or a component that accepts ref. Fragments, strings, numbers and other primitive values are not supported'
     );
@@ -36,7 +36,7 @@ export const HoverCardTarget = forwardRef<HTMLElement, HoverCardTargetProps>((pr
     return (
       <Popover.Target refProp={refProp} ref={ref} {...others}>
         {cloneElement(
-          _children[0],
+          child,
           eventPropsWrapperName
             ? { [eventPropsWrapperName]: { ...referenceProps, ref: ctx.reference } }
             : { ...referenceProps, ref: ctx.reference }
@@ -45,21 +45,15 @@ export const HoverCardTarget = forwardRef<HTMLElement, HoverCardTargetProps>((pr
     );
   }
 
-  const onMouseEnter = createEventHandler(
-    (_children[0].props as any).onMouseEnter,
-    ctx.openDropdown
-  );
-  const onMouseLeave = createEventHandler(
-    (_children[0].props as any).onMouseLeave,
-    ctx.closeDropdown
-  );
+  const onMouseEnter = createEventHandler((child.props as any).onMouseEnter, ctx.openDropdown);
+  const onMouseLeave = createEventHandler((child.props as any).onMouseLeave, ctx.closeDropdown);
 
   const eventListeners = { onMouseEnter, onMouseLeave };
 
   return (
     <Popover.Target refProp={refProp} ref={ref} {...others}>
       {cloneElement(
-        _children[0],
+        child,
         eventPropsWrapperName ? { [eventPropsWrapperName]: eventListeners } : eventListeners
       )}
     </Popover.Target>

--- a/packages/@mantine/core/src/components/Menu/MenuTarget/MenuTarget.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuTarget/MenuTarget.tsx
@@ -1,5 +1,5 @@
-import { Children, cloneElement, forwardRef } from 'react';
-import { createEventHandler, isElement, useProps } from '../../../core';
+import { cloneElement, forwardRef } from 'react';
+import { createEventHandler, getSingleElementChild, useProps } from '../../../core';
 import { Popover } from '../../Popover';
 import { useMenuContext } from '../Menu.context';
 
@@ -18,17 +18,17 @@ const defaultProps = {
 export const MenuTarget = forwardRef<HTMLElement, MenuTargetProps>((props, ref) => {
   const { children, refProp, ...others } = useProps('MenuTarget', defaultProps, props);
 
-  const _children = Children.toArray(children);
-  if (_children.length !== 1 || !isElement(_children[0])) {
+  const child = getSingleElementChild(children);
+  if (!child) {
     throw new Error(
       'Menu.Target component children should be an element or a component that accepts ref. Fragments, strings, numbers and other primitive values are not supported'
     );
   }
 
   const ctx = useMenuContext();
-  const _childrenProps = _children[0].props as any;
+  const _childProps = child.props as any;
 
-  const onClick = createEventHandler(_childrenProps.onClick, () => {
+  const onClick = createEventHandler(_childProps.onClick, () => {
     if (ctx.trigger === 'click') {
       ctx.toggleDropdown();
     } else if (ctx.trigger === 'click-hover') {
@@ -40,11 +40,11 @@ export const MenuTarget = forwardRef<HTMLElement, MenuTargetProps>((props, ref) 
   });
 
   const onMouseEnter = createEventHandler(
-    _childrenProps.onMouseEnter,
+    _childProps.onMouseEnter,
     () => (ctx.trigger === 'hover' || ctx.trigger === 'click-hover') && ctx.openDropdown()
   );
 
-  const onMouseLeave = createEventHandler(_childrenProps.onMouseLeave, () => {
+  const onMouseLeave = createEventHandler(_childProps.onMouseLeave, () => {
     if (ctx.trigger === 'hover') {
       ctx.closeDropdown();
     } else if (ctx.trigger === 'click-hover' && !ctx.openedViaClick) {
@@ -54,7 +54,7 @@ export const MenuTarget = forwardRef<HTMLElement, MenuTargetProps>((props, ref) 
 
   return (
     <Popover.Target refProp={refProp} popupType="menu" ref={ref} {...others}>
-      {cloneElement(_children[0], {
+      {cloneElement(child, {
         onClick,
         onMouseEnter,
         onMouseLeave,

--- a/packages/@mantine/core/src/components/Popover/PopoverTarget/PopoverTarget.tsx
+++ b/packages/@mantine/core/src/components/Popover/PopoverTarget/PopoverTarget.tsx
@@ -1,7 +1,7 @@
-import { Children, cloneElement } from 'react';
+import { cloneElement } from 'react';
 import cx from 'clsx';
 import { useMergedRef } from '@mantine/hooks';
-import { factory, Factory, getRefProp, isElement, useProps } from '../../../core';
+import { factory, Factory, getRefProp, getSingleElementChild, useProps } from '../../../core';
 import { usePopoverContext } from '../Popover.context';
 
 export interface PopoverTargetProps {
@@ -33,8 +33,8 @@ export const PopoverTarget = factory<PopoverTargetFactory>((props, ref) => {
     props
   );
 
-  const _children = Children.toArray(children);
-  if (_children.length !== 1 || !isElement(_children[0])) {
+  const child = getSingleElementChild(children);
+  if (!child) {
     throw new Error(
       'Popover.Target component children should be an element or a component that accepts ref. Fragments, strings, numbers and other primitive values are not supported'
     );
@@ -42,7 +42,7 @@ export const PopoverTarget = factory<PopoverTargetFactory>((props, ref) => {
 
   const forwardedProps: any = others;
   const ctx = usePopoverContext();
-  const targetRef = useMergedRef(ctx.reference, getRefProp(_children[0]), ref);
+  const targetRef = useMergedRef(ctx.reference, getRefProp(child), ref);
 
   const accessibleProps = ctx.withRoles
     ? {
@@ -53,18 +53,18 @@ export const PopoverTarget = factory<PopoverTargetFactory>((props, ref) => {
       }
     : {};
 
-  const _childrenProps = _children[0].props as any;
-  return cloneElement(_children[0], {
+  const childProps = child.props as any;
+  return cloneElement(child, {
     ...forwardedProps,
     ...accessibleProps,
     ...ctx.targetProps,
-    className: cx(ctx.targetProps.className, forwardedProps.className, _childrenProps.className),
+    className: cx(ctx.targetProps.className, forwardedProps.className, childProps.className),
     [refProp]: targetRef,
     ...(!ctx.controlled
       ? {
           onClick: () => {
             ctx.onToggle();
-            _childrenProps.onClick?.();
+            childProps.onClick?.();
           },
         }
       : null),

--- a/packages/@mantine/core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/@mantine/core/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { Children, cloneElement, useEffect, useRef } from 'react';
+import { cloneElement, useEffect, useRef } from 'react';
 import cx from 'clsx';
 import { useMergedRef } from '@mantine/hooks';
 import {
@@ -9,7 +9,7 @@ import {
   getDefaultZIndex,
   getRadius,
   getRefProp,
-  isElement,
+  getSingleElementChild,
   useDirection,
   useProps,
   useStyles,
@@ -234,8 +234,8 @@ export const Tooltip = factory<TooltipFactory>((_props, ref) => {
     varsResolver,
   });
 
-  const _children = Children.toArray(children);
-  if (!target && (_children.length !== 1 || !isElement(_children[0]))) {
+  const child = getSingleElementChild(children);
+  if (!target && !child) {
     return null;
   }
 
@@ -290,8 +290,8 @@ export const Tooltip = factory<TooltipFactory>((_props, ref) => {
   }
 
   // fallback to children-based approach
-  const _childrenProps = (_children[0] as React.ReactElement).props as any;
-  const targetRef = useMergedRef(tooltip.reference, getRefProp(_children[0]), ref);
+  const childProps = child!.props as any;
+  const targetRef = useMergedRef(tooltip.reference, getRefProp(child), ref);
   const transition = getTransitionProps(transitionProps, { duration: 100, transition: 'fade' });
 
   return (
@@ -340,7 +340,7 @@ export const Tooltip = factory<TooltipFactory>((_props, ref) => {
       </OptionalPortal>
 
       {cloneElement(
-        _children[0] as React.ReactElement,
+        child!,
         tooltip.getReferenceProps({
           onClick,
           onMouseEnter,
@@ -348,8 +348,8 @@ export const Tooltip = factory<TooltipFactory>((_props, ref) => {
           onMouseMove: props.onMouseMove,
           onPointerDown: props.onPointerDown,
           onPointerEnter: props.onPointerEnter,
-          ..._childrenProps,
-          className: cx(className, _childrenProps.className),
+          ...childProps,
+          className: cx(className, childProps.className),
           [refProp]: targetRef,
         })
       )}

--- a/packages/@mantine/core/src/components/Tooltip/TooltipFloating/TooltipFloating.tsx
+++ b/packages/@mantine/core/src/components/Tooltip/TooltipFloating/TooltipFloating.tsx
@@ -1,4 +1,4 @@
-import { Children, cloneElement } from 'react';
+import { cloneElement } from 'react';
 import { useMergedRef } from '@mantine/hooks';
 import {
   Box,
@@ -8,9 +8,9 @@ import {
   getDefaultZIndex,
   getRadius,
   getRefProp,
+  getSingleElementChild,
   getStyleObject,
   getThemeColor,
-  isElement,
   useMantineTheme,
   useProps,
   useStyles,
@@ -100,24 +100,24 @@ export const TooltipFloating = factory<TooltipFloatingFactory>((_props, ref) => 
     defaultOpened,
   });
 
-  const _children = Children.toArray(children);
-  if (_children.length !== 1 || !isElement(_children[0])) {
+  const child = getSingleElementChild(children);
+  if (!child) {
     throw new Error(
       '[@mantine/core] Tooltip.Floating component children should be an element or a component that accepts ref, fragments, strings, numbers and other primitive values are not supported'
     );
   }
 
-  const targetRef = useMergedRef(boundaryRef, getRefProp(_children[0]), ref);
-  const _childrenProps = _children[0].props as any;
+  const targetRef = useMergedRef(boundaryRef, getRefProp(child), ref);
+  const childProps = child.props as any;
 
   const onMouseEnter = (event: React.MouseEvent<unknown, MouseEvent>) => {
-    _childrenProps.onMouseEnter?.(event);
+    childProps.onMouseEnter?.(event);
     handleMouseMove(event);
     setOpened(true);
   };
 
   const onMouseLeave = (event: React.MouseEvent<unknown, MouseEvent>) => {
-    _childrenProps.onMouseLeave?.(event);
+    childProps.onMouseLeave?.(event);
     setOpened(false);
   };
 
@@ -143,8 +143,8 @@ export const TooltipFloating = factory<TooltipFloatingFactory>((_props, ref) => 
         </Box>
       </OptionalPortal>
 
-      {cloneElement(_children[0], {
-        ..._childrenProps,
+      {cloneElement(child, {
+        ...childProps,
         [refProp]: targetRef,
         onMouseEnter,
         onMouseLeave,

--- a/packages/@mantine/core/src/core/utils/get-single-element-child/get-single-element-child.ts
+++ b/packages/@mantine/core/src/core/utils/get-single-element-child/get-single-element-child.ts
@@ -1,0 +1,10 @@
+import { Children } from 'react';
+import { isElement } from '../is-element/is-element';
+
+export function getSingleElementChild(children: React.ReactNode) {
+  const _children = Children.toArray(children);
+  if (_children.length !== 1 || !isElement(_children[0])) {
+    return null;
+  }
+  return _children[0];
+}

--- a/packages/@mantine/core/src/core/utils/index.ts
+++ b/packages/@mantine/core/src/core/utils/index.ts
@@ -37,3 +37,4 @@ export {
   findElementsBySelector,
   getRootElement,
 } from './find-element-in-shadow-dom/find-element-in-shadow-dom';
+export { getSingleElementChild } from './get-single-element-child/get-single-element-child';


### PR DESCRIPTION
Occasionally, components like `Tooltip`, `Popover.Target`, `HoverCard.Target` and others, when used in a Next.js App Router based application, will cause an error similar to one of the following:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'onClick')
    at @mantine/core/MenuTarget (MenuTarget.tsx:30:52)
```
```
Uncaught TypeError: Cannot read properties of undefined (reading 'className')
    at @mantine/core/Tooltip (Tooltip.tsx:352:14)
```
```
Uncaught Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
```

(Some have already been reported in #7591.)

The reason for this is that the `children` prop received by these components can have an unexpected shape that these components cannot handle. Namely, sometimes `children` can be the [`Lazy`](https://github.com/facebook/react/blob/ec9cc003d232b5a3eed735311df152463a883b32/packages/shared/ReactSymbols.js#L33) type, which doesn't have a `props` field and cannot be passed directly to `cloneElement`.

More generally speaking, APIs like `cloneElement` and `children.props` seem to be ["soft deprecated"](https://github.com/facebook/react/issues/32392#issuecomment-3133110279), so they don't work well with newer React features. Nevertheless, React team [_did_ add support](https://github.com/facebook/react/pull/28284) for the Lazy type in `Children.map` and `Children.toArray` APIs. `Tooltip` and others can use them to handle these scenarios.

In the long term, `Children` APIs might also become deprecated though, so this is only a stopgap solution.

FYI, a similar workaround has also been applied to [radix-ui](https://github.com/radix-ui/primitives/pull/3680), although they use a different method. I find the `Children.toArray` approach to be nicer, as it delegates all the special handling to React itself.