### PR TITLE
fix: add missing role and aria-expanded to Combobox target

### DIFF
--- a/packages/@mantine/core/src/components/Combobox/use-combobox-target-props/use-combobox-target-props.ts
+++ b/packages/@mantine/core/src/components/Combobox/use-combobox-target-props/use-combobox-target-props.ts
@@ -91,21 +91,26 @@ export function useComboboxTargetProps({
   };
 
   const ariaAttributes = withAriaAttributes
-    ? {
-        'aria-haspopup': 'listbox' as const,
-        'aria-expanded': withExpandedAttribute
-          ? !!(ctx.store.listId && ctx.store.dropdownOpened)
-          : undefined,
-        'aria-controls':
-          ctx.store.dropdownOpened && ctx.store.listId ? ctx.store.listId : undefined,
-        'aria-activedescendant': ctx.store.dropdownOpened
-          ? selectedOptionId || undefined
-          : undefined,
-        autoComplete,
-        'data-expanded': ctx.store.dropdownOpened || undefined,
-        'data-mantine-stop-propagation': ctx.store.dropdownOpened || undefined,
-      }
-    : {};
+  ? {
+      role: 'combobox',
+
+      'aria-haspopup': 'listbox' as const,
+
+      'aria-expanded': ctx.store.dropdownOpened,
+
+      'aria-controls':
+        ctx.store.dropdownOpened && ctx.store.listId ? ctx.store.listId : undefined,
+
+      'aria-activedescendant': ctx.store.dropdownOpened
+        ? selectedOptionId || undefined
+        : undefined,
+
+      autoComplete,
+
+      'data-expanded': ctx.store.dropdownOpened || undefined,
+      'data-mantine-stop-propagation': ctx.store.dropdownOpened || undefined,
+    }
+  : {};
 
   return {
     ...ariaAttributes,


### PR DESCRIPTION
### Solved

This PR adds missing role and aria-expanded attributes to the Combobox trigger.

### Issue

Improves accessibility by making the component more compliant with ARIA practices and better for screen readers.

**Implementation**

Added appropriate role to the Combobox target
Added aria-expanded to reflect open/closed state