### PR TITLE
[@mantine/core] RollingNumber: Fix rendering "-0" for values that round to zero

### DIFF
--- a/packages/@mantine/core/src/components/RollingNumber/build-value.test.ts
+++ b/packages/@mantine/core/src/components/RollingNumber/build-value.test.ts
@@ -39,6 +39,11 @@ describe('buildValue', () => {
     expect(buildValue({ value: -42 })).toBe('-42');
   });
 
+  it('does not render "-0" for negative values that round to zero', () => {
+    expect(buildValue({ value: -0.4, decimalScale: 0 })).toBe('0');
+    expect(buildValue({ value: -0.001, decimalScale: 2, fixedDecimalScale: true })).toBe('0.00');
+  });
+
   it('handles negative values with prefix', () => {
     expect(buildValue({ value: -1234, prefix: '$ ', thousandSeparator: true })).toBe('$ -1,234');
   });

--- a/packages/@mantine/core/src/components/RollingNumber/get-digit-parts.test.ts
+++ b/packages/@mantine/core/src/components/RollingNumber/get-digit-parts.test.ts
@@ -25,6 +25,17 @@ describe('getDigitParts', () => {
     expect(result.intDigits).toEqual(['4', '2']);
   });
 
+  it('is not negative when a negative value rounds to zero', () => {
+    expect(getDigitParts({ value: -0.4, decimalScale: 0 }).negative).toBe(false);
+    expect(
+      getDigitParts({ value: -0.001, decimalScale: 2, fixedDecimalScale: true }).negative
+    ).toBe(false);
+  });
+
+  it('stays negative when a negative value rounds to a non-zero magnitude', () => {
+    expect(getDigitParts({ value: -0.6, decimalScale: 0 }).negative).toBe(true);
+  });
+
   it('handles decimal values', () => {
     const result = getDigitParts({ value: 3.14 });
     expect(result.intDigits).toEqual(['3']);

--- a/packages/@mantine/core/src/components/RollingNumber/get-digit-parts.ts
+++ b/packages/@mantine/core/src/components/RollingNumber/get-digit-parts.ts
@@ -57,8 +57,10 @@ export function getDigitParts({
   const intStr = dotIdx >= 0 ? str.slice(0, dotIdx) : str;
   const fracStr = dotIdx >= 0 ? str.slice(dotIdx + 1) : '';
 
+  const roundedToZero = !/[1-9]/.test(str);
+
   return {
-    negative: value < 0,
+    negative: value < 0 && !roundedToZero,
     intDigits: intStr.split(''),
     fracDigits: fracStr ? fracStr.split('') : [],
     hasDecimal: dotIdx >= 0,

--- a/packages/@mantine/core/src/components/RollingNumber/get-render-slots.test.ts
+++ b/packages/@mantine/core/src/components/RollingNumber/get-render-slots.test.ts
@@ -118,6 +118,21 @@ describe('getRenderSlots', () => {
     expect(signSlot).toMatchObject({ char: '-', empty: true });
   });
 
+  it('does not add a sign when a negative value rounds to zero', () => {
+    const current = getDigitParts({ value: -0.4, decimalScale: 0 });
+    const slots = getRenderSlots({ current, previous: current });
+    const signSlot = charSlots(slots).find((c) => c.key === 'sign');
+    expect(signSlot).toBeUndefined();
+  });
+
+  it('marks the sign as empty when transitioning to a value that rounds to zero', () => {
+    const prev = getDigitParts({ value: -5 });
+    const current = getDigitParts({ value: -0.4, decimalScale: 0 });
+    const slots = getRenderSlots({ current, previous: prev });
+    const signSlot = charSlots(slots).find((c) => c.key === 'sign');
+    expect(signSlot).toMatchObject({ char: '-', empty: true });
+  });
+
   it('adds decimal separator and fractional digits', () => {
     const current = getDigitParts({ value: 3.14, decimalScale: 2, fixedDecimalScale: true });
     const slots = getRenderSlots({ current, previous: current });


### PR DESCRIPTION
  ## Problem

  `RollingNumber` renders `"-0"` when a negative value rounds to zero:

  ```tsx
  <RollingNumber value={-0.4} decimalScale={0} />                      
```


  Root cause

  In getDigitParts, the sign was derived from the raw value (negative: value < 0)
  while the digits were derived from the rounded magnitude. A value whose magnitude
  rounds to zero therefore kept its minus sign, and both render paths (buildValue,
  getRenderSlots) rendered a leading -.

  Fix

  Treat the value as negative only when the rounded magnitude is non-zero:

  const roundedToZero = !/[1-9]/.test(str);
  return { negative: value < 0 && !roundedToZero, /* ... */ };

  getDigitParts is the single source of truth for the sign and is consumed by both
  render paths, so the fix applies everywhere. Values that round to a non-zero
  magnitude are unaffected — e.g. -0.6 with decimalScale={0} still renders "-1".