### PR TITLE
[mantine.dev] Disable eye dropper in swatches-only color input demo

### DIFF
--- a/apps/mantine.dev/src/pages/core/color-input.mdx
+++ b/apps/mantine.dev/src/pages/core/color-input.mdx
@@ -67,7 +67,8 @@ like in the [ColorPicker](/core/color-picker/) component:
 
 <Demo data={ColorPickerDemos.swatchesConfigurator} />
 
-If you need to restrict color picking to certain colors – disable the color picker and disallow free input:
+If you need to restrict color picking to certain colors – disable the color picker, disallow free input
+and hide the eye dropper:
 
 <Demo data={ColorInputDemos.swatchesOnly} />
 

--- a/packages/@docs/demos/src/demos/core/ColorInput/ColorInput.demo.swatchesOnly.tsx
+++ b/packages/@docs/demos/src/demos/core/ColorInput/ColorInput.demo.swatchesOnly.tsx
@@ -11,6 +11,7 @@ function Demo() {
       label="Your favorite color"
       disallowInput
       withPicker={false}
+      withEyeDropper={false}
       swatches={['#2e2e2e', '#868e96', '#fa5252', '#e64980', '#be4bdb', '#7950f2', '#4c6ef5', '#228be6', '#15aabf', '#12b886', '#40c057', '#82c91e', '#fab005', '#fd7e14']}
     />
   );
@@ -26,6 +27,7 @@ function Demo() {
       label="Your favorite color"
       disallowInput
       withPicker={false}
+      withEyeDropper={false}
       swatches={[
         '#2e2e2e',
         '#868e96',


### PR DESCRIPTION
This is a very minor nitpick 🤓 but this is supposed to demonstrate restricted color selection. However you can still choose any color using the color picker.