### PR TITLE
[DOCS] [@mantine/dates] add missing information to getting started

### DIFF
--- a/apps/mantine.dev/src/pages/dates/getting-started.mdx
+++ b/apps/mantine.dev/src/pages/dates/getting-started.mdx
@@ -36,8 +36,6 @@ After installing `@mantine/dates` package and importing styles, you can use all 
 
 <Demo data={DatePickerInputDemos.usage} />
 
-Get started with @mantine/dates package
-
 ## Date values as strings
 
 `@mantine/dates` components work with date strings: `YYYY-MM-DD` or `YYYY-MM-DD HH:mm:ss` depending on the component. Those strings do not include any timezone-specific information.

--- a/apps/mantine.dev/src/pages/dates/getting-started.mdx
+++ b/apps/mantine.dev/src/pages/dates/getting-started.mdx
@@ -36,6 +36,12 @@ After installing `@mantine/dates` package and importing styles, you can use all 
 
 <Demo data={DatePickerInputDemos.usage} />
 
+Get started with @mantine/dates package
+
+## Date values as strings
+
+`@mantine/dates` components work with date strings: `YYYY-MM-DD` or `YYYY-MM-DD HH:mm:ss` depending on the component. Those strings do not include any timezone-specific information.
+
 ## dayjs
 
 `@mantine/dates` components use [dayjs](https://day.js.org/) under the hood for date manipulations and formatting.


### PR DESCRIPTION
Added section on date values as strings for @mantine/dates.

Most of it comes from the 7->8 changelog, and **was missing from the docs** (and those formats are not obvious either)