### PR TITLE
[mantine.dev] Add Video to community extensions list

### DIFF
--- a/apps/mantine.dev/src/pages/x/extensions.mdx
+++ b/apps/mantine.dev/src/pages/x/extensions.mdx
@@ -61,6 +61,7 @@ Community extensions list:
 - [Spinner](https://gfazioli.github.io/mantine-spinner/) – SVG-based loading spinner with multiple animation variants
 - [SplitPane](https://gfazioli.github.io/mantine-split-pane/) – resizable split pane component
 - [TextAnimate](https://gfazioli.github.io/mantine-text-animate/) – text animation component
+- [Video](https://gfazioli.github.io/mantine-video/) – Mantine-native video player with compound API, headless useVideo hook, Picture-in-Picture, live timeline scrubbing, and an asBackground mode for hero sections
 - [Window](https://gfazioli.github.io/mantine-window/) – window component with drag and resize functionalities
 - [Mantine Form Builder](https://pradip-v2.github.io/mantine-form-builder/) – form builder and viewer components
 - [Mantine Choropleth Map](https://maetes.github.io/mantine-choropleth/) - Choropleth Map component for GeoJson


### PR DESCRIPTION
Adds [`@gfazioli/mantine-video`](https://www.npmjs.com/package/@gfazioli/mantine-video) to the community extensions list on https://mantine.dev/x/extensions, alphabetically between `TextAnimate` and `Window`.

## What it is

A Mantine-native video player for React 19 built on top of the native HTML `<video>` element. Three layers in one package:

- A polished default `<Video />` component with four variants (`overlay`, `minimal`, `floating`, `bordered`)
- A fully composable **compound API**: `Video.Controls`, `Video.PlayButton`, `Video.SkipButton`, `Video.Timeline`, `Video.TimeDisplay`, `Video.MuteButton`, `Video.CaptionsButton`, `Video.PiPButton`, `Video.FullscreenButton`
- A headless **`useVideo` hook** (16 state values + 16 actions) for fully custom UIs

Plus Picture-in-Picture with lifecycle callbacks, fullscreen, captions, live timeline scrubbing (YouTube-style frame preview while dragging), keyboard shortcuts, the full Mantine Styles API on every part, and an **`asBackground`** prop that turns the same player into a hero / section background in one line.

## Links

- 📦 npm: https://www.npmjs.com/package/@gfazioli/mantine-video
- 📖 Documentation & demos: https://gfazioli.github.io/mantine-video
- 🔗 GitHub repository: https://github.com/gfazioli/mantine-video