### PR TITLE
[@mantine/core] Accordion/Collapse: Add keepMountedMode prop

### DIFF
--- a/packages/@mantine/core/src/components/Accordion/Accordion.context.ts
+++ b/packages/@mantine/core/src/components/Accordion/Accordion.context.ts
@@ -17,6 +17,7 @@ export interface AccordionContextValue {
   variant: string | undefined;
   unstyled: boolean | undefined;
   keepMounted: boolean | undefined;
+  keepMountedMode: 'activity' | 'display-none' | undefined;
 }
 
 export const [AccordionProvider, useAccordionContext] = createSafeContext<AccordionContextValue>(

--- a/packages/@mantine/core/src/components/Accordion/Accordion.story.tsx
+++ b/packages/@mantine/core/src/components/Accordion/Accordion.story.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { TextInput } from '../TextInput';
 import { Accordion } from './Accordion';
 
@@ -110,6 +111,47 @@ export function WithInputs() {
       </Accordion>
 
       <TextInput label="Text input" />
+    </div>
+  );
+}
+
+function Timer() {
+  const [seconds, setSeconds] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => setSeconds((s) => s + 1), 1000);
+    return () => clearInterval(interval);
+  }, []);
+  return (
+    <div style={{ padding: 10, background: 'rgba(0,0,0,0.05)', borderRadius: 4 }}>
+      Timer running: {seconds}s
+    </div>
+  );
+}
+
+export function KeepMountedMode() {
+  return (
+    <div style={{ maxWidth: 500, margin: 'auto', padding: 40 }}>
+      <h3>keepMountedMode="display-none" (Timer keeps running when collapsed)</h3>
+      <Accordion keepMounted keepMountedMode="display-none" defaultValue="item-1">
+        <Accordion.Item value="item-1">
+          <Accordion.Control>Panel with Timer (Keep mounted display-none)</Accordion.Control>
+          <Accordion.Panel>
+            <Timer />
+          </Accordion.Panel>
+        </Accordion.Item>
+      </Accordion>
+
+      <h3 style={{ marginTop: 40 }}>
+        keepMountedMode="activity" (Timer pauses/resets when collapsed)
+      </h3>
+      <Accordion keepMounted keepMountedMode="activity" defaultValue="item-1">
+        <Accordion.Item value="item-1">
+          <Accordion.Control>Panel with Timer (Keep mounted activity)</Accordion.Control>
+          <Accordion.Panel>
+            <Timer />
+          </Accordion.Panel>
+        </Accordion.Item>
+      </Accordion>
     </div>
   );
 }

--- a/packages/@mantine/core/src/components/Accordion/Accordion.test.tsx
+++ b/packages/@mantine/core/src/components/Accordion/Accordion.test.tsx
@@ -279,4 +279,34 @@ describe('@mantine/core/Accordion', () => {
     expect(Accordion.Panel).toBe(AccordionPanel);
     expect(Accordion.Chevron).toBe(AccordionChevron);
   });
+
+  it('supports keepMountedMode="display-none" on Accordion level', () => {
+    render(
+      <Accordion keepMounted keepMountedMode="display-none" transitionDuration={0}>
+        <Accordion.Item value="item-1">
+          <Accordion.Control>Label 1</Accordion.Control>
+          <Accordion.Panel>test-item-1</Accordion.Panel>
+        </Accordion.Item>
+      </Accordion>
+    );
+
+    expect(screen.getByText('test-item-1').parentElement).toHaveStyle({
+      display: 'none',
+    });
+  });
+
+  it('supports keepMountedMode="display-none" override on AccordionPanel level', () => {
+    render(
+      <Accordion keepMounted keepMountedMode="activity" transitionDuration={0}>
+        <Accordion.Item value="item-1">
+          <Accordion.Control>Label 1</Accordion.Control>
+          <Accordion.Panel keepMountedMode="display-none">test-item-1</Accordion.Panel>
+        </Accordion.Item>
+      </Accordion>
+    );
+
+    expect(screen.getByText('test-item-1').parentElement).toHaveStyle({
+      display: 'none',
+    });
+  });
 });

--- a/packages/@mantine/core/src/components/Accordion/Accordion.tsx
+++ b/packages/@mantine/core/src/components/Accordion/Accordion.tsx
@@ -84,6 +84,9 @@ export interface AccordionProps<Multiple extends boolean = false>
 
   /** If set to `false`, panels are unmounted when collapsed. By default, panels stay mounted when collapsed. @default true */
   keepMounted?: boolean;
+
+  /** Controls how inactive panels content is hidden when `keepMounted` is `true`, `'activity'` – hidden with `Activity` component, `'display-none'` – hidden with `display: none` styles @default 'activity' */
+  keepMountedMode?: 'activity' | 'display-none';
 }
 
 export type AccordionFactory = Factory<{
@@ -111,6 +114,7 @@ const defaultProps = {
   variant: 'default',
   chevronSize: 'auto',
   chevronIconSize: 16,
+  keepMountedMode: 'activity',
 } satisfies Partial<AccordionProps>;
 
 const varsResolver = createVarsResolver<AccordionFactory>(
@@ -151,6 +155,7 @@ export const Accordion = genericFactory<AccordionFactory>((_props) => {
     chevronIconSize,
     attributes,
     keepMounted,
+    keepMountedMode,
     ...others
   } = props;
 
@@ -214,6 +219,7 @@ export const Accordion = genericFactory<AccordionFactory>((_props) => {
         variant,
         unstyled,
         keepMounted,
+        keepMountedMode,
       }}
     >
       <Box {...getStyles('root')} id={uid} {...others} variant={variant} data-accordion>

--- a/packages/@mantine/core/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
+++ b/packages/@mantine/core/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
@@ -23,6 +23,9 @@ export interface AccordionPanelProps
 
   /** If set, overrides the Accordion-level `keepMounted` value. When undefined (default), uses Accordion's `keepMounted` setting. */
   keepMounted?: boolean;
+
+  /** If set, overrides the Accordion-level `keepMountedMode` value. When undefined (default), uses Accordion's `keepMountedMode` setting. */
+  keepMountedMode?: 'activity' | 'display-none';
 }
 
 export type AccordionPanelFactory = Factory<{
@@ -33,11 +36,17 @@ export type AccordionPanelFactory = Factory<{
 }>;
 
 export const AccordionPanel = factory<AccordionPanelFactory>((props) => {
-  const { classNames, className, style, styles, vars, children, keepMounted, ...others } = useProps(
-    'AccordionPanel',
-    null,
-    props
-  );
+  const {
+    classNames,
+    className,
+    style,
+    styles,
+    vars,
+    children,
+    keepMounted,
+    keepMountedMode,
+    ...others
+  } = useProps('AccordionPanel', null, props);
 
   const { value } = useAccordionItemContext();
   const ctx = useAccordionContext();
@@ -51,6 +60,7 @@ export const AccordionPanel = factory<AccordionPanelFactory>((props) => {
       id={ctx.getRegionId(value)}
       aria-labelledby={ctx.getControlId(value)}
       keepMounted={keepMounted ?? ctx.keepMounted}
+      keepMountedMode={keepMountedMode ?? ctx.keepMountedMode}
       {...others}
     >
       <div {...ctx.getStyles('content', { classNames, styles })}>{children}</div>

--- a/packages/@mantine/core/src/components/Collapse/Collapse.test.tsx
+++ b/packages/@mantine/core/src/components/Collapse/Collapse.test.tsx
@@ -39,4 +39,16 @@ describe('@mantine/core/Collapse', () => {
 
     expect(ref.current).not.toBeNull();
   });
+
+  it('applies display: none style when keepMountedMode is display-none and expanded is false (transitionDuration is 0)', () => {
+    render(
+      <Collapse expanded={false} transitionDuration={0} keepMounted keepMountedMode="display-none">
+        <div>content</div>
+      </Collapse>
+    );
+
+    expect(screen.getByText('content').parentElement).toHaveStyle({
+      display: 'none',
+    });
+  });
 });

--- a/packages/@mantine/core/src/components/Collapse/Collapse.tsx
+++ b/packages/@mantine/core/src/components/Collapse/Collapse.tsx
@@ -35,6 +35,13 @@ export interface CollapseProps extends BoxProps, Omit<React.ComponentProps<'div'
 
   /** If set, the element is kept in the DOM when collapsed. When `true`, React 19 `Activity` is used to preserve state while collapsed. When `false`, the element is unmounted after the exit animation. @default true */
   keepMounted?: boolean;
+
+  /** Controls how the element is hidden when `keepMounted` is set:
+   * `'activity'` – hidden with React 19 `Activity` component,
+   * `'display-none'` – hidden with `display: none` styles
+   * @default 'activity'
+   */
+  keepMountedMode?: 'activity' | 'display-none';
 }
 
 export type CollapseFactory = Factory<{
@@ -48,6 +55,7 @@ const defaultProps = {
   animateOpacity: true,
   orientation: 'vertical',
   keepMounted: true,
+  keepMountedMode: 'activity',
 } satisfies Partial<CollapseProps>;
 
 export const Collapse = factory<CollapseFactory>((props) => {
@@ -61,6 +69,7 @@ export const Collapse = factory<CollapseFactory>((props) => {
     onTransitionStart,
     animateOpacity,
     keepMounted,
+    keepMountedMode,
     ref,
     orientation,
     ...others
@@ -83,7 +92,22 @@ export const Collapse = factory<CollapseFactory>((props) => {
   });
 
   if (duration === 0) {
-    if (keepMounted === true && env !== 'test') {
+    if (keepMounted === true && (keepMountedMode === 'display-none' || env !== 'test')) {
+      if (keepMountedMode === 'display-none') {
+        return (
+          <Box
+            {...others}
+            style={{
+              ...getStyleObject(style, theme),
+              ...(!expanded ? { display: 'none' } : {}),
+            }}
+            ref={ref}
+          >
+            {children}
+          </Box>
+        );
+      }
+
       return (
         <Activity mode={expanded ? 'visible' : 'hidden'}>
           <Box {...others} style={style} ref={ref}>
@@ -106,7 +130,12 @@ export const Collapse = factory<CollapseFactory>((props) => {
   if (keepMounted === false) {
     content = isExited ? null : children;
   } else if (keepMounted === true) {
-    content = <Activity mode={isExited ? 'hidden' : 'visible'}>{children}</Activity>;
+    content =
+      keepMountedMode === 'display-none' ? (
+        children
+      ) : (
+        <Activity mode={isExited ? 'hidden' : 'visible'}>{children}</Activity>
+      );
   } else {
     content = children;
   }
@@ -119,6 +148,9 @@ export const Collapse = factory<CollapseFactory>((props) => {
           opacity: expanded || !animateOpacity ? 1 : 0,
           transition: animateOpacity ? `opacity ${duration}ms ${transitionTimingFunction}` : 'none',
           ...getStyleObject(style, theme),
+          ...(keepMounted && keepMountedMode === 'display-none' && isExited
+            ? { display: 'none' }
+            : {}),
         },
         ref,
       })}


### PR DESCRIPTION
### Problem

Under React 19, the built-in `<Activity>` component is used by default in `Collapse` to hide collapsed elements while keeping them mounted in the DOM. However, when `<Activity mode="hidden">` is active, React cleans up and suspends all side effects (`useEffect`, `useLayoutEffect`) inside the hidden subtree. 

This causes background tasks inside collapsed Accordion panels, such as polling, WebSocket connections, event listeners, or custom state-syncing effects, to be paused and deactivated. Prior to this PR, there was no configuration option to override this behavior and keep background effects active when panels are collapsed.

### Solution

Added a new `keepMountedMode` prop with values `"activity" | "display-none"` (defaulting to `"activity"`) to `Collapse`, `Accordion`, and `AccordionPanel` components.

- `keepMountedMode="activity"` (default): Hides the content using React 19's `<Activity>` component, preserving performance by pausing hidden effects.
- `keepMountedMode="display-none"`: Hides the content using standard `display: none` styling instead. This keeps the React component tree fully active in the reconciliation cycle, allowing all background effects and processes to run normally when collapsed.

### Tests

Extended the unit test suites for both components:
- **`Collapse.test.tsx`**: Added a test to assert that `keepMountedMode="display-none"` correctly applies the `display: none` style when the panel is collapsed (`expanded={false}`) instead of using the `<Activity>` component.
- **`Accordion.test.tsx`**: Added tests verifying that setting `keepMountedMode="display-none"` on the `Accordion` level and overriding it on individual `AccordionPanel` elements successfully propagates the prop down to the underlying `Collapse` component, ensuring the panel is hidden with CSS styles.

All tests compile, formatting and typechecking are clean, and the complete verification suite passes successfully.

This closes [issue 8934](https://github.com/mantinedev/mantine/issues/8934) and [discussion 9012](https://github.com/orgs/mantinedev/discussions/9012).