### PR TITLE
Fix missing comma in createTheme example

### DIFF
--- a/apps/mantine.dev/src/components/ColorsGenerator/ColorsOutput/ColorsOutput.tsx
+++ b/apps/mantine.dev/src/components/ColorsGenerator/ColorsOutput/ColorsOutput.tsx
@@ -13,7 +13,7 @@ const myColor: MantineColorsTuple = ${JSON.stringify(colors, null, 2).replace(/"
 const theme = createTheme({
   colors: {
     myColor,
-  }
+  }, // Comma added
   primaryColor: 'myColor',
 });
 


### PR DESCRIPTION
## Description
Fixed a syntax error in the color generation example code where a comma was missing after the `colors` property in the `createTheme` configuration.

## Issue
The code example was missing a comma on line 15, causing a TypeScript compilation error:
```ts
const theme = createTheme({
  colors: {
    myColor,
  }  // Missing comma caused error
  primaryColor: 'myColor',
});
```

## Fix
Added the missing comma after the [colors] property object.

## Impact
This fix ensures the code example works correctly when copied by users and resolves the TypeScript compilation error ``` ',' expected. ``` No breaking changes.