### PR TITLE
[@mantine/form] Export FormProviderProps type

### DIFF
--- a/packages/@mantine/form/src/index.ts
+++ b/packages/@mantine/form/src/index.ts
@@ -10,3 +10,4 @@ export { formRootRule } from './validate/validate-values.js';
 export type * from './types';
 export type { UseFieldInput, UseFieldReturnType } from './use-field';
 export type { FormArrayElement, LooseKeys } from './paths.types.js';
+export type { FormProviderProps } from './FormProvider/FormProvider.js';


### PR DESCRIPTION
Closes #8985.

`FormProviderProps` is defined and exported from `FormProvider/FormProvider.tsx`, but it was never re-exported from the package entry (`@mantine/form/src/index.ts`). `createFormContext` is exported, yet its return type references `React.FC<FormProviderProps<Form>>`, so when a consumer re-exports the result of `createFormContext()` TypeScript cannot name the inferred type and fails with TS2742 ("The inferred type of X cannot be named without a reference to ...").

This adds the missing public type export, matching how the other type exports in the same file reference their source modules.

Verified the export resolves with a targeted `tsc --noEmit` on the `@mantine/form` tsconfig (no "has no exported member" error for `FormProviderProps`).
