### PR TITLE
[@mantine/tiptap] Fix bubble menu being overlapped by the toolbar

### DIFF
--- a/packages/@mantine/tiptap/src/RichTextEditor.module.css
+++ b/packages/@mantine/tiptap/src/RichTextEditor.module.css
@@ -62,6 +62,12 @@
     color: var(--mantine-color-placeholder);
   }
 
+  & :global(div:not(.ProseMirror)) {
+    /* Position the bubble menu above the toolbar. As it doesn't have its own selector,
+    assert that the non-ProseMirror div is the bubble or floating menu */
+    z-index: 2;
+  }
+
   & :global(pre) {
     font-family: var(--mantine-font-family-monospace);
     border-radius: var(--mantine-radius-default);
@@ -309,6 +315,7 @@
   gap: var(--mantine-spacing-sm);
   top: var(--rte-sticky-offset, 0px);
   background-color: var(--mantine-color-body);
+  z-index: 1;
   border-start-end-radius: var(--mantine-radius-default);
   border-start-start-radius: var(--mantine-radius-default);
   border-bottom: 1px solid;
@@ -332,7 +339,6 @@
 
   &:where([data-sticky]) {
     position: sticky;
-    z-index: 1;
   }
 }
 


### PR DESCRIPTION
Second try for #8416. As you correctly [identified](https://github.com/mantinedev/mantine/commit/d3ca1bcb9f872673aca275b944aa2c7e55666c4e), the first implementation caused the toolbar to break because it was hidden behind the content. Sorry about that. When the z-index was re-added, the same issue occurred again with sticky toolbars: https://codesandbox.io/p/devbox/tiptap-bubble-menu-hidden-by-toolbar-forked-4rgjpd

Unfortunately the tooltip has no identifier to target. It's just a [div with some inline style](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-bubble-menu/src/bubble-menu-plugin.ts) `<div style="visibility: visible; position: absolute; opacity: 1; width: max-content; left: 182.325px; top: 33.1px;" tabindex="0">`. This PR adds a z-index to all divs within the RTE content, assuming that these are only the bubble and floating menu. It also restores the original z-index to the top level of the toolbar.