### PR TITLE
[docs] Add Mantine Book to community extensions

### DIFF
--- a/apps/mantine.dev/src/pages/x/extensions.mdx
+++ b/apps/mantine.dev/src/pages/x/extensions.mdx
@@ -41,6 +41,7 @@ Community extensions list:
 - [MantineReactTable](https://v2.mantine-react-table.com/) – data table component based on TanStack table package
 - [Audio](https://gfazioli.github.io/mantine-audio/) – audio player with waveform visualization and live spectrum analyzer, built on Web Audio API
 - [BorderAnimate](https://gfazioli.github.io/mantine-border-animate/) – border animation styles (beam, glow, more...)
+- [Book](https://gfazioli.github.io/mantine-book/) – realistic iBooks-style book with draggable page curl – grab any point of the edge to turn pages, flat DOM fold or true 3D WebGL curl
 - [Clock](https://gfazioli.github.io/mantine-clock/) – analog clock component
 - [Compare](https://gfazioli.github.io/mantine-compare/) – image comparison slider component
 - [DepthSelect](https://gfazioli.github.io/mantine-depth-select/) – 3D stack select component inspired by macOS Time Machine


### PR DESCRIPTION
Adds [Mantine Book](https://gfazioli.github.io/mantine-book/) to the community extensions list (alphabetical order, between BorderAnimate and Clock).

A realistic iBooks-style book component built on Mantine: stack two-sided pages and turn them by dragging any point of the free edge in any direction — a pure-DOM reflection fold by default, or a true 3D WebGL curl, with hard covers, riffle through multi-page jumps, controlled navigation and full keyboard accessibility.

- Docs & demos: https://gfazioli.github.io/mantine-book/
- npm: https://www.npmjs.com/package/@gfazioli/mantine-book
- Repository: https://github.com/gfazioli/mantine-book

Same author as the other `gfazioli.github.io` extensions already listed (Audio, Video, Flip, …).