### PR TITLE
[@mantine/core] Select: prevent iOS autofill bubble on readonly

### DIFF
--- a/packages/@mantine/core/src/components/Select/Select.tsx
+++ b/packages/@mantine/core/src/components/Select/Select.tsx
@@ -126,6 +126,8 @@ export const Select = factory<SelectFactory>((_props, ref) => {
     onFocus,
     onBlur,
     onClick,
+    onPointerDown,
+    onDragStart,
     onChange,
     data,
     value,
@@ -354,6 +356,14 @@ export const Select = factory<SelectFactory>((_props, ref) => {
             onClick={(event) => {
               searchable ? combobox.openDropdown() : combobox.toggleDropdown();
               onClick?.(event);
+            }}
+            onPointerDown={(event) => {
+              (readOnly || !searchable) && event.preventDefault();
+              onPointerDown?.(event);
+            }}
+            onDragStart={(event) => {
+              (readOnly || !searchable) && event.preventDefault();
+              onDragStart?.(event);
             }}
             classNames={resolvedClassNames}
             styles={resolvedStyles}


### PR DESCRIPTION
Fixes [#6103](https://github.com/mantinedev/mantine/issues/6103).

If the `Select` component is `readonly` or not searchable, we prevent the pointer event from continuing, which is the event that causes the autofill bubble to appear (at least in modern iOS, I did not test earlier versions).