### PR TITLE
[codex] fix inline input aria metadata

### DIFF
--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.test.tsx
@@ -120,6 +120,22 @@ describe('@mantine/core/Checkbox', () => {
     expect(screen.getByRole('checkbox')).not.toBeDisabled();
   });
 
+  it('connects description and error message to input with aria-describedby', () => {
+    render(<Checkbox {...defaultProps} id="checkbox-test" />);
+    expect(screen.getByRole('checkbox')).toHaveAttribute(
+      'aria-describedby',
+      'checkbox-test-error checkbox-test-description'
+    );
+  });
+
+  it('sets aria-invalid attribute based on error prop', () => {
+    const { rerender } = render(<Checkbox error="test-error" />);
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-invalid', 'true');
+
+    rerender(<Checkbox error={false} />);
+    expect(screen.getByRole('checkbox')).not.toHaveAttribute('aria-invalid');
+  });
+
   it('supports rootRef', () => {
     const ref = createRef<HTMLDivElement>();
     render(<Checkbox {...defaultProps} rootRef={ref} />);

--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
@@ -206,6 +206,11 @@ export const Checkbox = factory<CheckboxFactory>((_props) => {
 
   const { styleProps, rest } = extractStyleProps(others);
   const uuid = useId(id);
+  const hasError = !!error && typeof error !== 'boolean';
+  const hasDescription = !!description;
+  const describedBy =
+    `${hasError ? `${uuid}-error` : ''} ${hasDescription ? `${uuid}-description` : ''}`.trim() ||
+    undefined;
 
   const withContextProps = {
     checked: ctx?.value.includes(rest.value as string) ?? checked,
@@ -265,6 +270,8 @@ export const Checkbox = factory<CheckboxFactory>((_props) => {
           {...withContextProps}
           disabled={finalDisabled}
           inert={rest.inert}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
           type="checkbox"
           onClick={(event) => {
             if (readOnly) {

--- a/packages/@mantine/core/src/components/Radio/Radio.test.tsx
+++ b/packages/@mantine/core/src/components/Radio/Radio.test.tsx
@@ -61,4 +61,20 @@ describe('@mantine/core/Radio', () => {
       errorSpy.mockRestore();
     }
   });
+
+  it('connects description and error message to input with aria-describedby', () => {
+    render(<Radio {...defaultProps} id="radio-test" />);
+    expect(screen.getByRole('radio')).toHaveAttribute(
+      'aria-describedby',
+      'radio-test-error radio-test-description'
+    );
+  });
+
+  it('sets aria-invalid attribute based on error prop', () => {
+    const { rerender } = render(<Radio error="test-error" />);
+    expect(screen.getByRole('radio')).toHaveAttribute('aria-invalid', 'true');
+
+    rerender(<Radio error={false} />);
+    expect(screen.getByRole('radio')).not.toHaveAttribute('aria-invalid');
+  });
 });

--- a/packages/@mantine/core/src/components/Radio/Radio.tsx
+++ b/packages/@mantine/core/src/components/Radio/Radio.tsx
@@ -196,6 +196,11 @@ export const Radio = factory<RadioFactory>((_props) => {
 
   const { styleProps, rest } = extractStyleProps(others);
   const uuid = useId(id);
+  const hasError = !!error && typeof error !== 'boolean';
+  const hasDescription = !!description;
+  const describedBy =
+    `${hasError ? `${uuid}-error` : ''} ${hasDescription ? `${uuid}-description` : ''}`.trim() ||
+    undefined;
 
   const contextChecked = ctx ? ctx.value === rest.value : undefined;
 
@@ -238,6 +243,8 @@ export const Radio = factory<RadioFactory>((_props) => {
           {...rest}
           {...withContextProps}
           component="input"
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
           mod={{ error: !!error, 'with-error-styles': withErrorStyles }}
           id={uuid}
           type="radio"

--- a/packages/@mantine/core/src/components/Switch/Switch.test.tsx
+++ b/packages/@mantine/core/src/components/Switch/Switch.test.tsx
@@ -86,4 +86,20 @@ describe('@mantine/core/Switch', () => {
     act(() => input.click());
     expect(input).toBeChecked();
   });
+
+  it('connects description and error message to input with aria-describedby', () => {
+    render(<Switch {...defaultProps} id="switch-test" />);
+    expect(screen.getByRole('switch')).toHaveAttribute(
+      'aria-describedby',
+      'switch-test-error switch-test-description'
+    );
+  });
+
+  it('sets aria-invalid attribute based on error prop', () => {
+    const { rerender } = render(<Switch error="test-error" />);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-invalid', 'true');
+
+    rerender(<Switch error={false} />);
+    expect(screen.getByRole('switch')).not.toHaveAttribute('aria-invalid');
+  });
 });

--- a/packages/@mantine/core/src/components/Switch/Switch.tsx
+++ b/packages/@mantine/core/src/components/Switch/Switch.tsx
@@ -172,6 +172,11 @@ export const Switch = factory<SwitchFactory>((_props) => {
 
   const { styleProps, rest } = extractStyleProps(others);
   const uuid = useId(id);
+  const hasError = !!error && typeof error !== 'boolean';
+  const hasDescription = !!description;
+  const describedBy =
+    `${hasError ? `${uuid}-error` : ''} ${hasDescription ? `${uuid}-description` : ''}`.trim() ||
+    undefined;
 
   const withContextProps = {
     checked: ctx?.value.includes(rest.value as string) ?? checked,
@@ -229,6 +234,8 @@ export const Switch = factory<SwitchFactory>((_props) => {
         type="checkbox"
         role="switch"
         inert={rest.inert}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={describedBy}
         {...getStyles('input')}
       />
 

--- a/packages/@mantine/core/src/utils/InlineInput/InlineInput.tsx
+++ b/packages/@mantine/core/src/utils/InlineInput/InlineInput.tsx
@@ -66,6 +66,11 @@ export function InlineInput({
   attributes,
   ...others
 }: InlineInputProps) {
+  const hasError = !!error && typeof error !== 'boolean';
+  const hasDescription = !!description;
+  const errorId = hasError ? `${id}-error` : undefined;
+  const descriptionId = hasDescription ? `${id}-description` : undefined;
+
   const getStyles = useStyles<InlineInputFactory>({
     name: __staticSelector,
     props: __stylesApiProps,
@@ -110,13 +115,18 @@ export function InlineInput({
           )}
 
           {description && (
-            <Input.Description size={size} __inheritStyles={false} {...getStyles('description')}>
+            <Input.Description
+              id={descriptionId}
+              size={size}
+              __inheritStyles={false}
+              {...getStyles('description')}
+            >
               {description}
             </Input.Description>
           )}
 
-          {error && typeof error !== 'boolean' && (
-            <Input.Error size={size} __inheritStyles={false} {...getStyles('error')}>
+          {hasError && (
+            <Input.Error id={errorId} size={size} __inheritStyles={false} {...getStyles('error')}>
               {error}
             </Input.Error>
           )}


### PR DESCRIPTION
## Summary
- add stable ids for inline input description and error elements
- wire ria-describedby and ria-invalid to checkbox, radio, and switch controls
- cover the new accessibility contract with targeted component tests

## Why
Checkbox error and description text rendered through InlineInput, but the actual input control was not linked to those elements. That meant screen readers did not announce error content for checkbox-like controls, and the controls also did not expose invalid state.

## Impact
Checkbox, radio, and switch now expose their description/error text through ria-describedby, and they set ria-invalid when error is present. This improves voice reader output without changing component APIs.

## Validation
- corepack yarn jest packages/@mantine/core/src/components/Checkbox/Checkbox.test.tsx packages/@mantine/core/src/components/Radio/Radio.test.tsx packages/@mantine/core/src/components/Switch/Switch.test.tsx --runInBand
- corepack yarn oxfmt --check packages/@mantine/core/src/components/Checkbox/Checkbox.tsx packages/@mantine/core/src/components/Radio/Radio.tsx packages/@mantine/core/src/components/Switch/Switch.tsx packages/@mantine/core/src/utils/InlineInput/InlineInput.tsx packages/@mantine/core/src/components/Checkbox/Checkbox.test.tsx packages/@mantine/core/src/components/Radio/Radio.test.tsx packages/@mantine/core/src/components/Switch/Switch.test.tsx

Fixes #8340