### PR TITLE
When at the bottom or top in Windows Edge, the browser will try to scroll the parent when using the scroll wheel.

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollAreaViewport/ScrollAreaViewport.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollAreaViewport/ScrollAreaViewport.tsx
@@ -6,14 +6,32 @@ import { useScrollAreaContext } from '../ScrollArea.context';
 export interface ScrollAreaViewportProps extends BoxProps, ElementProps<'div'> {}
 
 export const ScrollAreaViewport = forwardRef<HTMLDivElement, ScrollAreaViewportProps>(
-  ({ children, style, ...others }, ref) => {
+  ({ children, style, onWheel, ...others }, ref) => {
     const ctx = useScrollAreaContext();
     const rootRef = useMergedRef(ref, ctx.onViewportChange);
+
+    const handleWheel = (event: React.WheelEvent<HTMLDivElement>) => {
+      onWheel?.(event);
+
+      // Fix for Windows: Allow horizontal scrolling even when vertical scroll is at boundaries
+      // When at vertical boundaries, Windows tries to scroll the parent/page instead of allowing horizontal scroll
+      if (ctx.scrollbarXEnabled && ctx.viewport && event.shiftKey) {
+        const { scrollTop, scrollHeight, clientHeight, scrollWidth, clientWidth } = ctx.viewport;
+        const isAtTop = scrollTop < 1;
+        const isAtBottom = scrollTop >= scrollHeight - clientHeight - 1;
+        const canScrollHorizontally = scrollWidth > clientWidth;
+
+        if (canScrollHorizontally && (isAtTop || isAtBottom)) {
+          event.stopPropagation();
+        }
+      }
+    };
 
     return (
       <Box
         {...others}
         ref={rootRef}
+        onWheel={handleWheel}
         style={{
           overflowX: ctx.scrollbarXEnabled ? 'scroll' : 'hidden',
           overflowY: ctx.scrollbarYEnabled ? 'scroll' : 'hidden',


### PR DESCRIPTION
 We detect this case by looking for the shift key (unfortunately the `deltaX` value seems to always be -0)  being down during scroll and then stop propagation to allow the scroll area to move horizontally.

This would also prevent scrolling horizontally outside of the current container, we could add an additional check to make sure the scroll is not at a horizontal edge, but I am not sure if that is worth it.

Fixes https://github.com/mantinedev/mantine/issues/7050 and https://github.com/mantinedev/mantine/issues/8037