### PR TITLE
fix(docs): add autocomplete=off to homepage input demos to prevent Firefox password autofill

### DIFF
--- a/apps/mantine.dev/src/components/HomePage/HomePageComponents/demos/HomePageInputsDemo.tsx
+++ b/apps/mantine.dev/src/components/HomePage/HomePageComponents/demos/HomePageInputsDemo.tsx
@@ -15,6 +15,7 @@ import { DatePickerInput } from '@mantine/dates';
 const inputProps = {
   size: 'lg' as const,
   radius: 'md',
+  autoComplete: 'off',
 };
 
 export function HomePageInputsDemo() {


### PR DESCRIPTION
## Summary

Fixes #8682

Firefox identifies `PasswordInput` and `ColorInput` in the homepage component demos as login fields, triggering the password manager popup when navigating from `mantine.dev` to the Getting Started page.

## Changes

Added `autoComplete: 'off'` to the shared `inputProps` object in `HomePageInputsDemo.tsx`. This is a one-line change that applies to all demo inputs on the homepage, preventing Firefox from offering to save/fill passwords for these decorative demo inputs.

## Root Cause

Firefox password manager heuristics (see [Mozilla Bug 956906](https://bugzilla.mozilla.org/show_bug.cgi?id=956906)) detect `<input type="password">` elements on the page and assume they are part of a login form, even when they are just component demos. The `autocomplete="off"` attribute tells the browser these inputs are not login-related.

## Testing

- Verified the change only affects the docs site homepage demo, not the library components themselves
- The fix is minimal: 1 file changed, 1 line added