### PR TITLE
fix: allow Calendar theme overrides in DateTimePicker and DateInput

### DIFF
--- a/packages/@mantine/dates/src/components/Calendar/Calendar.tsx
+++ b/packages/@mantine/dates/src/components/Calendar/Calendar.tsx
@@ -258,7 +258,7 @@ export const Calendar = factory<CalendarFactory>((_props, ref) => {
     classNames:
       !__staticSelector || __staticSelector === 'Calendar'
         ? classNames
-        : [theme.components.Calendar?.classNames, classNames],
+        : ([theme.components.Calendar?.classNames, classNames] as any),
     styles:
       !__staticSelector || __staticSelector === 'Calendar'
         ? styles


### PR DESCRIPTION
closes #8585 
This PR will fix the issue of custom theme not being adapted by the DateInput and DateTimePicker component from the Calender component.

this file shows the fix which  i have done and manually fixed it by making a trial component
![Uploading Screenshot_2026-01-10_16-42-50.png…]()
