### PR TITLE
[@mantine/core] Menu: Add role="presentation" to non-semantic dropdown children

### DIFF
--- a/packages/@mantine/core/src/components/Menu/Menu.test.tsx
+++ b/packages/@mantine/core/src/components/Menu/Menu.test.tsx
@@ -161,6 +161,13 @@ describe('@mantine/core/Menu', () => {
     expect(document.querySelectorAll('.mantine-Menu-arrow')).toHaveLength(0);
   });
 
+  it('assigns role="presentation" to non-semantic dropdown children (#8971)', () => {
+    render(<TestContainer defaultOpened withArrow />);
+    const menu = screen.getByRole('menu');
+    expect(menu.querySelector('[data-autofocus]')).toHaveAttribute('role', 'presentation');
+    expect(menu.querySelector('.mantine-Menu-arrow')).toHaveAttribute('role', 'presentation');
+  });
+
   it('exposes related components as static properties', () => {
     expect(Menu.Item).toBe(MenuItem);
     expect(Menu.Dropdown).toBe(MenuDropdown);

--- a/packages/@mantine/core/src/components/Menu/MenuDropdown/MenuDropdown.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuDropdown/MenuDropdown.tsx
@@ -93,7 +93,13 @@ export const MenuDropdown = factory<MenuDropdownFactory>((props) => {
       onKeyDown={handleKeyDown}
     >
       {ctx.withInitialFocusPlaceholder && !ctx.hasSearch && (
-        <div tabIndex={-1} data-autofocus data-mantine-stop-propagation style={{ outline: 0 }} />
+        <div
+          role="presentation"
+          tabIndex={-1}
+          data-autofocus
+          data-mantine-stop-propagation
+          style={{ outline: 0 }}
+        />
       )}
       {children}
     </Popover.Dropdown>

--- a/packages/@mantine/core/src/utils/Floating/FloatingArrow/FloatingArrow.tsx
+++ b/packages/@mantine/core/src/utils/Floating/FloatingArrow/FloatingArrow.tsx
@@ -32,6 +32,7 @@ export function FloatingArrow({
 
   return (
     <div
+      role="presentation"
       {...others}
       style={{
         ...style,


### PR DESCRIPTION
## Fixes #8971

The `Menu.Dropdown` element has `role="menu"`, but it renders two non-semantic `<div>` children that have no role:

1. The initial-focus placeholder div (rendered when `withInitialFocusPlaceholder` is enabled).
2. The decorative floating arrow (`FloatingArrow`).

Per the WAI-ARIA spec, an element with `role="menu"` should only contain children with allowed roles (`menuitem`, `menuitemcheckbox`, `menuitemradio`, `group`, `presentation`, `none`, etc.). Bare `<div>`s without a role violate this and are flagged by accessibility auditing tools (e.g. axe-core `aria-required-children`).

## Changes

- Add `role="presentation"` to the initial-focus placeholder div in `MenuDropdown`.
- Add a default `role="presentation"` to `FloatingArrow` (decorative). It is spread before `{...others}`, so consumers can still override it.

## Test

Added a regression test in `Menu.test.tsx` asserting both the autofocus placeholder and the arrow expose `role="presentation"`.