### PR TITLE
[@mantine/core] Expose safe polygon options in Menu.Sub

### DIFF
--- a/apps/mantine.dev/src/pages/core/menu.mdx
+++ b/apps/mantine.dev/src/pages/core/menu.mdx
@@ -12,6 +12,11 @@ export default Layout(MDX_DATA.Menu);
 
 <Demo data={MenuDemos.sub} demoProps={{ defaultExpanded: false }} />
 
+Use `safeAreaPolygon` to keep a submenu open while the cursor moves from the target toward the dropdown.
+Pass an object to adjust [Floating UI `safePolygon`](https://floating-ui.com/docs/useHover#safepolygon) options, for example when `offset` creates a larger gap between the target and dropdown.
+
+<Demo data={MenuDemos.subSafeAreaPolygon} demoProps={{ defaultExpanded: false }} />
+
 ## Controlled
 
 The dropdown's opened state can be controlled with the `opened` and `onChange` props:

--- a/packages/@docs/demos/src/demos/core/Menu/Menu.demo.sub.tsx
+++ b/packages/@docs/demos/src/demos/core/Menu/Menu.demo.sub.tsx
@@ -121,3 +121,76 @@ export const sub: MantineDemo = {
   code,
   centered: true,
 };
+
+const safeAreaPolygonCode = `
+import { Button, Menu } from '@mantine/core';
+
+function Demo() {
+  return (
+    <Menu width={200} position="bottom-start">
+      <Menu.Target>
+        <Button>Toggle Menu</Button>
+      </Menu.Target>
+
+      <Menu.Dropdown>
+        <Menu.Item>Dashboard</Menu.Item>
+
+        <Menu.Sub offset={16} safeAreaPolygon={{ buffer: 16, requireIntent: false }}>
+          <Menu.Sub.Target>
+            <Menu.Sub.Item>Products</Menu.Sub.Item>
+          </Menu.Sub.Target>
+
+          <Menu.Sub.Dropdown>
+            <Menu.Item>All products</Menu.Item>
+            <Menu.Item>Categories</Menu.Item>
+            <Menu.Item>Tags</Menu.Item>
+            <Menu.Item>Attributes</Menu.Item>
+            <Menu.Item>Shipping classes</Menu.Item>
+          </Menu.Sub.Dropdown>
+        </Menu.Sub>
+
+        <Menu.Item>Customers</Menu.Item>
+        <Menu.Item>Reports</Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}
+`;
+
+function SafeAreaPolygonDemo() {
+  return (
+    <Menu width={200} position="bottom-start">
+      <Menu.Target>
+        <Button>Toggle Menu</Button>
+      </Menu.Target>
+
+      <Menu.Dropdown>
+        <Menu.Item>Dashboard</Menu.Item>
+
+        <Menu.Sub offset={16} safeAreaPolygon={{ buffer: 16, requireIntent: false }}>
+          <Menu.Sub.Target>
+            <Menu.Sub.Item>Products</Menu.Sub.Item>
+          </Menu.Sub.Target>
+
+          <Menu.Sub.Dropdown>
+            <Menu.Item>All products</Menu.Item>
+            <Menu.Item>Categories</Menu.Item>
+            <Menu.Item>Tags</Menu.Item>
+            <Menu.Item>Attributes</Menu.Item>
+            <Menu.Item>Shipping classes</Menu.Item>
+          </Menu.Sub.Dropdown>
+        </Menu.Sub>
+
+        <Menu.Item>Customers</Menu.Item>
+        <Menu.Item>Reports</Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}
+
+export const subSafeAreaPolygon: MantineDemo = {
+  type: 'code',
+  component: SafeAreaPolygonDemo,
+  code: safeAreaPolygonCode,
+  centered: true,
+};

--- a/packages/@docs/demos/src/demos/core/Menu/Menu.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/core/Menu/Menu.demos.story.tsx
@@ -57,3 +57,8 @@ export const Demo_sub = {
   name: '⭐ Demo: sub',
   render: renderDemo(demos.sub),
 };
+
+export const Demo_subSafeAreaPolygon = {
+  name: '⭐ Demo: sub(safeAreaPolygon)',
+  render: renderDemo(demos.subSafeAreaPolygon),
+};

--- a/packages/@docs/demos/src/demos/core/Menu/index.ts
+++ b/packages/@docs/demos/src/demos/core/Menu/index.ts
@@ -8,4 +8,4 @@ export { disabled } from './Menu.demo.disabled';
 export { customControl } from './Menu.demo.customControl';
 export { clickHover } from './Menu.demo.clickHover';
 export { navigation } from './Menu.demo.navigation';
-export { sub } from './Menu.demo.sub';
+export { sub, subSafeAreaPolygon } from './Menu.demo.sub';

--- a/packages/@mantine/core/src/components/Menu/Menu.story.tsx
+++ b/packages/@mantine/core/src/components/Menu/Menu.story.tsx
@@ -246,3 +246,36 @@ export function WithSubMenu() {
     </div>
   );
 }
+
+export function WithSubMenuSafeAreaPolygon() {
+  return (
+    <div style={{ padding: 400 }}>
+      <Menu width={200} position="bottom-start">
+        <Menu.Target>
+          <Button>Toggle menu</Button>
+        </Menu.Target>
+
+        <Menu.Dropdown>
+          <Menu.Item>Dashboard</Menu.Item>
+
+          <Menu.Sub offset={16} safeAreaPolygon={{ buffer: 16, requireIntent: false }}>
+            <Menu.Sub.Target>
+              <Menu.Sub.Item>Products</Menu.Sub.Item>
+            </Menu.Sub.Target>
+
+            <Menu.Sub.Dropdown>
+              <Menu.Item closeMenuOnClick={false}>All products</Menu.Item>
+              <Menu.Item closeMenuOnClick={false}>Categories</Menu.Item>
+              <Menu.Item closeMenuOnClick={false}>Tags</Menu.Item>
+              <Menu.Item closeMenuOnClick={false}>Attributes</Menu.Item>
+              <Menu.Item closeMenuOnClick={false}>Shipping classes</Menu.Item>
+            </Menu.Sub.Dropdown>
+          </Menu.Sub>
+
+          <Menu.Item>Customers</Menu.Item>
+          <Menu.Item>Reports</Menu.Item>
+        </Menu.Dropdown>
+      </Menu>
+    </div>
+  );
+}

--- a/packages/@mantine/core/src/components/Menu/MenuSub/MenuSub.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuSub/MenuSub.tsx
@@ -1,5 +1,11 @@
 import { use, useCallback, useRef } from 'react';
-import { safePolygon, useFloating, useHover, useInteractions } from '@floating-ui/react';
+import {
+  safePolygon,
+  useFloating,
+  useHover,
+  useInteractions,
+  type SafePolygonOptions,
+} from '@floating-ui/react';
 import { useDisclosure, useId } from '@mantine/hooks';
 import { ExtendComponent, Factory, useDirection, useProps } from '../../../core';
 import {
@@ -39,11 +45,15 @@ export interface MenuSubProps extends __PopoverProps {
 
   /** Props passed down to the `Transition` component that used to animate dropdown presence, use to configure duration and animation type @default { duration: 0 } */
   transitionProps?: TransitionOverride;
+
+  /** Determines whether submenu stays open while the cursor moves toward its dropdown. Pass an object to configure safe polygon behavior. @default true */
+  safeAreaPolygon?: boolean | SafePolygonOptions;
 }
 
 const defaultProps = {
   offset: 0,
   position: 'right-start',
+  safeAreaPolygon: true,
   transitionProps: { duration: 0 },
   openDelay: 0,
   middlewares: {
@@ -55,7 +65,7 @@ const defaultProps = {
 } satisfies Partial<MenuSubProps>;
 
 export function MenuSub(_props: MenuSubProps) {
-  const { children, closeDelay, openDelay, position, ...others } = useProps(
+  const { children, closeDelay, openDelay, position, safeAreaPolygon, ...others } = useProps(
     'MenuSub',
     defaultProps,
     _props
@@ -109,7 +119,9 @@ export function MenuSub(_props: MenuSubProps) {
 
   const { getReferenceProps, getFloatingProps } = useInteractions([
     useHover(context, {
-      handleClose: safePolygon(),
+      handleClose: safeAreaPolygon
+        ? safePolygon(typeof safeAreaPolygon === 'object' ? safeAreaPolygon : undefined)
+        : undefined,
       delay: { open: openDelay, close: closeDelay },
     }),
   ]);


### PR DESCRIPTION
### Summary

This PR exposes the underlying Floating UI `safePolygon` options on `Menu.Sub` via the `safeAreaPolygon` prop.

It keeps the current behavior by default with `safeAreaPolygon: true`, while allowing consumers to:

- disable the safe polygon behavior with `safeAreaPolygon={false}`
- tune the safe polygon behavior with options such as `buffer` and `requireIntent`
- account for submenu gaps introduced by positive `offset` values

### Testing

yarn jest packages/@mantine/core/src/components/Menu/Menu.test.tsx --runInBand

25 tests passed.
