### PR TITLE
docs: fix incorrect test command in contributing guide (#9000)

### DIFF
--- a/apps/mantine.dev/src/pages/contribute.mdx
+++ b/apps/mantine.dev/src/pages/contribute.mdx
@@ -20,7 +20,7 @@ First of all, thank you for showing interest in contributing to Mantine! All you
 - Decide on what you want to contribute.
 - If you would like to implement a new feature, discuss it with the maintainer ([GitHub Discussions](https://github.com/mantinedev/mantine/discussions/new) or [Discord](https://discord.gg/wbH82zuWMN)) before jumping into coding.
 - After finalizing issue details, you can begin working on the code.
-- Run tests with `npm test:all` and submit a PR once all tests have passed.
+- Run tests with `npm run test:all` and submit a PR once all tests have passed.
 - Get a code review and fix all issues noticed by the maintainer.
 - If you cannot finish your task or if you change your mind – that's totally fine! Just let us know in the GitHub issue that you created during the first step of this process. The Mantine community is friendly – we won't judge or ask any questions if you decide to cancel your submission.
 - Your PR is merged. You are awesome ❤️!


### PR DESCRIPTION
## Closes #9000

### What was wrong?
The contributing guide incorrectly instructed contributors to run `npm test:all`, but the actual command is `npm run test:all`.

### What I fixed
- Changed `npm test:all` to `npm run test:all` in the contributing guide

### Testing
- Ran `npm run test:all` - all tests passed

Closes #9000