### PR TITLE
[@mantine/spotlight] Fix SyntaxError thrown by triggerSelectedAction when listId is empty

### DIFF
--- a/packages/@mantine/spotlight/src/Spotlight.test.tsx
+++ b/packages/@mantine/spotlight/src/Spotlight.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, tests } from '@mantine-tests/core';
 import { Spotlight, SpotlightProps, SpotlightStylesNames } from './Spotlight';
-import { spotlight } from './spotlight.store';
+import { createSpotlightStore, spotlight, triggerSelectedAction } from './spotlight.store';
 import { SpotlightAction } from './SpotlightAction';
 import { SpotlightActionsList } from './SpotlightActionsList';
 import { SpotlightEmpty } from './SpotlightEmpty';
@@ -64,5 +64,10 @@ describe('@mantine/core/Spotlight', () => {
 
     expect(screen.getByText('Nothing found')).toBeInTheDocument();
     expect(container.querySelector('.mantine-Spotlight-actionsList')).toBe(null);
+  });
+
+  it('triggerSelectedAction does not throw when listId is empty', () => {
+    const store = createSpotlightStore();
+    expect(() => triggerSelectedAction(store)).not.toThrow();
   });
 });

--- a/packages/@mantine/spotlight/src/spotlight.store.ts
+++ b/packages/@mantine/spotlight/src/spotlight.store.ts
@@ -115,9 +115,9 @@ export function selectPreviousAction(store: SpotlightStore) {
 
 export function triggerSelectedAction(store: SpotlightStore) {
   const state = store.getState();
-  const selected = findElementByQuerySelector<HTMLButtonElement>(
-    `#${state.listId} [data-selected]`
-  );
+  const selected = state.listId
+    ? findElementByQuerySelector<HTMLButtonElement>(`#${state.listId} [data-selected]`)
+    : null;
   selected?.click();
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds a guard for an empty `listId` in `triggerSelectedAction` so it no longer constructs an invalid CSS selector and throws a `SyntaxError`.

## Why?

`createSpotlightStore` initializes `listId: ''`. If the consumer keeps `<Spotlight />` mounted globally, `listId` can also be reset between mount/unmount cycles (e.g. during route transitions). When a user presses Enter while the spotlight input has focus before `setListId` runs, `triggerSelectedAction` builds the selector `# [data-selected]` from `\`#${state.listId} [data-selected]\`` and calls `document.querySelector` with it, which throws:

```
SyntaxError: Failed to execute 'querySelector' on 'Document':
'# [data-selected]' is not a valid selector.
```

The same code path was already guarded in `selectAction` (line 94) with `state.listId ? ... : null`. This PR applies the same pattern to `triggerSelectedAction` for consistency.

## Changes

- `packages/@mantine/spotlight/src/spotlight.store.ts` — only call `findElementByQuerySelector` when `state.listId` is truthy, mirroring the existing `selectAction` pattern
- `packages/@mantine/spotlight/src/Spotlight.test.tsx` — add a regression test asserting `triggerSelectedAction` does not throw when `listId` is empty

## Verification

- `npx jest packages/@mantine/spotlight/src/Spotlight.test.tsx` — 44 passed (incl. new test)
- `npx tsc --noEmit` — passes
- `npx oxlint <changed files>` — 0 warnings, 0 errors
- `npx oxfmt --check <changed files>` — formatted