### PR TITLE
[@mantine/core] Fix renderOption type

### DIFF
--- a/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
@@ -124,7 +124,7 @@ export interface MultiSelectProps<Value extends Primitive = string>
   hiddenInputValuesDivider?: string;
 
   /** A function to render content of the option, replaces the default content of the option */
-  renderOption?: (item: ComboboxLikeRenderOptionInput<ComboboxItem>) => React.ReactNode;
+  renderOption?: (item: ComboboxLikeRenderOptionInput<ComboboxItem<Value>>) => React.ReactNode;
 
   /** A function to render content of the pill */
   renderPill?: (props: ComboboxRenderPillInput<Value>) => React.ReactNode;

--- a/packages/@mantine/core/src/components/Select/Select.tsx
+++ b/packages/@mantine/core/src/components/Select/Select.tsx
@@ -94,7 +94,7 @@ export interface SelectProps<Value extends Primitive = string>
   hiddenInputProps?: Omit<React.ComponentProps<'input'>, 'value'>;
 
   /** A function to render content of the option, replaces the default content of the option */
-  renderOption?: (item: ComboboxLikeRenderOptionInput<ComboboxItem>) => React.ReactNode;
+  renderOption?: (item: ComboboxLikeRenderOptionInput<ComboboxItem<Value>>) => React.ReactNode;
 
   /** Props passed down to the underlying `ScrollArea` component in the dropdown */
   scrollAreaProps?: ScrollAreaProps;


### PR DESCRIPTION
The `renderOption` type of `Select` and `MultiSelect` use the wrong default generic type. The PR fixes it by passing the generic `Value` type from the component to it.