### PR TITLE
fix: link checkbox errors to input with aria-describedby

### DIFF
--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.test.tsx
@@ -112,6 +112,32 @@ describe('@mantine/core/Checkbox', () => {
     expect(screen.getByRole('checkbox')).not.toHaveAttribute('data-error');
   });
 
+  it('has aria-describedby attribute with id of description element', () => {
+    render(<Checkbox description="test-description" />);
+    expect(screen.getByRole('checkbox')).toHaveAttribute(
+      'aria-describedby',
+      screen.getByText('test-description').id
+    );
+  });
+
+  it('has aria-describedby attribute with id of error element', () => {
+    render(<Checkbox error="test-error" />);
+    expect(screen.getByRole('checkbox')).toHaveAttribute(
+      'aria-describedby',
+      screen.getByText('test-error').id
+    );
+  });
+
+  it('has aria-describedby attribute with description and error ids', () => {
+    render(<Checkbox description="test-description" error="test-error" />);
+    const description = screen.getByText('test-description');
+    const error = screen.getByText('test-error');
+    expect(screen.getByRole('checkbox')).toHaveAttribute(
+      'aria-describedby',
+      `${description.id} ${error.id}`
+    );
+  });
+
   it('sets disabled attribute on input based on disabled prop', () => {
     const { rerender } = render(<Checkbox disabled />);
     expect(screen.getByRole('checkbox')).toBeDisabled();

--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.test.tsx
@@ -138,6 +138,33 @@ describe('@mantine/core/Checkbox', () => {
     );
   });
 
+  it('merges user-supplied aria-describedby with description and error ids', () => {
+    render(
+      <Checkbox description="test-description" error="test-error" aria-describedby="extra-id" />
+    );
+    const description = screen.getByText('test-description');
+    const error = screen.getByText('test-error');
+    expect(screen.getByRole('checkbox')).toHaveAttribute(
+      'aria-describedby',
+      `${description.id} ${error.id} extra-id`
+    );
+  });
+
+  it('preserves user-supplied aria-describedby when description and error are not set', () => {
+    render(<Checkbox aria-describedby="extra-id" />);
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-describedby', 'extra-id');
+  });
+
+  it('does not set aria-describedby when there is no description, error or user value', () => {
+    render(<Checkbox />);
+    expect(screen.getByRole('checkbox')).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('does not link aria-describedby to error when error is a boolean', () => {
+    render(<Checkbox error />);
+    expect(screen.getByRole('checkbox')).not.toHaveAttribute('aria-describedby');
+  });
+
   it('sets disabled attribute on input based on disabled prop', () => {
     const { rerender } = render(<Checkbox disabled />);
     expect(screen.getByRole('checkbox')).toBeDisabled();

--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
@@ -206,6 +206,9 @@ export const Checkbox = factory<CheckboxFactory>((_props) => {
 
   const { styleProps, rest } = extractStyleProps(others);
   const uuid = useId(id);
+  const descriptionId = description ? `${uuid}-description` : undefined;
+  const errorId = error && typeof error !== 'boolean' ? `${uuid}-error` : undefined;
+  const describedBy = [descriptionId, errorId].filter(Boolean).join(' ') || undefined;
 
   const withContextProps = {
     checked: ctx?.value.includes(rest.value as string) ?? checked,
@@ -263,6 +266,7 @@ export const Checkbox = factory<CheckboxFactory>((_props) => {
           {...getStyles('input', { focusable: true, variant })}
           {...rest}
           {...withContextProps}
+          aria-describedby={describedBy}
           disabled={finalDisabled}
           inert={rest.inert}
           type="checkbox"

--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
@@ -208,7 +208,8 @@ export const Checkbox = factory<CheckboxFactory>((_props) => {
   const uuid = useId(id);
   const descriptionId = description ? `${uuid}-description` : undefined;
   const errorId = error && typeof error !== 'boolean' ? `${uuid}-error` : undefined;
-  const describedBy = [descriptionId, errorId].filter(Boolean).join(' ') || undefined;
+  const describedBy =
+    [descriptionId, errorId, rest['aria-describedby']].filter(Boolean).join(' ') || undefined;
 
   const withContextProps = {
     checked: ctx?.value.includes(rest.value as string) ?? checked,

--- a/packages/@mantine/core/src/components/Radio/Radio.test.tsx
+++ b/packages/@mantine/core/src/components/Radio/Radio.test.tsx
@@ -33,6 +33,47 @@ describe('@mantine/core/Radio', () => {
     expect(Radio.Group).toBe(RadioGroup);
   });
 
+  it('has aria-describedby attribute with id of description element', () => {
+    render(<Radio description="test-description" />);
+    expect(screen.getByRole('radio')).toHaveAttribute(
+      'aria-describedby',
+      screen.getByText('test-description').id
+    );
+  });
+
+  it('has aria-describedby attribute with id of error element', () => {
+    render(<Radio error="test-error" />);
+    expect(screen.getByRole('radio')).toHaveAttribute(
+      'aria-describedby',
+      screen.getByText('test-error').id
+    );
+  });
+
+  it('has aria-describedby attribute with description and error ids', () => {
+    render(<Radio description="test-description" error="test-error" />);
+    const description = screen.getByText('test-description');
+    const error = screen.getByText('test-error');
+    expect(screen.getByRole('radio')).toHaveAttribute(
+      'aria-describedby',
+      `${description.id} ${error.id}`
+    );
+  });
+
+  it('merges user-supplied aria-describedby with description and error ids', () => {
+    render(<Radio description="test-description" error="test-error" aria-describedby="extra-id" />);
+    const description = screen.getByText('test-description');
+    const error = screen.getByText('test-error');
+    expect(screen.getByRole('radio')).toHaveAttribute(
+      'aria-describedby',
+      `${description.id} ${error.id} extra-id`
+    );
+  });
+
+  it('does not link aria-describedby to error when error is a boolean', () => {
+    render(<Radio error />);
+    expect(screen.getByRole('radio')).not.toHaveAttribute('aria-describedby');
+  });
+
   it('supports rootRef', () => {
     const ref = createRef<HTMLDivElement>();
     render(<Radio {...defaultProps} rootRef={ref} />);

--- a/packages/@mantine/core/src/components/Radio/Radio.tsx
+++ b/packages/@mantine/core/src/components/Radio/Radio.tsx
@@ -196,6 +196,10 @@ export const Radio = factory<RadioFactory>((_props) => {
 
   const { styleProps, rest } = extractStyleProps(others);
   const uuid = useId(id);
+  const descriptionId = description ? `${uuid}-description` : undefined;
+  const errorId = error && typeof error !== 'boolean' ? `${uuid}-error` : undefined;
+  const describedBy =
+    [descriptionId, errorId, rest['aria-describedby']].filter(Boolean).join(' ') || undefined;
 
   const contextChecked = ctx ? ctx.value === rest.value : undefined;
 
@@ -241,6 +245,7 @@ export const Radio = factory<RadioFactory>((_props) => {
           mod={{ error: !!error, 'with-error-styles': withErrorStyles }}
           id={uuid}
           type="radio"
+          aria-describedby={describedBy}
         />
         <Icon {...getStyles('icon')} aria-hidden />
       </Box>

--- a/packages/@mantine/core/src/components/Switch/Switch.test.tsx
+++ b/packages/@mantine/core/src/components/Switch/Switch.test.tsx
@@ -55,6 +55,49 @@ describe('@mantine/core/Switch', () => {
     expect(screen.getByRole('switch')).toBeDisabled();
   });
 
+  it('has aria-describedby attribute with id of description element', () => {
+    render(<Switch description="test-description" />);
+    expect(screen.getByRole('switch')).toHaveAttribute(
+      'aria-describedby',
+      screen.getByText('test-description').id
+    );
+  });
+
+  it('has aria-describedby attribute with id of error element', () => {
+    render(<Switch error="test-error" />);
+    expect(screen.getByRole('switch')).toHaveAttribute(
+      'aria-describedby',
+      screen.getByText('test-error').id
+    );
+  });
+
+  it('has aria-describedby attribute with description and error ids', () => {
+    render(<Switch description="test-description" error="test-error" />);
+    const description = screen.getByText('test-description');
+    const error = screen.getByText('test-error');
+    expect(screen.getByRole('switch')).toHaveAttribute(
+      'aria-describedby',
+      `${description.id} ${error.id}`
+    );
+  });
+
+  it('merges user-supplied aria-describedby with description and error ids', () => {
+    render(
+      <Switch description="test-description" error="test-error" aria-describedby="extra-id" />
+    );
+    const description = screen.getByText('test-description');
+    const error = screen.getByText('test-error');
+    expect(screen.getByRole('switch')).toHaveAttribute(
+      'aria-describedby',
+      `${description.id} ${error.id} extra-id`
+    );
+  });
+
+  it('does not link aria-describedby to error when error is a boolean', () => {
+    render(<Switch error />);
+    expect(screen.getByRole('switch')).not.toHaveAttribute('aria-describedby');
+  });
+
   it('exposes SwitchGroup component', () => {
     expect(Switch.Group).toBe(SwitchGroup);
   });

--- a/packages/@mantine/core/src/components/Switch/Switch.tsx
+++ b/packages/@mantine/core/src/components/Switch/Switch.tsx
@@ -172,6 +172,10 @@ export const Switch = factory<SwitchFactory>((_props) => {
 
   const { styleProps, rest } = extractStyleProps(others);
   const uuid = useId(id);
+  const descriptionId = description ? `${uuid}-description` : undefined;
+  const errorId = error && typeof error !== 'boolean' ? `${uuid}-error` : undefined;
+  const describedBy =
+    [descriptionId, errorId, rest['aria-describedby']].filter(Boolean).join(' ') || undefined;
 
   const withContextProps = {
     checked: ctx?.value.includes(rest.value as string) ?? checked,
@@ -229,6 +233,7 @@ export const Switch = factory<SwitchFactory>((_props) => {
         type="checkbox"
         role="switch"
         inert={rest.inert}
+        aria-describedby={describedBy}
         {...getStyles('input')}
       />
 

--- a/packages/@mantine/core/src/utils/InlineInput/InlineInput.tsx
+++ b/packages/@mantine/core/src/utils/InlineInput/InlineInput.tsx
@@ -78,6 +78,9 @@ export function InlineInput({
     attributes,
   });
 
+  const descriptionId = description ? `${id}-description` : undefined;
+  const errorId = error && typeof error !== 'boolean' ? `${id}-error` : undefined;
+
   return (
     <Box
       {...getStyles('root')}
@@ -110,13 +113,18 @@ export function InlineInput({
           )}
 
           {description && (
-            <Input.Description size={size} __inheritStyles={false} {...getStyles('description')}>
+            <Input.Description
+              id={descriptionId}
+              size={size}
+              __inheritStyles={false}
+              {...getStyles('description')}
+            >
               {description}
             </Input.Description>
           )}
 
           {error && typeof error !== 'boolean' && (
-            <Input.Error size={size} __inheritStyles={false} {...getStyles('error')}>
+            <Input.Error id={errorId} size={size} __inheritStyles={false} {...getStyles('error')}>
               {error}
             </Input.Error>
           )}


### PR DESCRIPTION
## Summary

Fix Checkbox accessibility so the input is linked to description and error content with `aria-describedby`.

## Changes

- add stable ids to `InlineInput` description and error elements
- wire `Checkbox` input to those ids via `aria-describedby`
- add tests for description and error associations

Closes #8340
