### PR TITLE
[@mantine/core] HueSlider: Forward color prop to underlying ColorSlider

### DIFF
--- a/packages/@mantine/core/src/components/ColorPicker/HueSlider/HueSlider.test.tsx
+++ b/packages/@mantine/core/src/components/ColorPicker/HueSlider/HueSlider.test.tsx
@@ -1,0 +1,36 @@
+import { render } from '@mantine-tests/core';
+import { HueSlider, HueSliderProps } from './HueSlider';
+
+const defaultProps: HueSliderProps = {
+  value: 180,
+  onChange: () => {},
+};
+
+describe('@mantine/core/HueSlider', () => {
+  it('forwards HTML attributes from `...others` to the underlying slider', () => {
+    const { container } = render(
+      <HueSlider {...defaultProps} data-testid="hue" aria-label="hue-slider" />
+    );
+
+    const slider = container.querySelector<HTMLElement>('[data-hue]');
+    expect(slider).not.toBeNull();
+    expect(slider).toHaveAttribute('data-testid', 'hue');
+    expect(slider).toHaveAttribute('aria-label', 'hue-slider');
+  });
+
+  it('forwards the `color` HTML attribute (was previously dropped before falling into `...others`)', () => {
+    const { container } = render(<HueSlider {...defaultProps} color="red" />);
+
+    const slider = container.querySelector<HTMLElement>('[data-hue]');
+    expect(slider).not.toBeNull();
+    expect(slider).toHaveAttribute('color', 'red');
+  });
+
+  it('still uses `value` to derive the thumb hue (the existing contract is unchanged)', () => {
+    const { container } = render(<HueSlider {...defaultProps} value={120} />);
+
+    const slider = container.querySelector<HTMLElement>('[data-hue]');
+    expect(slider).not.toBeNull();
+    expect(slider!.getAttribute('aria-valuenow')).toBe('120');
+  });
+});

--- a/packages/@mantine/core/src/components/ColorPicker/HueSlider/HueSlider.tsx
+++ b/packages/@mantine/core/src/components/ColorPicker/HueSlider/HueSlider.tsx
@@ -18,7 +18,7 @@ const defaultProps = {
 } satisfies Partial<HueSliderProps>;
 
 export const HueSlider = factory<HueSliderFactory>((props: HueSliderProps) => {
-  const { value, onChange, onChangeEnd, color, ...others } = useProps(
+  const { value, onChange, onChangeEnd, ...others } = useProps(
     'HueSlider',
     defaultProps,
     props


### PR DESCRIPTION
## Problem

`HueSlider.tsx` destructures `color` from props but never reads it and never spreads it into `...others`, so any `color` value passed to `<HueSlider color="..." />` is silently swallowed and never reaches the underlying `ColorSlider` (or its rendered `<div data-hue>`).

This looks like residue from a copy-paste of `AlphaSlider`, where `color` is a required, used prop (it drives the alpha gradient). `HueSlider` derives its thumb color from `value` alone (`thumbColor={hsl(${value}, 100%, 50%)}`) and does not need an explicit `color` prop.

## Repro

```tsx
import { HueSlider } from '@mantine/core';

<HueSlider value={180} onChange={() => {}} color="red" />
// before: the rendered <div data-hue> has no `color` attribute
// after:  the rendered <div data-hue> has `color="red"`
```

## Fix

Drop `color` from the destructure pattern. It now falls through into `...others` and is spread onto `<ColorSlider>` like every other passthrough prop. No new types are added; `color` was never declared in `HueSliderProps`, it was only being silently consumed.

```diff
- const { value, onChange, onChangeEnd, color, ...others } = useProps(
+ const { value, onChange, onChangeEnd, ...others } = useProps(
     'HueSlider',
     defaultProps,
     props
   );
```

## Tests

A new `packages/@mantine/core/src/components/ColorPicker/HueSlider/HueSlider.test.tsx` covers three axes:

- **Positive (forwarding)**: `data-testid` and `aria-label` reach the underlying `[data-hue]` element via `...others` (sanity-checks the spread path).
- **Positive (the actual fix)**: `color="red"` reaches the underlying `[data-hue]` element. Fails on `master`, passes on this branch.
- **Negative (regression preservation)**: `value` still drives `aria-valuenow` on the slider, the existing contract is unchanged.

Verified locally with `npm run jest -- packages/@mantine/core/src/components/ColorPicker/HueSlider/HueSlider.test.tsx`: 3/3 pass with the fix, the `color`-forwarding test fails without it (the other two still pass on baseline, which is the expected RED→GREEN delta for a single-prop fix).

`tsc --noEmit` at the repo root clean, `oxlint` on the two changed files clean. Pre-existing typecheck failures in `apps/mantine.dev` (workspace resolution) are unrelated.

Fixes #8922

## Note on disclosure

Bug surfacing, root-cause hypothesis (copy-paste from `AlphaSlider`) and suggested fix shape are from `@maether44` in the issue body. I confirmed the destructure on `master`, applied the one-line removal, wrote the three tests, and verified RED→GREEN locally. AI assistance was used while drafting parts of this PR body; the fix and tests reflect my own engineering decisions.