### PR TITLE
[@mantine/tiptap] Fix RichTextEditor controls crashing on null/destroyed editor

### DIFF
--- a/packages/@mantine/tiptap/src/RichTextEditorControl/RichTextEditorControl.tsx
+++ b/packages/@mantine/tiptap/src/RichTextEditorControl/RichTextEditorControl.tsx
@@ -126,13 +126,15 @@ export function createControl({
             safeEditor && isActive?.name
               ? safeEditor.isActive(isActive.name, isActive.attributes)
               : false,
-          disabled: safeEditor ? (isDisabled?.(safeEditor) ?? false) : false,
+          // Without a usable editor the operation cannot run, so the control must
+          // appear disabled regardless of whether a user-provided `isDisabled` exists.
+          disabled: safeEditor ? (isDisabled?.(safeEditor) ?? false) : true,
         };
       },
     });
 
     const active = editorState?.active ?? false;
-    const disabled = editorState?.disabled ?? false;
+    const disabled = editorState?.disabled ?? true;
 
     return (
       <RichTextEditorControlBase
@@ -142,7 +144,14 @@ export function createControl({
         icon={props.icon || icon}
         disabled={disabled}
         {...props}
-        onClick={() => (editor as any)?.chain().focus()[operation.name](operation.attributes).run()}
+        onClick={() => {
+          // Mirror the selector's guard so a click landing during teardown does not
+          // invoke commands on a `null`/destroyed editor.
+          if (!editor || editor.isDestroyed) {
+            return;
+          }
+          (editor as any).chain().focus()[operation.name](operation.attributes).run();
+        }}
       />
     );
   };

--- a/packages/@mantine/tiptap/src/RichTextEditorControl/RichTextEditorControl.tsx
+++ b/packages/@mantine/tiptap/src/RichTextEditorControl/RichTextEditorControl.tsx
@@ -115,12 +115,20 @@ export function createControl({
     const _label = labels[label] as string;
     const editorState = useEditorState({
       editor: editor ?? null,
-      selector: (ctx) => ({
-        active: isActive?.name
-          ? (ctx.editor?.isActive(isActive.name, isActive.attributes) ?? false)
-          : false,
-        disabled: isDisabled?.(ctx.editor) ?? false,
-      }),
+      selector: (ctx) => {
+        // `ctx.editor` is `null` on the first render before `useEditor()` produces an
+        // instance, and `editor.commandManager` is set to `null` by `editor.destroy()`.
+        // Either state would make `isDisabled?.(ctx.editor)` (which typically calls
+        // `editor.can()`) throw, taking down the surrounding tree.
+        const safeEditor = ctx.editor && !ctx.editor.isDestroyed ? ctx.editor : null;
+        return {
+          active:
+            safeEditor && isActive?.name
+              ? safeEditor.isActive(isActive.name, isActive.attributes)
+              : false,
+          disabled: safeEditor ? (isDisabled?.(safeEditor) ?? false) : false,
+        };
+      },
     });
 
     const active = editorState?.active ?? false;

--- a/packages/@mantine/tiptap/src/RichTextEditorControl/RichTextEditorLinkControl.tsx
+++ b/packages/@mantine/tiptap/src/RichTextEditorControl/RichTextEditorLinkControl.tsx
@@ -112,7 +112,8 @@ export const RichTextEditorLinkControl = factory<RichTextEditorLinkControlFactor
 
   const active = useEditorState({
     editor: ctx.editor ?? null,
-    selector: (state) => state.editor?.isActive('link') ?? false,
+    selector: (state) =>
+      state.editor && !state.editor.isDestroyed ? state.editor.isActive('link') : false,
   });
 
   const { resolvedClassNames, resolvedStyles } =


### PR DESCRIPTION
Closes #8899.

## Summary

Mantine 9.2.1's `createControl` calls `isDisabled?.(ctx.editor)` inside the new `useEditorState` selector without guarding against `ctx.editor` being `null` (initial render, before `useEditor()` produces an instance) or destroyed (`editor.destroy()` sets `commandManager = null`, after which `editor.can()` throws `Cannot read properties of null (reading 'can')`).

Both paths crash the surrounding React subtree synchronously during render, which means every consumer mounting a `RichTextEditor` with `Undo` / `Redo` / `TaskList.Sink` / `TaskList.Lift` is exposed to the crash on the first mount and on every unmount race. Issue #8899 has the full repro and stack trace.

## Fix

In `RichTextEditorControl.tsx` and `RichTextEditorLinkControl.tsx`, treat `ctx.editor` as unusable when it is `null` or `isDestroyed === true`, and short-circuit the selector to safe defaults in those states.

```ts
selector: (ctx) => {
  const safeEditor = ctx.editor && !ctx.editor.isDestroyed ? ctx.editor : null;
  return {
    active:
      safeEditor && isActive?.name
        ? safeEditor.isActive(isActive.name, isActive.attributes)
        : false,
    disabled: safeEditor ? (isDisabled?.(safeEditor) ?? false) : false,
  };
},
```

No behavior change for a live editor — `active` and `disabled` are computed exactly as before. Only the not-yet-mounted and post-`destroy()` windows are now safe.

## Test plan

- [x] `npx tsc --noEmit` (whole repo) passes
- [x] `npx oxfmt --check` on both files passes
- [x] `npx oxlint packages/@mantine/tiptap/src` reports 0 warnings / 0 errors
- [x] Reproduced the original crash against unpatched `9.2.1` using the snippet in #8899
- [x] Verified the patched build no longer crashes when the editor mounts/unmounts

> Note: `@mantine/tiptap` does not currently have any test files in the repo, so no regression test is added in this PR. Happy to add one if the maintainers want — it would require pulling in `@tiptap/*` + a jest setup that the package doesn't have today.
