### PR TITLE
docs: fix Affix component hidden by LLM affix (#8994)

### DIFF
--- a/apps/mantine.dev/src/components/MdxLlmAffix/MdxLlmAffix.module.css
+++ b/apps/mantine.dev/src/components/MdxLlmAffix/MdxLlmAffix.module.css
@@ -38,3 +38,7 @@
     color: light-dark(var(--mantine-color-cyan-8), var(--mantine-color-cyan-4));
   }
 }
+
+.affix {
+  transition: bottom 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}

--- a/apps/mantine.dev/src/components/MdxLlmAffix/MdxLlmAffix.tsx
+++ b/apps/mantine.dev/src/components/MdxLlmAffix/MdxLlmAffix.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { CheckIcon, CopyIcon, LightbulbFilamentIcon, RobotIcon } from '@phosphor-icons/react';
 import { ActionIcon, Affix, Card, Stack, Text, Tooltip } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { Frontmatter } from '@/types';
 import classes from './MdxLlmAffix.module.css';
+import { useWindowScroll } from '@mantine/hooks';
 
 interface MdxLlmAffixProps {
   meta: Frontmatter;
@@ -16,6 +17,16 @@ function getLlmUrl(slug: string) {
 export function MdxLlmAffix({ meta }: MdxLlmAffixProps) {
   const [copied, setCopied] = useState(false);
   const llmUrl = getLlmUrl(meta.slug);
+  const [scroll] = useWindowScroll();
+  const [bottomOffset, setBottomOffset] = useState(20);
+
+  useEffect(() => {
+    if (llmUrl.includes('affix') && scroll.y > 0) {
+      setBottomOffset(80);
+    } else {
+      setBottomOffset(20);
+    }
+  }, [llmUrl, scroll.y]);
 
   const handleCopy = async () => {
     try {
@@ -34,7 +45,11 @@ export function MdxLlmAffix({ meta }: MdxLlmAffixProps) {
   };
 
   return (
-    <Affix position={{ bottom: 20, right: 20 }} visibleFrom="sm">
+    <Affix
+      position={{ bottom: bottomOffset, right: 20 }}
+      visibleFrom="sm"
+      className={classes.affix}
+    >
       <Card className={classes.root}>
         <Text className={classes.title}>LLM</Text>
 


### PR DESCRIPTION
Fixes #8994

The Affix component in the docs was partially hidden behind the LLM affix.
Adjusted positioning to fix the overlap.

<img width="263" height="323" alt="8994" src="https://github.com/user-attachments/assets/bd4762b1-40db-4843-be0f-e6ab56c8cd91" />

- Ran `npm run test:all` 

Closes #8994 