### PR TITLE
[@mantine/form] Export LooseKeys type from public API

### DIFF
--- a/packages/@mantine/form/src/index.ts
+++ b/packages/@mantine/form/src/index.ts
@@ -14,4 +14,4 @@ export { joiResolver } from './resolvers/joi-resolver/joi-resolver';
 
 export type * from './types';
 export type { UseFieldInput, UseFieldReturnType } from './use-field';
-export type { FormArrayElement } from './paths.types.js';
+export type { FormArrayElement, LooseKeys } from './paths.types.js';


### PR DESCRIPTION
## Summary
- Export the `LooseKeys<T>` utility type from `@mantine/form` public API
- This type is already used internally and is useful for consumers who want to type form field paths

## Motivation
Currently, to use this type, consumers have to import it from deep within node_modules:
```typescript
import type { LooseKeys } from '@mantine/form/lib/paths.types';
```

This is fragile and not part of the public API contract.

## Real-world use case
This type is useful for typing arrays of field paths, for example in multi-step form validation:

```typescript
import { useForm, type LooseKeys } from '@mantine/form';

interface CreateTicketFormData {
  title: string;
  description: string;
  priority: string;
  typeSpecificFields?: {
    stepsToReproduce: string;
    expectedBehavior: string;
  };
}

const form = useForm<CreateTicketFormData>({ /* ... */ });

// Type-safe array of field paths for step-by-step validation
let fieldsToValidate: LooseKeys<CreateTicketFormData>[] = [];

switch (currentStep) {
  case 0:
    fieldsToValidate = ['title', 'priority'];
    break;
  case 1:
    fieldsToValidate = ['description', 'typeSpecificFields.stepsToReproduce'];
    break;
}

for (const fieldPath of fieldsToValidate) {
  form.validateField(fieldPath); // fieldPath is properly typed
}
```

## Test plan
- [x] Build passes (`yarn build @mantine/form`)
- [x] Type check passes (`yarn typecheck`)