### PR TITLE
[help.mantine.dev] Fix placeholder selector in docs: use &::placehold…

### DIFF
--- a/apps/help.mantine.dev/src/pages/q/inputs-placeholder-color.mdx
+++ b/apps/help.mantine.dev/src/pages/q/inputs-placeholder-color.mdx
@@ -16,7 +16,7 @@ export default Layout(meta);
 
 All Mantine inputs can be divided into two groups:
 
-- Inputs that are based on the `<input />` HTML element (for example, [TextInput](https://mantine.dev/core/text-input)). For these inputs, use the `&:placeholder` selector to change placeholder color.
+- Inputs that are based on the `<input />` HTML element (for example, [TextInput](https://mantine.dev/core/text-input)). For these inputs, use the `&::placeholder` selector to change placeholder color.
 - Inputs that are based on the `<button />` HTML element (for example, [DatePickerInput](https://mantine.dev/dates/date-picker-input)). For these inputs, use [Styles API](https://mantine.dev/styles/styles-api) to change placeholder color.
 
 <Demo data={InputPlaceholderColorDemo} />


### PR DESCRIPTION
## Fix Details

This PR corrects a CSS selector in the placeholder color documentation.

**What was changed:**
- Updated the placeholder selector from `&:placeholder` to `&::placeholder` in the input placeholder color documentation

**Why:**
The correct CSS pseudo-element syntax for styling placeholder text is `::placeholder` (double colon), not `:placeholder` (single colon). The double colon syntax is the proper pseudo-element notation in CSS.

**Validation:**
- TypeScript type checking: Passed
- Linting with oxlint: Passed (0 warnings, 0 errors)
- Single file modified, single line changed

This is a docs-only correction with no API or behavior changes.