### PR TITLE
Increase subpixel tolerance to fix `ScrollArea.onBottomReached()` while zoomed out.

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -219,8 +219,8 @@ export const ScrollArea = factory<ScrollAreaFactory>((_props, ref) => {
           viewportProps?.onScroll?.(e);
           onScrollPositionChange?.({ x: e.currentTarget.scrollLeft, y: e.currentTarget.scrollTop });
           const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
-          // threshold of -0.6 is required for some browsers that use sub-pixel rendering
-          if (scrollTop - (scrollHeight - clientHeight) >= -0.6) {
+          // threshold of -0.8 is required for some browsers that use sub-pixel rendering, specifically when zoomed out.
+          if (scrollTop - (scrollHeight - clientHeight) >= -0.8) {
             onBottomReached?.();
           }
           if (scrollTop === 0) {


### PR DESCRIPTION
Fixes https://github.com/mantinedev/mantine/issues/8608

I could only reproduce this issue when zoomed out to 33%, where I would see the difference between `(scrollTop - (scrollHeight - clientHeight) == 0.77`.   I found I could no longer reproduce the issue, even at extreme zooms with the tolerance set to 0.8. It does pass tests. 