### PR TITLE
[@mantine/core] SegmentedControl: Fix indicator border-radius collaps…

### DIFF
--- a/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.module.css
+++ b/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.module.css
@@ -45,7 +45,7 @@
   position: absolute;
   display: block;
   z-index: 1;
-  border-radius: calc(var(--sc-radius, var(--mantine-radius-default)) - 4px);
+  border-radius: calc(var(--sc-radius, var(--mantine-radius-default) - 4px));
 
   @mixin where-light {
     box-shadow: var(--sc-shadow, none);
@@ -67,7 +67,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   user-select: none;
-  border-radius: calc(var(--sc-radius, var(--mantine-radius-default)) - 4px);
+  border-radius: calc(var(--sc-radius, var(--mantine-radius-default) - 4px));
   font-size: var(--sc-font-size);
   padding: var(--sc-padding);
   transition: color var(--sc-transition-duration) var(--sc-transition-timing-function);
@@ -111,7 +111,7 @@
       inset: 0;
       z-index: 0;
       position: absolute;
-      border-radius: calc(var(--sc-radius, var(--mantine-radius-default)) - 4px);
+      border-radius: calc(var(--sc-radius, var(--mantine-radius-default) - 4px));
 
       @mixin where-light {
         box-shadow: var(--sc-shadow, none);


### PR DESCRIPTION
## Summary
  
  Closes #8904.

  `radius="sm"` (or `"xs"`) makes the SegmentedControl indicator/label/active-before render with `border-radius: 0`, because the current formula
  subtracts `4px` from the user-provided radius:
  
  ```css
  border-radius: calc(var(--sc-radius, var(--mantine-radius-default)) - 4px);

  For radius="sm" (4px), this resolves to 4px - 4px = 0. For radius="xs" (2px), it goes negative and clamps to 0. This is also visible on the docs
   demo at https://mantine.dev/core/segmented-control/.

  Introduced in c75a1fc when the default radius changed from sm to md — the - 4px was added to keep the indicator visually inset from the outer
  container, but it didn't account for users explicitly passing small radii.

  Fix

  Move the - 4px inside the var() fallback so it only applies to the default case:

  border-radius: calc(var(--sc-radius, var(--mantine-radius-default) - 4px));

  Behavior:
  Behavior:
  - No radius prop (default md): 8px - 4px = 4px (unchanged)
  - radius="xs": 2px (was 0)
  - radius="sm": 4px (was 0) — the reported bug
  - radius="md" / "lg" / "xl": now use the value as-is instead of value - 4px

  Trade-off: explicit radius="md" no longer renders identically to the default. The indicator gets a slightly larger radius (8px vs 4px
  previously). Per @giladgo's suggestion in the issue, this seems the cleanest fix — the visual change for explicit medium/large radii is minor
  compared to the broken-pill regression at small radii.

  Test plan

  - npx jest packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.test.tsx ✓ (45 tests)
  - npm run stylelint ✓
  - npm run typecheck ✓
  - Manual: render <SegmentedControl radius="sm" data={...} /> and confirm pills are rounded.