### PR TITLE
[@mantine/hooks] fix: type any in use-window-event hook

### DIFF
--- a/packages/@mantine/hooks/src/use-window-event/use-window-event.ts
+++ b/packages/@mantine/hooks/src/use-window-event/use-window-event.ts
@@ -1,14 +1,24 @@
-import { useEffect } from 'react';
+import { useEffect } from "react";
 
-export function useWindowEvent<K extends string>(
+export function useWindowEvent<K extends keyof WindowEventMap>(
   type: K,
-  listener: K extends keyof WindowEventMap
-    ? (this: Window, ev: WindowEventMap[K]) => void
-    : (this: Window, ev: CustomEvent) => void,
+  listener: (this: Window, ev: WindowEventMap[K]) => void,
+  options?: boolean | AddEventListenerOptions
+): void;
+
+export function useWindowEvent(
+  type: string,
+  listener: EventListenerOrEventListenerObject,
+  options?: boolean | AddEventListenerOptions
+): void;
+
+export function useWindowEvent(
+  type: string,
+  listener: EventListenerOrEventListenerObject,
   options?: boolean | AddEventListenerOptions
 ) {
   useEffect(() => {
-    window.addEventListener(type as any, listener, options);
-    return () => window.removeEventListener(type as any, listener, options);
-  }, [type, listener]);
+    window.addEventListener(type, listener, options);
+    return () => window.removeEventListener(type, listener, options);
+  }, [type, listener, options]);
 }


### PR DESCRIPTION
The `use-window-event` hook was typed any that wasn't good and developer friendly a typescript codebase. 

I added proper types to the hook.