### PR TITLE
[refactor] Fix grammar in test descriptions ("allows/allow to" -> "allows/allow you to")

### DIFF
--- a/packages/@mantine-tests/dates/src/it-supports-date-input-props.tsx
+++ b/packages/@mantine-tests/dates/src/it-supports-date-input-props.tsx
@@ -237,7 +237,7 @@ export function itSupportsDateInputProps(options: Options, name = 'supports date
       expectValue(container, 'test-placeholder');
     });
 
-    it('does not allow to deselect value if allowDeselect is not set (type="default")', async () => {
+    it('does not allow you to deselect value if allowDeselect is not set (type="default")', async () => {
       const { container } = render(
         <options.component {...options.props} type="default" placeholder="test-placeholder" />
       );
@@ -252,7 +252,7 @@ export function itSupportsDateInputProps(options: Options, name = 'supports date
       expect(getInputValue(container)).not.toBe('test-placeholder');
     });
 
-    it('allows to pick single date as range if allowSingleDateInRange prop is set (type="range")', async () => {
+    it('allows you to pick single date as range if allowSingleDateInRange prop is set (type="range")', async () => {
       const { container } = render(
         <options.component
           {...options.props}
@@ -271,7 +271,7 @@ export function itSupportsDateInputProps(options: Options, name = 'supports date
       expect(getInputValue(container)).not.toBe('test-placeholder');
     });
 
-    it('does not allow to pick single date as range if allowSingleDateInRange prop is not set (type="range")', async () => {
+    it('does not allow you to pick single date as range if allowSingleDateInRange prop is not set (type="range")', async () => {
       const { container } = render(
         <options.component {...options.props} type="range" placeholder="test-placeholder" />
       );

--- a/packages/@mantine/core/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/@mantine/core/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -26,7 +26,7 @@ describe('@mantine/core/Breadcrumbs', () => {
     expect(screen.getAllByText('test-separator')).toHaveLength(2);
   });
 
-  it('allows to set child className', () => {
+  it('allows you to set child className', () => {
     render(
       <Breadcrumbs>
         <button type="button" className="test-class">

--- a/packages/@mantine/core/src/components/Menu/MenuItem/MenuItem.test.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuItem/MenuItem.test.tsx
@@ -22,7 +22,7 @@ describe('@mantine/core/MenuItem', () => {
     providerStylesApi: false,
   });
 
-  it('allows to add onMouseEnter and onMouseLeave events', async () => {
+  it('allows you to add onMouseEnter and onMouseLeave events', async () => {
     const onMouseEnter = jest.fn();
     const onMouseLeave = jest.fn();
     render(<TestContainer onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} />);
@@ -35,7 +35,7 @@ describe('@mantine/core/MenuItem', () => {
     expect(onMouseLeave).toHaveBeenCalled();
   });
 
-  it('allows to add onClick event', async () => {
+  it('allows you to add onClick event', async () => {
     const spy = jest.fn();
     render(<TestContainer onClick={spy} />);
     expect(spy).not.toHaveBeenCalled();

--- a/packages/@mantine/core/src/components/Menu/MenuSubItem/MenuSubItem.test.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuSubItem/MenuSubItem.test.tsx
@@ -22,7 +22,7 @@ describe('@mantine/core/MenuSubItem', () => {
     providerStylesApi: false,
   });
 
-  it('allows to add onMouseEnter and onMouseLeave events', async () => {
+  it('allows you to add onMouseEnter and onMouseLeave events', async () => {
     const onMouseEnter = jest.fn();
     const onMouseLeave = jest.fn();
     render(<TestContainer onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} />);
@@ -35,7 +35,7 @@ describe('@mantine/core/MenuSubItem', () => {
     expect(onMouseLeave).toHaveBeenCalled();
   });
 
-  it('allows to add onClick event', async () => {
+  it('allows you to add onClick event', async () => {
     const spy = jest.fn();
     render(<TestContainer onClick={spy} />);
     expect(spy).not.toHaveBeenCalled();

--- a/packages/@mantine/core/src/components/Select/Select.test.tsx
+++ b/packages/@mantine/core/src/components/Select/Select.test.tsx
@@ -63,7 +63,7 @@ describe('@mantine/core/Select', () => {
     expect(screen.getByRole('combobox')).toHaveValue('');
   });
 
-  it('does not allow to deselect option if allowDeselect is false', async () => {
+  it('does not allow you to deselect option if allowDeselect is false', async () => {
     render(<Select {...defaultProps} defaultValue="test-1" allowDeselect={false} />);
     await userEvent.click(screen.getByRole('combobox'));
     await userEvent.click(screen.getByRole('option', { name: 'test-1' }));
@@ -331,7 +331,7 @@ describe('@mantine/core/Select', () => {
     expect(container.querySelector('.mantine-InputClearButton-root')).toBeInTheDocument();
   });
 
-  it('allows to change controlled search value when value is controlled and selected', async () => {
+  it('allows you to change controlled search value when value is controlled and selected', async () => {
     const Wrapper: React.FunctionComponent = () => {
       const [value, setValue] = useState<string | null>('Angular');
       const [searchValue, setSearchValue] = useState('');

--- a/packages/@mantine/core/src/components/Slider/Slider/Slider.test.tsx
+++ b/packages/@mantine/core/src/components/Slider/Slider/Slider.test.tsx
@@ -71,14 +71,14 @@ describe('@mantine/core/Slider', () => {
     expectInputValue('50', container);
   });
 
-  it('does not allow to set value greater than max', async () => {
+  it('does not allow you to set value greater than max', async () => {
     const { container } = render(<Slider defaultValue={115} step={10} max={120} />);
     expectInputValue('115', container);
     await pressArrow('right');
     expectInputValue('120', container);
   });
 
-  it('does not allow to set value smaller than min', async () => {
+  it('does not allow you to set value smaller than min', async () => {
     const { container } = render(<Slider defaultValue={50} step={10} min={45} />);
     expectInputValue('50', container);
     await pressArrow('left');

--- a/packages/@mantine/core/src/components/Tabs/Tabs.test.tsx
+++ b/packages/@mantine/core/src/components/Tabs/Tabs.test.tsx
@@ -200,14 +200,14 @@ describe('@mantine/core/Tabs', () => {
     expectActiveTab('tab-1');
   });
 
-  it('allows to deactivate tab when allowTabDeactivation is true', async () => {
+  it('allows you to deactivate tab when allowTabDeactivation is true', async () => {
     render(<Tabs {...defaultProps} defaultValue="tab-1" allowTabDeactivation />);
     expectActiveTab('tab-1');
     await clickTab('tab-1');
     expectActiveTab(null);
   });
 
-  it('allows to set root element id', () => {
+  it('allows you to set root element id', () => {
     const view = render(<Tabs {...defaultProps} defaultValue="tab-1" id="test-id" />);
     expect(view.container.querySelector('#test-id')).toBeInTheDocument();
   });

--- a/packages/@mantine/core/src/components/TreeSelect/TreeSelect.test.tsx
+++ b/packages/@mantine/core/src/components/TreeSelect/TreeSelect.test.tsx
@@ -155,7 +155,7 @@ describe('@mantine/core/TreeSelect', () => {
       expect(screen.getByRole('textbox')).toHaveValue('');
     });
 
-    it('does not allow to deselect option if allowDeselect is false', async () => {
+    it('does not allow you to deselect option if allowDeselect is false', async () => {
       render(<TreeSelect {...defaultProps} defaultValue="milk" allowDeselect={false} />);
       await userEvent.click(screen.getByRole('textbox'));
       await userEvent.click(screen.getByRole('option', { name: 'Milk' }));

--- a/packages/@mantine/dates/src/components/DateInput/DateInput.test.tsx
+++ b/packages/@mantine/dates/src/components/DateInput/DateInput.test.tsx
@@ -210,7 +210,7 @@ describe('@mantine/dates/DateInput', () => {
     expect(spy).toHaveBeenLastCalledWith(null);
   });
 
-  it('allows to clear input value when clearable is set (uncontrolled)', async () => {
+  it('allows you to clear input value when clearable is set (uncontrolled)', async () => {
     const { container } = render(
       <DateInput {...defaultProps} clearable defaultValue="2022-04-11" />
     );
@@ -221,7 +221,7 @@ describe('@mantine/dates/DateInput', () => {
     expectValue(container, '');
   });
 
-  it('allows to clear input value when clearable is set (controlled)', async () => {
+  it('allows you to clear input value when clearable is set (controlled)', async () => {
     const spy = jest.fn();
     const { container } = render(
       <DateInput {...defaultProps} clearable value="2022-04-11" onChange={spy} />
@@ -234,7 +234,7 @@ describe('@mantine/dates/DateInput', () => {
     expect(spy).toHaveBeenLastCalledWith(null);
   });
 
-  it('does not allow to clear input value when clearable is not set (uncontrolled)', async () => {
+  it('does not allow you to clear input value when clearable is not set (uncontrolled)', async () => {
     const { container } = render(
       <DateInput {...defaultProps} clearable={false} defaultValue="2022-04-11" />
     );
@@ -245,7 +245,7 @@ describe('@mantine/dates/DateInput', () => {
     expectValue(container, 'April 11, 2022');
   });
 
-  it('does not allow to clear input value when clearable is not set (controlled)', async () => {
+  it('does not allow you to clear input value when clearable is not set (controlled)', async () => {
     const spy = jest.fn();
     const { container } = render(
       <DateInput {...defaultProps} clearable={false} value="2022-04-11" onChange={spy} />
@@ -258,7 +258,7 @@ describe('@mantine/dates/DateInput', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it('allows to clear input value by clicking the selected date when clearable and allowDeselect are set (uncontrolled)', async () => {
+  it('allows you to clear input value by clicking the selected date when clearable and allowDeselect are set (uncontrolled)', async () => {
     const { container } = render(
       <DateInput {...defaultProps} clearable allowDeselect defaultValue="2022-04-01" />
     );
@@ -269,7 +269,7 @@ describe('@mantine/dates/DateInput', () => {
     expectValue(container, '');
   });
 
-  it('allows to clear input value by clicking the selected date when clearable and allowDeselect are set (controlled)', async () => {
+  it('allows you to clear input value by clicking the selected date when clearable and allowDeselect are set (controlled)', async () => {
     const spy = jest.fn();
     const { container } = render(
       <DateInput {...defaultProps} clearable allowDeselect value="2022-04-01" onChange={spy} />
@@ -282,7 +282,7 @@ describe('@mantine/dates/DateInput', () => {
     expect(spy).toHaveBeenLastCalledWith(null);
   });
 
-  it('does not allow to clear input value by clicking the selected date when allowDeselect is not set (uncontrolled)', async () => {
+  it('does not allow you to clear input value by clicking the selected date when allowDeselect is not set (uncontrolled)', async () => {
     const { container } = render(
       <DateInput {...defaultProps} clearable allowDeselect={false} defaultValue="2022-04-01" />
     );
@@ -293,7 +293,7 @@ describe('@mantine/dates/DateInput', () => {
     expectValue(container, 'April 1, 2022');
   });
 
-  it('does not allow to clear input value by clicking the selected date when allowDeselect is not set (controlled)', async () => {
+  it('does not allow you to clear input value by clicking the selected date when allowDeselect is not set (controlled)', async () => {
     const spy = jest.fn();
     const { container } = render(
       <DateInput

--- a/packages/@mantine/dates/src/components/Day/Day.test.tsx
+++ b/packages/@mantine/dates/src/components/Day/Day.test.tsx
@@ -60,7 +60,7 @@ describe('@mantine/dates/Day', () => {
     expect(screen.getByRole('button')).toHaveClass('mantine-Month-day');
   });
 
-  it('allows to customize day rendering with renderDay function', () => {
+  it('allows you to customize day rendering with renderDay function', () => {
     render(<Day {...defaultProps} renderDay={(date) => new Date(date).getFullYear()} />);
     expect(screen.getByRole('button')).toHaveTextContent('2022');
   });

--- a/packages/@mantine/form/src/tests/use-form/dirty.test.ts
+++ b/packages/@mantine/form/src/tests/use-form/dirty.test.ts
@@ -24,7 +24,7 @@ function tests(mode: FormMode) {
     expect(hook.result.current.isDirty()).toBe(false);
   });
 
-  it('allows to set dirty state with setDirty handler', () => {
+  it('allows you to set dirty state with setDirty handler', () => {
     const hook = renderHook(() => useForm());
     expect(hook.result.current.isDirty()).toBe(false);
     expect(hook.result.current.isDirty('a')).toBe(false);

--- a/packages/@mantine/form/src/tests/use-form/errors.test.ts
+++ b/packages/@mantine/form/src/tests/use-form/errors.test.ts
@@ -13,7 +13,7 @@ function tests(mode: FormMode) {
     expect(hook.result.current.errors).toStrictEqual({});
   });
 
-  it('allows to set errors object with setErrors handler', () => {
+  it('allows you to set errors object with setErrors handler', () => {
     const hook = renderHook(() => useForm({ mode }));
     act(() => hook.result.current.setErrors({ a: true, b: true }));
     expect(hook.result.current.errors).toStrictEqual({ a: true, b: true });

--- a/packages/@mantine/form/src/tests/use-form/insertListItem.test.ts
+++ b/packages/@mantine/form/src/tests/use-form/insertListItem.test.ts
@@ -29,7 +29,7 @@ function tests(mode: FormMode) {
     });
   });
 
-  it('allows to insert multiple values with consecutive insetListItem calls', () => {
+  it('allows you to insert multiple values with consecutive insetListItem calls', () => {
     const hook = renderHook(() => useForm({ mode, initialValues: { a: [{ b: 1 }, { b: 2 }] } }));
     act(() => {
       hook.result.current.insertListItem('a', { b: 3 });

--- a/packages/@mantine/form/src/tests/use-form/onSubmit.test.ts
+++ b/packages/@mantine/form/src/tests/use-form/onSubmit.test.ts
@@ -77,7 +77,7 @@ function tests(mode: FormMode) {
     );
   });
 
-  it('allows to call onSubmit without event', async () => {
+  it('allows you to call onSubmit without event', async () => {
     const hook = renderHook(() => useForm({ mode, initialValues: { a: 1 } }));
     const handleSubmit = jest.fn();
     await act(async () => hook.result.current.onSubmit(handleSubmit)());

--- a/packages/@mantine/form/src/tests/use-form/submitting.test.ts
+++ b/packages/@mantine/form/src/tests/use-form/submitting.test.ts
@@ -20,7 +20,7 @@ function tests(mode: FormMode) {
     });
   });
 
-  it('allows to set submitting state manually', () => {
+  it('allows you to set submitting state manually', () => {
     const hook = renderHook(() => useForm({ mode, initialValues: { a: 1, b: 2 } }));
     expect(hook.result.current.submitting).toBe(false);
 

--- a/packages/@mantine/form/src/tests/use-form/touched.test.ts
+++ b/packages/@mantine/form/src/tests/use-form/touched.test.ts
@@ -20,7 +20,7 @@ function tests(mode: FormMode) {
     expect(hook.result.current.isTouched()).toBe(true);
   });
 
-  it('allows to set touched state with setTouched handler', () => {
+  it('allows you to set touched state with setTouched handler', () => {
     const hook = renderHook(() => useForm({ mode }));
     expect(hook.result.current.isTouched()).toBe(false);
     expect(hook.result.current.isTouched('a')).toBe(false);

--- a/packages/@mantine/form/src/tests/use-form/validate-object.test.ts
+++ b/packages/@mantine/form/src/tests/use-form/validate-object.test.ts
@@ -90,7 +90,7 @@ function tests(mode: FormMode) {
     expect(hook.result.current.errors).toStrictEqual({});
   });
 
-  it('allows to validate values based on their path', async () => {
+  it('allows you to validate values based on their path', async () => {
     const hook = renderHook(() =>
       useForm({
         mode,

--- a/packages/@mantine/form/src/tests/use-form/values.test.ts
+++ b/packages/@mantine/form/src/tests/use-form/values.test.ts
@@ -7,7 +7,7 @@ describe('@mantine/form/values', () => {
     expect(hook.result.current.values).toStrictEqual({ a: 1, b: 2 });
   });
 
-  it('allows to initialize form without initial values', () => {
+  it('allows you to initialize form without initial values', () => {
     const hook = renderHook(() => useForm<{ a: 1; b: 2 }>());
     expect(hook.result.current.values).toStrictEqual({});
   });
@@ -59,7 +59,7 @@ describe('@mantine/form/values-uncontrolled', () => {
     expect(hook.result.current.getValues()).toStrictEqual({ a: 1, b: 2 });
   });
 
-  it('allows to initialize form without initial values', () => {
+  it('allows you to initialize form without initial values', () => {
     const hook = renderHook(() => useForm<{ a: 1; b: 2 }>({ mode: 'uncontrolled' }));
     expect(hook.result.current.getValues()).toStrictEqual({});
   });

--- a/packages/@mantine/hooks/src/use-state-history/use-state-history.test.ts
+++ b/packages/@mantine/hooks/src/use-state-history/use-state-history.test.ts
@@ -44,7 +44,7 @@ describe('@mantine/hooks/use-state-history', () => {
     expect(hook.result.current[2]).toStrictEqual({ history: [1, 2, 3, 4], current: 3 });
   });
 
-  it('does not allow to go back/forward beyond history', () => {
+  it('does not allow you to go back/forward beyond history', () => {
     const hook = renderHook(() => useStateHistory(1));
     act(() => hook.result.current[1].set(2));
     act(() => hook.result.current[1].set(3));

--- a/packages/@mantine/hooks/src/use-toggle/use-toggle.test.ts
+++ b/packages/@mantine/hooks/src/use-toggle/use-toggle.test.ts
@@ -36,7 +36,7 @@ describe('@mantine/hooks/use-toggle', () => {
     expect(hook.result.current[0]).toBe('dark');
   });
 
-  it('allows to set value', () => {
+  it('allows you to set value', () => {
     const hook = renderHook(() => useToggle(['dark', 'light'] as const));
 
     act(() => hook.result.current[1]('dark'));
@@ -46,13 +46,13 @@ describe('@mantine/hooks/use-toggle', () => {
     expect(hook.result.current[0]).toBe('dark');
   });
 
-  it('allows to set value with callback function', () => {
+  it('allows you to set value with callback function', () => {
     const hook = renderHook(() => useToggle(['dark', 'light'] as const));
     act(() => hook.result.current[1]((v) => v));
     expect(hook.result.current[0]).toBe('dark');
   });
 
-  it('allows to use hook without options', () => {
+  it('allows you to use hook without options', () => {
     const hook = renderHook(() => useToggle());
     expect(hook.result.current[0]).toBe(false);
     act(() => hook.result.current[1]());


### PR DESCRIPTION
Adds the missing direct object after "allow" in test descriptions across `@mantine` packages: `'allows to <verb>'` -> `'allows you to <verb>'` (and the same for the negative form `'does not allow to'`).

`'allow to <verb>'` lacks an explicit object in English; the convention is `'allow [someone] to <verb>'`.
