### PR TITLE
[@mantine/charts] Fix incorrect @default JSDoc values for several chart props

### DIFF
--- a/packages/@mantine/charts/src/BarsList/BarsList.tsx
+++ b/packages/@mantine/charts/src/BarsList/BarsList.tsx
@@ -64,7 +64,7 @@ export interface BarsListProps
   /** Controls gap between bars @default 5 */
   barGap?: MantineSpacing;
 
-  /** Minimum bar width @default 100 */
+  /** Minimum bar width @default 0 */
   minBarSize?: number | string;
 
   /** Bar height @default 32 */

--- a/packages/@mantine/charts/src/DonutChart/DonutChart.tsx
+++ b/packages/@mantine/charts/src/DonutChart/DonutChart.tsx
@@ -87,7 +87,7 @@ export interface DonutChartProps
   /** Controls thickness of the chart segments @default 20 */
   thickness?: number;
 
-  /** Controls chart width and height, height is increased by 40 if `withLabels` prop is set. Cannot be less than `thickness`. @default 80 */
+  /** Controls chart width and height, height is increased by 40 if `withLabels` prop is set. Cannot be less than `thickness`. @default 160 */
   size?: number;
 
   /** Controls width of segments stroke @default 1 */

--- a/packages/@mantine/charts/src/Heatmap/Heatmap.tsx
+++ b/packages/@mantine/charts/src/Heatmap/Heatmap.tsx
@@ -84,7 +84,7 @@ export interface HeatmapProps
   /** Width of weekday labels column @default 30 */
   weekdaysLabelsWidth?: number;
 
-  /** Height of month labels row @default 30 */
+  /** Height of month labels row @default 14 */
   monthsLabelsHeight?: number;
 
   /** Font size of month and weekday labels @default 12 */

--- a/packages/@mantine/charts/src/PieChart/PieChart.tsx
+++ b/packages/@mantine/charts/src/PieChart/PieChart.tsx
@@ -81,7 +81,7 @@ export interface PieChartProps
   /** Determines whether segments labels should have lines that connect the segment with the label @default true */
   withLabelsLine?: boolean;
 
-  /** Controls chart width and height, height is increased by 40 if `withLabels` prop is set. Cannot be less than `thickness`. @default 80 */
+  /** Controls chart width and height, height is increased by 40 if `withLabels` prop is set. Cannot be less than `thickness`. @default 160 */
   size?: number;
 
   /** Controls width of segments stroke @default 1 */


### PR DESCRIPTION
## What

Several chart props document a `@default` value in their JSDoc that does not match the actual value defined in the component's `defaultProps`. Since the props tables on mantine.dev are generated from these JSDoc comments, the documentation currently shows incorrect defaults.

| Component | Prop | JSDoc `@default` | Actual `defaultProps` |
| --- | --- | --- | --- |
| `DonutChart` | `size` | `80` | `160` |
| `PieChart` | `size` | `80` | `160` |
| `Heatmap` | `monthsLabelsHeight` | `30` | `14` |
| `BarsList` | `minBarSize` | `100` | `0` |

## Changes

Updated each JSDoc `@default` to match the real runtime default. Documentation-only change, no behavior is affected.