### PR TITLE
[@mantine/hooks] use-intersection: Use the last entry from a batched observer callback

### DIFF
--- a/packages/@mantine/hooks/src/use-intersection/use-intersection.test.ts
+++ b/packages/@mantine/hooks/src/use-intersection/use-intersection.test.ts
@@ -1,0 +1,62 @@
+import { act, renderHook } from '@testing-library/react';
+import { useIntersection } from './use-intersection';
+
+describe('@mantine/hooks/use-intersection', () => {
+  let lastCallback: IntersectionObserverCallback;
+  const original = window.IntersectionObserver;
+
+  beforeAll(() => {
+    class MockIntersectionObserver {
+      constructor(callback: IntersectionObserverCallback) {
+        lastCallback = callback;
+      }
+
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+    }
+
+    window.IntersectionObserver = MockIntersectionObserver as any;
+  });
+
+  afterAll(() => {
+    window.IntersectionObserver = original;
+  });
+
+  it('reports the latest entry when the observer delivers a batch of entries', () => {
+    const hook = renderHook(() => useIntersection());
+
+    act(() => {
+      hook.result.current.ref(document.createElement('div'));
+    });
+
+    const stale = { isIntersecting: false, intersectionRatio: 0 } as IntersectionObserverEntry;
+    const latest = { isIntersecting: true, intersectionRatio: 1 } as IntersectionObserverEntry;
+
+    act(() => {
+      lastCallback([stale, latest], {} as IntersectionObserver);
+    });
+
+    expect(hook.result.current.entry).toBe(latest);
+    expect(hook.result.current.entry?.isIntersecting).toBe(true);
+  });
+
+  it('reports the single entry when the observer delivers one entry', () => {
+    const hook = renderHook(() => useIntersection());
+
+    act(() => {
+      hook.result.current.ref(document.createElement('div'));
+    });
+
+    const entry = { isIntersecting: true, intersectionRatio: 1 } as IntersectionObserverEntry;
+
+    act(() => {
+      lastCallback([entry], {} as IntersectionObserver);
+    });
+
+    expect(hook.result.current.entry).toBe(entry);
+  });
+});

--- a/packages/@mantine/hooks/src/use-intersection/use-intersection.ts
+++ b/packages/@mantine/hooks/src/use-intersection/use-intersection.ts
@@ -24,8 +24,9 @@ export function useIntersection<T extends HTMLElement = any>(
         return;
       }
 
-      observer.current = new IntersectionObserver(([_entry]) => {
-        setEntry(_entry);
+      observer.current = new IntersectionObserver((entries) => {
+        // Entries might be batched (e.g. when the callback is delayed across frames), so we need to use the last entry to get the most recent state
+        setEntry(entries[entries.length - 1]);
       }, options);
 
       observer.current.observe(element);


### PR DESCRIPTION
Follow-up to #8509, which fixed the same issue in `use-in-viewport`.

`useIntersection` reads only the first entry from the observer callback:

```ts
new IntersectionObserver(([_entry]) => {
  setEntry(_entry);
}, options);
```

When the callback is delayed across frames (busy main thread, fast scrolling), the browser can queue more than one `IntersectionObserverEntry` for the observed element and deliver them in a single call. The first entry then holds an older state and the last one holds the current state, so the hook can report a stale `entry`. This is the same situation #8509 describes for `use-in-viewport`.

The fix mirrors #8509: read the last entry.

```ts
new IntersectionObserver((entries) => {
  setEntry(entries[entries.length - 1]);
}, options);
```

I left `use-resize-observer` as it is even though it also reads `entries[0]`: a `ResizeObserver` reports the current size of each target once per delivery instead of accumulating one entry per frame, so its first entry is already the latest.

Added a regression test that feeds a mock observer a two-entry batch and checks the hook keeps the last entry. Without the change the test fails because the hook returns the stale first entry.
