### PR TITLE
[@mantine/core] Collapse: Apply style and ref props when transitionDuration is 0

### DIFF
--- a/packages/@mantine/core/src/components/Collapse/Collapse.test.tsx
+++ b/packages/@mantine/core/src/components/Collapse/Collapse.test.tsx
@@ -1,4 +1,5 @@
-import { tests } from '@mantine-tests/core';
+import { createRef } from 'react';
+import { render, tests } from '@mantine-tests/core';
 import { Collapse, CollapseProps } from './Collapse';
 
 const defaultProps: CollapseProps = {
@@ -13,5 +14,24 @@ describe('@mantine/core/Collapse', () => {
     children: true,
     classes: false,
     displayName: '@mantine/core/Collapse',
+  });
+
+  it('applies style and ref props when transitionDuration is 0 (#9010)', () => {
+    const ref = createRef<HTMLDivElement>();
+    const { container } = render(
+      <Collapse
+        expanded
+        transitionDuration={0}
+        ref={ref}
+        style={{ color: 'red' }}
+        data-testid="collapse"
+      >
+        <div />
+      </Collapse>
+    );
+
+    const element = container.querySelector<HTMLDivElement>('[data-testid="collapse"]')!;
+    expect(element).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+    expect(ref.current).toBe(element);
   });
 });

--- a/packages/@mantine/core/src/components/Collapse/Collapse.tsx
+++ b/packages/@mantine/core/src/components/Collapse/Collapse.tsx
@@ -86,11 +86,17 @@ export const Collapse = factory<CollapseFactory>((props) => {
     if (keepMounted === true && env !== 'test') {
       return (
         <Activity mode={expanded ? 'visible' : 'hidden'}>
-          <Box {...others}>{children}</Box>
+          <Box {...others} ref={ref} style={getStyleObject(style, theme)}>
+            {children}
+          </Box>
         </Activity>
       );
     }
-    return expanded ? <Box {...others}>{children}</Box> : null;
+    return expanded ? (
+      <Box {...others} ref={ref} style={getStyleObject(style, theme)}>
+        {children}
+      </Box>
+    ) : null;
   }
 
   const isExited = collapse.state === 'exited';


### PR DESCRIPTION
## Fixes #9010

When `transitionDuration={0}` (or reduced motion forces the duration to `0`), `Collapse` short-circuits and renders a plain `Box`, but it does **not** forward the `style` and `ref` props. Both are destructured out of `...others`, so the early-return branches silently drop them. The normal (animated) branch forwards both via `getCollapseProps`.

This means consumers lose their inline styles and ref access whenever the collapse animation is disabled.

## Changes

- Forward `ref` and `style` (converted with `getStyleObject`) to the `Box` in both `duration === 0` return paths (the `Activity`-wrapped path and the plain conditional path).

## Test

Added a regression test asserting that, with `transitionDuration={0}`, the inline `style` is applied and the `ref` resolves to the rendered element.