### PR TITLE
[@mantine/notifications] Add callbacks to distinguish Auto Close vs Manual Close

### DIFF
--- a/apps/mantine.dev/src/pages/x/notifications.mdx
+++ b/apps/mantine.dev/src/pages/x/notifications.mdx
@@ -91,6 +91,8 @@ import {
 - `withBorder` – determines whether notification should have a border
 - `withCloseButton` – determines whether the close button should be visible
 - `onClose` – calls when notification is unmounted
+- `onAutoClose` – calls when notification is automatically closed via timeout
+- `onManualClose` – calls when the close button is clicked
 - `onOpen` – calls when notification is mounted
 - `autoClose` – defines timeout in ms on which notification will be automatically closed, use `false` to disable auto close
 - `message` – required notification body

--- a/packages/@mantine/core/src/components/Notification/Notification.tsx
+++ b/packages/@mantine/core/src/components/Notification/Notification.tsx
@@ -125,6 +125,12 @@ export const Notification = factory<NotificationFactory>((_props, ref) => {
     varsResolver,
   });
 
+  const handleCloseButtonEvent = (e: React.MouseEvent) => {
+    // A click on the close button shouldn't be mistaken for a click on the notification container
+    e.stopPropagation();
+    onClose?.();
+  };
+
   return (
     <Box
       {...getStyles('root')}
@@ -150,7 +156,7 @@ export const Notification = factory<NotificationFactory>((_props, ref) => {
           color="gray"
           {...closeButtonProps}
           unstyled={unstyled}
-          onClick={onClose}
+          onClick={handleCloseButtonEvent}
           {...getStyles('closeButton')}
         />
       )}

--- a/packages/@mantine/notifications/src/NotificationContainer.tsx
+++ b/packages/@mantine/notifications/src/NotificationContainer.tsx
@@ -15,14 +15,14 @@ export const NotificationContainer = forwardRef<HTMLDivElement, NotificationCont
     const autoCloseDuration = getAutoClose(autoClose, data.autoClose);
     const autoCloseTimeout = useRef<number>(-1);
 
-    const cancelAutoClose = () => window.clearTimeout(autoCloseTimeout.current);
+    const cancelAutoCloseTimer = () => window.clearTimeout(autoCloseTimeout.current);
 
     const handleHide = () => {
       onHide(data.id!);
-      cancelAutoClose();
+      cancelAutoCloseTimer();
     };
 
-    const handleAutoClose = () => {
+    const setAutoCloseTimer = () => {
       if (typeof autoCloseDuration === 'number') {
         autoCloseTimeout.current = window.setTimeout(handleHide, autoCloseDuration);
       }
@@ -33,8 +33,8 @@ export const NotificationContainer = forwardRef<HTMLDivElement, NotificationCont
     }, []);
 
     useEffect(() => {
-      handleAutoClose();
-      return cancelAutoClose;
+      setAutoCloseTimer();
+      return cancelAutoCloseTimer;
     }, [autoCloseDuration]);
 
     return (
@@ -43,8 +43,8 @@ export const NotificationContainer = forwardRef<HTMLDivElement, NotificationCont
         {...notificationProps}
         onClose={handleHide}
         ref={ref}
-        onMouseEnter={cancelAutoClose}
-        onMouseLeave={handleAutoClose}
+        onMouseEnter={cancelAutoCloseTimer}
+        onMouseLeave={setAutoCloseTimer}
       >
         {message}
       </Notification>

--- a/packages/@mantine/notifications/src/NotificationContainer.tsx
+++ b/packages/@mantine/notifications/src/NotificationContainer.tsx
@@ -22,9 +22,19 @@ export const NotificationContainer = forwardRef<HTMLDivElement, NotificationCont
       cancelAutoCloseTimer();
     };
 
+    const handleAutoClose = () => {
+      data.onAutoClose?.(data);
+      handleHide();
+    };
+
+    const handleManualClose = () => {
+      data.onManualClose?.(data);
+      handleHide();
+    };
+
     const setAutoCloseTimer = () => {
       if (typeof autoCloseDuration === 'number') {
-        autoCloseTimeout.current = window.setTimeout(handleHide, autoCloseDuration);
+        autoCloseTimeout.current = window.setTimeout(handleAutoClose, autoCloseDuration);
       }
     };
 
@@ -41,7 +51,7 @@ export const NotificationContainer = forwardRef<HTMLDivElement, NotificationCont
       <Notification
         {...others}
         {...notificationProps}
-        onClose={handleHide}
+        onClose={handleManualClose}
         ref={ref}
         onMouseEnter={cancelAutoCloseTimer}
         onMouseLeave={setAutoCloseTimer}

--- a/packages/@mantine/notifications/src/notifications.store.ts
+++ b/packages/@mantine/notifications/src/notifications.store.ts
@@ -30,6 +30,12 @@ export interface NotificationData
   /** Called when notification closes */
   onClose?: (props: NotificationData) => void;
 
+  /** Called when notification auto closes */
+  onAutoClose?: (props: NotificationData) => void;
+
+  /** Called when notification is closed manually */
+  onManualClose?: (props: NotificationData) => void;
+
   /** Called when notification opens */
   onOpen?: (props: NotificationData) => void;
 }


### PR DESCRIPTION
When a notification handled by the notification extension system closes, there's no indication if it was closed by the user (via the close button), or hidden by the auto-hide system.  
In the auto-hide case, I want to push it into a "notification queue" that the user can read in a separate drawer, but listening to onClose doesn't provide information about if it's already been acknowledged.

This PR fixes that by adding in additional callbacks for when each behavior is used. The overall API surface hasn't been changed, `onClose` still exists and functions as before.