### PR TITLE
  [@mantine/core] ScrollArea: Fix scrollbar never visible with offsetScrollbars="present"                                                  

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.test.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.test.tsx
@@ -21,6 +21,27 @@ function getViewport(container: HTMLElement) {
   return viewport;
 }
 
+function mockResizeObserver(observe: jest.Mock, unobserve: jest.Mock) {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(window, 'ResizeObserver');
+
+  Object.defineProperty(window, 'ResizeObserver', {
+    configurable: true,
+    writable: true,
+    value: jest.fn().mockImplementation(() => ({
+      observe,
+      unobserve,
+    })),
+  });
+
+  return () => {
+    if (originalDescriptor) {
+      Object.defineProperty(window, 'ResizeObserver', originalDescriptor);
+    } else {
+      Reflect.deleteProperty(window, 'ResizeObserver');
+    }
+  };
+}
+
 describe('@mantine/core/ScrollArea', () => {
   tests.itSupportsSystemProps<ScrollAreaProps, ScrollAreaStylesNames>({
     component: ScrollArea,
@@ -187,6 +208,24 @@ describe('@mantine/core/ScrollArea', () => {
 
     expect(bottomSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('observes viewport when offsetScrollbars is present', () => {
+    const observe = jest.fn();
+    const unobserve = jest.fn();
+    const restoreResizeObserver = mockResizeObserver(observe, unobserve);
+
+    try {
+      render(
+        <ScrollArea h={100} offsetScrollbars="present">
+          <div style={{ height: 500 }}>Content</div>
+        </ScrollArea>
+      );
+
+      expect(observe).toHaveBeenCalled();
+    } finally {
+      restoreResizeObserver();
+    }
+  });
 });
 
 describe('@mantine/core/ScrollAreaAutosize', () => {
@@ -195,5 +234,23 @@ describe('@mantine/core/ScrollAreaAutosize', () => {
     props: defaultProps,
     children: true,
     displayName: '@mantine/core/ScrollAreaAutosize',
+  });
+
+  it('observes viewport when onOverflowChange is provided', () => {
+    const observe = jest.fn();
+    const unobserve = jest.fn();
+    const restoreResizeObserver = mockResizeObserver(observe, unobserve);
+
+    try {
+      render(
+        <ScrollArea.Autosize h={100} onOverflowChange={jest.fn()}>
+          <div style={{ height: 500 }}>Content</div>
+        </ScrollArea.Autosize>
+      );
+
+      expect(observe).toHaveBeenCalled();
+    } finally {
+      restoreResizeObserver();
+    }
   });
 });

--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -1,4 +1,4 @@
-import { useEffectEvent, useRef, useState } from 'react';
+import { useCallback, useEffectEvent, useRef, useState } from 'react';
 import { useMergeRefs } from '@floating-ui/react';
 import { useIsomorphicEffect } from '@mantine/hooks';
 import {
@@ -204,7 +204,19 @@ export const ScrollArea = factory<ScrollAreaFactory>((_props) => {
   });
 
   const localViewportRef = useRef<HTMLDivElement>(null);
-  const combinedViewportRef = useMergeRefs([viewportRef, localViewportRef]);
+  const [viewportElement, setViewportElement] = useState<HTMLDivElement | null>(null);
+  const viewportCallbackRef = useCallback((node: HTMLDivElement | null) => {
+    setViewportElement((current) => (current === node ? current : node));
+  }, []);
+  const combinedViewportRef = useMergeRefs([viewportRef, localViewportRef, viewportCallbackRef]);
+
+  useResizeObserver(offsetScrollbars === 'present' ? viewportElement : null, () => {
+    const element = localViewportRef.current;
+    if (element) {
+      setVerticalThumbVisible(element.scrollHeight > element.clientHeight);
+      setHorizontalThumbVisible(element.scrollWidth > element.clientWidth);
+    }
+  });
 
   useIsomorphicEffect(() => {
     if (startScrollPosition && localViewportRef.current) {
@@ -214,14 +226,6 @@ export const ScrollArea = factory<ScrollAreaFactory>((_props) => {
       });
     }
   }, []);
-
-  useResizeObserver(offsetScrollbars === 'present' ? localViewportRef.current : null, () => {
-    const element = localViewportRef.current;
-    if (element) {
-      setVerticalThumbVisible(element.scrollHeight > element.clientHeight);
-      setHorizontalThumbVisible(element.scrollWidth > element.clientWidth);
-    }
-  });
 
   return (
     <ScrollAreaRoot
@@ -356,7 +360,17 @@ export const ScrollAreaAutosize = factory<ScrollAreaAutosizeFactory>((props) => 
 
   // Overflow detection (Autosize-only)
   const viewportObserverRef = useRef<HTMLDivElement>(null);
-  const combinedViewportRef = useMergeRefs([viewportRef, viewportObserverRef]);
+  const [viewportObserverElement, setViewportObserverElement] = useState<HTMLDivElement | null>(
+    null
+  );
+  const viewportObserverCallbackRef = useCallback((node: HTMLDivElement | null) => {
+    setViewportObserverElement((current) => (current === node ? current : node));
+  }, []);
+  const combinedViewportRef = useMergeRefs([
+    viewportRef,
+    viewportObserverRef,
+    viewportObserverCallbackRef,
+  ]);
 
   const overflowingRef = useRef(false);
   const didMountRef = useRef(false);
@@ -383,7 +397,7 @@ export const ScrollAreaAutosize = factory<ScrollAreaAutosizeFactory>((props) => 
     }
   });
 
-  useResizeObserver(onOverflowChange ? viewportObserverRef.current : null, handleOverflowCheck);
+  useResizeObserver(onOverflowChange ? viewportObserverElement : null, handleOverflowCheck);
 
   return (
     <Box {...others} variant={variant} style={[{ display: 'flex', overflow: 'hidden' }, style]}>


### PR DESCRIPTION
                                                                                                                         
  ## Summary                                                                                                                               
  - `useResizeObserver` received `ref.current` (null at first render) as its element argument — since ref assignment doesn't cause         
  re-render, the ResizeObserver was never attached                                                                                         
  - Replaced with callback ref + `useState` so the effect dependency updates after mount, correctly attaching the observer                 
  - Applied the same fix to `ScrollArea.Autosize`'s `onOverflowChange` detection which had the identical bug                               
                                                                                                                                           
  Fixes #8839                                                                                                                              
                                                                                                                                           
  ## Test plan                                                                                                                             
  - [ ] Added test: `observes viewport when offsetScrollbars is present`                                                                   
  - [ ] Existing ScrollArea tests pass (83/83)                                                                                             
  - [ ] Typecheck passes                                                                                                                   
  - [ ] Verify with reproduction: https://codesandbox.io/p/sandbox/vpkpp9                                                                  
                                                                             