### PR TITLE
fix: allow editing midnight timepicker hours

### DIFF
--- a/packages/@mantine/dates/src/components/SpinInput/SpinInput.tsx
+++ b/packages/@mantine/dates/src/components/SpinInput/SpinInput.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { clamp } from '@mantine/hooks';
 import { padTime } from '../TimePicker/utils/pad-time/pad-time';
 
@@ -35,6 +36,7 @@ export function SpinInput({
 }: SpinInputProps) {
   const maxDigit = getMaxDigit(max);
   const arrowsMax = max + 1 - step;
+  const shouldAdvanceZeroRef = useRef(false);
 
   const handleChange = (value: string) => {
     if (readOnly) {
@@ -53,11 +55,14 @@ export function SpinInput({
       const clampedValue =
         allowTemporaryZero && parsedValue === 0 && min > 0 ? 0 : clamp(parsedValue, min, max);
 
+      shouldAdvanceZeroRef.current = clampedValue === 0 && clearValue === '0';
       onChange(clampedValue);
 
       if (!disableAutoAdvance && (clampedValue > maxDigit || value.startsWith('00'))) {
         onNextInput?.();
       }
+    } else {
+      shouldAdvanceZeroRef.current = false;
     }
   };
 
@@ -67,19 +72,26 @@ export function SpinInput({
     }
 
     if (event.key === '0' || event.key === 'Num0') {
-      if (value === 0) {
+      const isValueSelected =
+        event.currentTarget.selectionStart === 0 &&
+        event.currentTarget.selectionEnd === event.currentTarget.value.length;
+
+      if (value === 0 && (!isValueSelected || shouldAdvanceZeroRef.current)) {
         event.preventDefault();
+        shouldAdvanceZeroRef.current = false;
         onNextInput?.();
       }
     }
 
     if (event.key === 'Home') {
       event.preventDefault();
+      shouldAdvanceZeroRef.current = false;
       onChange(min);
     }
 
     if (event.key === 'End') {
       event.preventDefault();
+      shouldAdvanceZeroRef.current = false;
       onChange(max);
     }
 
@@ -87,6 +99,7 @@ export function SpinInput({
       event.preventDefault();
 
       if (value !== null) {
+        shouldAdvanceZeroRef.current = false;
         onChange(null);
       } else {
         onPreviousInput?.();
@@ -105,12 +118,14 @@ export function SpinInput({
 
     if (event.key === 'ArrowUp') {
       event.preventDefault();
+      shouldAdvanceZeroRef.current = false;
       const newValue = value === null ? min : clamp(value + step, min, arrowsMax);
       onChange(newValue);
     }
 
     if (event.key === 'ArrowDown') {
       event.preventDefault();
+      shouldAdvanceZeroRef.current = false;
       const newValue = value === null ? arrowsMax : clamp(value - step, min, arrowsMax);
       onChange(newValue);
     }

--- a/packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx
@@ -37,6 +37,16 @@ describe('@mantine/dates/TimePicker', () => {
     expect(screen.getByLabelText('test-seconds')).toHaveFocus();
   });
 
+  it('allows editing 00 hours with a leading zero', async () => {
+    render(<TimePicker {...defaultProps} defaultValue="00:00" format="24h" />);
+
+    await userEvent.click(screen.getByLabelText('test-hours'));
+    await userEvent.type(document.activeElement!, '02');
+
+    expect(screen.getByLabelText('test-hours')).toHaveValue('02');
+    expect(screen.getByLabelText('test-minutes')).toHaveFocus();
+  });
+
   it('manages focus properly (12h format)', async () => {
     render(<TimePicker {...defaultProps} withSeconds format="12h" />);
 


### PR DESCRIPTION
Fixes #8967

This keeps the hours input editable when the current value is `00:00`. When the whole `00` hours field is selected, typing the first `0` should replace the selection and keep focus in the hours input so users can enter values like `02`.

The existing double-zero auto-advance behavior is preserved for user-entered temporary zero values.

Verification:

- `yarn jest packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx --runInBand`
- `yarn format:write:files packages/@mantine/dates/src/components/SpinInput/SpinInput.tsx packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx`
- `yarn oxlint packages/@mantine/dates/src/components/SpinInput/SpinInput.tsx packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx`
- `git diff --check`
