### PR TITLE
Update link to getting started page with full URL

### DIFF
--- a/apps/help.mantine.dev/src/pages/q/templates-usage.mdx
+++ b/apps/help.mantine.dev/src/pages/q/templates-usage.mdx
@@ -17,7 +17,7 @@ export default Layout(meta);
 Mantine provides a set of templates for most common use cases.
 A template is a set of configuration files that are required to
 get started with Mantine and a React framework of your choice.
-You can find a list of all available templates on the [getting started page](/getting-started).
+You can find a list of all available templates on the [getting started page](https://mantine.dev/getting-started/).
 
 ## Prerequisites
 


### PR DESCRIPTION
Previous link:
/(/getting-started/)
---> https://help.mantine.dev/getting-started
---> 404 not found