### PR TITLE
feat: Introduce Popover.Context and onOpen handler

### DIFF
--- a/apps/mantine.dev/src/pages/core/popover.mdx
+++ b/apps/mantine.dev/src/pages/core/popover.mdx
@@ -191,27 +191,6 @@ events, for example, `mouseup` and `touchend`:
 
 <Demo data={PopoverDemos.clickOutsideEvents} />
 
-## onOpen and onClose
-
-`onOpen` and `onClose` callbacks are called when dropdown opens and closes.
-
-```tsx
-import { Popover } from '@mantine/core';
-
-function Demo() {
-  return (
-    <Popover
-      withinPortal={false}
-      onOpen={() => console.log('opened')}
-      onClose={() => console.log('closed')}
-    >
-      <Popover.Target>{/* Target */}</Popover.Target>
-      <Popover.Dropdown>{/* Dropdown */}</Popover.Dropdown>
-    </Popover>
-  );
-}
-```
-
 ## onDismiss
 
 If you need to control opened state, but still want to close popover on outside clicks

--- a/apps/mantine.dev/src/pages/core/popover.mdx
+++ b/apps/mantine.dev/src/pages/core/popover.mdx
@@ -36,6 +36,36 @@ Controlled example with mouse events:
 
 <Demo data={PopoverDemos.hover} demoProps={{ toggle: false }} />
 
+## Context
+
+`Popover.Context` is a render prop component that gives you access to popover state and handlers.
+It can be used to build custom interactions (hover, focus, etc.) while still using `Popover.Target`
+and `Popover.Dropdown` components.
+
+```tsx
+import { Popover } from '@mantine/core';
+
+function Demo() {
+  return (
+    <Popover withinPortal={false} transitionProps={{ duration: 0 }}>
+      <Popover.Target>
+        <Popover.Context>
+          {({ onOpen, onClose }) => (
+            <button type="button" onMouseEnter={onOpen} onMouseLeave={onClose}>
+              Target
+            </button>
+          )}
+        </Popover.Context>
+      </Popover.Target>
+
+      <Popover.Dropdown>Dropdown</Popover.Dropdown>
+    </Popover>
+  );
+}
+```
+
+Use `context.onOpen`, `context.onClose` and `context.onToggle` handlers to control popover state.
+
 ## Focus trap
 
 If you need to use interactive elements (inputs, buttons, etc.) inside `Popover.Dropdown`, set `trapFocus` prop:
@@ -160,6 +190,27 @@ By default, `Popover` listens to `mousedown` and `touchstart` events. You can ch
 events, for example, `mouseup` and `touchend`:
 
 <Demo data={PopoverDemos.clickOutsideEvents} />
+
+## onOpen and onClose
+
+`onOpen` and `onClose` callbacks are called when dropdown opens and closes.
+
+```tsx
+import { Popover } from '@mantine/core';
+
+function Demo() {
+  return (
+    <Popover
+      withinPortal={false}
+      onOpen={() => console.log('opened')}
+      onClose={() => console.log('closed')}
+    >
+      <Popover.Target>{/* Target */}</Popover.Target>
+      <Popover.Dropdown>{/* Dropdown */}</Popover.Dropdown>
+    </Popover>
+  );
+}
+```
 
 ## onDismiss
 

--- a/packages/@mantine/core/src/components/Popover/Popover.context.ts
+++ b/packages/@mantine/core/src/components/Popover/Popover.context.ts
@@ -12,7 +12,7 @@ import { TransitionOverride } from '../Transition';
 import type { PopoverFactory } from './Popover';
 import { PopoverWidth } from './Popover.types';
 
-interface PopoverContext {
+export interface PopoverContext {
   x: number;
   y: number;
   arrowX: number | undefined;
@@ -37,6 +37,7 @@ interface PopoverContext {
   radius?: MantineRadius | undefined;
   shadow?: MantineShadow | undefined;
   onClose?: () => void;
+  onOpen?: () => void;
   onDismiss?: () => void;
   getDropdownId: () => string;
   getTargetId: () => string;

--- a/packages/@mantine/core/src/components/Popover/Popover.test.tsx
+++ b/packages/@mantine/core/src/components/Popover/Popover.test.tsx
@@ -131,4 +131,33 @@ describe('@mantine/core/Popover', () => {
     expect(Popover.Dropdown).toBe(PopoverDropdown);
     expect(Popover.Target).toBe(PopoverTarget);
   });
+
+  it('Popover.Context provides context and can control popover state', async () => {
+    render(
+      <Popover>
+        <Popover.Target>
+          <Popover.Context>
+            {({ onOpen, onClose }) => (
+              <button type="button" onMouseEnter={onOpen} onMouseLeave={onClose}>
+                test-target
+              </button>
+            )}
+          </Popover.Context>
+        </Popover.Target>
+
+        <Popover.Dropdown>
+          <div>test-dropdown</div>
+        </Popover.Dropdown>
+      </Popover>
+    );
+
+    expect(screen.queryAllByText('test-dropdown')).toHaveLength(0);
+
+    const button = screen.getByRole('button');
+    await userEvent.hover(button);
+    expect(screen.getByText('test-dropdown')).toBeInTheDocument();
+
+    await userEvent.unhover(button);
+    expect(screen.queryAllByText('test-dropdown')).toHaveLength(0);
+  });
 });

--- a/packages/@mantine/core/src/components/Popover/Popover.tsx
+++ b/packages/@mantine/core/src/components/Popover/Popover.tsx
@@ -27,7 +27,7 @@ import {
 import { Overlay, OverlayProps } from '../Overlay';
 import { BasePortalProps, OptionalPortal } from '../Portal';
 import { Transition, TransitionOverride } from '../Transition';
-import { PopoverContextProvider } from './Popover.context';
+import { PopoverContextProvider, usePopoverContext, type PopoverContext } from './Popover.context';
 import { PopoverMiddlewares, PopoverWidth } from './Popover.types';
 import { PopoverDropdown } from './PopoverDropdown/PopoverDropdown';
 import { PopoverTarget } from './PopoverTarget/PopoverTarget';
@@ -170,6 +170,15 @@ export type PopoverFactory = Factory<{
   stylesNames: PopoverStylesNames;
   vars: PopoverCssVariables;
 }>;
+
+export interface PopoverContextProps {
+  children: (context: PopoverContext) => React.ReactNode;
+}
+
+export function PopoverContext({ children }: PopoverContextProps) {
+  const context = usePopoverContext();
+  return <>{children(context)}</>;
+}
 
 const defaultProps = {
   position: 'bottom',
@@ -379,6 +388,7 @@ export function Popover(_props: PopoverProps) {
         closeOnEscape,
         onDismiss,
         onClose: popover.onClose,
+        onOpen: popover.onOpen,
         onToggle: popover.onToggle,
         getTargetId: () => `${uid}-target`,
         getDropdownId: () => `${uid}-dropdown`,
@@ -426,5 +436,6 @@ export function Popover(_props: PopoverProps) {
 
 Popover.Target = PopoverTarget;
 Popover.Dropdown = PopoverDropdown;
+Popover.Context = PopoverContext;
 Popover.displayName = '@mantine/core/Popover';
 Popover.extend = (input: ExtendComponent<PopoverFactory>) => input;

--- a/packages/@mantine/core/src/components/Popover/use-popover.ts
+++ b/packages/@mantine/core/src/components/Popover/use-popover.ts
@@ -145,6 +145,12 @@ export function usePopover(options: UsePopoverOptions) {
     }
   };
 
+  const onOpen = () => {
+    if (!_opened && !options.disabled) {
+      setOpened(true);
+    }
+  };
+
   const onToggle = () => {
     if (!options.disabled) {
       setOpened(!_opened);
@@ -208,6 +214,7 @@ export function usePopover(options: UsePopoverOptions) {
     floating,
     controlled: typeof options.opened === 'boolean',
     opened: _opened,
+    onOpen,
     onClose,
     onToggle,
   };


### PR DESCRIPTION
Adds `Popover.Context`, a render-prop component providing access to the popover context, including new `onOpen`. This allows custom state control while still using built-in components. I also Included documentation and a test case for hover behavior.

Example:

```ts
<Popover>
  <Popover.Target>
    <Popover.Context>
      {({ onOpen, onClose }) => (
        <button type="button" onMouseEnter={onOpen} onMouseLeave={onClose}>
          test-target
        </button>
      )}
    </Popover.Context>
  </Popover.Target>

  <Popover.Dropdown>
    <div>test-dropdown</div>
  </Popover.Dropdown>
</Popover>
```