### PR TITLE
[@mantine/core] fix: darkHidden missing in light LoadingOverlay

### DIFF
--- a/packages/@mantine/core/src/components/LoadingOverlay/LoadingOverlay.tsx
+++ b/packages/@mantine/core/src/components/LoadingOverlay/LoadingOverlay.tsx
@@ -137,6 +137,7 @@ export const LoadingOverlay = factory<LoadingOverlayFactory>((_props) => {
               className: _overlayProps?.className,
               style: _overlayProps?.style,
             })}
+            darkHidden
             unstyled={unstyled}
             color={overlayProps?.color || theme.white}
           />


### PR DESCRIPTION
In [this commit](https://github.com/mantinedev/mantine/commit/17acca212ebdcb107498f05071b73b6c718ce957) darkHidden has been removed (supposedly, by a mistake) from the light LoadingOverlay, this rendered both overlays at the same time with dark theme on.