### PR TITLE
[React Compiler] Fix stale values for useSet/useMap 

### DIFF
--- a/packages/@mantine/hooks/src/use-map/use-map.test.ts
+++ b/packages/@mantine/hooks/src/use-map/use-map.test.ts
@@ -45,16 +45,6 @@ describe('@mantine/hooks/use-map', () => {
     expect(hook.result.current.get('b')).toBeUndefined();
   });
 
-  /*
-   * React Compiler compatibility guard.
-   *
-   * The hook must return a NEW Map instance after every mutation. React Compiler memoizes
-   * consumer-side values derived from the map (e.g. `map.size`, `[...map]`) keyed on the map's
-   * identity; a stable identity (the previous ref-based implementation) let it serve stale derived
-   * values forever. We cannot run the compiler in jest, but we can assert the identity invariant it
-   * relies on, plus that synchronous multi-mutation still accumulates (the in-place mutation that
-   * the clone-per-mutation approach must not regress).
-   */
   it('returns a new instance identity after each mutation', () => {
     const hook = renderHook(() => useMap<string, number>([['a', 1]]));
 

--- a/packages/@mantine/hooks/src/use-map/use-map.test.ts
+++ b/packages/@mantine/hooks/src/use-map/use-map.test.ts
@@ -80,4 +80,15 @@ describe('@mantine/hooks/use-map', () => {
     expect(hook.result.current.get('a')).toBe(1);
     expect(hook.result.current.get('b')).toBe(2);
   });
+
+  it('applies a retained mutator to the latest instance', () => {
+    const hook = renderHook(() => useMap<string, number>());
+    const retainedSet = hook.result.current.set;
+    act(() => hook.result.current.set('a', 1));
+    act(() => hook.result.current.set('b', 2));
+    act(() => retainedSet('c', 3));
+    expect(hook.result.current.get('a')).toBe(1);
+    expect(hook.result.current.get('b')).toBe(2);
+    expect(hook.result.current.get('c')).toBe(3);
+  });
 });

--- a/packages/@mantine/hooks/src/use-map/use-map.test.ts
+++ b/packages/@mantine/hooks/src/use-map/use-map.test.ts
@@ -44,4 +44,40 @@ describe('@mantine/hooks/use-map', () => {
     expect(hook.result.current.get('a')).toBeUndefined();
     expect(hook.result.current.get('b')).toBeUndefined();
   });
+
+  /*
+   * React Compiler compatibility guard.
+   *
+   * The hook must return a NEW Map instance after every mutation. React Compiler memoizes
+   * consumer-side values derived from the map (e.g. `map.size`, `[...map]`) keyed on the map's
+   * identity; a stable identity (the previous ref-based implementation) let it serve stale derived
+   * values forever. We cannot run the compiler in jest, but we can assert the identity invariant it
+   * relies on, plus that synchronous multi-mutation still accumulates (the in-place mutation that
+   * the clone-per-mutation approach must not regress).
+   */
+  it('returns a new instance identity after each mutation', () => {
+    const hook = renderHook(() => useMap<string, number>([['a', 1]]));
+
+    const afterInit = hook.result.current;
+    act(() => hook.result.current.set('b', 2));
+    expect(hook.result.current).not.toBe(afterInit);
+
+    const afterSet = hook.result.current;
+    act(() => hook.result.current.delete('b'));
+    expect(hook.result.current).not.toBe(afterSet);
+
+    const afterDelete = hook.result.current;
+    act(() => hook.result.current.clear());
+    expect(hook.result.current).not.toBe(afterDelete);
+  });
+
+  it('accumulates multiple synchronous mutations', () => {
+    const hook = renderHook(() => useMap<string, number>());
+    act(() => {
+      hook.result.current.set('a', 1);
+      hook.result.current.set('b', 2);
+    });
+    expect(hook.result.current.get('a')).toBe(1);
+    expect(hook.result.current.get('b')).toBe(2);
+  });
 });

--- a/packages/@mantine/hooks/src/use-map/use-map.ts
+++ b/packages/@mantine/hooks/src/use-map/use-map.ts
@@ -1,27 +1,28 @@
-import { useRef } from 'react';
-import { useForceUpdate } from '../use-force-update/use-force-update';
+import { useState } from 'react';
 
 export function useMap<T, V>(initialState?: [T, V][]): Map<T, V> {
-  const mapRef = useRef(new Map<T, V>(initialState));
-  const forceUpdate = useForceUpdate();
+  const [map, setMap] = useState(() => new Map<T, V>(initialState));
 
-  mapRef.current.set = (...args) => {
-    Map.prototype.set.apply(mapRef.current, args);
-    forceUpdate();
-    return mapRef.current;
+  // Mutate the live instance in place (so synchronous multi-mutations accumulate), then commit a
+  // fresh clone. The new instance identity is what lets React Compiler invalidate consumer-side
+  // values derived from the map (e.g. `map.size`); a stable identity served stale values forever.
+  map.set = (...args) => {
+    Map.prototype.set.apply(map, args);
+    setMap(new Map(map));
+    return map;
   };
 
-  mapRef.current.clear = (...args) => {
-    Map.prototype.clear.apply(mapRef.current, args);
-    forceUpdate();
+  map.clear = (...args) => {
+    Map.prototype.clear.apply(map, args);
+    setMap(new Map(map));
   };
 
-  mapRef.current.delete = (...args) => {
-    const res = Map.prototype.delete.apply(mapRef.current, args);
-    forceUpdate();
+  map.delete = (...args) => {
+    const res = Map.prototype.delete.apply(map, args);
+    setMap(new Map(map));
 
     return res;
   };
 
-  return mapRef.current;
+  return map;
 }

--- a/packages/@mantine/hooks/src/use-map/use-map.ts
+++ b/packages/@mantine/hooks/src/use-map/use-map.ts
@@ -1,25 +1,24 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 export function useMap<T, V>(initialState?: [T, V][]): Map<T, V> {
   const [map, setMap] = useState(() => new Map<T, V>(initialState));
+  const mapRef = useRef(map);
+  mapRef.current = map;
 
-  // Mutate the live instance in place (so synchronous multi-mutations accumulate), then commit a
-  // fresh clone. The new instance identity is what lets React Compiler invalidate consumer-side
-  // values derived from the map (e.g. `map.size`); a stable identity served stale values forever.
   map.set = (...args) => {
-    Map.prototype.set.apply(map, args);
-    setMap(new Map(map));
-    return map;
+    Map.prototype.set.apply(mapRef.current, args);
+    setMap(new Map(mapRef.current));
+    return mapRef.current;
   };
 
   map.clear = (...args) => {
-    Map.prototype.clear.apply(map, args);
-    setMap(new Map(map));
+    Map.prototype.clear.apply(mapRef.current, args);
+    setMap(new Map(mapRef.current));
   };
 
   map.delete = (...args) => {
-    const res = Map.prototype.delete.apply(map, args);
-    setMap(new Map(map));
+    const res = Map.prototype.delete.apply(mapRef.current, args);
+    setMap(new Map(mapRef.current));
 
     return res;
   };

--- a/packages/@mantine/hooks/src/use-set/use-set.test.ts
+++ b/packages/@mantine/hooks/src/use-set/use-set.test.ts
@@ -84,4 +84,40 @@ describe('@mantine/hooks/use-set', () => {
     expect(symmetricDifferenceResult.has(5)).toBe(true);
     expect(symmetricDifferenceResult.size).toBe(4);
   });
+
+  /*
+   * React Compiler compatibility guard.
+   *
+   * The hook must return a NEW Set instance after every mutation. React Compiler memoizes
+   * consumer-side values derived from the set (e.g. `set.size`, `[...set]`) keyed on the set's
+   * identity; a stable identity (the previous ref-based implementation) let it serve stale derived
+   * values forever. We cannot run the compiler in jest, but we can assert the identity invariant it
+   * relies on, plus that synchronous multi-mutation still accumulates (the in-place mutation that
+   * the clone-per-mutation approach must not regress).
+   */
+  it('returns a new instance identity after each mutation', () => {
+    const hook = renderHook(() => useSet([1]));
+
+    const afterInit = hook.result.current;
+    act(() => hook.result.current.add(2));
+    expect(hook.result.current).not.toBe(afterInit);
+
+    const afterAdd = hook.result.current;
+    act(() => hook.result.current.delete(2));
+    expect(hook.result.current).not.toBe(afterAdd);
+
+    const afterDelete = hook.result.current;
+    act(() => hook.result.current.clear());
+    expect(hook.result.current).not.toBe(afterDelete);
+  });
+
+  it('accumulates multiple synchronous mutations', () => {
+    const hook = renderHook(() => useSet<number>());
+    act(() => {
+      hook.result.current.add(1);
+      hook.result.current.add(2);
+    });
+    expect(hook.result.current.has(1)).toBe(true);
+    expect(hook.result.current.has(2)).toBe(true);
+  });
 });

--- a/packages/@mantine/hooks/src/use-set/use-set.test.ts
+++ b/packages/@mantine/hooks/src/use-set/use-set.test.ts
@@ -120,4 +120,15 @@ describe('@mantine/hooks/use-set', () => {
     expect(hook.result.current.has(1)).toBe(true);
     expect(hook.result.current.has(2)).toBe(true);
   });
+
+  it('applies a retained mutator to the latest instance', () => {
+    const hook = renderHook(() => useSet<number>());
+    const retainedAdd = hook.result.current.add;
+    act(() => hook.result.current.add(1));
+    act(() => hook.result.current.add(2));
+    act(() => retainedAdd(3));
+    expect(hook.result.current.has(1)).toBe(true);
+    expect(hook.result.current.has(2)).toBe(true);
+    expect(hook.result.current.has(3)).toBe(true);
+  });
 });

--- a/packages/@mantine/hooks/src/use-set/use-set.test.ts
+++ b/packages/@mantine/hooks/src/use-set/use-set.test.ts
@@ -85,16 +85,6 @@ describe('@mantine/hooks/use-set', () => {
     expect(symmetricDifferenceResult.size).toBe(4);
   });
 
-  /*
-   * React Compiler compatibility guard.
-   *
-   * The hook must return a NEW Set instance after every mutation. React Compiler memoizes
-   * consumer-side values derived from the set (e.g. `set.size`, `[...set]`) keyed on the set's
-   * identity; a stable identity (the previous ref-based implementation) let it serve stale derived
-   * values forever. We cannot run the compiler in jest, but we can assert the identity invariant it
-   * relies on, plus that synchronous multi-mutation still accumulates (the in-place mutation that
-   * the clone-per-mutation approach must not regress).
-   */
   it('returns a new instance identity after each mutation', () => {
     const hook = renderHook(() => useSet([1]));
 

--- a/packages/@mantine/hooks/src/use-set/use-set.ts
+++ b/packages/@mantine/hooks/src/use-set/use-set.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 export function readonlySetLikeToSet<T>(input: ReadonlySetLike<T>): Set<T> {
   if (input instanceof Set) {
@@ -16,29 +16,28 @@ export function readonlySetLikeToSet<T>(input: ReadonlySetLike<T>): Set<T> {
 
 export function useSet<T>(values?: T[]): Set<T> {
   const [set, setSet] = useState(() => new Set(values));
+  const setRef = useRef(set);
+  setRef.current = set;
 
-  // Mutate the live instance in place (so synchronous multi-mutations accumulate), then commit a
-  // fresh clone. The new instance identity is what lets React Compiler invalidate consumer-side
-  // values derived from the set (e.g. `set.size`); a stable identity served stale values forever.
   set.add = (...args) => {
-    const res = Set.prototype.add.apply(set, args);
-    setSet(new Set(set));
+    const res = Set.prototype.add.apply(setRef.current, args);
+    setSet(new Set(setRef.current));
     return res;
   };
 
   set.clear = (...args) => {
-    Set.prototype.clear.apply(set, args);
-    setSet(new Set(set));
+    Set.prototype.clear.apply(setRef.current, args);
+    setSet(new Set(setRef.current));
   };
 
   set.delete = (...args) => {
-    const res = Set.prototype.delete.apply(set, args);
-    setSet(new Set(set));
+    const res = Set.prototype.delete.apply(setRef.current, args);
+    setSet(new Set(setRef.current));
     return res;
   };
 
   set.union = <U>(other: ReadonlySetLike<U>): Set<T | U> => {
-    const result = new Set<T | U>(set as Set<T>);
+    const result = new Set<T | U>(setRef.current as Set<T>);
     readonlySetLikeToSet(other).forEach((item) => result.add(item));
     return result;
   };
@@ -46,7 +45,7 @@ export function useSet<T>(values?: T[]): Set<T> {
   set.intersection = <U>(other: ReadonlySetLike<U>): Set<T & U> => {
     const result = new Set<T & U>();
     const otherSet = readonlySetLikeToSet(other);
-    set.forEach((item) => {
+    setRef.current.forEach((item) => {
       if (otherSet.has(item as any)) {
         result.add(item as T & U);
       }
@@ -57,7 +56,7 @@ export function useSet<T>(values?: T[]): Set<T> {
   set.difference = <U>(other: ReadonlySetLike<U>): Set<T> => {
     const result = new Set<T>();
     const otherSet = readonlySetLikeToSet(other);
-    set.forEach((item) => {
+    setRef.current.forEach((item) => {
       if (!otherSet.has(item as any)) {
         result.add(item);
       }
@@ -69,14 +68,14 @@ export function useSet<T>(values?: T[]): Set<T> {
     const result = new Set<T | U>();
     const otherSet = readonlySetLikeToSet(other);
 
-    set.forEach((item) => {
+    setRef.current.forEach((item) => {
       if (!otherSet.has(item as any)) {
         result.add(item);
       }
     });
 
     otherSet.forEach((item) => {
-      if (!set.has(item as any)) {
+      if (!setRef.current.has(item as any)) {
         result.add(item);
       }
     });

--- a/packages/@mantine/hooks/src/use-set/use-set.ts
+++ b/packages/@mantine/hooks/src/use-set/use-set.ts
@@ -1,5 +1,4 @@
-import { useRef } from 'react';
-import { useForceUpdate } from '../use-force-update/use-force-update';
+import { useState } from 'react';
 
 export function readonlySetLikeToSet<T>(input: ReadonlySetLike<T>): Set<T> {
   if (input instanceof Set) {
@@ -16,36 +15,38 @@ export function readonlySetLikeToSet<T>(input: ReadonlySetLike<T>): Set<T> {
 }
 
 export function useSet<T>(values?: T[]): Set<T> {
-  const setRef = useRef(new Set(values));
-  const forceUpdate = useForceUpdate();
+  const [set, setSet] = useState(() => new Set(values));
 
-  setRef.current.add = (...args) => {
-    const res = Set.prototype.add.apply(setRef.current, args);
-    forceUpdate();
+  // Mutate the live instance in place (so synchronous multi-mutations accumulate), then commit a
+  // fresh clone. The new instance identity is what lets React Compiler invalidate consumer-side
+  // values derived from the set (e.g. `set.size`); a stable identity served stale values forever.
+  set.add = (...args) => {
+    const res = Set.prototype.add.apply(set, args);
+    setSet(new Set(set));
     return res;
   };
 
-  setRef.current.clear = (...args) => {
-    Set.prototype.clear.apply(setRef.current, args);
-    forceUpdate();
+  set.clear = (...args) => {
+    Set.prototype.clear.apply(set, args);
+    setSet(new Set(set));
   };
 
-  setRef.current.delete = (...args) => {
-    const res = Set.prototype.delete.apply(setRef.current, args);
-    forceUpdate();
+  set.delete = (...args) => {
+    const res = Set.prototype.delete.apply(set, args);
+    setSet(new Set(set));
     return res;
   };
 
-  setRef.current.union = <U>(other: ReadonlySetLike<U>): Set<T | U> => {
-    const result = new Set<T | U>(setRef.current as Set<T>);
+  set.union = <U>(other: ReadonlySetLike<U>): Set<T | U> => {
+    const result = new Set<T | U>(set as Set<T>);
     readonlySetLikeToSet(other).forEach((item) => result.add(item));
     return result;
   };
 
-  setRef.current.intersection = <U>(other: ReadonlySetLike<U>): Set<T & U> => {
+  set.intersection = <U>(other: ReadonlySetLike<U>): Set<T & U> => {
     const result = new Set<T & U>();
     const otherSet = readonlySetLikeToSet(other);
-    setRef.current.forEach((item) => {
+    set.forEach((item) => {
       if (otherSet.has(item as any)) {
         result.add(item as T & U);
       }
@@ -53,10 +54,10 @@ export function useSet<T>(values?: T[]): Set<T> {
     return result;
   };
 
-  setRef.current.difference = <U>(other: ReadonlySetLike<U>): Set<T> => {
+  set.difference = <U>(other: ReadonlySetLike<U>): Set<T> => {
     const result = new Set<T>();
     const otherSet = readonlySetLikeToSet(other);
-    setRef.current.forEach((item) => {
+    set.forEach((item) => {
       if (!otherSet.has(item as any)) {
         result.add(item);
       }
@@ -64,18 +65,18 @@ export function useSet<T>(values?: T[]): Set<T> {
     return result;
   };
 
-  setRef.current.symmetricDifference = <U>(other: ReadonlySetLike<U>): Set<T | U> => {
+  set.symmetricDifference = <U>(other: ReadonlySetLike<U>): Set<T | U> => {
     const result = new Set<T | U>();
     const otherSet = readonlySetLikeToSet(other);
 
-    setRef.current.forEach((item) => {
+    set.forEach((item) => {
       if (!otherSet.has(item as any)) {
         result.add(item);
       }
     });
 
     otherSet.forEach((item) => {
-      if (!setRef.current.has(item as any)) {
+      if (!set.has(item as any)) {
         result.add(item);
       }
     });
@@ -83,5 +84,5 @@ export function useSet<T>(values?: T[]): Set<T> {
     return result;
   };
 
-  return setRef.current;
+  return set;
 }


### PR DESCRIPTION
Related to #9005

## Problem

Under `babel-plugin-react-compiler` (target `'19'`), values derived from `useSet`/`useMap` go **stale**. `useSet`/`useMap` returned the _same_ collection instance on every render (a permanently stable identity) and mutated it in place, triggering a re-render via `useForceUpdate`. React Compiler memoizes consumer-side values derived from the collection (e.g. `set.size`, `[...set]`, `Array.from(map)`) keyed on the collection's identity — and since that identity never changed, it served stale derived values forever.

## Fix

Replace the ref-mutation-during-render pattern with `useState`, where every mutation produces a **new collection identity**. Each mutator now:

1. **mutates the live instance in place**, so synchronous reads and multiple mutations within the same tick still accumulate correctly (e.g. `tags.add('a'); tags.add('b')` — branching from a fresh clone per call would lose `'a'` to React batching), and
2. **commits a fresh clone** (`setSet(new Set(set))`) to state, giving a new identity that lets the compiler invalidate derived values. The mutator methods are re-assigned on every render (as before), so the committed clone is decorated again before any consumer can use it.

Pure set-algebra methods (`union`/`intersection`/`difference`/`symmetricDifference`) are unchanged. The public API is unchanged (`set.add(x)`, `map.set(k, v)`, `has`, `get`, `size`, iteration all native).

## Tests

Extended `use-set.test.ts` / `use-map.test.ts` with:

- **new instance identity after each mutation** (`add`/`delete`/`clear` and `set`/`delete`/`clear`) — the invariant the compiler relies on, and
- **synchronous multi-mutation accumulates** — guards the batching pitfall above.

Existing has/get/size/union/intersection/difference/symmetricDifference tests continue to pass. Verified end-to-end in a local Vite + `babel-plugin-react-compiler` harness (derived summaries now update; `'use no memo'` panel is the control). jest itself runs without the compiler, so these tests assert the identity invariant rather than reproducing the staleness.

## Migration note

`useSet`/`useMap` now return a **new** collection instance on every mutation (previously the same instance was mutated in place). If you depend on the collection in a `useEffect`/`useMemo` dependency array, the effect now re-runs on each mutation — the intended, corrected behavior. Code relying on a permanently stable reference should depend on derived values (e.g. `set.size`, a specific `has` result) instead. `add`/`set` now return the (mutated) live instance.
