### PR TITLE
[@mantine/core] Box: Fix typo in exported STYLE_PROPS_DATA constant name

### DIFF
--- a/apps/mantine.dev/src/components/StylePropsTable/StylePropsTable.tsx
+++ b/apps/mantine.dev/src/components/StylePropsTable/StylePropsTable.tsx
@@ -1,4 +1,4 @@
-import { Breadcrumbs, Code, STYlE_PROPS_DATA } from '@mantine/core';
+import { Breadcrumbs, Code, STYLE_PROPS_DATA } from '@mantine/core';
 import { MdxDataTable } from '@/components/MdxProvider';
 
 const THEME_KEYS: Record<string, string> = {
@@ -8,7 +8,7 @@ const THEME_KEYS: Record<string, string> = {
   lineHeight: 'theme.lineHeights',
 };
 
-export function StylePropsTable({ source = STYlE_PROPS_DATA }: { source: any }) {
+export function StylePropsTable({ source = STYLE_PROPS_DATA }: { source: any }) {
   const data = Object.keys(source).map((propName) => {
     const propData = source[propName];
     const themeKey = THEME_KEYS[propData.type];

--- a/packages/@mantine/core/src/core/Box/Box.tsx
+++ b/packages/@mantine/core/src/core/Box/Box.tsx
@@ -15,7 +15,7 @@ import {
   extractStyleProps,
   MantineStyleProps,
   parseStyleProps,
-  STYlE_PROPS_DATA,
+  STYLE_PROPS_DATA,
 } from './style-props';
 import { useRandomClassName } from './use-random-classname/use-random-classname';
 
@@ -90,7 +90,7 @@ function _Box({
   const parsedStyleProps = parseStyleProps({
     styleProps,
     theme,
-    data: STYlE_PROPS_DATA,
+    data: STYLE_PROPS_DATA,
   });
 
   const deduplicateInlineStyles = useMantineDeduplicateInlineStyles();

--- a/packages/@mantine/core/src/core/Box/style-props/index.ts
+++ b/packages/@mantine/core/src/core/Box/style-props/index.ts
@@ -1,5 +1,5 @@
 export * from './style-props.types';
 export { extractStyleProps } from './extract-style-props/extract-style-props';
-export { STYlE_PROPS_DATA } from './style-props-data';
+export { STYLE_PROPS_DATA } from './style-props-data';
 export { parseStyleProps } from './parse-style-props/parse-style-props';
 export type { SystemPropData } from './style-props-data';

--- a/packages/@mantine/core/src/core/Box/style-props/parse-style-props/parse-style-props.test.ts
+++ b/packages/@mantine/core/src/core/Box/style-props/parse-style-props/parse-style-props.test.ts
@@ -1,12 +1,12 @@
 import { DEFAULT_THEME } from '../../../MantineProvider';
-import { STYlE_PROPS_DATA } from '../style-props-data';
+import { STYLE_PROPS_DATA } from '../style-props-data';
 import { parseStyleProps } from './parse-style-props';
 
 describe('@mantine/core/Box/parse-style-props', () => {
   it('parses non responsive style props correctly', () => {
     expect(
       parseStyleProps({
-        data: STYlE_PROPS_DATA,
+        data: STYLE_PROPS_DATA,
         styleProps: { p: '1.5rem', mx: 32, c: 'red.5', opacity: 0.65 },
         theme: DEFAULT_THEME,
       })
@@ -26,7 +26,7 @@ describe('@mantine/core/Box/parse-style-props', () => {
   it('parses responsive style props correctly', () => {
     expect(
       parseStyleProps({
-        data: STYlE_PROPS_DATA,
+        data: STYLE_PROPS_DATA,
         styleProps: {
           p: { base: '1.5rem', xs: '2rem' },
           mx: { base: 32, xs: 64 },
@@ -61,7 +61,7 @@ describe('@mantine/core/Box/parse-style-props', () => {
   it('parses combination of responsive and non responsive style props correctly', () => {
     expect(
       parseStyleProps({
-        data: STYlE_PROPS_DATA,
+        data: STYLE_PROPS_DATA,
         styleProps: {
           p: { base: 24, xs: 32 },
           mx: 64,
@@ -95,7 +95,7 @@ describe('@mantine/core/Box/parse-style-props', () => {
   it('correctly parses values with multiple breakpoints', () => {
     expect(
       parseStyleProps({
-        data: STYlE_PROPS_DATA,
+        data: STYLE_PROPS_DATA,
         styleProps: {
           p: { base: '1.5rem', xs: '2rem', md: '3rem' },
           mx: { base: 32, xs: 64, md: 128 },
@@ -139,7 +139,7 @@ describe('@mantine/core/Box/parse-style-props', () => {
   it('parses logical style props correctly', () => {
     expect(
       parseStyleProps({
-        data: STYlE_PROPS_DATA,
+        data: STYLE_PROPS_DATA,
         styleProps: { mis: 10, mie: 15, pis: 20, pie: 25 },
         theme: DEFAULT_THEME,
       })

--- a/packages/@mantine/core/src/core/Box/style-props/style-props-data.ts
+++ b/packages/@mantine/core/src/core/Box/style-props/style-props-data.ts
@@ -6,7 +6,7 @@ export interface SystemPropData {
   property: string | string[];
 }
 
-export const STYlE_PROPS_DATA: Record<keyof MantineStyleProps, SystemPropData> = {
+export const STYLE_PROPS_DATA: Record<keyof MantineStyleProps, SystemPropData> = {
   m: { type: 'spacing', property: 'margin' },
   mt: { type: 'spacing', property: 'marginTop' },
   mb: { type: 'spacing', property: 'marginBottom' },


### PR DESCRIPTION
## What

The exported constant `STYlE_PROPS_DATA` (in `core/Box/style-props/style-props-data.ts`) has a typo — a lowercase `l` in `STYlE`. It should be `STYLE_PROPS_DATA`, consistent with the sibling constant `FLEX_STYLE_PROPS_DATA`.

## Changes

Renamed `STYlE_PROPS_DATA` → `STYLE_PROPS_DATA` across all references:

- `core/Box/style-props/style-props-data.ts` (definition)
- `core/Box/style-props/index.ts` (re-export)
- `core/Box/Box.tsx` (import + usage)
- `core/Box/style-props/parse-style-props/parse-style-props.test.ts` (test usage)
- `apps/mantine.dev/.../StylePropsTable.tsx` (docs usage)

No behavior change. The existing `parse-style-props` test suite passes.

> Note: this constant is an internal implementation detail and is not part of the documented public API, but it is re-exported from `@mantine/core`. Happy to add a deprecated alias for the old name if maintainers prefer to avoid any breaking change.