### PR TITLE
[@mantine/core] Notification: Remove variant prop from NotificationProps

### DIFF
--- a/packages/@mantine/core/src/components/Notification/Notification.tsx
+++ b/packages/@mantine/core/src/components/Notification/Notification.tsx
@@ -33,8 +33,6 @@ export interface NotificationProps
   extends BoxProps,
     StylesApiProps<NotificationFactory>,
     ElementProps<'div', 'title'> {
-  variant?: string;
-
   /** Called when the close button is clicked */
   onClose?: () => void;
 
@@ -105,7 +103,6 @@ export const Notification = factory<NotificationFactory>((_props, ref) => {
     style,
     styles,
     unstyled,
-    variant,
     vars,
     mod,
     loaderProps,
@@ -133,7 +130,6 @@ export const Notification = factory<NotificationFactory>((_props, ref) => {
       {...getStyles('root')}
       mod={[{ 'data-with-icon': !!icon || loading, 'data-with-border': withBorder }, mod]}
       ref={ref}
-      variant={variant}
       role={role || 'alert'}
       {...others}
     >


### PR DESCRIPTION
# What
Fixes https://github.com/mantinedev/mantine/issues/8535

Removes `variant` property type definition from `NotificationProps` to enable overwriting similar to other components.

# Changes

- Removed `variant` property from `NotificationProps` interface
- Removed `variant` property extraction inside the `Notification` component render (it is now passed via `other`

# How it works

- Extending `NotificationProps` in the mantine.d.ts (ex) file with custom `variant` definition will now allow the type overwriting instead of hardcoded `string` type.