### PR TITLE
Add Mantine Depth Select and Mantine Lens Select to community extensions

### DIFF
--- a/apps/mantine.dev/src/pages/x/extensions.mdx
+++ b/apps/mantine.dev/src/pages/x/extensions.mdx
@@ -42,9 +42,11 @@ Community extensions list:
 - [BorderAnimate](https://gfazioli.github.io/mantine-border-animate/) – border animation styles (beam, glow, more...)
 - [Clock](https://gfazioli.github.io/mantine-clock/) – analog clock component
 - [Compare](https://gfazioli.github.io/mantine-compare/) – image comparison slider component
+- [DepthSelect](https://gfazioli.github.io/mantine-depth-select/) – 3D stack select component inspired by macOS Time Machine
 - [Flip](https://gfazioli.github.io/mantine-flip/) – flip animation component
 - [JsonTree](https://gfazioli.github.io/mantine-json-tree/) – interactive JSON tree viewer with syntax highlighting
 - [Led](https://gfazioli.github.io/mantine-led/) – LED indicator component for status feedback
+- [LensSelect](https://gfazioli.github.io/mantine-lens-select/) – fisheye/lens magnification select with count mode and macOS Dock effect
 - [ListViewTable](https://gfazioli.github.io/mantine-list-view-table/) – Finder-style list view table with column reordering and resizing
 - [Marquee](https://gfazioli.github.io/mantine-marquee/) – marquee component
 - [Mask](https://gfazioli.github.io/mantine-mask/) – cursor-follow spotlight mask component


### PR DESCRIPTION
Add two new community extension components to the extensions page:

- **[DepthSelect](https://gfazioli.github.io/mantine-depth-select/)** — A 3D stack select component inspired by macOS Time Machine. Navigate through stacked cards with perspective transforms and smooth transitions.

![social](https://github.com/user-attachments/assets/f2388604-ff8e-4565-8cf8-7c685d4118d6)


- **[LensSelect](https://gfazioli.github.io/mantine-lens-select/)** — A fisheye/lens magnification select with count mode and macOS Dock effect. Supports min/max/step range, compound components, and full Styles API.

![social](https://github.com/user-attachments/assets/c4df0b30-c18d-4048-a6d7-ecdb375b3d23)


Both are open-source, MIT-licensed, built with the [extension template](https://github.com/mantinedev/extension-template), and compatible with Mantine 9.

- [npm: @gfazioli/mantine-depth-select](https://www.npmjs.com/package/@gfazioli/mantine-depth-select)
- [npm: @gfazioli/mantine-lens-select](https://www.npmjs.com/package/@gfazioli/mantine-lens-select)