### PR TITLE
NumberInput: Document onMinReached, onMaxReached and selectAllOnFocus props

### DIFF
--- a/apps/mantine.dev/src/pages/core/number-input.mdx
+++ b/apps/mantine.dev/src/pages/core/number-input.mdx
@@ -135,6 +135,40 @@ If you need to disable value clamping entirely, set `clampBehavior="none"`.
 
 <Demo data={NumberInputDemos.strictClamp} />
 
+## Boundary callbacks
+
+Use `onMinReached` and `onMaxReached` to call a function when the value hits the `min` or `max` boundary.
+These callbacks are triggered when the user attempts to increment beyond `max` or decrement below `min`
+using the controls or keyboard arrows.
+
+```tsx
+import { NumberInput } from '@mantine/core';
+
+function Demo() {
+  return (
+    <NumberInput
+      min={0}
+      max={100}
+      onMinReached={() => console.log('Minimum value reached')}
+      onMaxReached={() => console.log('Maximum value reached')}
+    />
+  );
+}
+```
+
+## Select all on focus
+
+Set `selectAllOnFocus` to automatically select the entire input value when the field receives focus.
+This is useful when you expect users to replace the value rather than edit it:
+
+```tsx
+import { NumberInput } from '@mantine/core';
+
+function Demo() {
+  return <NumberInput selectAllOnFocus defaultValue={100} />;
+}
+```
+
 ## Prefix and suffix
 
 Set the `prefix` and `suffix` props to add a given string to the start or end of the input value:


### PR DESCRIPTION
## Summary
- Added documentation for `onMinReached` and `onMaxReached` callback props
- Added documentation for `selectAllOnFocus` prop
- These props exist in the component source (NumberInput.tsx lines 258-264) but had no mention in the docs

## Motivation
Users can only discover these useful props by reading the source code. This PR makes them visible in the official docs.
