### PR TITLE
[mantine.dev] Add Audio to community extensions list

### DIFF
--- a/apps/mantine.dev/src/pages/x/extensions.mdx
+++ b/apps/mantine.dev/src/pages/x/extensions.mdx
@@ -39,7 +39,7 @@ Community extensions list:
 - [ContextMenu](https://icflorescu.github.io/mantine-contextmenu/) – context menu component
 - [DataTable](https://icflorescu.github.io/mantine-datatable/) – data table component without dependencies
 - [MantineReactTable](https://v2.mantine-react-table.com/) – data table component based on TanStack table package
-- [Audio](https://gfazioli.github.io/mantine-audio/) – audio player with waveform visualisation and live spectrum analyser, built on Web Audio API
+- [Audio](https://gfazioli.github.io/mantine-audio/) – audio player with waveform visualization and live spectrum analyzer, built on Web Audio API
 - [BorderAnimate](https://gfazioli.github.io/mantine-border-animate/) – border animation styles (beam, glow, more...)
 - [Clock](https://gfazioli.github.io/mantine-clock/) – analog clock component
 - [Compare](https://gfazioli.github.io/mantine-compare/) – image comparison slider component

--- a/apps/mantine.dev/src/pages/x/extensions.mdx
+++ b/apps/mantine.dev/src/pages/x/extensions.mdx
@@ -39,6 +39,7 @@ Community extensions list:
 - [ContextMenu](https://icflorescu.github.io/mantine-contextmenu/) – context menu component
 - [DataTable](https://icflorescu.github.io/mantine-datatable/) – data table component without dependencies
 - [MantineReactTable](https://v2.mantine-react-table.com/) – data table component based on TanStack table package
+- [Audio](https://gfazioli.github.io/mantine-audio/) – audio player with waveform visualisation and live spectrum analyser, built on Web Audio API
 - [BorderAnimate](https://gfazioli.github.io/mantine-border-animate/) – border animation styles (beam, glow, more...)
 - [Clock](https://gfazioli.github.io/mantine-clock/) – analog clock component
 - [Compare](https://gfazioli.github.io/mantine-compare/) – image comparison slider component


### PR DESCRIPTION
Adds a new entry in https://mantine.dev/x/extensions for the just-released `@gfazioli/mantine-audio` v1.0.0.

It's the audio counterpart to `mantine-video` (PR #8907): a Mantine-native audio player with **waveform visualisation** and a **live spectrum analyser**, built on the Web Audio API. Same three-layer architecture (drop-in default `<Audio />`, composable compound API, headless `useAudio` hook).

- npm: https://www.npmjs.com/package/@gfazioli/mantine-audio
- Docs: https://gfazioli.github.io/mantine-audio
- Repo: https://github.com/gfazioli/mantine-audio