### PR TITLE
[mantine.dev] Fix docs mobile navbar scroll lock margin

### DIFF
--- a/apps/mantine.dev/src/components/Shell/DocsNavbar/DocsMobileNavbar.tsx
+++ b/apps/mantine.dev/src/components/Shell/DocsNavbar/DocsMobileNavbar.tsx
@@ -14,7 +14,7 @@ export function DocsMobileNavbar() {
   const isMobile = useMediaQuery('(max-width: 67.5em)');
 
   return (
-    <ReactRemoveScroll enabled={isMobile}>
+    <ReactRemoveScroll enabled={isMobile} removeScrollBar={false}>
       <nav className={classes.mobileNavbar}>
         <ScrollArea h="calc(100vh - var(--docs-header-height))" type="never">
           <div className={classes.mobileNavbarInner}>{categories}</div>


### PR DESCRIPTION
## Summary

Closes #8831.

Prevents the docs mobile navbar scroll lock from adding scrollbar gap compensation to the `body` when the menu is opened.

## Changes

- Set `removeScrollBar={false}` on `ReactRemoveScroll` in `DocsMobileNavbar`.

## Verification

- Tested on Windows (Chrome and Edge)
- `npm run test:all` (All 587 test suites passed)
