### PR TITLE
[@mantine/core] implements selectFirstOptionOnDropdownOpen

### DIFF
--- a/packages/@mantine/core/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/@mantine/core/src/components/Autocomplete/Autocomplete.tsx
@@ -99,6 +99,7 @@ export const Autocomplete = factory<AutocompleteFactory>((_props, ref) => {
     value,
     defaultValue,
     selectFirstOptionOnChange,
+    selectFirstOptionOnDropdownOpen,
     onOptionSubmit,
     comboboxProps,
     readOnly,
@@ -136,7 +137,12 @@ export const Autocomplete = factory<AutocompleteFactory>((_props, ref) => {
   const combobox = useCombobox({
     opened: dropdownOpened,
     defaultOpened: defaultDropdownOpened,
-    onDropdownOpen,
+    onDropdownOpen: () => {
+      onDropdownOpen?.();
+      if (selectFirstOptionOnDropdownOpen) {
+        combobox.selectFirstOption();
+      }
+    },
     onDropdownClose: () => {
       onDropdownClose?.();
       // Required for autoSelectOnBlur to work correctly

--- a/packages/@mantine/core/src/components/Combobox/Combobox.types.ts
+++ b/packages/@mantine/core/src/components/Combobox/Combobox.types.ts
@@ -51,6 +51,9 @@ export interface ComboboxLikeProps {
   /** If set, the first option is selected when value changes, `false` by default */
   selectFirstOptionOnChange?: boolean;
 
+  /** If set, the first option is selected when dropdown opens, `false` by default */
+  selectFirstOptionOnDropdownOpen?: boolean;
+
   /** Called when option is submitted from dropdown with mouse click or `Enter` key */
   onOptionSubmit?: (value: string) => void;
 

--- a/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
@@ -149,6 +149,7 @@ export const MultiSelect = factory<MultiSelectFactory>((_props, ref) => {
     onDropdownOpen,
     onDropdownClose,
     selectFirstOptionOnChange,
+    selectFirstOptionOnDropdownOpen,
     onOptionSubmit,
     comboboxProps,
     filter,
@@ -217,7 +218,12 @@ export const MultiSelect = factory<MultiSelectFactory>((_props, ref) => {
   const combobox = useCombobox({
     opened: dropdownOpened,
     defaultOpened: defaultDropdownOpened,
-    onDropdownOpen,
+    onDropdownOpen: () => {
+      onDropdownOpen?.();
+      if (selectFirstOptionOnDropdownOpen) {
+        combobox.selectFirstOption();
+      }
+    },
     onDropdownClose: () => {
       onDropdownClose?.();
       combobox.resetSelectedOption();

--- a/packages/@mantine/core/src/components/Select/Select.tsx
+++ b/packages/@mantine/core/src/components/Select/Select.tsx
@@ -131,6 +131,7 @@ export const Select = factory<SelectFactory>((_props, ref) => {
     value,
     defaultValue,
     selectFirstOptionOnChange,
+    selectFirstOptionOnDropdownOpen,
     onOptionSubmit,
     comboboxProps,
     readOnly,
@@ -203,7 +204,11 @@ export const Select = factory<SelectFactory>((_props, ref) => {
     defaultOpened: defaultDropdownOpened,
     onDropdownOpen: () => {
       onDropdownOpen?.();
-      combobox.updateSelectedOptionIndex('active', { scrollIntoView: true });
+      if (selectFirstOptionOnDropdownOpen) {
+        combobox.selectFirstOption();
+      } else {
+        combobox.updateSelectedOptionIndex('active', { scrollIntoView: true });
+      }
     },
     onDropdownClose: () => {
       onDropdownClose?.();

--- a/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
+++ b/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
@@ -146,6 +146,7 @@ export const TagsInput = factory<TagsInputFactory>((_props, ref) => {
     onDropdownOpen,
     onDropdownClose,
     selectFirstOptionOnChange,
+    selectFirstOptionOnDropdownOpen,
     onOptionSubmit,
     comboboxProps,
     filter,
@@ -209,7 +210,12 @@ export const TagsInput = factory<TagsInputFactory>((_props, ref) => {
   const combobox = useCombobox({
     opened: dropdownOpened,
     defaultOpened: defaultDropdownOpened,
-    onDropdownOpen,
+    onDropdownOpen: () => {
+      onDropdownOpen?.();
+      if (selectFirstOptionOnDropdownOpen) {
+        combobox.selectFirstOption();
+      }
+    },
     onDropdownClose: () => {
       onDropdownClose?.();
       combobox.resetSelectedOption();


### PR DESCRIPTION
This PR implements a `selectFirstOptionOnDropdownOpen` option in `ComboboxLike` components.

This option makes the dropdown automatically select the first option when it's opened. It is a convenient behavior for keyboard users.