### PR TITLE
fix(form): export FormProviderProps from public entrypoint

### DIFF
--- a/packages/@mantine/form/src/index.ts
+++ b/packages/@mantine/form/src/index.ts
@@ -1,5 +1,6 @@
 export { useForm } from './use-form.js';
 export { createFormContext } from './FormProvider/FormProvider.js';
+export type { FormProviderProps } from './FormProvider/FormProvider';
 export { createFormActions } from './actions/index.js';
 export { FORM_INDEX } from './form-index.js';
 export * from './validators/index.js';


### PR DESCRIPTION
## What this fixes

`FormProviderProps` is used as the prop type for `FormProvider` (returned by `createFormContext`), but it was never re-exported from `@mantine/form`'s public entrypoint. This caused a TS2742 error for consumers building with `declaration: true` and `moduleResolution: "bundler"` who tried to re-export `FormProvider` from their own component library.

## Change

Added a single type export in `packages/@mantine/form/src/index.ts`:

\`\`\`ts
export type { FormProviderProps } from './FormProvider/FormProvider';
\`\`\`

## Testing

Ran `npm run typecheck` — passes cleanly across root, `mantine.dev`, and `help.mantine.dev`.

Fixes #8985