### PR TITLE
[@mantine/core] MultiSelect: Fix clearable text overlap

### DIFF
--- a/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
@@ -343,7 +343,9 @@ export const MultiSelect = factory<MultiSelectFactory>((_props, ref) => {
 
   const filteredData = filterPickedValues({ data: parsedData, value: _value });
   const _clearable = clearable && _value.length > 0 && !disabled && !readOnly;
-  const pillsListStyle = _clearable ? { paddingInlineEnd: clearSectionOffset[size] } : undefined;
+  const pillsListStyle = _clearable
+    ? { paddingInlineEnd: clearSectionOffset[size] ?? clearSectionOffset.sm }
+    : undefined;
 
   return (
     <>


### PR DESCRIPTION
## Description
Fixes #8632 - MultiSelect clearable: text overlaps with clear icon
                                                          
### Changes
- Added `paddingInlineEnd` to `Pill.Group` when clearable is enabled                                    
- Uses same padding values as `InputClearSection` for consistency (xs: 41px, sm: 50px, md: 60px, lg: 72px, xl: 89px)                                                  
- Padding only applied when clearable is true AND has selected values
                                                             
**As-is:** Text overlaps clear button
<img width="359" height="103" alt="SCR-20260124-idmw" src="https://github.com/user-attachments/assets/e4062bca-ffde-4bd0-af20-d8fd8b3f5280" />

**To-be:** Proper spacing between text and clear button
<img width="369" height="88" alt="SCR-20260124-iudh" src="https://github.com/user-attachments/assets/739fc2c3-24bb-46fb-a5c0-035458db5152" />
                       
