### PR TITLE
[@mantine/core] Checkbox: Add aria-describedby support for error and description (#8340)

### DIFF
--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.test.tsx
@@ -133,4 +133,45 @@ describe('@mantine/core/Checkbox', () => {
     render(<Checkbox {...defaultProps} rootRef={ref} />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });
+
+  it('sets aria-describedby on input when error is present', () => {
+    render(<Checkbox label="test-label" error="test-error" />);
+    const input = screen.getByRole('checkbox');
+    const ariaDescribedBy = input.getAttribute('aria-describedby');
+
+    expect(ariaDescribedBy).toBeTruthy();
+    expect(screen.getByText('test-error')).toHaveAttribute('id', ariaDescribedBy);
+  });
+
+  it('sets aria-describedby on input when description is present', () => {
+    render(<Checkbox label="test-label" description="test-description" />);
+    const input = screen.getByRole('checkbox');
+    const ariaDescribedBy = input.getAttribute('aria-describedby');
+
+    expect(ariaDescribedBy).toBeTruthy();
+    expect(screen.getByText('test-description')).toHaveAttribute('id', ariaDescribedBy);
+  });
+
+  it('sets aria-describedby on input referencing both description and error when both are present', () => {
+    render(<Checkbox label="test-label" description="test-description" error="test-error" />);
+    const input = screen.getByRole('checkbox');
+    const ariaDescribedBy = input.getAttribute('aria-describedby');
+
+    expect(ariaDescribedBy).toBeTruthy();
+    const ids = ariaDescribedBy!.split(' ');
+    expect(ids).toHaveLength(2);
+
+    const descriptionElement = screen.getByText('test-description');
+    const errorElement = screen.getByText('test-error');
+
+    expect(ids).toContain(descriptionElement.getAttribute('id')!);
+    expect(ids).toContain(errorElement.getAttribute('id')!);
+  });
+
+  it('does not set aria-describedby when neither description nor error are present', () => {
+    render(<Checkbox label="test-label" />);
+    const input = screen.getByRole('checkbox');
+
+    expect(input.getAttribute('aria-describedby')).toBeNull();
+  });
 });

--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
@@ -160,6 +160,14 @@ export const Checkbox = factory<CheckboxFactory>((_props, forwardedRef) => {
   const ctx = useCheckboxGroupContext();
   const _size = size || ctx?.size;
 
+  const descriptionId = useId();
+  const errorId = useId();
+
+  const ariaDescribedBy =
+    [description ? descriptionId : null, error && typeof error !== 'boolean' ? errorId : null]
+      .filter(Boolean)
+      .join(' ') || undefined;
+
   const getStyles = useStyles<CheckboxFactory>({
     name: 'Checkbox',
     props,
@@ -220,6 +228,8 @@ export const Checkbox = factory<CheckboxFactory>((_props, forwardedRef) => {
       variant={variant}
       ref={rootRef}
       mod={mod}
+      descriptionId={descriptionId}
+      errorId={errorId}
       {...styleProps}
       {...wrapperProps}
     >
@@ -233,6 +243,7 @@ export const Checkbox = factory<CheckboxFactory>((_props, forwardedRef) => {
           {...rest}
           {...withContextProps}
           type="checkbox"
+          aria-describedby={ariaDescribedBy}
         />
 
         <Icon indeterminate={indeterminate} {...getStyles('icon')} />

--- a/packages/@mantine/core/src/utils/InlineInput/InlineInput.tsx
+++ b/packages/@mantine/core/src/utils/InlineInput/InlineInput.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from 'react';
+import { useId } from '@mantine/hooks';
 import { Input } from '../../components/Input';
 import {
   Box,
@@ -38,6 +39,9 @@ export interface InlineInputProps
   labelPosition?: 'left' | 'right';
   bodyElement?: any;
   labelElement?: any;
+  descriptionId?: string;
+  errorId?: string;
+  inputDescribedBy?: string;
 }
 
 export type InlineInputFactory = Factory<{
@@ -69,10 +73,19 @@ export const InlineInput = forwardRef<HTMLDivElement, InlineInputProps>(
       vars,
       mod,
       attributes,
+      descriptionId: providedDescriptionId,
+      errorId: providedErrorId,
+      inputDescribedBy,
       ...others
     },
     ref
   ) => {
+    const generatedDescriptionId = useId();
+    const generatedErrorId = useId();
+
+    const descriptionId = providedDescriptionId || generatedDescriptionId;
+    const errorId = providedErrorId || generatedErrorId;
+
     const getStyles = useStyles<InlineInputFactory>({
       name: __staticSelector,
       props: __stylesApiProps,
@@ -118,13 +131,18 @@ export const InlineInput = forwardRef<HTMLDivElement, InlineInputProps>(
             )}
 
             {description && (
-              <Input.Description size={size} __inheritStyles={false} {...getStyles('description')}>
+              <Input.Description
+                id={descriptionId}
+                size={size}
+                __inheritStyles={false}
+                {...getStyles('description')}
+              >
                 {description}
               </Input.Description>
             )}
 
             {error && typeof error !== 'boolean' && (
-              <Input.Error size={size} __inheritStyles={false} {...getStyles('error')}>
+              <Input.Error id={errorId} size={size} __inheritStyles={false} {...getStyles('error')}>
                 {error}
               </Input.Error>
             )}


### PR DESCRIPTION
## What

Fixes #8340

Checkbox error messages are now accessible to screen readers like VoiceOver. Previously, the error and description text were not announced when focusing on the checkbox input.

## Changes

- Added `aria-describedby` attribute to checkbox input element
- The attribute references the IDs of description and error elements
- Updated InlineInput to accept optional `descriptionId` and `errorId` props
- Added test cases to verify the accessibility improvements

## How it works

When a Checkbox has an error or description:
1. Generate unique IDs for description/error elements
2. Set these IDs on the actual description/error elements
3. Link the checkbox input to these elements via `aria-describedby`

This ensures screen readers properly announce the description and error messages when users focus on the checkbox.

## Testing

All tests pass (54/54):
- ✅ aria-describedby set correctly when only error is present
- ✅ aria-describedby set correctly when only description is present  
- ✅ aria-describedby references both IDs when both are present
- ✅ No aria-describedby when neither is present

Tested with Mac VoiceOver - error messages are now properly announced. 🎉