### PR TITLE
 [@mantine/core] Select: fix clear button not showing for falsy primitive values

### DIFF
--- a/packages/@mantine/core/src/components/Select/Select.test.tsx
+++ b/packages/@mantine/core/src/components/Select/Select.test.tsx
@@ -283,6 +283,54 @@ describe('@mantine/core/Select', () => {
     expect(input).toHaveStyle({ color: 'rgb(255, 0, 0)' });
   });
 
+  it('displays clear button when clearable is true and value is set', () => {
+    const { container } = render(
+      <Select data={['test-1', 'test-2']} value="test-1" clearable onChange={() => {}} />
+    );
+    expect(container.querySelector('.mantine-InputClearButton-root')).toBeInTheDocument();
+  });
+
+  it('does not display clear button when clearable is true and value is null', () => {
+    const { container } = render(
+      <Select data={['test-1', 'test-2']} value={null} clearable onChange={() => {}} />
+    );
+    expect(container.querySelector('.mantine-InputClearButton-root')).not.toBeInTheDocument();
+  });
+
+  it('displays clear button when clearable is true and value is false', () => {
+    const { container } = render(
+      <Select
+        data={[{ value: false, label: 'False option' }]}
+        value={false}
+        clearable
+        onChange={() => {}}
+      />
+    );
+    expect(container.querySelector('.mantine-InputClearButton-root')).toBeInTheDocument();
+  });
+
+  it('displays clear button when clearable is true and value is 0', () => {
+    const { container } = render(
+      <Select data={[{ value: 0, label: 'Zero option' }]} value={0} clearable onChange={() => {}} />
+    );
+    expect(container.querySelector('.mantine-InputClearButton-root')).toBeInTheDocument();
+  });
+
+  it('displays clear button when clearable is true and value is an empty string', () => {
+    const { container } = render(
+      <Select
+        data={[
+          { value: '', label: 'Empty' },
+          { value: 'test-1', label: 'Test 1' },
+        ]}
+        value=""
+        clearable
+        onChange={() => {}}
+      />
+    );
+    expect(container.querySelector('.mantine-InputClearButton-root')).toBeInTheDocument();
+  });
+
   it('allows to change controlled search value when value is controlled and selected', async () => {
     const Wrapper: React.FunctionComponent = () => {
       const [value, setValue] = useState<string | null>('Angular');

--- a/packages/@mantine/core/src/components/Select/Select.tsx
+++ b/packages/@mantine/core/src/components/Select/Select.tsx
@@ -295,7 +295,7 @@ export const Select = genericFactory<SelectFactory>((_props) => {
     />
   );
 
-  const _clearable = clearable && !!_value && !disabled && !readOnly;
+  const _clearable = clearable && _value != null && !disabled && !readOnly;
 
   return (
     <>


### PR DESCRIPTION
Fixes #8894

## Problem

When `Select` has the `clearable` prop and the current value is a falsy primitive (`false`, `0`, `""`), the clear button does not appear even though a valid option is selected.

The condition `!!_value` incorrectly treats falsy values as "no value":

```tsx
// Before
const _clearable = clearable && !!_value && !disabled && !readOnly;
```

## Fix

Replaced `!!_value` with `_value != null` so the clear button is hidden only when the value is actually absent (`null`).

```tsx
// After
const _clearable = clearable && _value != null && !disabled && !readOnly;
```

Applied the fix to `Select` clear button visibility checks.

## Tests added

* [x] displays clear button when clearable is true and value is set
* [x] does not display clear button when clearable is true and value is null
* [x] displays clear button when clearable is true and value is an empty string
* [x] displays clear button when clearable is true and value is false
* [x] displays clear button when clearable is true and value is 0
