### PR TITLE
fix(@mantine/modals): improve context modal type inference

### DIFF
--- a/packages/@mantine/modals/src/context.ts
+++ b/packages/@mantine/modals/src/context.ts
@@ -41,15 +41,9 @@ export interface ModalsContextProps {
 
 export interface MantineModalsOverride {}
 
-export type MantineModalsOverwritten = MantineModalsOverride extends {
-  modals: Record<string, React.FC<ContextModalProps<any>>>;
-}
-  ? MantineModalsOverride
-  : {
-      modals: Record<string, React.FC<ContextModalProps<any>>>;
-    };
-
-export type MantineModals = MantineModalsOverwritten['modals'];
+export type MantineModals = MantineModalsOverride extends { modals: infer M }
+  ? M
+  : Record<string, React.FC<ContextModalProps<any>>>;
 
 export type MantineModal = keyof MantineModals;
 


### PR DESCRIPTION
## Summary
Fixes #8588.

Replaces the conditional type pattern in `MantineModalsOverwritten` with direct type inference using `infer`. This prevents type widening to `string` when module augmentation is used, ensuring strict type safety for `openContextModal` keys.

## Changes
- Updated `MantineModals` type definition in `packages/@mantine/modals/src/context.ts` to use `infer` for better type resolution.

## Verification
- Validated that invalid modal keys now throw a TypeScript error.
- Verified backward compatibility for non-augmented setups.
- Ran tests and linting for `@mantine/modals`.