### PR TITLE
[@mantine/core] NavLink: Fix typo in story button label

### DIFF
--- a/packages/@mantine/core/src/components/NavLink/NavLink.story.tsx
+++ b/packages/@mantine/core/src/components/NavLink/NavLink.story.tsx
@@ -130,7 +130,7 @@ export function DynamicNestedItems() {
         {nested}
       </NavLink>
       <Button onClick={increment}>Add item</Button>
-      <Button onClick={decrement}>Remove item item</Button>
+      <Button onClick={decrement}>Remove item</Button>
     </div>
   );
 }


### PR DESCRIPTION
Removes a duplicate "item" in the NavLink dynamic-nested story. Sibling button on the line above renders "Add item", so the counterpart should read "Remove item".
