### PR TITLE
Fix Slider mark labels in RTL

### DIFF
--- a/packages/@mantine/core/src/components/Slider/Slider.module.css
+++ b/packages/@mantine/core/src/components/Slider/Slider.module.css
@@ -261,6 +261,10 @@
   cursor: pointer;
   user-select: none;
 
+  @mixin where-rtl {
+    transform: translate(calc(50% - var(--slider-size) / 2), calc(var(--mantine-spacing-xs) / 2));
+  }
+
   @mixin where-light {
     color: var(--mantine-color-gray-6);
   }


### PR DESCRIPTION
Fixes #8991

## Summary
- Center Slider mark labels correctly in RTL horizontal layouts.
- Keep existing vertical Slider mark label positioning unchanged.

## Tests
- `yarn exec oxfmt --check packages/@mantine/core/src/components/Slider/Slider.module.css`
- `yarn stylelint packages/@mantine/core/src/components/Slider/Slider.module.css --cache=false`
- `yarn jest packages/@mantine/core/src/components/Slider/Slider/Slider.test.tsx packages/@mantine/core/src/components/Slider/RangeSlider/RangeSlider.test.tsx --runInBand`
- `git diff --check`
