### PR TITLE
[@mantine/hooks] fix: focus on removed DOM

### DIFF
--- a/packages/@mantine/hooks/src/use-focus-trap/scope-tab.ts
+++ b/packages/@mantine/hooks/src/use-focus-trap/scope-tab.ts
@@ -11,6 +11,7 @@ export function scopeTab(node: HTMLElement, event: KeyboardEvent) {
   let leavingFinalTabbable = finalTabbable === root.activeElement || node === root.activeElement;
 
   const activeElement = root.activeElement as Element;
+  if (!activeElement) return;  // detached node or no focus
   const activeElementIsRadio =
     activeElement.tagName === 'INPUT' && activeElement.getAttribute('type') === 'radio';
   if (activeElementIsRadio) {


### PR DESCRIPTION
# Problem summary

When Mantine's focus trap tries to process a DOM node that was removed before the trap could release, you get:
`Cannot read properties of undefined (reading 'tagName') from @mantine/hooks/use-focus-trap/scope-tab.mjs`

# Proposed solution
Guarding against activeElement being undefined or null should do the trick.

