### PR TITLE
fix(FunnelChart): strokeColor and labelColor forwarded to DOM

### DIFF
--- a/packages/@mantine/charts/src/FunnelChart/FunnelChart.tsx
+++ b/packages/@mantine/charts/src/FunnelChart/FunnelChart.tsx
@@ -137,6 +137,8 @@ export const FunnelChart = factory<FunnelChartFactory>((_props, ref) => {
     funnelProps,
     labelsPosition,
     tooltipDataSource,
+    strokeColor,
+    labelColor,
     attributes,
     ...others
   } = props;


### PR DESCRIPTION
Fixes #8759

\`strokeColor\` and \`labelColor\` were missing from the destructuring list,
so both props ended up in \`...others\` and got forwarded to the inner \`Box\`,
triggering React DOM warnings.

Both are already handled by \`varsResolver\` to set CSS custom properties,
so they don't need to reach the DOM. Adding them to the destructuring is enough.