### PR TITLE
[@mantine/core] Menu: Mark non-menuitem dropdown children as presentational

### DIFF
--- a/packages/@mantine/core/src/components/Menu/Menu.test.tsx
+++ b/packages/@mantine/core/src/components/Menu/Menu.test.tsx
@@ -161,6 +161,19 @@ describe('@mantine/core/Menu', () => {
     expect(document.querySelectorAll('.mantine-Menu-arrow')).toHaveLength(0);
   });
 
+  it('assigns role="presentation" to non-menuitem children of role="menu" (issue #8971)', () => {
+    render(<TestContainer defaultOpened withArrow />);
+    const menu = screen.getByRole('menu');
+
+    const autofocusPlaceholder = menu.querySelector('[data-autofocus]');
+    expect(autofocusPlaceholder).not.toBeNull();
+    expect(autofocusPlaceholder).toHaveAttribute('role', 'presentation');
+
+    const arrow = menu.querySelector('.mantine-Menu-arrow');
+    expect(arrow).not.toBeNull();
+    expect(arrow).toHaveAttribute('role', 'presentation');
+  });
+
   it('exposes related components as static properties', () => {
     expect(Menu.Item).toBe(MenuItem);
     expect(Menu.Dropdown).toBe(MenuDropdown);

--- a/packages/@mantine/core/src/components/Menu/MenuDropdown/MenuDropdown.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuDropdown/MenuDropdown.tsx
@@ -93,7 +93,13 @@ export const MenuDropdown = factory<MenuDropdownFactory>((props) => {
       onKeyDown={handleKeyDown}
     >
       {ctx.withInitialFocusPlaceholder && !ctx.hasSearch && (
-        <div tabIndex={-1} data-autofocus data-mantine-stop-propagation style={{ outline: 0 }} />
+        <div
+          role="presentation"
+          tabIndex={-1}
+          data-autofocus
+          data-mantine-stop-propagation
+          style={{ outline: 0 }}
+        />
       )}
       {children}
     </Popover.Dropdown>

--- a/packages/@mantine/core/src/utils/Floating/FloatingArrow/FloatingArrow.tsx
+++ b/packages/@mantine/core/src/utils/Floating/FloatingArrow/FloatingArrow.tsx
@@ -32,6 +32,7 @@ export function FloatingArrow({
 
   return (
     <div
+      role="presentation"
       {...others}
       style={{
         ...style,


### PR DESCRIPTION
Fixes #8971.

### Problem
`Menu.Dropdown` renders a `<div role="menu">` whose direct children include two
decorative wrappers without any ARIA role:

- the initial-focus placeholder (`data-autofocus`) used when `withInitialFocusPlaceholder` is enabled;
- the floating arrow (`.mantine-Menu-arrow`) rendered when `withArrow` is set.

Per WAI-ARIA 1.2, elements with `role="menu"` may only contain children whose
role is `menuitem`, `menuitemradio`, `menuitemcheckbox`, `separator`,
`presentation`/`none`, or `group` containing the above. Untagged `<div>`s are
not permitted and are flagged by accessibility audits.

### Fix
Add `role="presentation"` to both decorative children so they become
semantically transparent:

- `MenuDropdown.tsx`: set `role="presentation"` directly on the autofocus placeholder div.
- `FloatingArrow.tsx`: default the arrow div to `role="presentation"`. The role
  is set before the `{...others}` spread, so any caller that wants a different
  role can still override it. This is correct across `Popover`, `Tooltip`,
  `HoverCard`, and `Menu` — the arrow is a decorative element with no semantic
  meaning in any of these contexts.

### Tests
Added a regression test in `Menu.test.tsx` that opens a `Menu` with
`withArrow` and asserts both the autofocus placeholder and the arrow expose
`role="presentation"`. Existing tests (`Menu` + `Popover` + `Tooltip` +
`HoverCard` + `Floating` utils, 528 tests across 18 suites) still pass; no
public API change.

### Notes
- No new props, no behavioural changes, purely an accessibility metadata fix.
- I considered scoping the arrow change to `Popover.Dropdown` only (passing
  `role="presentation"` from the call site) to keep blast radius minimal, but
  `FloatingArrow` is decorative everywhere it is used and a default is both
  smaller and harder to forget at a new call site.

