### PR TITLE
Fix MaskInput uncontrolled form integration

### DIFF
--- a/apps/mantine.dev/src/pages/core/mask-input.mdx
+++ b/apps/mantine.dev/src/pages/core/mask-input.mdx
@@ -58,7 +58,9 @@ Use the `resetRef` prop to get a function that clears the input value imperative
 
 `MaskInput` is uncontrolled by design – it manages its own DOM value internally.
 To integrate with [use-form](/form/use-form), pass the initial value via `defaultValue`
-and use the `onChangeRaw` callback to write the raw (unmasked) value to form state:
+and use the `onChangeRaw` callback to write the raw (unmasked) value to form state.
+In uncontrolled form mode, pass `{ forceUpdate: false }` to `form.setFieldValue` so the
+input is not remounted on every keystroke:
 
 <Demo data={MaskInputDemos.withUseForm} />
 

--- a/packages/@docs/demos/src/demos/core/MaskInput/MaskInput.demo.withUseForm.tsx
+++ b/packages/@docs/demos/src/demos/core/MaskInput/MaskInput.demo.withUseForm.tsx
@@ -19,7 +19,7 @@ function Demo() {
         mask="(999) 999-9999"
         placeholder="(___) ___-____"
         label="Phone"
-        onChangeRaw={(raw) => form.setFieldValue('phone', raw)}
+        onChangeRaw={(raw) => form.setFieldValue('phone', raw, { forceUpdate: false })}
       />
 
       <Button type="submit" mt="md">
@@ -42,7 +42,7 @@ function Demo() {
         mask="(999) 999-9999"
         placeholder="(___) ___-____"
         label="Phone"
-        onChangeRaw={(raw) => form.setFieldValue('phone', raw)}
+        onChangeRaw={(raw) => form.setFieldValue('phone', raw, { forceUpdate: false })}
       />
 
       <Button type="submit" mt="md">

--- a/packages/@docs/demos/src/demos/form/Form.demo.allComponents.tsx
+++ b/packages/@docs/demos/src/demos/form/Form.demo.allComponents.tsx
@@ -1717,7 +1717,7 @@ function Demo() {
         label="Phone"
         key={form.key('phone')}
         defaultValue={form.getValues().phone}
-        onChangeRaw={(raw) => form.setFieldValue('phone', raw)}
+        onChangeRaw={(raw) => form.setFieldValue('phone', raw, { forceUpdate: false })}
       />
 
       <Group mt="md">
@@ -1744,7 +1744,7 @@ function DemoMaskInput() {
         label="Phone"
         key={form.key('phone')}
         defaultValue={form.getValues().phone}
-        onChangeRaw={(raw) => form.setFieldValue('phone', raw)}
+        onChangeRaw={(raw) => form.setFieldValue('phone', raw, { forceUpdate: false })}
       />
 
       <Group mt="md">

--- a/packages/@mantine/core/src/components/MaskInput/MaskInput.test.tsx
+++ b/packages/@mantine/core/src/components/MaskInput/MaskInput.test.tsx
@@ -1,6 +1,14 @@
 import { createRef } from 'react';
 import { act, fireEvent } from '@testing-library/react';
-import { inputDefaultProps, inputStylesApiSelectors, render, tests } from '@mantine-tests/core';
+import { useForm } from '@mantine/form';
+import {
+  inputDefaultProps,
+  inputStylesApiSelectors,
+  render,
+  screen,
+  tests,
+  userEvent,
+} from '@mantine-tests/core';
 import { __InputStylesNames } from '../Input';
 import { MaskInput, MaskInputProps } from './MaskInput';
 
@@ -37,6 +45,25 @@ describe('@mantine/core/MaskInput', () => {
     componentName: 'MaskInput',
   });
 
+  it('formats defaultValue on mount without calling change handlers', () => {
+    const onChangeRaw = jest.fn();
+    const onComplete = jest.fn();
+
+    render(
+      <MaskInput
+        mask="(999) 999-9999"
+        label="Phone"
+        defaultValue="1234567890"
+        onChangeRaw={onChangeRaw}
+        onComplete={onComplete}
+      />
+    );
+
+    expect(screen.getByLabelText('Phone')).toHaveValue('(123) 456-7890');
+    expect(onChangeRaw).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
   it('clears the input value when resetRef is called', () => {
     const resetRef = createRef<() => void>();
     const onChangeRaw = jest.fn();
@@ -58,5 +85,38 @@ describe('@mantine/core/MaskInput', () => {
 
     expect(input.value).toBe('');
     expect(onChangeRaw).toHaveBeenLastCalledWith('', '');
+  });
+
+  it('submits raw values with uncontrolled form updates', async () => {
+    const handleSubmit = jest.fn();
+
+    function TestForm() {
+      const form = useForm({
+        mode: 'uncontrolled',
+        initialValues: { phone: '' },
+      });
+
+      return (
+        <form onSubmit={form.onSubmit(handleSubmit)}>
+          <MaskInput
+            mask="(999) 999-9999"
+            label="Phone"
+            key={form.key('phone')}
+            defaultValue={form.getValues().phone}
+            onChangeRaw={(raw) => form.setFieldValue('phone', raw, { forceUpdate: false })}
+          />
+          <button type="submit">Submit</button>
+        </form>
+      );
+    }
+
+    render(<TestForm />);
+
+    await userEvent.click(screen.getByLabelText('Phone'));
+    await userEvent.keyboard('1234567890');
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(screen.getByLabelText('Phone')).toHaveValue('(123) 456-7890');
+    expect(handleSubmit.mock.calls[0][0]).toStrictEqual({ phone: '1234567890' });
   });
 });

--- a/packages/@mantine/hooks/src/use-mask/use-mask.ts
+++ b/packages/@mantine/hooks/src/use-mask/use-mask.ts
@@ -370,6 +370,51 @@ export function useMask(options: UseMaskOptions): UseMaskReturnValue {
     return getResolvedOptions(opts, rawValue);
   }, [rawValue]);
 
+  const applyValue = useCallback(
+    ({
+      reprocessed,
+      newRaw,
+      displayValue,
+      resolvedSlots,
+      cursorPos,
+      notifyChange,
+    }: {
+      reprocessed: string;
+      newRaw: string;
+      displayValue: string;
+      resolvedSlots: MaskSlot[];
+      cursorPos?: number;
+      notifyChange: boolean;
+    }) => {
+      const opts = optionsRef.current;
+
+      processedRef.current = reprocessed;
+      displayValueRef.current = displayValue;
+      rawValueRef.current = newRaw;
+      setMaskedValue(displayValue);
+      setRawValue(newRaw);
+
+      if (inputRef.current) {
+        inputRef.current.value = displayValue;
+        if (cursorPos !== undefined && document.activeElement === inputRef.current) {
+          const pos = Math.min(cursorPos, reprocessed.length);
+          inputRef.current.setSelectionRange(pos, pos);
+        }
+      }
+
+      if (notifyChange && opts.onChangeRaw) {
+        opts.onChangeRaw(newRaw, displayValue);
+      }
+
+      const complete = checkComplete(reprocessed, resolvedSlots);
+      if (notifyChange && complete && !wasCompleteRef.current && opts.onComplete) {
+        opts.onComplete(displayValue, newRaw);
+      }
+      wasCompleteRef.current = complete;
+    },
+    []
+  );
+
   const updateValue = useCallback(
     (newMasked: string, cursorPos?: number) => {
       const opts = optionsRef.current;
@@ -390,33 +435,50 @@ export function useMask(options: UseMaskOptions): UseMaskReturnValue {
 
       const displayValue = buildDisplayValue(reprocessed, resolvedSlots, slotChar, shouldShowSlots);
 
-      processedRef.current = reprocessed;
-      displayValueRef.current = displayValue;
-      rawValueRef.current = newRaw;
-      setMaskedValue(displayValue);
-      setRawValue(newRaw);
-
-      if (inputRef.current) {
-        inputRef.current.value = displayValue;
-        if (cursorPos !== undefined && document.activeElement === inputRef.current) {
-          const pos = Math.min(cursorPos, reprocessed.length);
-          inputRef.current.setSelectionRange(pos, pos);
-        }
-      }
-
-      if (opts.onChangeRaw) {
-        opts.onChangeRaw(newRaw, displayValue);
-      }
-
-      const complete = checkComplete(reprocessed, resolvedSlots);
-      if (complete && !wasCompleteRef.current && opts.onComplete) {
-        opts.onComplete(displayValue, newRaw);
-      }
-      wasCompleteRef.current = complete;
+      applyValue({
+        reprocessed,
+        newRaw,
+        displayValue,
+        resolvedSlots,
+        cursorPos,
+        notifyChange: true,
+      });
 
       return { displayValue, newRaw, reprocessed, resolvedSlots };
     },
-    [getOptions]
+    [applyValue, getOptions]
+  );
+
+  const initializeInputValue = useCallback(
+    (node: HTMLInputElement) => {
+      const opts = optionsRef.current;
+
+      if (!node.value) {
+        return false;
+      }
+
+      const { slots: initialSlots, slotChar: initialSlotChar } = getResolvedOptions(opts, '');
+      const initialProcessed = processInput(node.value, initialSlots, initialSlotChar);
+      const initialRaw = extractRaw(initialProcessed, initialSlots);
+      const { slots: resolvedSlots, slotChar } = getResolvedOptions(opts, initialRaw);
+      const reprocessed = processInput(node.value, resolvedSlots, slotChar);
+      const newRaw = extractRaw(reprocessed, resolvedSlots);
+      const showSlots = opts.alwaysShowMask || isFocusedRef.current;
+      const showOnFocus = opts.showMaskOnFocus !== false;
+      const shouldShowSlots = showSlots && (showOnFocus || reprocessed.length > 0);
+      const displayValue = buildDisplayValue(reprocessed, resolvedSlots, slotChar, shouldShowSlots);
+
+      applyValue({
+        reprocessed,
+        newRaw,
+        displayValue,
+        resolvedSlots,
+        notifyChange: false,
+      });
+
+      return true;
+    },
+    [applyValue]
   );
 
   const pushUndoState = useCallback(() => {
@@ -895,7 +957,9 @@ export function useMask(options: UseMaskOptions): UseMaskReturnValue {
 
         setAriaAttributes(node);
 
-        if (options.alwaysShowMask && !node.value) {
+        const hasInitialValue = initializeInputValue(node);
+
+        if (options.alwaysShowMask && !hasInitialValue) {
           const { slots, slotChar } = getResolvedOptions(options, '');
           const display = buildDisplayValue('', slots, slotChar, true);
           node.value = display;
@@ -912,6 +976,7 @@ export function useMask(options: UseMaskOptions): UseMaskReturnValue {
       handleMouseUp,
       handleKeyDown,
       handlePaste,
+      initializeInputValue,
       setAriaAttributes,
       options,
     ]


### PR DESCRIPTION
## Summary

- initialize `useMask` from an input's mounted DOM value so `MaskInput defaultValue` is masked and internal raw/display state stays in sync
- document the uncontrolled `useForm` integration with `form.setFieldValue(..., { forceUpdate: false })` to avoid remounting the input on every keystroke
- add regression coverage for `defaultValue` initialization and raw value submission from an uncontrolled form integration

Fixes #8944.

## Tests

- `npx jest packages/@mantine/core/src/components/MaskInput/MaskInput.test.tsx packages/@mantine/hooks/src/use-mask/use-mask.test.ts --runInBand`
- `npx oxfmt --check packages/@mantine/hooks/src/use-mask/use-mask.ts packages/@mantine/core/src/components/MaskInput/MaskInput.test.tsx packages/@docs/demos/src/demos/form/Form.demo.allComponents.tsx packages/@docs/demos/src/demos/core/MaskInput/MaskInput.demo.withUseForm.tsx`
- `npx oxlint packages/@mantine/hooks/src/use-mask/use-mask.ts packages/@mantine/core/src/components/MaskInput/MaskInput.test.tsx packages/@docs/demos/src/demos/form/Form.demo.allComponents.tsx packages/@docs/demos/src/demos/core/MaskInput/MaskInput.demo.withUseForm.tsx`
- `NODE_OPTIONS=--max-old-space-size=4096 npx tsc --noEmit --pretty false`
- `npm run test:validate-package-json`
- `npm run test:validate-packages-files`