### PR TITLE
[@mantine/core] Fix SemiCircleProgress not being displayed

### DIFF
--- a/packages/@mantine/core/src/components/SemiCircleProgress/SemiCircleProgress.test.tsx
+++ b/packages/@mantine/core/src/components/SemiCircleProgress/SemiCircleProgress.test.tsx
@@ -54,4 +54,13 @@ describe('@mantine/core/SemiCircleProgress', () => {
     render(<SemiCircleProgress {...defaultProps} label="test-label" orientation="down" />);
     expect(screen.getByText('test-label')).toHaveAttribute('data-orientation', 'down');
   });
+
+  it('sets svg dimensions based on size prop', () => {
+    const { container } = render(<SemiCircleProgress {...defaultProps} size={240} />);
+    const svg = container.querySelector('svg');
+
+    expect(svg).toHaveAttribute('width', '240');
+    expect(svg).toHaveAttribute('height', '120');
+    expect(svg).toHaveAttribute('viewBox', '0 0 240 120');
+  });
 });

--- a/packages/@mantine/core/src/components/SemiCircleProgress/SemiCircleProgress.tsx
+++ b/packages/@mantine/core/src/components/SemiCircleProgress/SemiCircleProgress.tsx
@@ -172,7 +172,7 @@ export const SemiCircleProgress = factory<SemiCircleProgressFactory>((_props) =>
         </div>
       )}
 
-      <svg viewBox={`0 0 ${size} ${size / 2}`} {...getStyles('svg')}>
+      <svg width={size} height={size / 2} viewBox={`0 0 ${size} ${size / 2}`} {...getStyles('svg')}>
         <circle
           cx={coordinateForCircle}
           cy={coordinateForCircle}


### PR DESCRIPTION
## What is the purpose of this pull request?

  Fixes #8840.

  `SemiCircleProgress` lost explicit SVG dimensions when `viewBox` was added. As a result, the component no longer guaranteed that the
  `size` prop controlled the rendered SVG size, which could make the progress indicator appear missing in some layouts.

  This PR restores the explicit `width` and `height` attributes on the SVG while keeping the `viewBox`.

  ## What was changed?

  - Added `width={size}` and `height={size / 2}` to the `SemiCircleProgress` SVG
  - Added a regression test to verify SVG `width`, `height`, and `viewBox` values are derived from the `size` prop

  ## Testing

  ```sh
  npx jest packages/@mantine/core/src/components/SemiCircleProgress/SemiCircleProgress.test.tsx --runInBand

  Result:

  Test Suites: 1 passed
  Tests: 47 passed