### PR TITLE
docs: fix duplicated words in Modal/AppShell example texts

### DIFF
--- a/apps/mantine.dev/src/app-shell-examples/examples/FullLayout/FullLayout.tsx
+++ b/apps/mantine.dev/src/app-shell-examples/examples/FullLayout/FullLayout.tsx
@@ -23,7 +23,7 @@ export function FullLayout() {
         <Text>This is the main section, your app content here.</Text>
         <Text>AppShell example with all elements: Navbar, Header, Aside, Footer.</Text>
         <Text>All elements except AppShell.Main have fixed position.</Text>
-        <Text>Aside is hidden on on md breakpoint and cannot be opened when it is collapsed</Text>
+        <Text>Aside is hidden on md breakpoint and cannot be opened when it is collapsed</Text>
       </AppShell.Main>
       <AppShell.Aside p="md">Aside</AppShell.Aside>
       <AppShell.Footer p="md">Footer</AppShell.Footer>

--- a/packages/@docs/demos/src/demos/core/Modal/Modal.demo.fullScreen.tsx
+++ b/packages/@docs/demos/src/demos/core/Modal/Modal.demo.fullScreen.tsx
@@ -45,7 +45,7 @@ function Demo() {
         transitionProps={{ transition: 'fade', duration: 200 }}
       >
         <Text mb="xl">
-          It takes the entire screen and does not not have overlay and border-radius, you can use it
+          It takes the entire screen and does not have overlay and border-radius, you can use it
           small screens to save up some space. It also has fade transition by default, but you can
           change that with transition prop. Now here is an authentication form used in previous
           examples to see the difference.


### PR DESCRIPTION
Two one-line typo fixes for duplicated words in example/demo strings:
- `packages/@docs/demos/src/demos/core/Modal/Modal.demo.fullScreen.tsx` — "does not not have overlay" → "does not have overlay"
- `apps/mantine.dev/src/app-shell-examples/examples/FullLayout/FullLayout.tsx` — "Aside is hidden on on md breakpoint" → "Aside is hidden on md breakpoint"

No code/behavior change.