### PR TITLE
fix(MantineProvider): mergeMantineTheme no longer mutates DEFAULT_THEME.headings

### DIFF
--- a/packages/@mantine/core/src/core/MantineProvider/merge-mantine-theme/merge-mantine-theme.test.ts
+++ b/packages/@mantine/core/src/core/MantineProvider/merge-mantine-theme/merge-mantine-theme.test.ts
@@ -95,4 +95,24 @@ describe('@mantine/core/merge-mantine-theme', () => {
   it('merges theme and override correctly when override is undefined', () => {
     expect(mergeMantineTheme(DEFAULT_THEME, undefined)).toBe(DEFAULT_THEME);
   });
+
+  it('does not mutate currentTheme.headings when only fontFamily is overridden', () => {
+    const originalFontFamily = DEFAULT_THEME.headings.fontFamily;
+    const originalHeadings = DEFAULT_THEME.headings;
+
+    mergeMantineTheme(DEFAULT_THEME, { fontFamily: 'mutation-canary' });
+
+    expect(DEFAULT_THEME.headings.fontFamily).toBe(originalFontFamily);
+    expect(DEFAULT_THEME.headings).toBe(originalHeadings);
+  });
+
+  it('does not leak fontFamily across successive merges', () => {
+    const originalFontFamily = DEFAULT_THEME.headings.fontFamily;
+
+    mergeMantineTheme(DEFAULT_THEME, { fontFamily: 'first-tenant-font' });
+    const subsequent = mergeMantineTheme(DEFAULT_THEME, { defaultRadius: 'sm' });
+
+    expect(subsequent.headings.fontFamily).toBe(originalFontFamily);
+    expect(subsequent.headings.fontFamily).not.toBe('first-tenant-font');
+  });
 });

--- a/packages/@mantine/core/src/core/MantineProvider/merge-mantine-theme/merge-mantine-theme.ts
+++ b/packages/@mantine/core/src/core/MantineProvider/merge-mantine-theme/merge-mantine-theme.ts
@@ -45,8 +45,11 @@ export function mergeMantineTheme(
 
   const result = deepMerge(currentTheme, themeOverride);
 
+  // deepMerge does a shallow root spread, so result.headings still aliases
+  // currentTheme.headings when the override has no `headings` key. Reassign
+  // rather than mutate to keep the input (typically DEFAULT_THEME) untouched.
   if (themeOverride.fontFamily && !themeOverride.headings?.fontFamily) {
-    result.headings.fontFamily = themeOverride.fontFamily;
+    result.headings = { ...result.headings, fontFamily: themeOverride.fontFamily };
   }
 
   validateMantineTheme(result);


### PR DESCRIPTION
# `mergeMantineTheme` mutates `DEFAULT_THEME.headings.fontFamily` via shallow-spread aliasing

## TL;DR

When a theme override sets `fontFamily` but not `headings.fontFamily`, `mergeMantineTheme` mutates the shared module-level `DEFAULT_THEME.headings.fontFamily`. The mutation survives for the lifetime of the JS realm and corrupts every subsequent merge — including merges with no override at all.

In SSR apps, this means **the first request that renders with a custom font permanently changes the heading font of every other request** until the Node process restarts.

## Affected version

`@mantine/core@9.1.1` (and presumably 9.x, possibly earlier).

## Reproduction

```ts
import { DEFAULT_THEME, mergeMantineTheme } from '@mantine/core'

console.log('before:', DEFAULT_THEME.headings.fontFamily)
// → "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji"

mergeMantineTheme(DEFAULT_THEME, {
  fontFamily: 'system-ui, sans-serif',
})

console.log('after:', DEFAULT_THEME.headings.fontFamily)
// → "system-ui, sans-serif"   ← MUTATED

// And subsequent merges that don't touch fontFamily inherit the corruption:
const next = mergeMantineTheme(DEFAULT_THEME, { defaultRadius: 'sm' })
console.log('next:', next.headings.fontFamily)
// → "system-ui, sans-serif"   ← still wrong
```

## Root cause

In `packages/@mantine/core/src/core/MantineProvider/merge-mantine-theme/merge-mantine-theme.ts`:

```ts
function mergeMantineTheme(currentTheme, themeOverride) {
  if (!themeOverride) { /* … */ }
  const result = deepMerge(currentTheme, themeOverride);
  if (themeOverride.fontFamily && !themeOverride.headings?.fontFamily)
    result.headings.fontFamily = themeOverride.fontFamily;  // ← mutation
  validateMantineTheme(result);
  return result;
}
```

And `deepMerge` (in `packages/@mantine/core/src/core/utils/deep-merge/deep-merge.ts`):

```ts
function deepMerge(target, source) {
  const result = { ...target };  // shallow spread — result.headings === target.headings
  // … only re-creates nested objects for keys present in `source`
}
```

When `themeOverride.headings` is undefined, `deepMerge` doesn't recurse into `headings`, so `result.headings` is still **the same reference as `currentTheme.headings`**. The subsequent `result.headings.fontFamily = ...` writes through to `currentTheme.headings`, which is `DEFAULT_THEME` for all top-level merges. `DEFAULT_THEME` lives in module scope, so the mutation persists.

## Real-world impact

In a multi-tenant Next.js (App Router) app, this manifests as a hydration mismatch on `<style data-mantine-styles>` whenever a request crosses a tenant boundary:

1. Tenant A renders with `theme.fontFamily = 'system-ui, …'` → `DEFAULT_THEME.headings.fontFamily` is mutated to `'system-ui, …'`.
2. Tenant B (no fontFamily override, e.g. an admin or auth page) renders.
3. Tenant B's emitted CSS has:
   - `--mantine-font-family: <Mantine default>` (correct — `theme.fontFamily` wasn't overridden)
   - `--mantine-font-family-headings: 'system-ui, …'` ← **leaked from tenant A**
4. The client tree (which doesn't see the mutation, since hydration computes its own theme) renders different CSS than the SSR HTML → React reports a hydration mismatch on the `<style>` block.

Because the mutation is module-level, it cannot be reset without restarting the Node process. HMR / page reload / client navigation all observe the corruption.

## Workaround for users

Always set `headings.fontFamily` explicitly in your override, even if it duplicates `fontFamily`:

```ts
createTheme({
  fontFamily: 'system-ui, sans-serif',
  headings: { fontFamily: 'system-ui, sans-serif' },  // forces deep-merge path, avoids the mutation
})
```

This makes `themeOverride.headings.fontFamily` truthy so the offending conditional doesn't fire, and the deep-merge inside `deepMerge` produces a fresh `headings` object instead of aliasing the default.

## Suggested fix

Either:

**(a) Stop mutating in the conditional** — clone `result.headings` first:

```ts
const result = deepMerge(currentTheme, themeOverride);
if (themeOverride.fontFamily && !themeOverride.headings?.fontFamily) {
  result.headings = { ...result.headings, fontFamily: themeOverride.fontFamily };
}
```

**(b) Always deep-clone nested objects in `deepMerge`** so `result.headings` is never aliased to the source. Slightly heavier but matches user expectations for an "immutable merge" helper.

(a) is the smaller, more surgical fix.

## Severity

I'd argue this is high-severity for SSR consumers — silent global state corruption that produces hard-to-diagnose hydration warnings, with the symptom only appearing on cross-tenant navigation in the same process. We spent ~8 hours bisecting before locating it; reproducing it in isolation requires understanding shallow-spread aliasing, which makes the trail cold.
