### PR TITLE
[@mantine/core] Checkbox, Switch, Radio: link error message via aria-describedby

### DIFF
--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.test.tsx
@@ -112,6 +112,19 @@ describe('@mantine/core/Checkbox', () => {
     expect(screen.getByRole('checkbox')).not.toHaveAttribute('data-error');
   });
 
+  it('links error message to input via aria-describedby', () => {
+    render(<Checkbox id="cb-test" error="This field is required" />);
+    const input = screen.getByRole('checkbox');
+    const errorEl = screen.getByText('This field is required');
+    expect(input).toHaveAttribute('aria-describedby', 'cb-test-error');
+    expect(errorEl.closest('[id]')).toHaveAttribute('id', 'cb-test-error');
+  });
+
+  it('does not set aria-describedby when no error', () => {
+    render(<Checkbox id="cb-test" />);
+    expect(screen.getByRole('checkbox')).not.toHaveAttribute('aria-describedby');
+  });
+
   it('sets disabled attribute on input based on disabled prop', () => {
     const { rerender } = render(<Checkbox disabled />);
     expect(screen.getByRole('checkbox')).toBeDisabled();

--- a/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/@mantine/core/src/components/Checkbox/Checkbox.tsx
@@ -206,6 +206,7 @@ export const Checkbox = factory<CheckboxFactory>((_props) => {
 
   const { styleProps, rest } = extractStyleProps(others);
   const uuid = useId(id);
+  const errorId = error ? `${uuid}-error` : undefined;
 
   const withContextProps = {
     checked: ctx?.value.includes(rest.value as string) ?? checked,
@@ -241,6 +242,7 @@ export const Checkbox = factory<CheckboxFactory>((_props) => {
       label={label}
       description={description}
       error={error}
+      errorId={errorId}
       disabled={finalDisabled}
       classNames={classNames}
       styles={styles}
@@ -261,6 +263,7 @@ export const Checkbox = factory<CheckboxFactory>((_props) => {
           ref={useMergedRef(inputRef, ref)}
           mod={{ error: !!error }}
           {...getStyles('input', { focusable: true, variant })}
+          aria-describedby={errorId}
           {...rest}
           {...withContextProps}
           disabled={finalDisabled}

--- a/packages/@mantine/core/src/components/Radio/Radio.tsx
+++ b/packages/@mantine/core/src/components/Radio/Radio.tsx
@@ -196,6 +196,7 @@ export const Radio = factory<RadioFactory>((_props) => {
 
   const { styleProps, rest } = extractStyleProps(others);
   const uuid = useId(id);
+  const errorId = error ? `${uuid}-error` : undefined;
 
   const contextChecked = ctx ? ctx.value === rest.value : undefined;
 
@@ -220,6 +221,7 @@ export const Radio = factory<RadioFactory>((_props) => {
       label={label}
       description={description}
       error={error}
+      errorId={errorId}
       disabled={withContextProps.disabled}
       classNames={classNames}
       styles={styles}
@@ -241,6 +243,7 @@ export const Radio = factory<RadioFactory>((_props) => {
           mod={{ error: !!error, 'with-error-styles': withErrorStyles }}
           id={uuid}
           type="radio"
+          aria-describedby={errorId}
         />
         <Icon {...getStyles('icon')} aria-hidden />
       </Box>

--- a/packages/@mantine/core/src/components/Switch/Switch.tsx
+++ b/packages/@mantine/core/src/components/Switch/Switch.tsx
@@ -172,6 +172,7 @@ export const Switch = factory<SwitchFactory>((_props) => {
 
   const { styleProps, rest } = extractStyleProps(others);
   const uuid = useId(id);
+  const errorId = error ? `${uuid}-error` : undefined;
 
   const withContextProps = {
     checked: ctx?.value.includes(rest.value as string) ?? checked,
@@ -200,6 +201,7 @@ export const Switch = factory<SwitchFactory>((_props) => {
       label={label}
       description={description}
       error={error}
+      errorId={errorId}
       disabled={_disabled}
       bodyElement="label"
       labelElement="span"
@@ -228,6 +230,7 @@ export const Switch = factory<SwitchFactory>((_props) => {
         id={uuid}
         type="checkbox"
         role="switch"
+        aria-describedby={errorId}
         inert={rest.inert}
         {...getStyles('input')}
       />

--- a/packages/@mantine/core/src/utils/InlineInput/InlineInput.tsx
+++ b/packages/@mantine/core/src/utils/InlineInput/InlineInput.tsx
@@ -31,6 +31,7 @@ export interface InlineInputProps
   id: string;
   disabled: boolean | undefined;
   error: React.ReactNode;
+  errorId?: string;
   size: MantineSize | (string & {}) | undefined;
   labelPosition?: 'left' | 'right';
   bodyElement?: any;
@@ -55,6 +56,7 @@ export function InlineInput({
   id,
   disabled,
   error,
+  errorId,
   size,
   labelPosition = 'left',
   bodyElement = 'div',
@@ -116,7 +118,7 @@ export function InlineInput({
           )}
 
           {error && typeof error !== 'boolean' && (
-            <Input.Error size={size} __inheritStyles={false} {...getStyles('error')}>
+            <Input.Error size={size} __inheritStyles={false} id={errorId} {...getStyles('error')}>
               {error}
             </Input.Error>
           )}


### PR DESCRIPTION
## Problem

Fixes #8340

Screen readers (VoiceOver, NVDA) do not announce the error message when a `Checkbox`, `Switch`, or `Radio` has an `error` prop. This is because:

- The error element rendered by `InlineInput` has no `id`
- The `<input>` has no `aria-describedby` pointing to it

`TextInput` and other text-based inputs handle this correctly through `InputWrapper` → `InputWrapperProvider` → `describedBy` context, but inline inputs (Checkbox, Switch, Radio) use `InlineInput` which had no equivalent mechanism.

## Fix

Three-part change:

### 1. `InlineInput` — accept `errorId` and forward it to `Input.Error`
Added optional `errorId?: string` prop. When provided it is passed as `id` to the rendered `Input.Error` element so assistive technology can find it by id.

### 2. `Checkbox` — wire `errorId` to the input
Derives `errorId = error ? \`${uuid}-error\` : undefined` and passes it to:
- `InlineInput` as `errorId` (gives the error element its id)
- The `<input>` as `aria-describedby` (links input → error message)

### 3. `Switch` and `Radio` — same fix
Both use `InlineInput` and had the same gap. Applying the identical pattern keeps behaviour consistent across all inline form controls.

## Testing

New tests in `Checkbox.test.tsx`:
- `links error message to input via aria-describedby` — asserts both the input attribute and the error element id
- `does not set aria-describedby when no error` — asserts no spurious attribute when error is absent