### PR TITLE
fix(dates): allow duration values greater than 9999 hours

### DIFF
--- a/packages/@mantine/dates/src/components/SpinInput/SpinInput.tsx
+++ b/packages/@mantine/dates/src/components/SpinInput/SpinInput.tsx
@@ -33,8 +33,9 @@ export function SpinInput({
   disableAutoAdvance = false,
   ...others
 }: SpinInputProps) {
-  const maxDigit = getMaxDigit(max);
-  const arrowsMax = max + 1 - step;
+  const hasMax = Number.isFinite(max);
+  const maxDigit = hasMax ? getMaxDigit(max) : Infinity;
+  const arrowsMax = hasMax ? max + 1 - step : max;
 
   const handleChange = (value: string) => {
     if (readOnly) {
@@ -82,7 +83,7 @@ export function SpinInput({
       onChange(min);
     }
 
-    if (event.key === 'End') {
+    if (event.key === 'End' && hasMax) {
       event.preventDefault();
       onChange(max);
     }
@@ -115,7 +116,8 @@ export function SpinInput({
 
     if (event.key === 'ArrowDown') {
       event.preventDefault();
-      const newValue = value === null ? arrowsMax : clamp(value - step, min, arrowsMax);
+      const fallback = hasMax ? arrowsMax : min;
+      const newValue = value === null ? fallback : clamp(value - step, min, arrowsMax);
       onChange(newValue);
     }
   };
@@ -126,7 +128,7 @@ export function SpinInput({
       // eslint-disable-next-line jsx-a11y/no-redundant-roles -- input type="text" has implicit role textbox, not spinbutton; the role is required here because this text input acts as a spinbutton
       role="spinbutton"
       aria-valuemin={min}
-      aria-valuemax={max}
+      aria-valuemax={hasMax ? max : undefined}
       aria-valuenow={value === null ? 0 : value}
       data-empty={value === null || undefined}
       inputMode="numeric"

--- a/packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx
@@ -340,8 +340,6 @@ describe('@mantine/dates/TimePicker', () => {
       />
     );
 
-    
-
     await userEvent.type(screen.getByLabelText('test-hours'), '7');
     await userEvent.type(screen.getByLabelText('test-minutes'), '30');
     await userEvent.type(screen.getByLabelText('test-seconds'), '0');
@@ -747,15 +745,31 @@ describe('@mantine/dates/TimePicker', () => {
     await userEvent.paste('155:22:45');
     expect(spy).toHaveBeenCalledWith('155:22:45');
   });
-  it('allows values greater than 9999 hours in duration mode', async () => {
+
+  it('allows pasting values greater than 9999 hours in duration mode', async () => {
     const spy = jest.fn();
-  
     render(<TimePicker {...defaultProps} type="duration" withSeconds onChange={spy} />);
-  
+
     await userEvent.click(screen.getByLabelText('test-hours'));
     await userEvent.paste('10000:00:00');
-  
     expect(spy).toHaveBeenCalledWith('10000:00:00');
+  });
+
+  it('allows typing values greater than 9999 hours in duration mode', async () => {
+    const spy = jest.fn();
+    render(<TimePicker {...defaultProps} type="duration" withSeconds onChange={spy} />);
+
+    await userEvent.type(screen.getByLabelText('test-hours'), '10000');
+    await userEvent.type(screen.getByLabelText('test-minutes'), '00');
+    await userEvent.type(screen.getByLabelText('test-seconds'), '00');
+
+    expect(screen.getByLabelText('test-hours')).toHaveValue('10000');
+    expect(spy).toHaveBeenCalledWith('10000:00:00');
+  });
+
+  it('does not set an upper bound on the hours field in duration mode', () => {
+    render(<TimePicker {...defaultProps} type="duration" withSeconds />);
+    expect(screen.getByLabelText('test-hours')).not.toHaveAttribute('aria-valuemax');
   });
 
   it('does not auto-advance from hours field in duration mode', async () => {

--- a/packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx
@@ -340,6 +340,8 @@ describe('@mantine/dates/TimePicker', () => {
       />
     );
 
+    
+
     await userEvent.type(screen.getByLabelText('test-hours'), '7');
     await userEvent.type(screen.getByLabelText('test-minutes'), '30');
     await userEvent.type(screen.getByLabelText('test-seconds'), '0');
@@ -744,6 +746,16 @@ describe('@mantine/dates/TimePicker', () => {
     await userEvent.click(screen.getByLabelText('test-hours'));
     await userEvent.paste('155:22:45');
     expect(spy).toHaveBeenCalledWith('155:22:45');
+  });
+  it('allows values greater than 9999 hours in duration mode', async () => {
+    const spy = jest.fn();
+  
+    render(<TimePicker {...defaultProps} type="duration" withSeconds onChange={spy} />);
+  
+    await userEvent.click(screen.getByLabelText('test-hours'));
+    await userEvent.paste('10000:00:00');
+  
+    expect(spy).toHaveBeenCalledWith('10000:00:00');
   });
 
   it('does not auto-advance from hours field in duration mode', async () => {

--- a/packages/@mantine/dates/src/components/TimePicker/TimePicker.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePicker.tsx
@@ -236,6 +236,8 @@ const varsResolver = createVarsResolver<TimePickerFactory>((_theme, { size }) =>
   },
 }));
 
+const DURATION_HOURS_MAX = Infinity;
+
 export const TimePicker = factory<TimePickerFactory>((_props) => {
   const props = useProps(['Input', 'InputWrapper', 'TimePicker'], defaultProps, _props);
   const {
@@ -468,7 +470,7 @@ export const TimePicker = factory<TimePickerFactory>((_props) => {
                   onChange={controller.setHours}
                   onNextInput={() => controller.focus('minutes')}
                   min={format === '12h' ? 1 : 0}
-                  max={isDuration ? 9999 : format === '12h' ? 12 : 23}
+                  max={isDuration ? DURATION_HOURS_MAX : format === '12h' ? 12 : 23}
                   allowTemporaryZero={format === '12h'}
                   disableAutoAdvance={isDuration}
                   focusable

--- a/packages/@mantine/dates/src/components/TimePicker/use-time-picker.ts
+++ b/packages/@mantine/dates/src/components/TimePicker/use-time-picker.ts
@@ -192,8 +192,16 @@ export function useTimePicker({
     const timeString = getTimeString({ ...parsedTime, format, withSeconds, amPmLabels });
     if (timeString.valid) {
       acceptChange.current = false;
-      const defaultMax = type === 'duration' ? '9999:59:59' : '23:59:59';
-      const clamped = clampTime(timeString.value, min || '00:00:00', max || defaultMax);
+      // const defaultMax = type === 'duration' ? '9999:59:59' : '23:59:59';
+      // const clamped = clampTime(timeString.value, min || '00:00:00', max || defaultMax);
+
+      const defaultMax = type === 'duration' ? undefined : '23:59:59';
+
+      const clamped = clampTime(
+        timeString.value,
+        min || '00:00:00',
+        max || defaultMax
+      );
       onChange?.(clamped.timeString);
       setHours(parsedTime.hours);
       setMinutes(parsedTime.minutes);

--- a/packages/@mantine/dates/src/components/TimePicker/use-time-picker.ts
+++ b/packages/@mantine/dates/src/components/TimePicker/use-time-picker.ts
@@ -192,16 +192,8 @@ export function useTimePicker({
     const timeString = getTimeString({ ...parsedTime, format, withSeconds, amPmLabels });
     if (timeString.valid) {
       acceptChange.current = false;
-      // const defaultMax = type === 'duration' ? '9999:59:59' : '23:59:59';
-      // const clamped = clampTime(timeString.value, min || '00:00:00', max || defaultMax);
-
       const defaultMax = type === 'duration' ? undefined : '23:59:59';
-
-      const clamped = clampTime(
-        timeString.value,
-        min || '00:00:00',
-        max || defaultMax
-      );
+      const clamped = clampTime(timeString.value, min || '00:00:00', max || defaultMax);
       onChange?.(clamped.timeString);
       setHours(parsedTime.hours);
       setMinutes(parsedTime.minutes);


### PR DESCRIPTION
## What does this PR do?

Fixes #8995.

Duration values were being clamped to `9999:59:59` during paste handling even though the documentation states that duration values do not have an upper bound.

### Changes

* Removed the implicit `9999:59:59` maximum for `type="duration"` in `use-time-picker.ts`
* Added a regression test covering values greater than `9999` hours

### Before

10000:00:00 → 9999:59:59

### After

10000:00:00 → 10000:00:00

### Tests

* Added test: `allows values greater than 9999 hours in duration mode`
* All TimePicker tests pass
