### PR TITLE
[React Compiler] Fix useForm getters

### DIFF
--- a/packages/@mantine/form/src/hooks/use-form-status/use-form-status.ts
+++ b/packages/@mantine/form/src/hooks/use-form-status/use-form-status.ts
@@ -115,6 +115,15 @@ export function useFormStatus<Values extends Record<string, any>>({
     setDirty(clearedState, currentDirty !== dirty);
   }, []);
 
+  /*
+   * The getters below intentionally include `ref.current` in their dependency arrays.
+   * They read mutable refs that the form reassigns to fresh objects on every change
+   * (e.g. setPath returns a deep clone via klona). Keying useCallback on `ref.current`
+   * makes the getter identity change exactly when its underlying data changes, and stay
+   * stable otherwise. React Compiler memoizes a call expression by callee identity, so a
+   * `[]` dependency array (or a state-mirror dep that does not update in uncontrolled mode)
+   * would let it cache and serve a stale value. Do NOT "simplify" these deps to `[]`.
+   */
   const isTouched: GetFieldStatus<Values> = useCallback(
     (path) => getStatus(touchedRef.current, path),
     [touchedRef.current]

--- a/packages/@mantine/form/src/hooks/use-form-status/use-form-status.ts
+++ b/packages/@mantine/form/src/hooks/use-form-status/use-form-status.ts
@@ -115,15 +115,8 @@ export function useFormStatus<Values extends Record<string, any>>({
     setDirty(clearedState, currentDirty !== dirty);
   }, []);
 
-  /*
-   * The getters below intentionally include `ref.current` in their dependency arrays.
-   * They read mutable refs that the form reassigns to fresh objects on every change
-   * (e.g. setPath returns a deep clone via klona). Keying useCallback on `ref.current`
-   * makes the getter identity change exactly when its underlying data changes, and stay
-   * stable otherwise. React Compiler memoizes a call expression by callee identity, so a
-   * `[]` dependency array (or a state-mirror dep that does not update in uncontrolled mode)
-   * would let it cache and serve a stale value. Do NOT "simplify" these deps to `[]`.
-   */
+  // Getters key on `ref.current` so identity updates when the data does. Do not simplify to `[]`:
+  // that serves stale values under React Compiler.
   const isTouched: GetFieldStatus<Values> = useCallback(
     (path) => getStatus(touchedRef.current, path),
     [touchedRef.current]

--- a/packages/@mantine/form/src/hooks/use-form-status/use-form-status.ts
+++ b/packages/@mantine/form/src/hooks/use-form-status/use-form-status.ts
@@ -117,7 +117,7 @@ export function useFormStatus<Values extends Record<string, any>>({
 
   const isTouched: GetFieldStatus<Values> = useCallback(
     (path) => getStatus(touchedRef.current, path),
-    []
+    [touchedRef.current]
   );
 
   const clearFieldDirty: ClearFieldDirty = useCallback(
@@ -139,28 +139,31 @@ export function useFormStatus<Values extends Record<string, any>>({
     []
   );
 
-  const isDirty: GetFieldStatus<Values> = useCallback((path) => {
-    if (path) {
-      const overriddenValue = getPath(path, dirtyRef.current);
-      if (typeof overriddenValue === 'boolean') {
-        return overriddenValue;
+  const isDirty: GetFieldStatus<Values> = useCallback(
+    (path) => {
+      if (path) {
+        const overriddenValue = getPath(path, dirtyRef.current);
+        if (typeof overriddenValue === 'boolean') {
+          return overriddenValue;
+        }
+
+        const sliceOfValues = getPath(path, $values.refValues.current);
+        const sliceOfInitialValues = getPath(path, $values.valuesSnapshot.current);
+        return !isEqual(sliceOfValues, sliceOfInitialValues);
       }
 
-      const sliceOfValues = getPath(path, $values.refValues.current);
-      const sliceOfInitialValues = getPath(path, $values.valuesSnapshot.current);
-      return !isEqual(sliceOfValues, sliceOfInitialValues);
-    }
+      const isOverridden = Object.keys(dirtyRef.current).length > 0;
+      if (isOverridden) {
+        return getStatus(dirtyRef.current);
+      }
 
-    const isOverridden = Object.keys(dirtyRef.current).length > 0;
-    if (isOverridden) {
-      return getStatus(dirtyRef.current);
-    }
+      return !isEqual($values.refValues.current, $values.valuesSnapshot.current);
+    },
+    [dirtyRef.current, $values.refValues.current, $values.valuesSnapshot.current]
+  );
 
-    return !isEqual($values.refValues.current, $values.valuesSnapshot.current);
-  }, []);
-
-  const getDirty = useCallback(() => dirtyRef.current, []);
-  const getTouched = useCallback(() => touchedRef.current, []);
+  const getDirty = useCallback(() => dirtyRef.current, [dirtyRef.current]);
+  const getTouched = useCallback(() => touchedRef.current, [touchedRef.current]);
 
   return {
     touchedState,

--- a/packages/@mantine/form/src/hooks/use-form-status/use-form-status.ts
+++ b/packages/@mantine/form/src/hooks/use-form-status/use-form-status.ts
@@ -115,8 +115,6 @@ export function useFormStatus<Values extends Record<string, any>>({
     setDirty(clearedState, currentDirty !== dirty);
   }, []);
 
-  // Getters key on `ref.current` so identity updates when the data does. Do not simplify to `[]`:
-  // that serves stale values under React Compiler.
   const isTouched: GetFieldStatus<Values> = useCallback(
     (path) => getStatus(touchedRef.current, path),
     [touchedRef.current]

--- a/packages/@mantine/form/src/hooks/use-form-validating/use-form-validating.ts
+++ b/packages/@mantine/form/src/hooks/use-form-validating/use-form-validating.ts
@@ -26,15 +26,18 @@ export function useFormValidating(): $FormValidating {
     setFormValidatingState(value);
   }, []);
 
-  const isValidating = useCallback((path?: string) => {
-    if (path) {
-      return !!validatingRef.current[path];
-    }
-    if (formValidatingRef.current) {
-      return true;
-    }
-    return Object.values(validatingRef.current).some(Boolean);
-  }, []);
+  const isValidating = useCallback(
+    (path?: string) => {
+      if (path) {
+        return !!validatingRef.current[path];
+      }
+      if (formValidatingRef.current) {
+        return true;
+      }
+      return Object.values(validatingRef.current).some(Boolean);
+    },
+    [validatingRef.current, formValidatingRef.current]
+  );
 
   const getAbortSignal = useCallback((path: string) => {
     abortControllers.current[path]?.abort();

--- a/packages/@mantine/form/src/hooks/use-form-values/use-form-values.ts
+++ b/packages/@mantine/form/src/hooks/use-form-values/use-form-values.ts
@@ -132,8 +132,8 @@ export function useFormValues<Values extends Record<PropertyKey, any>>({
     });
   }, [setValues]);
 
-  const getValues = useCallback(() => refValues.current, []);
-  const getValuesSnapshot = useCallback(() => valuesSnapshot.current, []);
+  const getValues = useCallback(() => refValues.current, [refValues.current]);
+  const getValuesSnapshot = useCallback(() => valuesSnapshot.current, [valuesSnapshot.current]);
 
   const resetField = useCallback(
     (path: PropertyKey, subscribers?: (SetFieldValueSubscriber<Values> | null | undefined)[]) => {

--- a/packages/@mantine/form/src/tests/use-field/compiler-stability.test.ts
+++ b/packages/@mantine/form/src/tests/use-field/compiler-stability.test.ts
@@ -1,0 +1,44 @@
+import { act, renderHook } from '@testing-library/react';
+import { useField } from '../../use-field';
+
+/*
+ * React Compiler compatibility guard for useField (mirrors the useForm guard).
+ *
+ * useField's getters (`getValue`, `isTouched`, `isDirty`) read mutable refs and are wrapped in
+ * `useCallback` keyed on the ref's current value. The field reassigns `valueRef`/`touchedRef`
+ * on every change, so the getter identity changes exactly when its data changes. This is the
+ * invariant React Compiler relies on to avoid caching a stale call result; a `[]` dependency
+ * array would reintroduce the staleness. We assert it here without running the compiler.
+ */
+
+describe('@mantine/form/use-field compiler stability', () => {
+  it('changes getter identity after a value change', () => {
+    const hook = renderHook(() => useField({ initialValue: 'test' }));
+
+    const before = {
+      getValue: hook.result.current.getValue,
+      isDirty: hook.result.current.isDirty,
+    };
+
+    act(() => hook.result.current.getInputProps().onChange('new value'));
+
+    expect(hook.result.current.getValue).not.toBe(before.getValue);
+    expect(hook.result.current.isDirty).not.toBe(before.isDirty);
+  });
+
+  it('keeps a stable getter identity across a re-render with no data change', () => {
+    const hook = renderHook(() => useField({ initialValue: 'test' }));
+
+    const before = {
+      getValue: hook.result.current.getValue,
+      isTouched: hook.result.current.isTouched,
+      isDirty: hook.result.current.isDirty,
+    };
+
+    act(() => hook.rerender());
+
+    expect(hook.result.current.getValue).toBe(before.getValue);
+    expect(hook.result.current.isTouched).toBe(before.isTouched);
+    expect(hook.result.current.isDirty).toBe(before.isDirty);
+  });
+});

--- a/packages/@mantine/form/src/tests/use-field/compiler-stability.test.ts
+++ b/packages/@mantine/form/src/tests/use-field/compiler-stability.test.ts
@@ -1,16 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { useField } from '../../use-field';
 
-/*
- * React Compiler compatibility guard for useField (mirrors the useForm guard).
- *
- * useField's getters (`getValue`, `isTouched`, `isDirty`) read mutable refs and are wrapped in
- * `useCallback` keyed on the ref's current value. The field reassigns `valueRef`/`touchedRef`
- * on every change, so the getter identity changes exactly when its data changes. This is the
- * invariant React Compiler relies on to avoid caching a stale call result; a `[]` dependency
- * array would reintroduce the staleness. We assert it here without running the compiler.
- */
-
 describe('@mantine/form/use-field compiler stability', () => {
   it('changes getter identity after a value change', () => {
     const hook = renderHook(() => useField({ initialValue: 'test' }));
@@ -24,6 +14,13 @@ describe('@mantine/form/use-field compiler stability', () => {
 
     expect(hook.result.current.getValue).not.toBe(before.getValue);
     expect(hook.result.current.isDirty).not.toBe(before.isDirty);
+  });
+
+  it('changes isTouched identity after the field is touched', () => {
+    const hook = renderHook(() => useField({ initialValue: 'test' }));
+    const before = hook.result.current.isTouched;
+    act(() => hook.result.current.getInputProps().onFocus?.());
+    expect(hook.result.current.isTouched).not.toBe(before);
   });
 
   it('keeps a stable getter identity across a re-render with no data change', () => {
@@ -40,5 +37,20 @@ describe('@mantine/form/use-field compiler stability', () => {
     expect(hook.result.current.getValue).toBe(before.getValue);
     expect(hook.result.current.isTouched).toBe(before.isTouched);
     expect(hook.result.current.isDirty).toBe(before.isDirty);
+  });
+
+  it('reads current data from getters retained across renders', () => {
+    const hook = renderHook(() => useField({ initialValue: 'test' }));
+
+    const retainedGetValue = hook.result.current.getValue;
+    const retainedIsDirty = hook.result.current.isDirty;
+    const retainedIsTouched = hook.result.current.isTouched;
+
+    act(() => hook.result.current.getInputProps().onFocus?.());
+    act(() => hook.result.current.getInputProps().onChange('new value'));
+
+    expect(retainedGetValue()).toBe('new value');
+    expect(retainedIsDirty()).toBe(true);
+    expect(retainedIsTouched()).toBe(true);
   });
 });

--- a/packages/@mantine/form/src/tests/use-form/compiler-stability.test.ts
+++ b/packages/@mantine/form/src/tests/use-form/compiler-stability.test.ts
@@ -2,27 +2,6 @@ import { act, renderHook } from '@testing-library/react';
 import { FormMode } from '../../types';
 import { useForm } from '../../use-form';
 
-/*
- * React Compiler compatibility guard.
- *
- * The form getters that read mutable refs are wrapped in `useCallback` keyed on the ref's
- * current value (e.g. `[refValues.current]`). The form reassigns those refs to fresh objects
- * on every change, so each getter's identity changes exactly when its underlying data changes
- * and stays stable otherwise.
- *
- * React Compiler memoizes a call expression by its callee identity, so this identity change is
- * what forces it to re-invoke the getter rather than serve a stale cached value. We cannot run
- * the compiler in jest, but we can assert the invariant it relies on:
- *
- *   1. after a value change, the getter is a NEW reference (so the compiler re-invokes), and
- *   2. across an inert re-render with no data change, the getter keeps a STABLE reference (so
- *      consumer dependency arrays do not fire spuriously).
- *
- * Both are asserted in controlled AND uncontrolled mode. A regression to `useCallback(fn, [])`
- * breaks (1) in both modes; a regression to a state-mirror dep like `[stateValues]` breaks (1)
- * in uncontrolled mode, where the state mirror does not update on change.
- */
-
 function tests(mode: FormMode) {
   it('changes getter identity after a value change', () => {
     const hook = renderHook(() => useForm({ mode, initialValues: { a: 1 } }));
@@ -30,13 +9,18 @@ function tests(mode: FormMode) {
     const before = {
       isDirty: hook.result.current.isDirty,
       getValues: hook.result.current.getValues,
-      getInitialValues: hook.result.current.getInitialValues,
+      getDirty: hook.result.current.getDirty,
+      getTouched: hook.result.current.getTouched,
+      isValid: hook.result.current.isValid,
     };
 
     act(() => hook.result.current.setFieldValue('a', 5));
 
     expect(hook.result.current.isDirty).not.toBe(before.isDirty);
     expect(hook.result.current.getValues).not.toBe(before.getValues);
+    expect(hook.result.current.getDirty).not.toBe(before.getDirty);
+    expect(hook.result.current.getTouched).not.toBe(before.getTouched);
+    expect(hook.result.current.isValid).not.toBe(before.isValid);
   });
 
   it('changes isTouched identity after a field is touched', () => {
@@ -46,22 +30,82 @@ function tests(mode: FormMode) {
     expect(hook.result.current.isTouched).not.toBe(before);
   });
 
+  it('changes getInitialValues identity after the initial values change', () => {
+    const hook = renderHook(() => useForm({ mode, initialValues: { a: 1 } }));
+    const before = hook.result.current.getInitialValues;
+    act(() => hook.result.current.setInitialValues({ a: 5 }));
+    act(() => hook.rerender());
+    expect(hook.result.current.getInitialValues).not.toBe(before);
+  });
+
+  it('changes isValidating identity when validation state changes', async () => {
+    const hook = renderHook(() =>
+      useForm({ mode, initialValues: { a: '' }, validate: { a: async () => 'error' } })
+    );
+    const before = hook.result.current.isValidating;
+    await act(async () => {
+      await hook.result.current.validateField('a');
+    });
+    expect(hook.result.current.isValidating).not.toBe(before);
+  });
+
   it('keeps a stable getter identity across a re-render with no data change', () => {
     const hook = renderHook(() => useForm({ mode, initialValues: { a: 1 } }));
 
     const before = {
       isDirty: hook.result.current.isDirty,
       isTouched: hook.result.current.isTouched,
+      getDirty: hook.result.current.getDirty,
+      getTouched: hook.result.current.getTouched,
       getValues: hook.result.current.getValues,
       getInitialValues: hook.result.current.getInitialValues,
+      isValid: hook.result.current.isValid,
+      isValidating: hook.result.current.isValidating,
     };
 
     act(() => hook.rerender());
 
     expect(hook.result.current.isDirty).toBe(before.isDirty);
     expect(hook.result.current.isTouched).toBe(before.isTouched);
+    expect(hook.result.current.getDirty).toBe(before.getDirty);
+    expect(hook.result.current.getTouched).toBe(before.getTouched);
     expect(hook.result.current.getValues).toBe(before.getValues);
     expect(hook.result.current.getInitialValues).toBe(before.getInitialValues);
+    expect(hook.result.current.isValid).toBe(before.isValid);
+    expect(hook.result.current.isValidating).toBe(before.isValidating);
+  });
+
+  it('gives getInputNode a fresh identity each render (never memoized)', () => {
+    const hook = renderHook(() => useForm({ mode, initialValues: { a: 1 } }));
+    const before = hook.result.current.getInputNode;
+    act(() => hook.rerender());
+    expect(hook.result.current.getInputNode).not.toBe(before);
+  });
+
+  it('reads current data from getters retained across renders', () => {
+    const hook = renderHook(() =>
+      useForm({
+        mode,
+        initialValues: { a: 1 },
+        validate: { a: (value) => (value < 2 ? 'error' : null) },
+      })
+    );
+
+    const retained = {
+      getValues: hook.result.current.getValues,
+      isDirty: hook.result.current.isDirty,
+      getDirty: hook.result.current.getDirty,
+      getTouched: hook.result.current.getTouched,
+      isValid: hook.result.current.isValid,
+    };
+
+    act(() => hook.result.current.setFieldValue('a', 5));
+
+    expect(retained.getValues().a).toBe(5);
+    expect(retained.isDirty()).toBe(true);
+    expect(retained.getTouched().a).toBe(true);
+    expect(retained.getDirty().a).toBe(true);
+    expect(retained.isValid()).toBe(true);
   });
 }
 

--- a/packages/@mantine/form/src/tests/use-form/compiler-stability.test.ts
+++ b/packages/@mantine/form/src/tests/use-form/compiler-stability.test.ts
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react';
+import { FormMode } from '../../types';
+import { useForm } from '../../use-form';
+
+/*
+ * React Compiler compatibility guard.
+ *
+ * The form getters that read mutable refs are wrapped in `useCallback` keyed on the ref's
+ * current value (e.g. `[refValues.current]`). The form reassigns those refs to fresh objects
+ * on every change, so each getter's identity changes exactly when its underlying data changes
+ * and stays stable otherwise.
+ *
+ * React Compiler memoizes a call expression by its callee identity, so this identity change is
+ * what forces it to re-invoke the getter rather than serve a stale cached value. We cannot run
+ * the compiler in jest, but we can assert the invariant it relies on:
+ *
+ *   1. after a value change, the getter is a NEW reference (so the compiler re-invokes), and
+ *   2. across an inert re-render with no data change, the getter keeps a STABLE reference (so
+ *      consumer dependency arrays do not fire spuriously).
+ *
+ * Both are asserted in controlled AND uncontrolled mode. A regression to `useCallback(fn, [])`
+ * breaks (1) in both modes; a regression to a state-mirror dep like `[stateValues]` breaks (1)
+ * in uncontrolled mode, where the state mirror does not update on change.
+ */
+
+function tests(mode: FormMode) {
+  it('changes getter identity after a value change', () => {
+    const hook = renderHook(() => useForm({ mode, initialValues: { a: 1 } }));
+
+    const before = {
+      isDirty: hook.result.current.isDirty,
+      getValues: hook.result.current.getValues,
+      getInitialValues: hook.result.current.getInitialValues,
+    };
+
+    act(() => hook.result.current.setFieldValue('a', 5));
+
+    expect(hook.result.current.isDirty).not.toBe(before.isDirty);
+    expect(hook.result.current.getValues).not.toBe(before.getValues);
+  });
+
+  it('changes isTouched identity after a field is touched', () => {
+    const hook = renderHook(() => useForm({ mode, initialValues: { a: 1 } }));
+    const before = hook.result.current.isTouched;
+    act(() => hook.result.current.setFieldValue('a', 5));
+    expect(hook.result.current.isTouched).not.toBe(before);
+  });
+
+  it('keeps a stable getter identity across a re-render with no data change', () => {
+    const hook = renderHook(() => useForm({ mode, initialValues: { a: 1 } }));
+
+    const before = {
+      isDirty: hook.result.current.isDirty,
+      isTouched: hook.result.current.isTouched,
+      getValues: hook.result.current.getValues,
+      getInitialValues: hook.result.current.getInitialValues,
+    };
+
+    act(() => hook.rerender());
+
+    expect(hook.result.current.isDirty).toBe(before.isDirty);
+    expect(hook.result.current.isTouched).toBe(before.isTouched);
+    expect(hook.result.current.getValues).toBe(before.getValues);
+    expect(hook.result.current.getInitialValues).toBe(before.getInitialValues);
+  });
+}
+
+describe('@mantine/form/use-form compiler stability (controlled)', () => {
+  tests('controlled');
+});
+
+describe('@mantine/form/use-form compiler stability (uncontrolled)', () => {
+  tests('uncontrolled');
+});

--- a/packages/@mantine/form/src/use-field.ts
+++ b/packages/@mantine/form/src/use-field.ts
@@ -201,11 +201,14 @@ export function useField<
     setTouched(false);
   }, [initialValue]);
 
-  const getValue = useCallback(() => valueRef.current, []);
+  const getValue = useCallback(() => valueRef.current, [valueRef.current]);
 
-  const isTouched = useCallback(() => touchedRef.current, []);
+  const isTouched = useCallback(() => touchedRef.current, [touchedRef.current]);
 
-  const isDirty = useCallback(() => valueRef.current !== initialValue, [initialValue]);
+  const isDirty = useCallback(
+    () => valueRef.current !== initialValue,
+    [valueRef.current, initialValue]
+  );
 
   const _validate = useCallback(async () => {
     const validationResult = validate?.(valueRef.current);

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -400,12 +400,7 @@ export function useForm<
 
   const key: Key<Values> = (path) => `${formKey}-${String(path)}-${fieldKeys[String(path)] || 0}`;
 
-  /*
-   * Plain function (not useCallback): this performs a live DOM query, so its result must never
-   * be memoized. A stable identity would let React Compiler cache the returned node and serve a
-   * stale element after the DOM changes. There is no ref value to key a useCallback on here, so
-   * a fresh identity each render is the correct way to keep the query live under the compiler.
-   */
+  // Plain function (not useCallback): a live DOM query must never be memoized by React Compiler.
   const getInputNode: GetInputNode<Values> = (path) =>
     document.querySelector(`[data-path="${getDataPath(name, path)}"]`);
 

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -400,7 +400,6 @@ export function useForm<
 
   const key: Key<Values> = (path) => `${formKey}-${String(path)}-${fieldKeys[String(path)] || 0}`;
 
-  // Plain function (not useCallback): a live DOM query must never be memoized by React Compiler.
   const getInputNode: GetInputNode<Values> = (path) =>
     document.querySelector(`[data-path="${getDataPath(name, path)}"]`);
 

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -395,15 +395,19 @@ export function useForm<
       }
       return !result.hasErrors;
     },
-    [rules, resolveValidationError]
+    [rules, resolveValidationError, $values.refValues.current]
   );
 
   const key: Key<Values> = (path) => `${formKey}-${String(path)}-${fieldKeys[String(path)] || 0}`;
 
-  const getInputNode: GetInputNode<Values> = useCallback(
-    (path) => document.querySelector(`[data-path="${getDataPath(name, path)}"]`),
-    []
-  );
+  /*
+   * Plain function (not useCallback): this performs a live DOM query, so its result must never
+   * be memoized. A stable identity would let React Compiler cache the returned node and serve a
+   * stale element after the DOM changes. There is no ref value to key a useCallback on here, so
+   * a fresh identity each render is the correct way to keep the query live under the compiler.
+   */
+  const getInputNode: GetInputNode<Values> = (path) =>
+    document.querySelector(`[data-path="${getDataPath(name, path)}"]`);
 
   const resetField = useCallback(
     (path: PropertyKey) => {


### PR DESCRIPTION
Related to #9005

## Problem

When a consumer app enables `babel-plugin-react-compiler` (target `'19'`), getters returned from `useForm`/`useField` return **stale values forever**. The headline symptom: `const { isDirty } = form; isDirty()` keeps returning `false` after the user types, so a Submit button gated on `isDirty()` never enables — while `form.isDirty()` (property access) works.

**Root cause.** The affected getters are wrapped in `useCallback(fn, [])`, giving them a permanently stable identity, and they read mutable refs internally. React Compiler memoizes the call expression `isDirty()` keyed on the stable callee + stable (empty) args and never re-invokes it, so the cached return value goes stale. Property access escapes this because `form` is rebuilt as a fresh object literal every render.

## Fix

Key each affected getter's `useCallback` on the **current value of the ref it reads** (e.g. `[refValues.current]`, `[dirtyRef.current]`, `[valuesSnapshot.current]`) instead of `[]`. The form always **reassigns** these refs to a fresh object on every change (`setPath` deep-clones via `klona`; `setValues` reassigns `refValues.current`), so the dependency changes exactly when the underlying data changes — in both controlled and uncontrolled mode — and stays stable otherwise.

This is deliberately **not** a plain-function conversion: a plain function would fix the compiler bug but allocate a new identity every render, which is a breaking change for consumers that place a getter in a dependency array. Keying on `ref.current` fixes the bug **and** preserves a stable identity that changes only when the data changes — which is _more_ correct for dependency arrays than today's permanent stability (today `[isDirty]` never re-fires even when dirtiness flips).

`getInputNode` is the one exception, converted to a plain function: it performs a live `document.querySelector` with no ref to key on, so its result must never be memoized.

### Getters changed

- `use-form-status`: `isDirty`, `isTouched`, `getDirty`, `getTouched`
- `use-form-values`: `getValues`, `getValuesSnapshot`
- `use-form-validating`: `isValidating`
- `use-form`: `isValid`, `getInputNode` (plain function)
- `use-field`: `getValue`, `isTouched`, `isDirty`

Setters/actions (`setFieldValue`, `setValues`, `validate`, `reset`, `resetDirty`, …) are intentionally left as-is — their identity is relied on in dependency arrays and their return value is never cached, so they don't trigger the bug.

## Note on the `ref.current` dependency

Keying `useCallback` on `ref.current` is unconventional (`exhaustive-deps` normally warns against it, since refs are usually mutated in place). It is correct here only because the form **reassigns** these refs to fresh objects rather than mutating in place. A multi-line comment documents this invariant at each site. It may be prudent for us to use React state instead of refs, but that's a larger refactor.

## Tests

Added `compiler-stability.test.ts` for both `use-form` (controlled + uncontrolled) and `use-field`, asserting the invariant the compiler relies on:

1. after a value change, the getter has a **new** identity (so the compiler re-invokes), and
2. across an inert re-render with no data change, the getter keeps a **stable** identity (so consumer dependency arrays don't fire spuriously).

Limitation: jest runs without the compiler, so these assert the identity invariant rather than reproducing the staleness directly. End-to-end behavior was verified in a local Vite + `babel-plugin-react-compiler` harness in both modes.

## Migration note

These getters no longer have a _permanently_ stable identity — their identity now changes when their underlying data changes. Consumers placing a getter in a dependency array will see it re-fire when the data changes (previously it never re-fired). This is the corrected behavior; depending on the called value (or using `onValuesChange`) remains the documented guidance.
