### PR TITLE
[@mantine/core] CloseButton: Fix Close button iconSize comment

### DIFF
--- a/packages/@mantine/core/src/components/CloseButton/CloseButton.tsx
+++ b/packages/@mantine/core/src/components/CloseButton/CloseButton.tsx
@@ -34,7 +34,7 @@ export interface __CloseButtonProps {
   /** Sets `disabled` attribute, assigns disabled styles */
   disabled?: boolean;
 
-  /** `X` icon `width` and `height` @default `80%` */
+  /** `X` icon `width` and `height` @default `70%` */
   iconSize?: number | string;
 
   /** Content rendered inside the button. For example `VisuallyHidden` with label for screen readers. */


### PR DESCRIPTION
I'm not sure if I should fix the [document](https://mantine.dev/core/close-button/?t=props) or fix the code, but I modified the code as the official document.

It was written as 80% on the official document, but it was applied as 70% on the actual code.


- ## Document

<img width="650" height="45" alt="image" src="https://github.com/user-attachments/assets/f6e15a23-dd50-4244-ac45-54b3efb0c5f0" />


- ## Actually

<img width="545" height="63" alt="image" src="https://github.com/user-attachments/assets/b31414c2-80aa-48c5-ad77-8a7e1c576247" />

<img width="349" height="61" alt="image" src="https://github.com/user-attachments/assets/ae4379f9-6098-4f61-8db3-28c834969f89" />


- ## Changes

<img width="382" height="52" alt="image" src="https://github.com/user-attachments/assets/1c9b72fc-4a4e-47f6-b66c-6c50468cbac3" />
