### PR TITLE
[@mantine/mcp-server] Handle CLI metadata flags

### DIFF
--- a/packages/@mantine/mcp-server/bin/mcp-server.cjs
+++ b/packages/@mantine/mcp-server/bin/mcp-server.cjs
@@ -1,3 +1,29 @@
 #!/usr/bin/env node
 
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`Usage: mcp-server
+
+Starts the Mantine MCP server.
+
+Options:
+  -h, --help     Show help
+  -v, --version  Show version`);
+  process.exit(0);
+}
+
+if (args.includes('--version') || args.includes('-v')) {
+  console.log(require('../package.json').version);
+  process.exit(0);
+}
+
+const unknownOption = args.find((arg) => arg.startsWith('-'));
+
+if (unknownOption) {
+  console.error(`Unknown option: ${unknownOption}`);
+  console.error('Run mcp-server --help for usage.');
+  process.exit(1);
+}
+
 require('../cjs/index.cjs');


### PR DESCRIPTION
### Summary

Handles top-level CLI metadata flags in the `@mantine/mcp-server` bin entrypoint before the MCP server is required:

- `mcp-server --help` / `-h` prints concise usage and exits 0
- `mcp-server --version` / `-v` prints the package version and exits 0
- unknown top-level flags print a short error and exit non-zero

Normal server startup remains unchanged when no flags are passed.

Fixes #8965

### Verification

```bash
node packages/@mantine/mcp-server/bin/mcp-server.cjs --help
node packages/@mantine/mcp-server/bin/mcp-server.cjs --version
node packages/@mantine/mcp-server/bin/mcp-server.cjs --definitely-not-a-real-flag
```