### PR TITLE
docs: Update /colors-generator example to set myColor as primaryColor

### DIFF
--- a/apps/mantine.dev/src/components/ColorsGenerator/ColorsOutput/ColorsOutput.tsx
+++ b/apps/mantine.dev/src/components/ColorsGenerator/ColorsOutput/ColorsOutput.tsx
@@ -14,6 +14,7 @@ const theme = createTheme({
   colors: {
     myColor,
   }
+  primaryColor: 'myColor',
 });
 
 function Demo() {


### PR DESCRIPTION
I generated a project using the [vite template](https://github.com/mantinedev/vite-template). I followed the usage example in the [colors generator](https://mantine.dev/colors-generator/) and it doesn't update the default blue color.

Turns out we have to set the `myColor` as `primaryColor`.