### PR TITLE
[@mantine/core] ScrollArea: Fix `overscrollBehaviour` prop not being available in `ScrollArea.Autosize` component

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -286,6 +286,7 @@ export const ScrollAreaAutosize = factory<ScrollAreaAutosizeFactory>((props, ref
     type,
     dir,
     offsetScrollbars,
+    overscrollBehavior,
     viewportRef,
     onScrollPositionChange,
     unstyled,
@@ -363,6 +364,7 @@ export const ScrollAreaAutosize = factory<ScrollAreaAutosizeFactory>((props, ref
           type={type}
           dir={dir}
           offsetScrollbars={offsetScrollbars}
+          overscrollBehavior={overscrollBehavior}
           viewportRef={combinedViewportRef}
           onScrollPositionChange={onScrollPositionChange}
           unstyled={unstyled}


### PR DESCRIPTION
Fixed: `overscrollBehaviour` prop for `ScrollArea.Autosize`