### PR TITLE
[mantine.dev] Add Fumadocs community template

### DIFF
--- a/apps/mantine.dev/src/components/MdxProvider/MdxTemplatesList/community-data.ts
+++ b/apps/mantine.dev/src/components/MdxProvider/MdxTemplatesList/community-data.ts
@@ -39,6 +39,12 @@ export const COMMUNITY_TEMPLATES_DATA: Template[] = [
   },
   {
     type: 'next',
+    name: 'fumadocs-documentation-template',
+    link: 'https://github.com/gfazioli/next-app-fumadocs-template',
+    description: 'Fumadocs + Mantine template',
+  },
+  {
+    type: 'next',
     name: 'next-saas-template',
     link: 'https://github.com/AshutoshDash1999/nextjs-mantine-boilerplate',
     description: 'Next.js SaaS boilerplate with Mantine',


### PR DESCRIPTION
Adds [next-app-fumadocs-template](https://github.com/gfazioli/next-app-fumadocs-template) to the community templates list, next to the existing Nextra template.

It is a documentation-site starter built on **fumadocs-core (headless)** with the docs UI implemented 100% with Mantine — no Tailwind, no fumadocs-ui. It is the Fumadocs sibling of [next-app-nextra-template](https://github.com/gfazioli/next-app-nextra-template), already listed here.

Live demo: https://gfazioli.github.io/next-app-fumadocs-template/