### PR TITLE
[@mantine/core] Tree: Fix arrow key navigation focusing hidden nodes

### DIFF
--- a/packages/@mantine/core/src/components/Tree/Tree.test.tsx
+++ b/packages/@mantine/core/src/components/Tree/Tree.test.tsx
@@ -71,6 +71,17 @@ describe('@mantine/core/Tree', () => {
       expect(document.activeElement).toBe(nodes[1]);
     });
 
+    it('skips collapsed kept-mounted nodes during arrow navigation', async () => {
+      render(<Tree data={complexTreeData} keepMounted />);
+      const nodes = screen.getAllByRole('treeitem');
+
+      nodes[0].focus();
+      await userEvent.keyboard('{ArrowDown}');
+
+      expect(document.activeElement).toBe(nodes[1]);
+      expect(document.activeElement).toHaveAttribute('data-value', 'node-2');
+    });
+
     it('handles Space to expand/collapse when expandOnSpace is true', async () => {
       const TestComponent = () => {
         const tree = useTree();

--- a/packages/@mantine/core/src/components/Tree/TreeNode.tsx
+++ b/packages/@mantine/core/src/components/Tree/TreeNode.tsx
@@ -19,6 +19,17 @@ function getValuesRange(anchor: string | null, value: string | undefined, flatVa
   return flatValues.slice(start, end + 1);
 }
 
+function isVisibleTreeNode(node: HTMLElement, root: Element) {
+  for (let current: HTMLElement | null = node; current && current !== root; ) {
+    if (current.style.display === 'none') {
+      return false;
+    }
+    current = current.parentElement;
+  }
+
+  return true;
+}
+
 interface TreeNodeProps {
   node: TreeNodeData;
   getStyles: GetStylesApi<TreeFactory>;
@@ -138,7 +149,7 @@ export function TreeNode({
       event.stopPropagation();
       event.preventDefault();
       const nodes = Array.from(root.querySelectorAll<HTMLLIElement>('[role=treeitem]')).filter(
-        (treeNode) => treeNode.style.display !== 'none'
+        (treeNode) => isVisibleTreeNode(treeNode, root)
       );
       const index = nodes.indexOf(event.currentTarget as HTMLLIElement);
 


### PR DESCRIPTION
When `keepMounted` is enabled, collapsed subtrees stay in the DOM inside an Activity component, which hides them by setting display: none on the wrapping `<ul>`. ArrowUp/ArrowDown navigation filtered treeitems by their own inline style.display, which never matched these nested `<li>` elements, so focus moved into hidden nodes (and stalled, since display:none elements are not focusable). Navigation now walks ancestors up to the tree root and skips any node inside a hidden subtree.

### Current buggy behaviour:
> Cannot arrow navigate to package.json.
<img width="976" height="493" alt="broken" src="https://github.com/user-attachments/assets/9c4f5bae-6a62-41a9-8571-08b6921b6d06" />

### After this fix:
<img width="976" height="493" alt="fixed" src="https://github.com/user-attachments/assets/54257914-8452-4cb4-8e5b-3800342d4ac8" />
