### PR TITLE
Fix form validate type inference

### DIFF
--- a/packages/@mantine/form/src/tests/use-form/validate-types.test.ts
+++ b/packages/@mantine/form/src/tests/use-form/validate-types.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react';
+import { useForm } from '../../use-form';
+
+describe('@mantine/form/validate-type-safety', () => {
+  it('accepts valid validate keys from initialValues', () => {
+    const hook = renderHook(() =>
+      useForm({
+        initialValues: { firstName: '', lastName: '' },
+        validate: {
+          firstName: (value) => (value.length < 2 ? 'Too short' : null),
+          lastName: (value) => (value.length < 2 ? 'Too short' : null),
+        },
+      })
+    );
+
+    expect(hook.result.current).toBeDefined();
+  });
+
+  it('accepts partial validate keys', () => {
+    const hook = renderHook(() =>
+      useForm({
+        initialValues: { firstName: '', lastName: '' },
+        validate: {
+          firstName: (value) => (value.length < 2 ? 'Too short' : null),
+        },
+      })
+    );
+
+    expect(hook.result.current).toBeDefined();
+  });
+
+  it('rejects unknown validate keys not present in initialValues', () => {
+    renderHook(() =>
+      useForm({
+        initialValues: { firstName: '', lastName: '' },
+        validate: {
+          // @ts-expect-error: 'unknownField' is not a key of initialValues
+          unknownField: (value: string) => (value.length < 2 ? 'Too short' : null),
+          firstName: (value) => (value.length < 2 ? 'Too short' : null),
+        },
+      })
+    );
+  });
+});

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -26,7 +26,12 @@ import {
   UseFormInput,
   UseFormReturnType,
 } from './types';
-import { formRootRule, shouldValidateOnChange, validateFieldValue, validateValues } from './validate';
+import {
+  formRootRule,
+  shouldValidateOnChange,
+  validateFieldValue,
+  validateValues,
+} from './validate';
 
 export function useForm<
   Values extends Record<string, any>,
@@ -40,7 +45,8 @@ export function useForm<
   Values extends Record<string, any>,
   TransformedValues = Values,
   Rules extends FormRulesRecord<Values> &
-    Record<Exclude<keyof Rules, keyof Values | typeof formRootRule>, never> = FormRulesRecord<Values>,
+    Record<Exclude<keyof Rules, keyof Values | typeof formRootRule>, never> =
+    FormRulesRecord<Values>,
 >(
   input: UseFormInput<Values, TransformedValues> & { validate: Rules }
 ): UseFormReturnType<Values, TransformedValues, Rules>;

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -26,7 +26,7 @@ import {
   UseFormInput,
   UseFormReturnType,
 } from './types';
-import { shouldValidateOnChange, validateFieldValue, validateValues } from './validate';
+import { formRootRule, shouldValidateOnChange, validateFieldValue, validateValues } from './validate';
 
 export function useForm<
   Values extends Record<string, any>,
@@ -39,7 +39,8 @@ export function useForm<
 export function useForm<
   Values extends Record<string, any>,
   TransformedValues = Values,
-  Rules extends FormRulesRecord<Values> = FormRulesRecord<Values>,
+  Rules extends FormRulesRecord<Values> &
+    Record<Exclude<keyof Rules, keyof Values | typeof formRootRule>, never> = FormRulesRecord<Values>,
 >(
   input: UseFormInput<Values, TransformedValues> & { validate: Rules }
 ): UseFormReturnType<Values, TransformedValues, Rules>;


### PR DESCRIPTION
## Problem

The useForm hook allows unknown keys in the validate option that are not present in initialValues, which is a type safety gap.

##  Solution

Unknown keys in validate are now inferred as never, causing a type error when keys not present in initialValues are used.

This should not affect runtime behavior, as unrecognized keys in the validate rules record are already silently ignored during validation.

```javascript
const form = useForm({
  initialValues: {
      orange: '',
      banana: '',
    },
    validate: {
      orange: (value) => value.length < 2 ? 'Too Short' : null,
      banana: (value) => value.length < 2 ? 'Too Short' : null,
      unknownProperty: () => null,
    },
);

form.validate().errors; //  { orange: 'Too Short', banana: 'Too Short' };
```

**As-is**
<img width="357" height="127" alt="스크린샷 2026-04-13 오후 7 38 30" src="https://github.com/user-attachments/assets/38eafd6d-044c-4c01-b0b8-299e914206e6" />

**To-be**
<img width="359" height="127" alt="스크린샷 2026-04-13 오후 7 38 06" src="https://github.com/user-attachments/assets/5c6a83ea-99aa-48dd-9f9f-4dbf289a06e2" />
