### PR TITLE
[@mantine/code-highlight] fix missing export and incorrect docs

### DIFF
--- a/apps/mantine.dev/src/pages/x/code-highlight.mdx
+++ b/apps/mantine.dev/src/pages/x/code-highlight.mdx
@@ -139,7 +139,7 @@ or use a different library.
 Example of creating a custom shiki adapter with custom themes and logic:
 
 ```tsx
-import type { CodeHighlightAdapter, stripShikiCodeBlocks } from '@mantine/code-highlight';
+import { type CodeHighlightAdapter, stripShikiCodeBlocks } from '@mantine/code-highlight';
 
 // Shiki transformers can be used to highlight diffs and other notations
 // https://shiki.style/packages/transformers
@@ -162,12 +162,12 @@ async function loadShiki() {
 export const customShikiAdapter: CodeHighlightAdapter = {
   // loadContext is called on client side to load shiki highlighter
   // It is required to be used if your library requires async initialization
-  // The value returned from loadContext is passed to createHighlighter as ctx argument
+  // The value returned from loadContext is passed to getHighlighter as ctx argument
   loadContext: loadShiki,
 
   // ctx is the value returned from loadContext
   // or null if loadContext is not used or has not resolved yet
-  createHighlighter: (ctx) => {
+  getHighlighter: (ctx) => {
     if (!ctx) {
       return ({ code }) => ({ highlightedCode: code, isHighlighted: false });
     }

--- a/packages/@mantine/code-highlight/src/index.ts
+++ b/packages/@mantine/code-highlight/src/index.ts
@@ -38,3 +38,5 @@ export type {
 } from './CodeHighlight/InlineCodeHighlight';
 
 export type { CodeHighlightControlProps } from './CodeHighlight/CodeHighlightControl/CodeHighlightControl';
+
+export type { CodeHighlightAdapter } from './CodeHighlightProvider/CodeHighlightProvider';


### PR DESCRIPTION
This PR:

- Exports the `CodeHighlightAdapter` type.
  - This type is used in existing documentation so I've used that as an assumption that it should be exported.
- Updates incorrect documentation.

Fixes: #8578.