### PR TITLE
[@mantine/core] Highlight | Fix wholeWord unicode matching

### DIFF
--- a/packages/@mantine/core/src/components/Highlight/Highlight.test.tsx
+++ b/packages/@mantine/core/src/components/Highlight/Highlight.test.tsx
@@ -132,6 +132,18 @@ describe('@mantine/core/Highlight', () => {
       expect(marks[0].textContent).toBe('test');
       expect(marks[1].textContent).toBe('testing');
     });
+
+    it('supports unicode letters in wholeWord matching', () => {
+      const { container } = render(
+        <Highlight highlight="īdem" wholeWord>
+          ergō numerus syllabārum et vōcālium īdem est
+        </Highlight>
+      );
+
+      const marks = container.querySelectorAll('mark');
+      expect(marks).toHaveLength(1);
+      expect(marks[0].textContent).toBe('īdem');
+    });
   });
 
   it('adds data-highlight attribute to mark elements', () => {

--- a/packages/@mantine/core/src/components/Highlight/highlighter/highlighter.test.ts
+++ b/packages/@mantine/core/src/components/Highlight/highlighter/highlighter.test.ts
@@ -123,5 +123,22 @@ describe('@mantine/core/Highlight/highlighter', () => {
         { chunk: '-case testing', highlighted: false },
       ]);
     });
+
+    it('supports unicode letters in wholeWord matching', () => {
+      const text = 'ergō numerus syllabārum et vōcālium īdem est';
+      expect(highlighter(text, 'īdem', { wholeWord: true })).toStrictEqual([
+        { chunk: 'ergō numerus syllabārum et vōcālium ', highlighted: false },
+        { chunk: 'īdem', highlighted: true },
+        { chunk: ' est', highlighted: false },
+      ]);
+    });
+
+    it('does not match inside unicode words when wholeWord is true', () => {
+      const text = 'īdem īdemque';
+      expect(highlighter(text, 'īdem', { wholeWord: true })).toStrictEqual([
+        { chunk: 'īdem', highlighted: true },
+        { chunk: ' īdemque', highlighted: false },
+      ]);
+    });
   });
 });

--- a/packages/@mantine/core/src/components/Highlight/highlighter/highlighter.ts
+++ b/packages/@mantine/core/src/components/Highlight/highlighter/highlighter.ts
@@ -42,8 +42,9 @@ export function highlighter(
           .sort((a, b) => b.length - a.length)
           .join('|');
 
-  const pattern = options.wholeWord ? `\\b(${matcher})\\b` : `(${matcher})`;
-  const re = new RegExp(pattern, 'gi');
+  const pattern = options.wholeWord ? `(?<!\\p{L})(${matcher})(?!\\p{L})` : `(${matcher})`;
+
+  const re = new RegExp(pattern, options.wholeWord ? 'giu' : 'gi');
   const chunks = value
     .split(re)
     .map((part, index) => ({ chunk: part, highlighted: index % 2 === 1 }))


### PR DESCRIPTION
I first reproduced the problem by using Highlight with wholeWord on a string that contains a non‑ASCII word like īdem, and confirmed it did not get highlighted. Next I traced the behavior into packages/@mantine/core/src/components/Highlight/highlighter/highlighter.ts and saw that when wholeWord is enabled it builds the regex with \b(${matcher})\b, which only treats ASCII letters/digits/underscore as “word characters”. 

Then I replaced those \b boundaries with Unicode-aware “letter boundaries” using Unicode property escapes, so the pattern becomes (?<!\p{L})(${matcher})(?!\p{L}), and I updated the RegExp flags to include the u flag (giu) when wholeWord is true so \p{L} is supported. 
After that, I added unit/component tests that highlight īdem correctly and make sure we don’t match inside a longer Unicode word (e.g. īdem should not match inside īdemque). Finally I ran typecheck, lint, formatting, and the relevant Jest tests to verify everything is fine.