### PR TITLE
[@mantine/core] Chip: Fix --chip-checked-padding to use padding-inline

### DIFF
--- a/packages/@mantine/core/src/components/Chip/Chip.module.css
+++ b/packages/@mantine/core/src/components/Chip/Chip.module.css
@@ -56,7 +56,7 @@
   color: var(--mantine-color-text);
 
   &:where([data-checked]) {
-    padding: var(--chip-checked-padding);
+    padding-inline: var(--chip-checked-padding);
   }
 
   &:where([data-disabled]) {


### PR DESCRIPTION
## Summary
- Fixed `--chip-checked-padding` CSS variable to use `padding-inline` instead of `padding`
- The documentation states this variable "Controls horizontal padding when chip is checked", but the CSS was applying padding to all sides

<img width="1009" height="503" alt="image" src="https://github.com/user-attachments/assets/37d0e6ff-bc8f-42bd-b1c3-095ee8cdf84d" />


## Changes
```diff
&:where([data-checked]) {
-    padding: var(--chip-checked-padding);
+    padding-inline: var(--chip-checked-padding);
}
```
