### PR TITLE
Document returnFocus default for Menu

### DIFF
--- a/packages/@mantine/core/src/components/Menu/Menu.tsx
+++ b/packages/@mantine/core/src/components/Menu/Menu.tsx
@@ -91,6 +91,9 @@ export interface MenuProps extends __PopoverProps, StylesApiProps<MenuFactory> {
 
   /** If set, focus placeholder element is added before items @default `true` */
   withInitialFocusPlaceholder?: boolean;
+
+  /** Determines whether focus should be automatically returned to control when dropdown closes @default `true` */
+  returnFocus?: boolean;
 }
 
 const defaultProps = {


### PR DESCRIPTION
Fixed incorrect returnFocus default value documentation for `Menu`. 

Currently, it says the default value is false, which is wrong. It's true by default for `Menu`, false by default for `Popover` (which is where this error comes from - `Menu` inherits docs from `Popover`).