### PR TITLE
[@mantine/core] implements selectFirstOptionOnDataChange

### DIFF
--- a/packages/@mantine/core/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/@mantine/core/src/components/Autocomplete/Autocomplete.tsx
@@ -103,6 +103,7 @@ export const Autocomplete = factory<AutocompleteFactory>((_props, ref) => {
     defaultValue,
     selectFirstOptionOnChange,
     selectFirstOptionOnDropdownOpen,
+    selectFirstOptionOnDataChange,
     onOptionSubmit,
     comboboxProps,
     readOnly,
@@ -170,6 +171,12 @@ export const Autocomplete = factory<AutocompleteFactory>((_props, ref) => {
       combobox.selectFirstOption();
     }
   }, [selectFirstOptionOnChange, _value]);
+
+  useEffect(() => {
+    if (selectFirstOptionOnDataChange) {
+      combobox.selectFirstOption();
+    }
+  }, [selectFirstOptionOnDataChange, optionsLockup]);
 
   const clearButton = (
     <Combobox.ClearButton

--- a/packages/@mantine/core/src/components/Combobox/Combobox.types.ts
+++ b/packages/@mantine/core/src/components/Combobox/Combobox.types.ts
@@ -54,6 +54,9 @@ export interface ComboboxLikeProps {
   /** If set, the first option is selected when dropdown opens, `false` by default */
   selectFirstOptionOnDropdownOpen?: boolean;
 
+  /** If set, the first option is selected when `data` changes, `false` by default */
+  selectFirstOptionOnDataChange?: boolean;
+
   /** Called when option is submitted from dropdown with mouse click or `Enter` key */
   onOptionSubmit?: (value: string) => void;
 

--- a/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
@@ -162,6 +162,7 @@ export const MultiSelect = factory<MultiSelectFactory>((_props, ref) => {
     onDropdownClose,
     selectFirstOptionOnChange,
     selectFirstOptionOnDropdownOpen,
+    selectFirstOptionOnDataChange,
     onOptionSubmit,
     comboboxProps,
     filter,
@@ -321,6 +322,12 @@ export const MultiSelect = factory<MultiSelectFactory>((_props, ref) => {
       combobox.selectFirstOption();
     }
   }, [selectFirstOptionOnChange, _searchValue]);
+
+  useEffect(() => {
+    if (selectFirstOptionOnDataChange) {
+      combobox.selectFirstOption();
+    }
+  }, [selectFirstOptionOnDataChange, optionsLockup]);
 
   useEffect(() => {
     _value.forEach((val) => {

--- a/packages/@mantine/core/src/components/Select/Select.tsx
+++ b/packages/@mantine/core/src/components/Select/Select.tsx
@@ -136,6 +136,7 @@ export const Select = factory<SelectFactory>((_props, ref) => {
     defaultValue,
     selectFirstOptionOnChange,
     selectFirstOptionOnDropdownOpen,
+    selectFirstOptionOnDataChange,
     onOptionSubmit,
     comboboxProps,
     readOnly,
@@ -238,6 +239,12 @@ export const Select = factory<SelectFactory>((_props, ref) => {
       combobox.selectFirstOption();
     }
   }, [selectFirstOptionOnChange, search]);
+
+  useEffect(() => {
+    if (selectFirstOptionOnDataChange) {
+      combobox.selectFirstOption();
+    }
+  }, [selectFirstOptionOnDataChange, optionsLockup]);
 
   useEffect(() => {
     if (value === null) {

--- a/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
+++ b/packages/@mantine/core/src/components/TagsInput/TagsInput.tsx
@@ -151,6 +151,7 @@ export const TagsInput = factory<TagsInputFactory>((_props, ref) => {
     onDropdownClose,
     selectFirstOptionOnChange,
     selectFirstOptionOnDropdownOpen,
+    selectFirstOptionOnDataChange,
     onOptionSubmit,
     comboboxProps,
     filter,
@@ -377,6 +378,12 @@ export const TagsInput = factory<TagsInputFactory>((_props, ref) => {
       combobox.selectFirstOption();
     }
   }, [selectFirstOptionOnChange, _value, _searchValue]);
+
+  useEffect(() => {
+    if (selectFirstOptionOnDataChange) {
+      combobox.selectFirstOption();
+    }
+  }, [selectFirstOptionOnDataChange, optionsLockup]);
 
   const clearButton = (
     <Combobox.ClearButton


### PR DESCRIPTION
Adds a `selectFirstOptionOnDataChange` option for combobox-like components. When enabled, the combobox automatically selects the first option whenever its data changes. This is useful when options are dynamically updated (e.g., from a backend search), allowing the first result to be preselected and improving the experience for keyboard users.