### PR TITLE
docs: fix typo in MultiSelect onMaxValues JSDoc

### DIFF
--- a/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/@mantine/core/src/components/MultiSelect/MultiSelect.tsx
@@ -76,7 +76,7 @@ export interface MultiSelectProps<Value extends Primitive = string>
   /** Called when the clear button is clicked */
   onClear?: () => void;
 
-  /** Called when user attemps to select more values than allowed */
+  /** Called when user attempts to select more values than allowed */
   onMaxValues?: () => void;
 
   /** Controlled search value */


### PR DESCRIPTION
## What

Fixes a typo in the JSDoc comment for the `onMaxValues` prop of
`MultiSelect`: `attemps` → `attempts`.

## Why

This comment is rendered in IDE hover tooltips for every consumer of the
component, so the typo is directly user-facing rather than internal.

## Scope

Single-line JSDoc change — no code, types, or behavior affected.