### PR TITLE
Add aria-valuetext support to Slider and RangeSlider

### DIFF
--- a/apps/mantine.dev/src/pages/core/range-slider.mdx
+++ b/apps/mantine.dev/src/pages/core/range-slider.mdx
@@ -167,6 +167,24 @@ function Demo() {
 }
 ```
 
+When `scale` is used or the displayed value is formatted (for example as a currency or
+percentage), set `thumbValueText` to provide a human-readable value for screen readers.
+It is rendered as `aria-valuetext` on both thumbs. When a function is provided, it receives
+the scaled value of the corresponding thumb:
+
+```tsx
+import { RangeSlider } from '@mantine/core';
+
+function Demo() {
+  return (
+    <RangeSlider
+      scale={(v) => v * 10}
+      thumbValueText={(value) => `${value}%`}
+    />
+  );
+}
+```
+
 ## Keyboard interactions
 
 <KeyboardEventsTable

--- a/apps/mantine.dev/src/pages/core/slider.mdx
+++ b/apps/mantine.dev/src/pages/core/slider.mdx
@@ -190,6 +190,24 @@ function Demo() {
 }
 ```
 
+When `scale` is used or the displayed value is formatted (for example as a currency or
+percentage), set `thumbValueText` to provide a human-readable value for screen readers.
+It is rendered as `aria-valuetext` on the thumb. When a function is provided, it receives
+the scaled value:
+
+```tsx
+import { Slider } from '@mantine/core';
+
+function Demo() {
+  return (
+    <Slider
+      scale={(v) => v * 10}
+      thumbValueText={(value) => `$${value}`}
+    />
+  );
+}
+```
+
 ## Keyboard interactions
 
 <KeyboardEventsTable

--- a/packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.test.tsx
+++ b/packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.test.tsx
@@ -256,4 +256,18 @@ describe('@mantine/core/RangeSlider', () => {
     expect(screen.getByLabelText('From slider')).toBeInTheDocument();
     expect(screen.getByLabelText('To slider')).toBeInTheDocument();
   });
+
+  it('sets aria-valuetext for both thumbs from callback', () => {
+    render(
+      <RangeSlider
+        defaultValue={[20, 80]}
+        scale={(value) => value * 10}
+        ariaValueText={(value) => `${value}%`}
+      />
+    );
+
+    const sliders = getSliders();
+    expect(sliders[0]).toHaveAttribute('aria-valuetext', '200%');
+    expect(sliders[1]).toHaveAttribute('aria-valuetext', '800%');
+  });
 });

--- a/packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.test.tsx
+++ b/packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.test.tsx
@@ -257,12 +257,26 @@ describe('@mantine/core/RangeSlider', () => {
     expect(screen.getByLabelText('To slider')).toBeInTheDocument();
   });
 
+  it('does not set aria-valuetext when thumbValueText is not provided', () => {
+    render(<RangeSlider defaultValue={[20, 80]} />);
+    const sliders = getSliders();
+    expect(sliders[0]).not.toHaveAttribute('aria-valuetext');
+    expect(sliders[1]).not.toHaveAttribute('aria-valuetext');
+  });
+
+  it('sets aria-valuetext for both thumbs from a string', () => {
+    render(<RangeSlider defaultValue={[20, 80]} thumbValueText="custom" />);
+    const sliders = getSliders();
+    expect(sliders[0]).toHaveAttribute('aria-valuetext', 'custom');
+    expect(sliders[1]).toHaveAttribute('aria-valuetext', 'custom');
+  });
+
   it('sets aria-valuetext for both thumbs from callback', () => {
     render(
       <RangeSlider
         defaultValue={[20, 80]}
         scale={(value) => value * 10}
-        ariaValueText={(value) => `${value}%`}
+        thumbValueText={(value) => `${value}%`}
       />
     );
 

--- a/packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.tsx
+++ b/packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.tsx
@@ -126,6 +126,9 @@ export interface RangeSliderProps
   /** `aria-label` for both thumbs (overridden by thumbFromLabel/thumbToLabel if provided) */
   thumbLabel?: string;
 
+  /** `aria-valuetext` for both thumbs */
+  ariaValueText?: string | ((value: number) => string);
+
   /** First thumb `aria-label` */
   thumbFromLabel?: string;
 
@@ -205,6 +208,7 @@ export const RangeSlider = factory<RangeSliderFactory>((_props) => {
     labelAlwaysOn,
     thumbFromLabel,
     thumbToLabel,
+    ariaValueText,
     showLabelOnHover,
     thumbChildren,
     disabled,
@@ -595,6 +599,7 @@ export const RangeSlider = factory<RangeSliderFactory>((_props) => {
               }
             }}
             thumbLabel={thumbFromLabel}
+            ariaValueText={ariaValueText}
             onMouseDown={() => handleThumbMouseDown(0)}
             onFocus={() => setFocused(0)}
             showLabelOnHover={showLabelOnHover}
@@ -621,6 +626,7 @@ export const RangeSlider = factory<RangeSliderFactory>((_props) => {
                 thumbs.current[1] = node;
               }
             }}
+            ariaValueText={ariaValueText}
             onMouseDown={() => handleThumbMouseDown(1)}
             onFocus={() => setFocused(1)}
             showLabelOnHover={showLabelOnHover}

--- a/packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.tsx
+++ b/packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.tsx
@@ -126,8 +126,8 @@ export interface RangeSliderProps
   /** `aria-label` for both thumbs (overridden by thumbFromLabel/thumbToLabel if provided) */
   thumbLabel?: string;
 
-  /** `aria-valuetext` for both thumbs */
-  ariaValueText?: string | ((value: number) => string);
+  /** `aria-valuetext` for both thumbs. When a function is provided, it receives the scaled value. */
+  thumbValueText?: string | ((value: number) => string);
 
   /** First thumb `aria-label` */
   thumbFromLabel?: string;
@@ -208,7 +208,7 @@ export const RangeSlider = factory<RangeSliderFactory>((_props) => {
     labelAlwaysOn,
     thumbFromLabel,
     thumbToLabel,
-    ariaValueText,
+    thumbValueText,
     showLabelOnHover,
     thumbChildren,
     disabled,
@@ -599,7 +599,7 @@ export const RangeSlider = factory<RangeSliderFactory>((_props) => {
               }
             }}
             thumbLabel={thumbFromLabel}
-            ariaValueText={ariaValueText}
+            thumbValueText={thumbValueText}
             onMouseDown={() => handleThumbMouseDown(0)}
             onFocus={() => setFocused(0)}
             showLabelOnHover={showLabelOnHover}
@@ -626,7 +626,7 @@ export const RangeSlider = factory<RangeSliderFactory>((_props) => {
                 thumbs.current[1] = node;
               }
             }}
-            ariaValueText={ariaValueText}
+            thumbValueText={thumbValueText}
             onMouseDown={() => handleThumbMouseDown(1)}
             onFocus={() => setFocused(1)}
             showLabelOnHover={showLabelOnHover}

--- a/packages/@mantine/core/src/components/Slider/Slider/Slider.test.tsx
+++ b/packages/@mantine/core/src/components/Slider/Slider/Slider.test.tsx
@@ -112,6 +112,14 @@ describe('@mantine/core/Slider', () => {
     expect(screen.getByText('test-label-60')).toBeInTheDocument();
   });
 
+  it('sets aria-valuetext from string or callback', () => {
+    const { rerender } = render(<Slider value={50} ariaValueText="$50" />);
+    expect(screen.getByRole('slider')).toHaveAttribute('aria-valuetext', '$50');
+
+    rerender(<Slider value={50} scale={(v) => v * 10} ariaValueText={(value) => `$${value}`} />);
+    expect(screen.getByRole('slider')).toHaveAttribute('aria-valuetext', '$500');
+  });
+
   it('clamps initial value based on min prop', () => {
     const { container } = render(<Slider defaultValue={60} min={100} />);
     expectInputValue('100', container);

--- a/packages/@mantine/core/src/components/Slider/Slider/Slider.test.tsx
+++ b/packages/@mantine/core/src/components/Slider/Slider/Slider.test.tsx
@@ -112,11 +112,16 @@ describe('@mantine/core/Slider', () => {
     expect(screen.getByText('test-label-60')).toBeInTheDocument();
   });
 
+  it('does not set aria-valuetext when thumbValueText is not provided', () => {
+    render(<Slider value={50} />);
+    expect(screen.getByRole('slider')).not.toHaveAttribute('aria-valuetext');
+  });
+
   it('sets aria-valuetext from string or callback', () => {
-    const { rerender } = render(<Slider value={50} ariaValueText="$50" />);
+    const { rerender } = render(<Slider value={50} thumbValueText="$50" />);
     expect(screen.getByRole('slider')).toHaveAttribute('aria-valuetext', '$50');
 
-    rerender(<Slider value={50} scale={(v) => v * 10} ariaValueText={(value) => `$${value}`} />);
+    rerender(<Slider value={50} scale={(v) => v * 10} thumbValueText={(value) => `$${value}`} />);
     expect(screen.getByRole('slider')).toHaveAttribute('aria-valuetext', '$500');
   });
 

--- a/packages/@mantine/core/src/components/Slider/Slider/Slider.tsx
+++ b/packages/@mantine/core/src/components/Slider/Slider/Slider.tsx
@@ -93,6 +93,9 @@ export interface SliderProps
   /** Thumb `aria-label` */
   thumbLabel?: string;
 
+  /** Thumb `aria-valuetext` */
+  ariaValueText?: string | ((value: number) => string);
+
   /** Determines whether the label should be displayed when the slider is hovered @default true */
   showLabelOnHover?: boolean;
 
@@ -181,6 +184,7 @@ export const Slider = factory<SliderFactory>((_props) => {
     labelTransitionProps,
     labelAlwaysOn,
     thumbLabel,
+    ariaValueText,
     showLabelOnHover,
     thumbChildren,
     disabled,
@@ -458,6 +462,7 @@ export const Slider = factory<SliderFactory>((_props) => {
             labelTransitionProps={labelTransitionProps}
             labelAlwaysOn={labelAlwaysOn}
             thumbLabel={thumbLabel}
+            ariaValueText={ariaValueText}
             showLabelOnHover={showLabelOnHover}
             isHovered={hovered}
             disabled={disabled}

--- a/packages/@mantine/core/src/components/Slider/Slider/Slider.tsx
+++ b/packages/@mantine/core/src/components/Slider/Slider/Slider.tsx
@@ -93,8 +93,8 @@ export interface SliderProps
   /** Thumb `aria-label` */
   thumbLabel?: string;
 
-  /** Thumb `aria-valuetext` */
-  ariaValueText?: string | ((value: number) => string);
+  /** Thumb `aria-valuetext`. When a function is provided, it receives the scaled value. */
+  thumbValueText?: string | ((value: number) => string);
 
   /** Determines whether the label should be displayed when the slider is hovered @default true */
   showLabelOnHover?: boolean;
@@ -184,7 +184,7 @@ export const Slider = factory<SliderFactory>((_props) => {
     labelTransitionProps,
     labelAlwaysOn,
     thumbLabel,
-    ariaValueText,
+    thumbValueText,
     showLabelOnHover,
     thumbChildren,
     disabled,
@@ -462,7 +462,7 @@ export const Slider = factory<SliderFactory>((_props) => {
             labelTransitionProps={labelTransitionProps}
             labelAlwaysOn={labelAlwaysOn}
             thumbLabel={thumbLabel}
-            ariaValueText={ariaValueText}
+            thumbValueText={thumbValueText}
             showLabelOnHover={showLabelOnHover}
             isHovered={hovered}
             disabled={disabled}

--- a/packages/@mantine/core/src/components/Slider/Thumb/Thumb.tsx
+++ b/packages/@mantine/core/src/components/Slider/Thumb/Thumb.tsx
@@ -10,6 +10,7 @@ export interface ThumbProps extends Omit<React.ComponentProps<'div'>, 'value'> {
   position: number;
   dragging: boolean;
   label: React.ReactNode;
+  ariaValueText?: string | ((value: number) => string);
   onKeyDownCapture?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
   onMouseDown?: (event: any) => void;
   labelTransitionProps: TransitionOverride | undefined;
@@ -36,6 +37,7 @@ export function Thumb({
   labelTransitionProps,
   labelAlwaysOn,
   thumbLabel,
+  ariaValueText,
   onFocus,
   onBlur,
   showLabelOnHover,
@@ -50,6 +52,7 @@ export function Thumb({
   const [focused, setFocused] = useState(false);
 
   const isVisible = labelAlwaysOn || dragging || focused || (showLabelOnHover && isHovered);
+  const valueText = typeof ariaValueText === 'function' ? ariaValueText(value) : ariaValueText;
 
   return (
     <Box<'div'>
@@ -59,6 +62,7 @@ export function Thumb({
       aria-valuemax={max}
       aria-valuemin={min}
       aria-valuenow={value}
+      aria-valuetext={valueText}
       aria-disabled={disabled}
       aria-orientation={orientation}
       ref={ref}

--- a/packages/@mantine/core/src/components/Slider/Thumb/Thumb.tsx
+++ b/packages/@mantine/core/src/components/Slider/Thumb/Thumb.tsx
@@ -10,7 +10,7 @@ export interface ThumbProps extends Omit<React.ComponentProps<'div'>, 'value'> {
   position: number;
   dragging: boolean;
   label: React.ReactNode;
-  ariaValueText?: string | ((value: number) => string);
+  thumbValueText?: string | ((value: number) => string);
   onKeyDownCapture?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
   onMouseDown?: (event: any) => void;
   labelTransitionProps: TransitionOverride | undefined;
@@ -37,7 +37,7 @@ export function Thumb({
   labelTransitionProps,
   labelAlwaysOn,
   thumbLabel,
-  ariaValueText,
+  thumbValueText,
   onFocus,
   onBlur,
   showLabelOnHover,
@@ -52,7 +52,7 @@ export function Thumb({
   const [focused, setFocused] = useState(false);
 
   const isVisible = labelAlwaysOn || dragging || focused || (showLabelOnHover && isHovered);
-  const valueText = typeof ariaValueText === 'function' ? ariaValueText(value) : ariaValueText;
+  const valueText = typeof thumbValueText === 'function' ? thumbValueText(value) : thumbValueText;
 
   return (
     <Box<'div'>


### PR DESCRIPTION
## Summary

Adds optional `ariaValueText` prop to `Slider` and `RangeSlider` so authors can provide a human-readable accessible value (string or callback). The prop is passed to the thumb(s) and rendered as `aria-valuetext`. This makes screen readers announce formatted or scaled values (e.g., "$50", "50%") and addresses accessibility request mantinedev/mantine#8870.

## Changes

- Add `ariaValueText?: string | ((value: number) => string)` to:
  - packages/@mantine/core/src/components/Slider/Slider/Slider.tsx
  - packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.tsx
- Pass `ariaValueText` to `Thumb` and render `aria-valuetext` in:
  - packages/@mantine/core/src/components/Slider/Thumb/Thumb.tsx
- Tests:
  - Added assertions in Slider and RangeSlider tests to verify `aria-valuetext` (including scaled values)

## Files touched

- packages/@mantine/core/src/components/Slider/Thumb/Thumb.tsx
- packages/@mantine/core/src/components/Slider/Slider/Slider.tsx
- packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.tsx
- packages/@mantine/core/src/components/Slider/Slider/Slider.test.tsx
- packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.test.tsx

## Why

The WAI-ARIA slider pattern recommends `aria-valuetext` to provide a human-readable representation of the current value. When `scale` or formatted labels are used, assistive technology should be able to announce the formatted value, not only the raw numeric value.

## How I tested locally

- Unit tests (slider files only):
  npm run jest packages/@mantine/core/src/components/Slider/Slider/Slider.test.tsx packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.test.tsx

- Formatting:
  npm run format:write:files <changed-files>

- Lint:
  npx oxlint <changed-files>

- Typecheck:
  npm run typecheck

All the focused tests passed locally and repo typecheck completed in my environment.

## Manual test steps

1. Open a demo or app page that renders a slider (or create a small demo):
```tsx
<Slider scale={(v) => v * 10} ariaValueText={(value) => `$${value}`} />
```
2. Inspect the thumb element in DevTools and verify it has `aria-valuetext="$500"` (example).
3. Optionally use a screen reader to confirm the announced value matches the formatted value.

## Checklist

- [x] Tests added/updated for the change
- [x] Code formatted (oxfmt)
- [x] Linted (oxlint)
- [x] Typecheck passes
- [ ] Changelog entry (optional)
