### PR TITLE
[@mantine/hooks] use-color-scheme: Fix typo in test descriptio

### DIFF
--- a/packages/@mantine/hooks/src/use-color-scheme/use-color-scheme.test.tsx
+++ b/packages/@mantine/hooks/src/use-color-scheme/use-color-scheme.test.tsx
@@ -29,7 +29,7 @@ describe('@mantine/hooks/use-color-scheme', () => {
     return colorScheme;
   }
 
-  it('correctly returns initial dark state state without useEffect', () => {
+  it('correctly returns initial dark state without useEffect', () => {
     window.matchMedia = mockMatchMedia;
     render(<WrapperComponent initialValue="dark" getInitialValueInEffect={false} />);
     expect(trace).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Fix a duplicate "state" in a test description (`packages/@mantine/hooks/src/use-color-scheme/use-color-scheme.test.tsx`).
