### PR TITLE
[@mantine/core] Highlight: Fix wholeWord matching for non-ASCII characters

### DIFF
--- a/packages/@mantine/core/src/components/Highlight/highlighter/highlighter.test.ts
+++ b/packages/@mantine/core/src/components/Highlight/highlighter/highlighter.test.ts
@@ -123,5 +123,46 @@ describe('@mantine/core/Highlight/highlighter', () => {
         { chunk: '-case testing', highlighted: false },
       ]);
     });
+
+    it('matches whole word containing non-ASCII letters', () => {
+      const text = 'ergō numerus syllabārum et vōcālium īdem est';
+      expect(highlighter(text, 'īdem', { wholeWord: true })).toStrictEqual([
+        { chunk: 'ergō numerus syllabārum et vōcālium ', highlighted: false },
+        { chunk: 'īdem', highlighted: true },
+        { chunk: ' est', highlighted: false },
+      ]);
+    });
+
+    it('matches whole word containing accented characters', () => {
+      const text = 'I love café and croissant';
+      expect(highlighter(text, 'café', { wholeWord: true })).toStrictEqual([
+        { chunk: 'I love ', highlighted: false },
+        { chunk: 'café', highlighted: true },
+        { chunk: ' and croissant', highlighted: false },
+      ]);
+    });
+
+    it('does not match partial word across Unicode letter boundary', () => {
+      const text = 'cafés are nice';
+      expect(highlighter(text, 'café', { wholeWord: true })).toStrictEqual([
+        { chunk: 'cafés are nice', highlighted: false },
+      ]);
+    });
+
+    it('does not match word adjacent to digit', () => {
+      const text = 'test test1 final';
+      expect(highlighter(text, 'test', { wholeWord: true })).toStrictEqual([
+        { chunk: 'test', highlighted: true },
+        { chunk: ' test1 final', highlighted: false },
+      ]);
+    });
+
+    it('does not match word adjacent to underscore', () => {
+      const text = 'hello hello_world end';
+      expect(highlighter(text, 'hello', { wholeWord: true })).toStrictEqual([
+        { chunk: 'hello', highlighted: true },
+        { chunk: ' hello_world end', highlighted: false },
+      ]);
+    });
   });
 });

--- a/packages/@mantine/core/src/components/Highlight/highlighter/highlighter.ts
+++ b/packages/@mantine/core/src/components/Highlight/highlighter/highlighter.ts
@@ -1,5 +1,5 @@
 function escapeRegex(value: string) {
-  return value.replace(/[-[\]{}()*+?.,\\^$|#]/g, '\\$&');
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
 }
 
 export interface HighlightChunk {
@@ -42,8 +42,10 @@ export function highlighter(
           .sort((a, b) => b.length - a.length)
           .join('|');
 
-  const pattern = options.wholeWord ? `\\b(${matcher})\\b` : `(${matcher})`;
-  const re = new RegExp(pattern, 'gi');
+  const pattern = options.wholeWord
+    ? `(?<![\\p{L}\\p{N}_])(${matcher})(?![\\p{L}\\p{N}_])`
+    : `(${matcher})`;
+  const re = new RegExp(pattern, options.wholeWord ? 'giu' : 'gi');
   const chunks = value
     .split(re)
     .map((part, index) => ({ chunk: part, highlighted: index % 2 === 1 }))


### PR DESCRIPTION
 Closes #8838.

## Bug
`Highlight` with `wholeWord` fails to match words that contain non-ASCII letters (`īdem`, `café`, `тест`). Reporter traced this to `highlighter.ts:45`, where the regex uses
ASCII `\b`. Since `\w` in JavaScript regex is ASCII-only (`[A-Za-z0-9_]`), characters like `é` and `ī` are treated as non-word, producing spurious word boundaries inside words.

## Fix
Two changes in `packages/@mantine/core/src/components/Highlight/highlighter/highlighter.ts`:
1. **`wholeWord` pattern**: replace `\b...\b` with Unicode-aware lookarounds `(?<![\p{L}\p{N}_])...(?![\p{L}\p{N}_])` and add the `u` flag. The character class `[\p{L}\p{N}_]` mirrors `\b`'s notion of "word character" (`\w` = letters + digits + underscore) but in a Unicode-aware way: any Unicode letter or number, plus underscore.
2. **`escapeRegex`**: tightened to escape only the actual ECMAScript regex syntax characters (`\ ^ $ . * + ? ( ) [ ] { } |`). The previous version also escaped `-`, `,`, `#`, which are not regex syntax. In non-`u` mode this over-escaping was a no-op, but under the new `u` flag it would throw `SyntaxError` for any wholeWord search containing those characters. Behavior is unchanged for the existing test suite.

## Tests (TDD)
Added 5 new test cases under `wholeWord option` in `highlighter.test.ts`:
- Reporter's exact case: `īdem` matches in Latin text.
- Common accented case: `café` matches in `I love café and croissant`.
- Negative Unicode case: `café` does NOT match inside `cafés` (lookahead correctly sees `s` as a letter).
- Digit-adjacent case: `test` does NOT match inside `test1` (lookahead sees `1` as `\p{N}`).
- Underscore-adjacent case: `hello` does NOT match inside `hello_world` (lookahead sees `_`).

Verified TDD red -> green: with the original code, the first three Unicode tests fail; the underscore test fails after only adding `[\p{L}\p{N}]` (without `_`). All 74 Highlight tests pass after the full fix.
`npx oxlint` and `npm run format:write:files` both pass on the changed files.