### PR TITLE
[@mantine/core] Splitter: Add reset on double-click functionality

### DIFF
--- a/packages/@mantine/core/src/components/Splitter/Splitter.test.tsx
+++ b/packages/@mantine/core/src/components/Splitter/Splitter.test.tsx
@@ -1,3 +1,6 @@
+import { createRef } from 'react';
+import { act, fireEvent } from '@testing-library/react';
+import { UseSplitterReturnValue } from '@mantine/hooks';
 import { render, screen, tests } from '@mantine-tests/core';
 import { Splitter, SplitterProps, SplitterStylesNames } from './Splitter';
 
@@ -64,5 +67,51 @@ describe('@mantine/core/Splitter', () => {
   it('sets aria-orientation on handles', () => {
     render(<Splitter {...defaultProps} />);
     expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'horizontal');
+  });
+
+  it('resets adjacent panes to their default ratio when their handle is double-clicked', () => {
+    const ref = createRef<UseSplitterReturnValue>();
+    render(
+      <Splitter splitterRef={ref}>
+        <Splitter.Pane defaultSize={20} key="1">
+          A
+        </Splitter.Pane>
+        <Splitter.Pane defaultSize={30} key="2">
+          B
+        </Splitter.Pane>
+        <Splitter.Pane defaultSize={50} key="3">
+          C
+        </Splitter.Pane>
+      </Splitter>
+    );
+
+    act(() => ref.current!.setSizes([10, 20, 70]));
+
+    fireEvent.doubleClick(screen.getAllByRole('separator')[0]);
+
+    expect(ref.current!.sizes).toEqual([12, 18, 70]);
+  });
+
+  it('does not reset on double click when resetOnDoubleClick is false', () => {
+    const ref = createRef<UseSplitterReturnValue>();
+    render(
+      <Splitter splitterRef={ref} resetOnDoubleClick={false}>
+        <Splitter.Pane defaultSize={20} key="1">
+          A
+        </Splitter.Pane>
+        <Splitter.Pane defaultSize={30} key="2">
+          B
+        </Splitter.Pane>
+        <Splitter.Pane defaultSize={50} key="3">
+          C
+        </Splitter.Pane>
+      </Splitter>
+    );
+
+    act(() => ref.current!.setSizes([10, 20, 70]));
+
+    fireEvent.doubleClick(screen.getAllByRole('separator')[0]);
+
+    expect(ref.current!.sizes).toEqual([10, 20, 70]);
   });
 });

--- a/packages/@mantine/core/src/components/Splitter/Splitter.tsx
+++ b/packages/@mantine/core/src/components/Splitter/Splitter.tsx
@@ -76,6 +76,9 @@ export interface SplitterProps
   /** Determines whether the thumb with grip icon is displayed on the handle @default true */
   withHandle?: boolean;
 
+  /** Restore the two panes adjacent to a handle to their default ratio (preserving their combined size) when the handle is double-clicked @default true */
+  resetOnDoubleClick?: boolean;
+
   /** Ref to imperative splitter API (sizes, collapse, expand, etc.) */
   splitterRef?: React.RefObject<UseSplitterReturnValue | null>;
 
@@ -97,6 +100,7 @@ const defaultProps = {
   orientation: 'horizontal',
   lineSize: 2,
   withHandle: true,
+  resetOnDoubleClick: true,
 } satisfies Partial<SplitterProps>;
 
 const varsResolver = createVarsResolver<SplitterFactory>((theme, { lineSize, handleColor }) => ({
@@ -122,6 +126,7 @@ export const Splitter = factory<SplitterFactory>((_props) => {
     handleColor,
     handleIcon,
     withHandle,
+    resetOnDoubleClick,
     splitterRef,
     children,
     className,
@@ -160,6 +165,7 @@ export const Splitter = factory<SplitterFactory>((_props) => {
     step,
     shiftStep,
     dir,
+    resetOnDoubleClick,
   });
 
   useImperativeHandle(splitterRef, () => splitter, [splitter]);

--- a/packages/@mantine/hooks/src/use-splitter/use-splitter.test.tsx
+++ b/packages/@mantine/hooks/src/use-splitter/use-splitter.test.tsx
@@ -696,4 +696,75 @@ describe('useSplitter', () => {
       expect(sum).toBe(100);
     });
   });
+
+  describe('reset', () => {
+    it('reset(handleIndex) restores adjacent panels to their default ratio and leaves other panels untouched', () => {
+      const { result } = renderHook(() =>
+        useSplitter({ panels: [{ defaultSize: 20 }, { defaultSize: 30 }, { defaultSize: 50 }] })
+      );
+
+      act(() => {
+        result.current.setSizes([10, 20, 70]);
+      });
+
+      act(() => {
+        result.current.reset(0);
+      });
+
+      // combined size of panes 0 and 1 (30) preserved, restored to 20:30 ratio
+      expect(result.current.sizes).toEqual([12, 18, 70]);
+    });
+
+    it('reset clamps adjacent panels to their min constraints', () => {
+      const { result } = renderHook(() =>
+        useSplitter({
+          panels: [{ defaultSize: 20 }, { defaultSize: 60, min: 50 }, { defaultSize: 20 }],
+        })
+      );
+
+      act(() => {
+        result.current.setSizes([55, 5, 40]);
+      });
+
+      act(() => {
+        result.current.reset(0);
+      });
+
+      // default ratio would put pane 0 at 15, but pane 1 must keep its min of 50
+      expect(result.current.sizes).toEqual([10, 50, 40]);
+    });
+
+    it('double-clicking a handle resets its adjacent panels to the default ratio', () => {
+      render(
+        <TestComponent panels={[{ defaultSize: 20 }, { defaultSize: 30 }, { defaultSize: 50 }]} />
+      );
+
+      const handle = screen.getByTestId('handle-0');
+      for (let i = 0; i < 10; i++) {
+        fireEvent.keyDown(handle, { key: 'ArrowRight' });
+      }
+      expect(handle.getAttribute('aria-valuenow')).toBe('30');
+
+      fireEvent.doubleClick(handle);
+      expect(handle.getAttribute('aria-valuenow')).toBe('20');
+    });
+
+    it('does not reset on double click when resetOnDoubleClick is false', () => {
+      render(
+        <TestComponent
+          panels={[{ defaultSize: 20 }, { defaultSize: 30 }, { defaultSize: 50 }]}
+          resetOnDoubleClick={false}
+        />
+      );
+
+      const handle = screen.getByTestId('handle-0');
+      for (let i = 0; i < 10; i++) {
+        fireEvent.keyDown(handle, { key: 'ArrowRight' });
+      }
+      expect(handle.getAttribute('aria-valuenow')).toBe('30');
+
+      fireEvent.doubleClick(handle);
+      expect(handle.getAttribute('aria-valuenow')).toBe('30');
+    });
+  });
 });

--- a/packages/@mantine/hooks/src/use-splitter/use-splitter.ts
+++ b/packages/@mantine/hooks/src/use-splitter/use-splitter.ts
@@ -55,6 +55,8 @@ export interface UseSplitterOptions {
   shiftStep?: number;
   /** Text direction for keyboard nav, `'ltr'` by default */
   dir?: 'ltr' | 'rtl';
+  /** Restore the two panels adjacent to a handle to their default ratio (preserving their combined size) when the handle is double-clicked, `true` by default */
+  resetOnDoubleClick?: boolean;
   /** Enable/disable the hook, `true` by default */
   enabled?: boolean;
 }
@@ -78,6 +80,7 @@ export interface UseSplitterReturnValue<T extends HTMLElement = any> {
     'aria-valuemax': number;
     tabIndex: number;
     onKeyDown: React.KeyboardEventHandler;
+    onDoubleClick: React.MouseEventHandler;
     'data-active': boolean | undefined;
     'data-orientation': 'horizontal' | 'vertical';
   };
@@ -89,6 +92,9 @@ export interface UseSplitterReturnValue<T extends HTMLElement = any> {
   expand: (panelIndex: number) => void;
   /** Toggle collapse of a panel */
   toggleCollapse: (panelIndex: number) => void;
+  /** Reset the two panels adjacent to a handle to their default ratio, preserving
+   * their combined size */
+  reset: (handleIndex: number) => void;
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -377,6 +383,7 @@ export function useSplitter<T extends HTMLElement = any>(
     step = 1,
     shiftStep = 10,
     dir = 'ltr',
+    resetOnDoubleClick = true,
     enabled = true,
   } = options;
 
@@ -479,6 +486,52 @@ export function useSplitter<T extends HTMLElement = any>(
     [collapsePanel, expandPanel]
   );
 
+  const emitCollapseTransitions = useCallback(
+    (prev: number[], next: number[], indices: number[], preCollapseSnapshot: number[]) => {
+      const onChange = optionsRef.current.onCollapseChange;
+      for (const idx of indices) {
+        const wasCollapsed = prev[idx] === 0;
+        const nowCollapsed = next[idx] === 0;
+        if (!wasCollapsed && nowCollapsed) {
+          preCollapseSizesRef.current = [...preCollapseSnapshot];
+          onChange?.(idx, true);
+        } else if (wasCollapsed && !nowCollapsed) {
+          onChange?.(idx, false);
+        }
+      }
+    },
+    []
+  );
+
+  const reset = useCallback(
+    (handleIndex: number) => {
+      const prev = currentSizesRef.current;
+      const currentPanels = optionsRef.current.panels;
+
+      const beforeIdx = handleIndex;
+      const afterIdx = handleIndex + 1;
+      if (beforeIdx < 0 || afterIdx >= prev.length) {
+        return;
+      }
+
+      const total = prev[beforeIdx] + prev[afterIdx];
+      const defBefore = currentPanels[beforeIdx].defaultSize;
+      const defAfter = currentPanels[afterIdx].defaultSize;
+      const defTotal = defBefore + defAfter;
+      const targetBefore = defTotal === 0 ? total / 2 : total * (defBefore / defTotal);
+
+      const next = applyAdjacentOnly(
+        prev,
+        currentPanels,
+        beforeIdx,
+        targetBefore - prev[beforeIdx]
+      );
+      emitCollapseTransitions(prev, next, [beforeIdx, afterIdx], prev);
+      updateSizes(next);
+    },
+    [emitCollapseTransitions, updateSizes]
+  );
+
   const containerRefCallback: React.RefCallback<T | null> = useCallback((node) => {
     containerRef.current = node;
   }, []);
@@ -569,24 +622,12 @@ export function useSplitter<T extends HTMLElement = any>(
           );
 
           const prevSizes = currentSizesRef.current;
-          const beforeWasCollapsed = prevSizes[s.handleIndex] === 0;
-          const afterWasCollapsed = prevSizes[s.handleIndex + 1] === 0;
-          const beforeNowCollapsed = newSizes[s.handleIndex] === 0;
-          const afterNowCollapsed = newSizes[s.handleIndex + 1] === 0;
-
-          if (!beforeWasCollapsed && beforeNowCollapsed) {
-            preCollapseSizesRef.current = [...s.startSizes];
-            opts.onCollapseChange?.(s.handleIndex, true);
-          } else if (beforeWasCollapsed && !beforeNowCollapsed) {
-            opts.onCollapseChange?.(s.handleIndex, false);
-          }
-
-          if (!afterWasCollapsed && afterNowCollapsed) {
-            preCollapseSizesRef.current = [...s.startSizes];
-            opts.onCollapseChange?.(s.handleIndex + 1, true);
-          } else if (afterWasCollapsed && !afterNowCollapsed) {
-            opts.onCollapseChange?.(s.handleIndex + 1, false);
-          }
+          emitCollapseTransitions(
+            prevSizes,
+            newSizes,
+            [s.handleIndex, s.handleIndex + 1],
+            s.startSizes
+          );
 
           currentSizesRef.current = newSizes;
           setCurrentSizes(newSizes);
@@ -732,27 +773,15 @@ export function useSplitter<T extends HTMLElement = any>(
 
           if (delta !== 0) {
             const newSizes = applyConstraints(currentSizes, panels, index, delta, redistribute);
-            const beforeWas = currentSizes[index] === 0;
-            const afterWas = currentSizes[index + 1] === 0;
-            const beforeNow = newSizes[index] === 0;
-            const afterNow = newSizes[index + 1] === 0;
-
-            if (!beforeWas && beforeNow) {
-              preCollapseSizesRef.current = [...currentSizes];
-              onCollapseChange?.(index, true);
-            } else if (beforeWas && !beforeNow) {
-              onCollapseChange?.(index, false);
-            }
-
-            if (!afterWas && afterNow) {
-              preCollapseSizesRef.current = [...currentSizes];
-              onCollapseChange?.(index + 1, true);
-            } else if (afterWas && !afterNow) {
-              onCollapseChange?.(index + 1, false);
-            }
-
+            emitCollapseTransitions(currentSizes, newSizes, [index, index + 1], currentSizes);
             updateSizes(newSizes);
           }
+        },
+        onDoubleClick: () => {
+          if (!enabled || !resetOnDoubleClick) {
+            return;
+          }
+          reset(index);
         },
         'data-active': activeHandle === index || undefined,
         'data-orientation': orient,
@@ -766,12 +795,14 @@ export function useSplitter<T extends HTMLElement = any>(
       dir,
       step,
       shiftStep,
+      resetOnDoubleClick,
       activeHandle,
       redistribute,
       getHandleRefCallback,
       toggleCollapsePanel,
       updateSizes,
-      onCollapseChange,
+      emitCollapseTransitions,
+      reset,
     ]
   );
 
@@ -803,6 +834,7 @@ export function useSplitter<T extends HTMLElement = any>(
     collapse: collapsePanel,
     expand: expandPanel,
     toggleCollapse: toggleCollapsePanel,
+    reset,
   };
 }
 


### PR DESCRIPTION
Adds the ability to reset a `Splitter` handle by double-clicking it. Double-clicking a handle restores its two adjacent panes to their default ratio while preserving their combined size, so other panes are left untouched.

Double-click-to-reset is a near-universal convention for splitters/resizable panels (VS Code, browser devtools, most IDE layouts etc). I think this would be nice quality of life improvement to Mantine :) 

IMO this should be default behaviour and you can out-out via passing `resetOnDoubleClick={false}`

https://github.com/user-attachments/assets/537e0a0b-cceb-47ac-8e5b-991b4d5ea821

### Other libraries
Here are few other component libraries that have this behaviour:
- [Shadcn](https://ui.shadcn.com/docs/components/radix/resizable) (default behaviour)
- [And design](https://ant.design/components/splitter?utm_source=chatgpt.com#splitter-demo-reset) (supports via `onDraggerDoubleClick`)
- [Mantine split pane](https://gfazioli.github.io/mantine-split-pane/#reset-with-double-click) As a bonus (but would be nice to not need separate package)