### PR TITLE
fix(PopoverTarget): pass event to child onClick handler

### DIFF
--- a/packages/@mantine/core/src/components/Popover/PopoverTarget/PopoverTarget.tsx
+++ b/packages/@mantine/core/src/components/Popover/PopoverTarget/PopoverTarget.tsx
@@ -62,7 +62,7 @@ export const PopoverTarget = factory<PopoverTargetFactory>((props, ref) => {
     [refProp]: targetRef,
     ...(!ctx.controlled
       ? {
-          onClick: (event) => {
+          onClick: (event: React.MouseEvent<HTMLElement>) => {
             ctx.onToggle();
             childProps.onClick?.(event);
           },


### PR DESCRIPTION
Fixes: #8757 

Passes down event object down to the child onClick function when PopoverTarget component was in "uncontrolled" state.