### PR TITLE
Fix Combobox dropdown z-index inside FloatingWindow

### DIFF
--- a/packages/@mantine/core/src/components/Combobox/Combobox.tsx
+++ b/packages/@mantine/core/src/components/Combobox/Combobox.tsx
@@ -11,6 +11,7 @@ import {
   useProps,
   useStyles,
 } from '../../core';
+import { useFloatingWindowContext } from '../FloatingWindow/FloatingWindow.context';
 import { __PopoverProps, Popover } from '../Popover';
 import { ComboboxProvider } from './Combobox.context';
 import { ComboboxChevron, ComboboxChevronProps } from './ComboboxChevron/ComboboxChevron';
@@ -128,6 +129,14 @@ const varsResolver = createVarsResolver<ComboboxFactory>((_, { size, dropdownPad
   },
 }));
 
+function getFloatingWindowDropdownZIndex(zIndex: React.CSSProperties['zIndex'] | undefined) {
+  if (zIndex === undefined) {
+    return undefined;
+  }
+
+  return typeof zIndex === 'number' ? zIndex + 1 : `calc(${zIndex} + 1)`;
+}
+
 export const Combobox = (_props: ComboboxProps) => {
   const props = useProps('Combobox', defaultProps, _props);
   const {
@@ -144,12 +153,14 @@ export const Combobox = (_props: ComboboxProps) => {
     resetSelectionOnOptionHover,
     __staticSelector,
     readOnly,
+    zIndex,
     attributes,
     ...others
   } = props;
 
   const uncontrolledStore = useCombobox();
   const store = controlledStore || uncontrolledStore;
+  const floatingWindow = useFloatingWindowContext();
 
   const getStyles = useStyles<ComboboxFactory>({
     name: __staticSelector || 'Combobox',
@@ -182,6 +193,7 @@ export const Combobox = (_props: ComboboxProps) => {
       <Popover
         opened={store.dropdownOpened}
         preventPositionChangeWhenVisible={false}
+        zIndex={zIndex ?? getFloatingWindowDropdownZIndex(floatingWindow?.zIndex)}
         {...others}
         onChange={(_opened) => !_opened && onDropdownClose()}
         withRoles={false}

--- a/packages/@mantine/core/src/components/FloatingWindow/FloatingWindow.context.ts
+++ b/packages/@mantine/core/src/components/FloatingWindow/FloatingWindow.context.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+interface FloatingWindowContextValue {
+  zIndex: React.CSSProperties['zIndex'];
+}
+
+export const FloatingWindowContext = createContext<FloatingWindowContextValue | null>(null);
+
+export function useFloatingWindowContext() {
+  return useContext(FloatingWindowContext);
+}

--- a/packages/@mantine/core/src/components/FloatingWindow/FloatingWindow.tsx
+++ b/packages/@mantine/core/src/components/FloatingWindow/FloatingWindow.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../core';
 import { Paper, PaperBaseProps } from '../Paper';
 import { OptionalPortal, PortalProps } from '../Portal';
+import { FloatingWindowContext } from './FloatingWindow.context';
 import classes from './FloatingWindow.module.css';
 
 export type FloatingWindowStylesNames = 'root';
@@ -110,15 +111,17 @@ export const FloatingWindow = factory<FloatingWindowFactory>((_props) => {
   ]);
 
   return (
-    <OptionalPortal withinPortal={withinPortal} {...portalProps}>
-      <Paper
-        ref={useMergedRef(ref, floatingWindow.ref)}
-        mod={[{ dragging: floatingWindow.isDragging }, mod]}
-        {...getStyles('root')}
-        {...others}
-        __vars={{ '--floating-window-z-index': zIndex.toString() }}
-      />
-    </OptionalPortal>
+    <FloatingWindowContext.Provider value={{ zIndex }}>
+      <OptionalPortal withinPortal={withinPortal} {...portalProps}>
+        <Paper
+          ref={useMergedRef(ref, floatingWindow.ref)}
+          mod={[{ dragging: floatingWindow.isDragging }, mod]}
+          {...getStyles('root')}
+          {...others}
+          __vars={{ '--floating-window-z-index': zIndex.toString() }}
+        />
+      </OptionalPortal>
+    </FloatingWindowContext.Provider>
   );
 });
 

--- a/packages/@mantine/core/src/components/Select/Select.test.tsx
+++ b/packages/@mantine/core/src/components/Select/Select.test.tsx
@@ -7,6 +7,7 @@ import {
   tests,
   userEvent,
 } from '@mantine-tests/core';
+import { FloatingWindow } from '../FloatingWindow';
 import { Input } from '../Input';
 import { Select, SelectProps, SelectStylesNames } from './Select';
 
@@ -209,6 +210,16 @@ describe('@mantine/core/Select', () => {
   it('renders loading indicator when loading prop is set', () => {
     const { container } = render(<Select {...defaultProps} loading />);
     expect(container.querySelector('.mantine-Loader-root')).toBeInTheDocument();
+  });
+
+  it('renders dropdown above FloatingWindow by default', () => {
+    render(
+      <FloatingWindow withinPortal={false}>
+        <Select {...defaultProps} dropdownOpened />
+      </FloatingWindow>
+    );
+
+    expect(document.querySelector('.mantine-Select-dropdown')).toHaveStyle({ zIndex: 401 });
   });
 
   it('supports uncontrolled state with numeric values', async () => {


### PR DESCRIPTION
## Summary
- raise the Combobox dropdown z-index when it is rendered inside `FloatingWindow`
- provide `FloatingWindow` z-index through context so nested Combobox/Select instances can inherit it
- add a regression test covering `Select` opened inside `FloatingWindow`

## Testing
- Added focused regression coverage in `packages/@mantine/core/src/components/Select/Select.test.tsx`

Closes #8813