### PR TITLE
fix(hooks): correct return type for useLocalStorage when no defaultValue

### DIFF
--- a/packages/@mantine/hooks/src/use-local-storage/use-local-storage.ts
+++ b/packages/@mantine/hooks/src/use-local-storage/use-local-storage.ts
@@ -1,5 +1,7 @@
-import { createStorage, readValue, UseStorageOptions } from './create-storage';
+import { createStorage, readValue, UseStorageOptions, UseStorageReturnValue } from './create-storage';
 
+export function useLocalStorage<T>(props: UseStorageOptions<T> & { defaultValue: T }): UseStorageReturnValue<T>;
+export function useLocalStorage<T>(props: UseStorageOptions<T>): UseStorageReturnValue<T | undefined>;
 export function useLocalStorage<T = string>(props: UseStorageOptions<T>) {
   return createStorage<T>('localStorage', 'use-local-storage')(props);
 }


### PR DESCRIPTION
When useLocalStorage is called without a defaultValue prop, the return type now correctly includes '| undefined' since the actual value can be undefined at runtime when the key doesn't exist in localStorage.

Fixes #8769