### PR TITLE
[@mantine/dates] TimePicker: Fix AM/PM input accepting arbitrary text

### DIFF
--- a/packages/@mantine/dates/src/components/TimePicker/AmPmInput/AmPmInput.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/AmPmInput/AmPmInput.tsx
@@ -85,7 +85,8 @@ export const AmPmInput = forwardRef<HTMLSelectElement, AmPmInputProps>(
           ref={ref as any}
           value={displayValue}
           size={inputSize}
-          onChange={(event) => !readOnly && onChange(event.target.value || null)}
+          readOnly
+          onChange={() => {}}
           onClick={((event: any) => event.stopPropagation()) as any}
           onKeyDown={handleKeyDown as any}
           onMouseDown={(event) => {


### PR DESCRIPTION
The AM/PM input in the TimePicker component previously allowed users to enter arbitrary text, which caused incorrect parsing of values. This update enforces read-only behavior on the AM/PM input, preventing any invalid input and ensuring that users can only select from valid AM/PM values.

Fixes #8530