### PR TITLE
[mantine.dev] Fix Typography page metadata and Theming sidebar link colliding with core Typography

### DIFF
--- a/apps/mantine.dev/src/mdx/data/mdx-theming-data.ts
+++ b/apps/mantine.dev/src/mdx/data/mdx-theming-data.ts
@@ -36,7 +36,7 @@ export const MDX_THEMING_DATA: Record<string, Frontmatter> = {
     hideHeader: true,
   },
 
-  Typography: {
+  TypographyTheming: {
     title: 'Typography',
     slug: '/theming/typography',
     search: 'Change fonts, @font-face',

--- a/apps/mantine.dev/src/mdx/mdx-nav-data.ts
+++ b/apps/mantine.dev/src/mdx/mdx-nav-data.ts
@@ -94,7 +94,7 @@ const THEMING_PAGES_GROUP: MdxPagesCategory[] = [
       MDX_DATA.ThemeObject,
       MDX_DATA.Colors,
       MDX_DATA.ColorSchemes,
-      MDX_DATA.Typography,
+      MDX_DATA.TypographyTheming,
       MDX_DATA.DefaultProps,
     ],
   },

--- a/apps/mantine.dev/src/pages/theming/typography.mdx
+++ b/apps/mantine.dev/src/pages/theming/typography.mdx
@@ -3,7 +3,7 @@ import { ThemingDemos } from '@docs/demos';
 import { Layout } from '@/layout';
 import { MDX_DATA } from '@/mdx';
 
-export default Layout(MDX_DATA.Typography);
+export default Layout(MDX_DATA.TypographyTheming);
 
 # Typography
 


### PR DESCRIPTION
Closes #8848.

## Bug
`apps/mantine.dev/src/mdx/mdx-data.ts` builds a single `MDX_DATA` map by spreading multiple data files. Both `MDX_THEMING_DATA` and `MDX_CORE_DATA` define a `Typography` key.
Since `MDX_CORE_DATA` is spread after `MDX_THEMING_DATA`, `MDX_DATA.Typography` always resolves to the core component entry (slug `/core/typography`), overriding the theming entry.

Verified locally on `/theming/typography/` against master. The collision causes five visible defects, not just the one in the report:
- The Theming sidebar Typography entry links to `/core/typography/` (the originally reported bug).
- "Edit this page" link points to `pages/core/typography.mdx` (wrong, this is the theming page).
- A "View source code" link to `@mantine/core/src/components/Typography/Typography.tsx` is shown (wrong, theming page is not tied to a component source).
- An `@mantine/core` npm package label is shown (wrong, theming pages are not tied to a package).
- LLM doc link points to `/llms/core-typography.md` instead of `/llms/theming-typography.md`.

## Fix

Rename `MDX_THEMING_DATA.Typography` to `MDX_THEMING_DATA.TypographyTheming` to remove the namespace collision, then update the two call sites that should reference the theming version:
- `apps/mantine.dev/src/mdx/data/mdx-theming-data.ts`: rename the key.
- `apps/mantine.dev/src/mdx/mdx-nav-data.ts`: reference `MDX_DATA.TypographyTheming` in `THEMING_PAGES_GROUP`; the `COMPONENTS_PAGES_GROUP` reference is left unchanged so it still points at core `Typography`.
- `apps/mantine.dev/src/pages/theming/typography.mdx`: reference `MDX_DATA.TypographyTheming` for layout metadata.

3 lines changed across 3 files.

## Verification
Verified locally with `yarn docs` by toggling the fix on/off via `git stash`. Before the fix, all five defects above are visible. After the fix, all five are corrected, and `/core/typography/` continues to render unchanged (the components-side reference still resolves to core `Typography`).
`npx oxlint` and `npm run format:write:files` both pass on the changed files.