### PR TITLE
[@mantine/charts] Heatmap: Clamp colors for values outside domain

### DIFF
--- a/packages/@mantine/charts/src/Heatmap/get-heat-color/get-heat-color.test.ts
+++ b/packages/@mantine/charts/src/Heatmap/get-heat-color/get-heat-color.test.ts
@@ -13,4 +13,12 @@ describe('@mantine/charts/get-heat-color', () => {
   it('returns the last color when min equals max (all values identical)', () => {
     expect(getHeatColor({ value: 5, min: 5, max: 5, colors })).toBe('4');
   });
+
+  it('clamps values above max to the last color', () => {
+    expect(getHeatColor({ value: 150, min: 0, max: 100, colors })).toBe('4');
+  });
+
+  it('clamps values below min to the first color', () => {
+    expect(getHeatColor({ value: -200, min: 0, max: 100, colors })).toBe('1');
+  });
 });

--- a/packages/@mantine/charts/src/Heatmap/get-heat-color/get-heat-color.ts
+++ b/packages/@mantine/charts/src/Heatmap/get-heat-color/get-heat-color.ts
@@ -7,6 +7,7 @@ interface GetHeatColorInput {
 
 export function getHeatColor({ value, min, max, colors }: GetHeatColorInput) {
   const percent = max === min ? 1 : (value - min) / (max - min);
-  const colorIndex = Math.round((colors.length - 1) * percent);
+  const clampedPercent = Math.min(1, Math.max(0, percent));
+  const colorIndex = Math.round((colors.length - 1) * clampedPercent);
   return colors[colorIndex];
 }


### PR DESCRIPTION
## Problem

  When a custom `domain` is provided to `Heatmap` (e.g. `domain={[0, 100]}` to keep
  colors consistent across multiple heatmaps) and a cell value falls **outside** that
  domain (e.g. an outlier of `150`), the cell renders with **no fill**.

  ## Cause

  In `getHeatColor`, `percent` is computed as `(value - min) / (max - min)`. For
  out-of-domain values, `percent` leaves the `[0, 1]` range, so `colorIndex` goes out
  of bounds and `colors[colorIndex]` is `undefined`:

  | value | domain | `percent` | result |
  |-------|--------|-----------|--------|
  | `150` | `[0, 100]` | `1.5` | `undefined` (no fill) |
  | `-20` | `[0, 100]` | `-0.2` | `undefined` (no fill) |
  | `50` | `[0, 100]` | `0.5` | correct color |

  ## Fix

  Clamp `percent` to `[0, 1]` so out-of-domain values map to the nearest edge color —
  above `max` maps to the last color, below `min` to the first. This matches the
  existing contract that `getHeatColor` always returns a color (already enforced for
  the `min === max` case).

  ```diff
  - const colorIndex = Math.round((colors.length - 1) * percent);
  + const clampedPercent = Math.min(1, Math.max(0, percent));
  + const colorIndex = Math.round((colors.length - 1) * clampedPercent);

  Tests

  Two regression tests added to get-heat-color.test.ts (value above max, value below
  min). Full test suite passes (14732 tests) and typecheck is clean.