### PR TITLE
update ChartTooltip valueFormatter type

### DIFF
--- a/packages/@mantine/charts/src/ChartTooltip/ChartTooltip.tsx
+++ b/packages/@mantine/charts/src/ChartTooltip/ChartTooltip.tsx
@@ -100,7 +100,7 @@ export interface ChartTooltipProps
   series?: ChartSeries[];
 
   /** A function to format values */
-  valueFormatter?: (value: number) => string;
+  valueFormatter?: (value: number) => React.ReactNode;
 
   /** Determines whether the color swatch should be visible @default `true` */
   showColor?: boolean;


### PR DESCRIPTION
Minor issue: the usage accepts a `ReactNode`, but the type specifies a `string`.