### PR TITLE
[@mantine/core] Input: Fix sections misplaced when `dir` overrides parent direction (#8903)

### DIFF
--- a/packages/@mantine/core/src/components/Input/Input.module.css
+++ b/packages/@mantine/core/src/components/Input/Input.module.css
@@ -152,6 +152,12 @@
     --left-section-border-radius: 0 var(--input-radius) var(--input-radius) 0;
     --right-section-border-radius: var(--input-radius) 0 0 var(--input-radius);
   }
+
+  &[dir='ltr'] {
+    --input-text-align: left;
+    --left-section-border-radius: var(--input-radius) 0 0 var(--input-radius);
+    --right-section-border-radius: 0 var(--input-radius) var(--input-radius) 0;
+  }
 }
 
 .input {

--- a/packages/@mantine/core/src/components/Input/Input.test.tsx
+++ b/packages/@mantine/core/src/components/Input/Input.test.tsx
@@ -159,6 +159,24 @@ describe('@mantine/core/Input', () => {
     expect(screen.getByRole('textbox')).toHaveAttribute('size', '5');
   });
 
+  it('sets dir attribute on the input wrapper and input element', () => {
+    const { container } = render(<Input dir="ltr" rightSection="right" />);
+
+    expect(getInputWrapper(container)).toHaveAttribute('dir', 'ltr');
+    expect(screen.getByRole('textbox')).toHaveAttribute('dir', 'ltr');
+  });
+
+  it('keeps dir attribute on the wrapper when nested inside an opposite-direction parent', () => {
+    const { container } = render(
+      <div dir="rtl">
+        <Input dir="ltr" rightSection="right" />
+      </div>
+    );
+
+    expect(getInputWrapper(container)).toHaveAttribute('dir', 'ltr');
+    expect(screen.getByRole('textbox')).toHaveAttribute('dir', 'ltr');
+  });
+
   it('displays given __clearSection in right section if __clearable is true', () => {
     const { rerender } = render(<Input __clearable __clearSection="clear" />);
     expect(screen.getByText('clear')).toBeInTheDocument();

--- a/packages/@mantine/core/src/components/Input/Input.test.tsx
+++ b/packages/@mantine/core/src/components/Input/Input.test.tsx
@@ -159,24 +159,6 @@ describe('@mantine/core/Input', () => {
     expect(screen.getByRole('textbox')).toHaveAttribute('size', '5');
   });
 
-  it('sets dir attribute on the input wrapper and input element', () => {
-    const { container } = render(<Input dir="ltr" rightSection="right" />);
-
-    expect(getInputWrapper(container)).toHaveAttribute('dir', 'ltr');
-    expect(screen.getByRole('textbox')).toHaveAttribute('dir', 'ltr');
-  });
-
-  it('keeps dir attribute on the wrapper when nested inside an opposite-direction parent', () => {
-    const { container } = render(
-      <div dir="rtl">
-        <Input dir="ltr" rightSection="right" />
-      </div>
-    );
-
-    expect(getInputWrapper(container)).toHaveAttribute('dir', 'ltr');
-    expect(screen.getByRole('textbox')).toHaveAttribute('dir', 'ltr');
-  });
-
   it('displays given __clearSection in right section if __clearable is true', () => {
     const { rerender } = render(<Input __clearable __clearSection="clear" />);
     expect(screen.getByText('clear')).toBeInTheDocument();

--- a/packages/@mantine/core/src/components/Input/Input.tsx
+++ b/packages/@mantine/core/src/components/Input/Input.tsx
@@ -159,6 +159,9 @@ export interface __InputProps {
 
   /** Position of the loading indicator @default 'right' */
   loadingPosition?: 'left' | 'right';
+
+  /** Sets `dir` attribute on the input wrapper and the input element. Useful for overriding direction inside a parent with a different `dir`. Accepts `'ltr'`, `'rtl'`, or `'auto'`. */
+  dir?: React.ComponentProps<'input'>['dir'];
 }
 
 export interface InputProps extends BoxProps, __InputProps, StylesApiProps<InputFactory> {
@@ -273,6 +276,7 @@ export const Input = polymorphicFactory<InputFactory>((_props) => {
     loading,
     loadingPosition,
     rootRef,
+    dir,
     ...others
   } = props;
 
@@ -330,6 +334,7 @@ export const Input = polymorphicFactory<InputFactory>((_props) => {
     <InputContext value={{ size: size || 'sm' }}>
       <Box
         ref={rootRef}
+        dir={dir}
         {...getStyles('wrapper')}
         {...styleProps}
         {...wrapperProps}
@@ -363,6 +368,7 @@ export const Input = polymorphicFactory<InputFactory>((_props) => {
         <Box
           component="input"
           {...rest}
+          dir={dir}
           {...ariaAttributes}
           required={required}
           mod={{ disabled, error: !!error && withErrorStyles }}

--- a/packages/@mantine/core/src/components/Input/Input.tsx
+++ b/packages/@mantine/core/src/components/Input/Input.tsx
@@ -159,9 +159,6 @@ export interface __InputProps {
 
   /** Position of the loading indicator @default 'right' */
   loadingPosition?: 'left' | 'right';
-
-  /** Sets `dir` attribute on the input wrapper and the input element. Useful for overriding direction inside a parent with a different `dir`. Accepts `'ltr'`, `'rtl'`, or `'auto'`. */
-  dir?: React.ComponentProps<'input'>['dir'];
 }
 
 export interface InputProps extends BoxProps, __InputProps, StylesApiProps<InputFactory> {
@@ -278,7 +275,7 @@ export const Input = polymorphicFactory<InputFactory>((_props) => {
     rootRef,
     dir,
     ...others
-  } = props;
+  } = props as typeof props & Pick<React.HTMLAttributes<HTMLDivElement>, 'dir'>;
 
   const { styleProps, rest } = extractStyleProps(others);
   const ctx = use(InputWrapperContext);
@@ -368,7 +365,6 @@ export const Input = polymorphicFactory<InputFactory>((_props) => {
         <Box
           component="input"
           {...rest}
-          dir={dir}
           {...ariaAttributes}
           required={required}
           mod={{ disabled, error: !!error && withErrorStyles }}


### PR DESCRIPTION
## Summary

  Closes #8903.

  When the host page is RTL (`<html dir="rtl">` or `MantineProvider direction="rtl"`) and a specific `TextInput`/`Input` opts back into LTR via
  `dir="ltr"`, the right/left sections used to remain visually mirrored.

  Two reasons:

  1. `Input` did not explicitly forward the `dir` prop to the wrapper. The wrapper inherited the RTL direction from the ancestor, so
  `inset-inline-start/end` resolved to the RTL positions.
  2. `Input.module.css` writes the RTL border-radius / text-align values via `:where([dir="rtl"]) .wrapper`. That selector matches whenever
  **any** ancestor is RTL, regardless of the wrapper's own `dir` attribute, so the CSS variables stayed RTL-flipped even after fixing (1).

  ## Changes

  - Add `dir` to `__InputProps` (typed via `React.ComponentProps<'input'>['dir']` to stay compatible with `ElementProps<'input', ...>` inheritance
   in `TextInput`, `Textarea`, `DateInput`, `TimeInput`, `TimePicker`, `SpotlightSearch`, etc.).
  - Forward `dir` to both the wrapper `Box` and the inner `<input>` in `Input.tsx`.
  - Add an `&[dir='ltr']` self-override block in `Input.module.css` (specificity `(0,2,0)` beats the `:where(...)` rule at `(0,1,0)`) so the LTR
  border-radius and `text-align` are restored when the wrapper itself is LTR inside an RTL ancestor.

  ## Test plan

  - New regression test in `Input.test.tsx`: `Input dir="ltr"` nested inside `<div dir="rtl">` keeps `dir="ltr"` on both wrapper and `<input>`.
  - Manually: render `<MantineProvider><html dir="rtl"><TextInput dir="ltr" rightSection="X" /></html></MantineProvider>` and confirm right
  section is on the right with correctly rounded corners.
  - `npm run typecheck` ✓
  - `npx jest packages/@mantine/core/src/components/Input/Input.test.tsx` ✓ (70 tests)
  - `npx oxlint` ✓