### PR TITLE
[@mantine/hooks] use-media-query: Catch matchMedia errors when reading the initial value synchronously

### DIFF
--- a/packages/@mantine/hooks/src/use-media-query/use-media-query.test.ts
+++ b/packages/@mantine/hooks/src/use-media-query/use-media-query.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { useMediaQuery } from './use-media-query';
+
+describe('@mantine/hooks/use-media-query', () => {
+  const original = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = original;
+  });
+
+  it('does not crash on render when matchMedia throws and the value is read synchronously', () => {
+    // Safari throws when matchMedia is called inside a cross-origin iframe (#8189)
+    window.matchMedia = (() => {
+      throw new Error('SecurityError');
+    }) as any;
+
+    const hook = renderHook(() =>
+      useMediaQuery('(min-width: 200px)', undefined, { getInitialValueInEffect: false })
+    );
+
+    expect(hook.result.current).toBe(false);
+  });
+
+  it('reads the initial value synchronously when matchMedia works', () => {
+    window.matchMedia = ((query: string) =>
+      ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList) as any;
+
+    const hook = renderHook(() =>
+      useMediaQuery('(min-width: 200px)', undefined, { getInitialValueInEffect: false })
+    );
+
+    expect(hook.result.current).toBe(true);
+  });
+});

--- a/packages/@mantine/hooks/src/use-media-query/use-media-query.ts
+++ b/packages/@mantine/hooks/src/use-media-query/use-media-query.ts
@@ -10,7 +10,12 @@ function getInitialValue(query: string, initialValue?: boolean) {
   }
 
   if (typeof window !== 'undefined' && 'matchMedia' in window) {
-    return window.matchMedia(query).matches;
+    try {
+      return window.matchMedia(query).matches;
+    } catch (e) {
+      // Safari iframe compatibility issue
+      return false;
+    }
   }
 
   return false;


### PR DESCRIPTION
#8189 fixed a Safari crash where `window.matchMedia` exists but throws when called inside a cross-origin iframe. That PR wrapped the call inside the effect in a `try/catch`, but the same call in `getInitialValue` was left unguarded:

```ts
if (typeof window !== 'undefined' && 'matchMedia' in window) {
  return window.matchMedia(query).matches;
}
```

`getInitialValue` runs during render when a consumer passes `{ getInitialValueInEffect: false }` (used to read the value synchronously and avoid a flash on first paint). The `'matchMedia' in window` check only confirms the method exists, which is exactly the case in the Safari iframe scenario, so the call still throws and crashes the render. The effect path no longer crashes after #8189, but this synchronous path does.

The fix mirrors #8189: wrap the call in `try/catch` and fall back to `false`.

Added a test that makes `matchMedia` throw and renders with `getInitialValueInEffect: false`. Without the change the render throws; with it the hook returns `false`.
