### PR TITLE
[@mantine/dates] TimePicker: Allow entering 01-09 hours over a selected 00 value

### DIFF
--- a/packages/@mantine/dates/src/components/SpinInput/SpinInput.tsx
+++ b/packages/@mantine/dates/src/components/SpinInput/SpinInput.tsx
@@ -67,7 +67,11 @@ export function SpinInput({
     }
 
     if (event.key === '0' || event.key === 'Num0') {
-      if (value === 0) {
+      const { selectionStart, selectionEnd, value: inputValue } = event.currentTarget;
+      const isEntireValueSelected =
+        inputValue.length > 0 && selectionStart === 0 && selectionEnd === inputValue.length;
+
+      if (value === 0 && !isEntireValueSelected) {
         event.preventDefault();
         onNextInput?.();
       }

--- a/packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx
@@ -50,6 +50,19 @@ describe('@mantine/dates/TimePicker', () => {
     expect(screen.getByLabelText('test-am-pm')).toHaveFocus();
   });
 
+  // https://github.com/mantinedev/mantine/issues/8967
+  it('allows entering 01-09 hours over a selected 00 value', async () => {
+    render(<TimePicker {...defaultProps} format="24h" defaultValue="00:00" />);
+
+    const hoursInput = screen.getByLabelText('test-hours');
+    await userEvent.click(hoursInput);
+    await userEvent.keyboard('02');
+
+    expect(hoursInput).toHaveValue('02');
+    expect(screen.getByLabelText('test-minutes')).toHaveFocus();
+    expect(screen.getByLabelText('test-minutes')).toHaveValue('00');
+  });
+
   it('handles backspace key correctly', async () => {
     render(<TimePicker {...defaultProps} withSeconds format="24h" />);
 
@@ -713,7 +726,7 @@ describe('@mantine/dates/TimePicker', () => {
     await userEvent.type(screen.getByLabelText('test-hours'), '0');
     expect(screen.getByLabelText('test-hours')).toHaveFocus();
 
-    await userEvent.type(screen.getByLabelText('test-hours'), '0');
+    await userEvent.keyboard('0');
     expect(screen.getByLabelText('test-minutes')).toHaveFocus();
   });
 


### PR DESCRIPTION
Fixes #8967

### Problem

When the hours field shows `00` (e.g. the value is `00:00`), clicking the field selects its text, and pressing `0` as the first digit of `01`–`09` immediately moves focus to minutes: the `keydown` handler advances on `0` whenever the field's value is `0`, before the input event can apply the replacement. Times `01:xx`–`09:xx` cannot be typed over a zero value at all — the leading `0` always jumps away. Reproducible on the docs demo.

### Fix

Skip the advance when the entire field text is selected: in that state the keystroke replaces the value and starts a new entry, so the field keeps focus with `0` applied and the next digit completes the hour (`02` → focus moves to minutes through the regular `00`-prefix path). Pressing `0` again with no selection still completes `00` and advances, both for an empty field and after an over-selection restart.

The existing `moves focus to the next input when double zero is entered` test typed each `0` through a separate `userEvent.type()` call, and each call clicks the field first — re-selecting the text between keystrokes. The second keystroke now lands as `userEvent.keyboard('0')` on the already-focused field, which matches how a user actually types `00`; the asserted behavior (double zero advances) is unchanged.

### Tests

`allows entering 01-09 hours over a selected 00 value` fails on `master` (the `0` jumps to minutes, so hours stay `00` and the `2` lands in minutes) and passes with this change. `@mantine/dates` suite: 2110 passed / 0 failed. `tsc --noEmit`, `oxlint`, and `format:write:files` on the changed files are clean.
