### PR TITLE
[@mantine/core] add missing role attributes for menu children

### DIFF
--- a/packages/@mantine/core/src/components/Menu/Menu.test.tsx
+++ b/packages/@mantine/core/src/components/Menu/Menu.test.tsx
@@ -161,6 +161,39 @@ describe('@mantine/core/Menu', () => {
     expect(document.querySelectorAll('.mantine-Menu-arrow')).toHaveLength(0);
   });
 
+  describe('ARIA roles of dropdown children', () => {
+    it('assigns role="presentation" to the initial focus placeholder', () => {
+      render(<TestContainer defaultOpened />);
+      const placeholder = screen.getByRole('menu').querySelector('[data-autofocus]');
+      expect(placeholder).toHaveAttribute('role', 'presentation');
+    });
+
+    it('assigns role="presentation" to the arrow', () => {
+      render(<TestContainer defaultOpened withArrow />);
+      expect(document.querySelector('.mantine-Menu-arrow')).toHaveAttribute('role', 'presentation');
+    });
+
+    it('assigns role="separator" to Menu.Divider and role="presentation" to Menu.Label', () => {
+      render(
+        <Menu transitionProps={{ duration: 0 }} withinPortal={false} defaultOpened>
+          <Menu.Target>
+            <button type="button">test-target</button>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Label>Section</Menu.Label>
+            <Menu.Item>Item</Menu.Item>
+            <Menu.Divider />
+          </Menu.Dropdown>
+        </Menu>
+      );
+      expect(screen.getByText('Section')).toHaveAttribute('role', 'presentation');
+      expect(screen.getByRole('menu').querySelector('.mantine-Menu-divider')).toHaveAttribute(
+        'role',
+        'separator'
+      );
+    });
+  });
+
   it('exposes related components as static properties', () => {
     expect(Menu.Item).toBe(MenuItem);
     expect(Menu.Dropdown).toBe(MenuDropdown);

--- a/packages/@mantine/core/src/components/Menu/MenuDivider/MenuDivider.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuDivider/MenuDivider.tsx
@@ -31,7 +31,11 @@ export const MenuDivider = factory<MenuDividerFactory>((props) => {
   const ctx = useMenuContext();
 
   return (
-    <Box {...ctx.getStyles('divider', { className, style, styles, classNames })} {...others} />
+    <Box
+      role="separator"
+      {...ctx.getStyles('divider', { className, style, styles, classNames })}
+      {...others}
+    />
   );
 });
 

--- a/packages/@mantine/core/src/components/Menu/MenuDropdown/MenuDropdown.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuDropdown/MenuDropdown.tsx
@@ -93,7 +93,13 @@ export const MenuDropdown = factory<MenuDropdownFactory>((props) => {
       onKeyDown={handleKeyDown}
     >
       {ctx.withInitialFocusPlaceholder && !ctx.hasSearch && (
-        <div tabIndex={-1} data-autofocus data-mantine-stop-propagation style={{ outline: 0 }} />
+        <div
+          role="presentation"
+          tabIndex={-1}
+          data-autofocus
+          data-mantine-stop-propagation
+          style={{ outline: 0 }}
+        />
       )}
       {children}
     </Popover.Dropdown>

--- a/packages/@mantine/core/src/components/Menu/MenuLabel/MenuLabel.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuLabel/MenuLabel.tsx
@@ -30,7 +30,13 @@ export const MenuLabel = factory<MenuLabelFactory>((props) => {
   );
   const ctx = useMenuContext();
 
-  return <Box {...ctx.getStyles('label', { className, style, styles, classNames })} {...others} />;
+  return (
+    <Box
+      role="presentation"
+      {...ctx.getStyles('label', { className, style, styles, classNames })}
+      {...others}
+    />
+  );
 });
 
 MenuLabel.classes = classes;

--- a/packages/@mantine/core/src/components/Popover/PopoverDropdown/PopoverDropdown.tsx
+++ b/packages/@mantine/core/src/components/Popover/PopoverDropdown/PopoverDropdown.tsx
@@ -130,6 +130,7 @@ export const PopoverDropdown = factory<PopoverDropdownFactory>((_props) => {
               {children}
 
               <FloatingArrow
+                role="presentation"
                 ref={ctx.arrowRef}
                 arrowX={ctx.arrowX}
                 arrowY={ctx.arrowY}


### PR DESCRIPTION
Fixes #8971
added separator role for menu divider and presentation role for menu label and auto-focus placeholder