### PR TITLE
[@mantine/core] use-popover: reorder middlewares to apply flip before shift

### DIFF
--- a/packages/@mantine/core/src/components/Popover/use-popover.ts
+++ b/packages/@mantine/core/src/components/Popover/use-popover.ts
@@ -71,6 +71,12 @@ function getPopoverMiddlewares(
     middlewaresOptions.flip = false;
   }
 
+  if (middlewaresOptions.flip) {
+    middlewares.push(
+      typeof middlewaresOptions.flip === 'boolean' ? flip() : flip(middlewaresOptions.flip)
+    );
+  }
+  
   if (middlewaresOptions.shift) {
     middlewares.push(
       shift(
@@ -78,12 +84,6 @@ function getPopoverMiddlewares(
           ? { limiter: limitShift(), padding: 5 }
           : { limiter: limitShift(), padding: 5, ...middlewaresOptions.shift }
       )
-    );
-  }
-
-  if (middlewaresOptions.flip) {
-    middlewares.push(
-      typeof middlewaresOptions.flip === 'boolean' ? flip() : flip(middlewaresOptions.flip)
     );
   }
 


### PR DESCRIPTION
## Summary

This PR changes the middleware order from `shift` → `flip` to `flip` → `shift` in `use-popover`.

This ensures that `flip` has a chance to reposition the floating element to the opposite side before `shift` adjusts it within viewport bounds.

Fixes #8464

## Problem

When a Menu is positioned at the edge of the screen, its SubMenu overlaps with the parent Menu instead of flipping to the opposite side.

**Root cause**: `shift` runs first and pushes the SubMenu into the viewport, preventing `flip` from triggering.

## Solution

Reorder middlewares so that `flip` is always applied before `shift`.

## Before / After

#### MenuSub

Before

https://github.com/user-attachments/assets/f77d87db-510c-4156-83d5-13ab8ad4adce

After

https://github.com/user-attachments/assets/30bc9c50-7beb-4f67-b43a-4a6c993f00e3

#### Popover

Before

https://github.com/user-attachments/assets/a95d831b-6cfc-4675-a0ea-f2c3c23a25de

After

https://github.com/user-attachments/assets/dadf17f3-419d-4805-beca-1b4bb4645359


### Additional context

[floating-ui recommends](https://floating-ui.com/docs/flip#combining-with-shift) `flip` → `shift` order specifically for edge-aligned placements (e.g. `top-start`) to preserve alignment.

However, the overlap issue occurs regardless of alignment—it happens whenever there's insufficient space and `shift` pushes the element over its trigger. Applying this order to all placements ensures consistent behavior and prevents overlap issues across all use cases.