### PR TITLE
[@mantine/core] Radio: Center icon via translate transform

### DIFF
--- a/packages/@mantine/core/src/components/Radio/Radio.module.css
+++ b/packages/@mantine/core/src/components/Radio/Radio.module.css
@@ -29,6 +29,7 @@
 .icon {
   color: var(--radio-icon-color);
   opacity: var(--radio-icon-opacity, 0);
+  translate: -50% -50%;
   transform: var(--radio-icon-transform, scale(0.2) translateY(rem(10px)));
   transition:
     opacity 100ms ease,
@@ -37,8 +38,8 @@
   width: var(--radio-icon-size);
   height: var(--radio-icon-size);
   position: absolute;
-  top: calc(50% - var(--radio-icon-size) / 2);
-  left: calc(50% - var(--radio-icon-size) / 2);
+  top: 50%;
+  left: 50%;
 }
 
 .radio {


### PR DESCRIPTION
Radio icon was centered via `calc(50% - size/2)`, which renders off-center on displays with fractional scaling (125%, 150%)                  
                                                                                                    
Switched to `top/left: 50%` + `translate: -50% -50%` so the compositor anti-aliases sub-pixel offsets instead of pixel snapping