### PR TITLE
[mantine.dev] HtmlText: Sanitize markdown rendering

### DIFF
--- a/apps/mantine.dev/src/components/HtmlText/HtmlText.test.tsx
+++ b/apps/mantine.dev/src/components/HtmlText/HtmlText.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from '@jest/globals';
+import { render } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { HtmlText, replaceMarkdown } from './HtmlText';
+
+describe('@mantine.dev/HtmlText', () => {
+  it('escapes raw html input', () => {
+    const result = replaceMarkdown('<script>alert(1)</script>');
+
+    expect(result).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(result).not.toContain('<script>');
+  });
+
+  it('sanitizes unsafe markdown links', () => {
+    const result = replaceMarkdown('[Click](javascript:alert(1))');
+
+    expect(result).toContain('href="#"');
+    expect(result).toContain('target="_blank"');
+    expect(result).toContain('rel="noreferrer"');
+  });
+
+  it('keeps safe links unchanged', () => {
+    const result = replaceMarkdown('[Mantine](https://mantine.dev)');
+
+    expect(result).toContain('href="https://mantine.dev"');
+  });
+
+  it('renders escaped content in component', () => {
+    const { container } = render(
+      <MantineProvider>
+        <HtmlText>{'<img src=x onerror=alert(1) />'}</HtmlText>
+      </MantineProvider>
+    );
+
+    expect(container.querySelector('img')).toBe(null);
+    expect(container.textContent).toContain('<img src=x onerror=alert(1) />');
+  });
+});

--- a/apps/mantine.dev/src/components/HtmlText/HtmlText.tsx
+++ b/apps/mantine.dev/src/components/HtmlText/HtmlText.tsx
@@ -5,12 +5,34 @@ interface HtmlTextProps extends TextProps, ElementProps<'span', 'color'> {
   children: string;
 }
 
-function replaceMarkdown(str: string): string {
+function escapeHtml(str: string): string {
   return str
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function sanitizeHref(href: string): string {
+  const normalized = href.trim();
+
+  if (/^(https?:|mailto:|tel:)/i.test(normalized)) {
+    return normalized;
+  }
+
+  return '#';
+}
+
+export function replaceMarkdown(str: string): string {
+  return escapeHtml(str)
     .replace(/`([^`]+)`/g, '<code>$1</code>')
     .replace(/!important!/g, '<b>Important</b>')
     .replace(/@deprecated/g, '<i>Deprecated:</i>')
-    .replace(/\[([^\]]+)\]\((.*?)\)/g, '<a href="$2" target="_blank" ref="noreferrer">$1</a>')
+    .replace(/\[([^\]]+)\]\((.*?)\)/g, (_, text, href) => {
+      const safeHref = sanitizeHref(String(href));
+      return `<a href="${safeHref}" target="_blank" rel="noreferrer">${text}</a>`;
+    })
     .replace(/(?:^|\n)((?:- .+(?:\n|$))+)/g, (_, list) => {
       const items = list.replace(/(?:^|\n)- (.+)/g, '<li>$1</li>');
       return `<ul>${items}</ul>`;


### PR DESCRIPTION
## Summary

Harden `HtmlText` in the docs app by escaping input before markdown conversion and sanitizing markdown link targets.

Closes #8867

## What changed

- Escapes raw HTML before applying markdown replacements.
- Sanitizes link `href` values to allow only safe protocols.
- Uses `rel="noreferrer"` on generated links.
- Adds tests covering HTML escaping and unsafe link handling.

## Validation

- `npm run typecheck`
- `npm run oxlint -- apps/mantine.dev/src/components/HtmlText/HtmlText.tsx apps/mantine.dev/src/components/HtmlText/HtmlText.test.tsx`
- `npm run jest -- apps/mantine.dev/src/components/HtmlText/HtmlText.test.tsx`
- `npm run format:write:files apps/mantine.dev/src/components/HtmlText/HtmlText.tsx apps/mantine.dev/src/components/HtmlText/HtmlText.test.tsx`