### PR TITLE
[@mantine/core] MultiSelect: Fix chevron not opening dropdown when clearable is enabled

### DIFF
--- a/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
@@ -418,7 +418,7 @@ export const MultiSelect = factory<MultiSelectFactory>((_props, ref) => {
             withErrorStyles={withErrorStyles}
             __stylesApiProps={{
               ...props,
-              rightSectionPointerEvents: rightSectionPointerEvents || (_clearable ? 'all' : 'none'),
+              rightSectionPointerEvents: rightSectionPointerEvents || 'none',
               multiline: true,
             }}
             pointer={!searchable}


### PR DESCRIPTION
## Description
Resolves https://github.com/mantinedev/mantine/issues/8640
Fixes dropdown not opening when clicking the chevron icon in MultiSelect with clearable={true} and selected values.

### Problem
When MultiSelect has clearable={true} enabled with selected values, the right section's pointer-events was set to 'all'. This
caused the right section to intercept all click events, preventing clicks on the chevron from reaching the underlying input's onClick handler that toggles the dropdown.

This issue is related to [e2ffcd2](https://github.com/mantinedev/mantine/commit/e2ffcd2af680baeb20298ce5ed0e69428d3363ca)

**as-is**
![Jan-28-2026 07-27-07](https://github.com/user-attachments/assets/6ea81363-a4bc-448d-bbce-ddcb39fb4761)

**to-be**
![Jan-28-2026 07-49-50](https://github.com/user-attachments/assets/6257dbf7-a7d8-4c90-a30d-4e9968b34cf3)
