### PR TITLE
[@mantine/core] Fix input sections direction handling

### DIFF
--- a/packages/@mantine/core/src/components/Input/Input.module.css
+++ b/packages/@mantine/core/src/components/Input/Input.module.css
@@ -152,6 +152,18 @@
     --left-section-border-radius: 0 var(--input-radius) var(--input-radius) 0;
     --right-section-border-radius: var(--input-radius) 0 0 var(--input-radius);
   }
+
+  &:where([dir='ltr']) {
+    --input-text-align: left;
+    --left-section-border-radius: var(--input-radius) 0 0 var(--input-radius);
+    --right-section-border-radius: 0 var(--input-radius) var(--input-radius) 0;
+  }
+
+  &:where([dir='rtl']) {
+    --input-text-align: right;
+    --left-section-border-radius: 0 var(--input-radius) var(--input-radius) 0;
+    --right-section-border-radius: var(--input-radius) 0 0 var(--input-radius);
+  }
 }
 
 .input {

--- a/packages/@mantine/core/src/components/Input/Input.test.tsx
+++ b/packages/@mantine/core/src/components/Input/Input.test.tsx
@@ -159,6 +159,12 @@ describe('@mantine/core/Input', () => {
     expect(screen.getByRole('textbox')).toHaveAttribute('size', '5');
   });
 
+  it('sets dir attribute on input wrapper based on input dir prop', () => {
+    const { container } = render(<Input dir="ltr" />);
+    expect(getInputWrapper(container)).toHaveAttribute('dir', 'ltr');
+    expect(screen.getByRole('textbox')).toHaveAttribute('dir', 'ltr');
+  });
+
   it('displays given __clearSection in right section if __clearable is true', () => {
     const { rerender } = render(<Input __clearable __clearSection="clear" />);
     expect(screen.getByText('clear')).toBeInTheDocument();

--- a/packages/@mantine/core/src/components/Input/Input.tsx
+++ b/packages/@mantine/core/src/components/Input/Input.tsx
@@ -277,6 +277,7 @@ export const Input = polymorphicFactory<InputFactory>((_props) => {
   } = props;
 
   const { styleProps, rest } = extractStyleProps(others);
+  const inputDirection = (rest as { dir?: React.HTMLAttributes<HTMLElement>['dir'] }).dir;
   const ctx = use(InputWrapperContext);
   const stylesCtx: InputStylesCtx = { offsetBottom: ctx?.offsetBottom, offsetTop: ctx?.offsetTop };
 
@@ -332,6 +333,7 @@ export const Input = polymorphicFactory<InputFactory>((_props) => {
         ref={rootRef}
         {...getStyles('wrapper')}
         {...styleProps}
+        dir={inputDirection}
         {...wrapperProps}
         mod={[
           {

--- a/packages/@mantine/core/src/components/PasswordInput/PasswordInput.test.tsx
+++ b/packages/@mantine/core/src/components/PasswordInput/PasswordInput.test.tsx
@@ -145,6 +145,12 @@ describe('@mantine/core/PasswordInput', () => {
     expect(input.type).toBe('text');
   });
 
+  it('sets dir attribute on input wrapper based on input dir prop', () => {
+    const { container } = render(<PasswordInput label="Password" dir="ltr" />);
+    expect(container.querySelector('.mantine-Input-wrapper')).toHaveAttribute('dir', 'ltr');
+    expect(screen.getByLabelText('Password')).toHaveAttribute('dir', 'ltr');
+  });
+
   it('passes visibilityToggleButtonProps to toggle button', () => {
     render(
       <PasswordInput

--- a/packages/@mantine/core/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/@mantine/core/src/components/PasswordInput/PasswordInput.tsx
@@ -146,6 +146,7 @@ export const PasswordInput = factory<PasswordInputFactory>((_props) => {
   });
 
   const { styleProps, rest } = extractStyleProps(others);
+  const inputDirection = (rest as { dir?: React.HTMLAttributes<HTMLElement>['dir'] }).dir;
   const errorId = errorProps?.id || `${uuid}-error`;
   const descriptionId = descriptionProps?.id || `${uuid}-description`;
   const hasError = !!error && typeof error !== 'boolean';
@@ -215,6 +216,7 @@ export const PasswordInput = factory<PasswordInputFactory>((_props) => {
     >
       <Input
         component="div"
+        dir={inputDirection}
         error={error}
         leftSection={leftSection}
         size={size}


### PR DESCRIPTION
Fixes #8903

### Summary
- pass explicit `dir` from Input to the internal input wrapper
- add wrapper-level direction overrides for input text alignment and section border radii
- pass explicit `dir` through PasswordInput internal Input wrapper

### Testing
- npx jest packages/@mantine/core/src/components/Input/Input.test.tsx packages/@mantine/core/src/components/PasswordInput/PasswordInput.test.tsx packages/@mantine/core/src/components/InputBase/InputBase.test.tsx packages/@mantine/core/src/components/TextInput/TextInput.test.tsx
- npm run build
- npx oxlint packages/@mantine/core/src/components/Input/Input.tsx packages/@mantine/core/src/components/Input/Input.test.tsx packages/@mantine/core/src/components/PasswordInput/PasswordInput.tsx packages/@mantine/core/src/components/PasswordInput/PasswordInput.test.tsx
- npm run stylelint
- npm run typecheck