### PR TITLE
[@mantine/core] Textarea: Fix accessibility false positives for autosize (#8712)

### DIFF
--- a/packages/@mantine/core/src/components/Textarea/Textarea.tsx
+++ b/packages/@mantine/core/src/components/Textarea/Textarea.tsx
@@ -1,4 +1,5 @@
 import TextareaAutosize from 'react-textarea-autosize';
+import { useEffect } from 'react';
 import {
   BoxProps,
   ElementProps,
@@ -50,6 +51,33 @@ export const Textarea = factory<TextareaFactory>((props, ref) => {
 
   const shouldAutosize = autosize && getEnv() !== 'test';
   const autosizeProps = shouldAutosize ? { maxRows, minRows } : {};
+
+  useEffect(() => {
+    if (!shouldAutosize || typeof document === 'undefined') {
+      return undefined;
+    }
+
+    const setMirrorAttributes = () => {
+      document
+        .querySelectorAll<HTMLTextAreaElement>('textarea[aria-hidden="true"][tabindex="-1"]')
+        .forEach((element) => {
+          if (
+            element.style.position === 'absolute' &&
+            element.style.visibility === 'hidden' &&
+            element.style.zIndex === '-1000'
+          ) {
+            element.setAttribute('role', 'presentation');
+            element.setAttribute('aria-label', 'autosize measurement mirror textarea');
+          }
+        });
+    };
+
+    // Workaround for react-textarea-autosize hidden mirror textarea.
+    // Remove when upstream sets required accessibility attributes on mirror textarea.
+    requestAnimationFrame(setMirrorAttributes);
+
+    return undefined;
+  }, [shouldAutosize]);
 
   return (
     <InputBase<any>

--- a/packages/@mantine/core/src/components/Textarea/Textarea.tsx
+++ b/packages/@mantine/core/src/components/Textarea/Textarea.tsx
@@ -1,5 +1,5 @@
-import TextareaAutosize from 'react-textarea-autosize';
 import { useEffect } from 'react';
+import TextareaAutosize from 'react-textarea-autosize';
 import {
   BoxProps,
   ElementProps,


### PR DESCRIPTION
The hidden mirror <textarea> used internally by react-textarea-autosize (when autosize is enabled) triggers the error “Form control does not have a corresponding label”

Although the mirror element has aria-hidden="true" and tabindex="-1" and is not interactive or visible to users, tools like WAVE still flag it because it lacks an accessible name.

### Solution

This PR adds a runtime patch that detects the hidden mirror <textarea> based on aria-hidden="true, tabindex="-1", and some styles. Then, it adds role="presentation" and aria-label="autosize measurement mirror textarea".

The patch runs only when autosize is enabled and does not affect other textareas.

### Notes
- This is a workaround until react-textarea-autosize includes proper accessibility attributes on the mirror element.
- Screen readers and real user accessibility are not impacted. 
- The change eliminates WAVE false positives on the Textarea documentation page.