### PR TITLE
[@mantine/core] Button: Native tooltip for button

### DIFF
--- a/apps/mantine.dev/src/pages/core/button.mdx
+++ b/apps/mantine.dev/src/pages/core/button.mdx
@@ -75,6 +75,16 @@ selectors:
 
 <Demo data={ButtonDemos.disabledStyles} />
 
+## Native CSS tooltip
+
+You can create a simple tooltip without JavaScript by using CSS Anchor Positioning. The button is used as an anchor,
+and the tooltip is positioned relative to it with `position-anchor` and `anchor()` CSS functions.
+
+Note that this approach is intended only for simple tooltips. For more advanced use cases, such as controlled state,
+delays, arrows, portals and better browser support, use the [Tooltip](/core/tooltip) component.
+
+<Demo data={ButtonDemos.nativeTooltip} />
+
 ## Disabled button with Tooltip
 
 The `onMouseLeave` event [is not triggered](https://github.com/facebook/react/issues/18753) when a `Button` is disabled, so if you need to use a

--- a/apps/mantine.dev/src/pages/core/button.mdx
+++ b/apps/mantine.dev/src/pages/core/button.mdx
@@ -80,8 +80,11 @@ selectors:
 You can create a simple tooltip without JavaScript by using CSS Anchor Positioning. The button is used as an anchor,
 and the tooltip is positioned relative to it with `position-anchor` and `anchor()` CSS functions.
 
-Note that this approach is intended only for simple tooltips. For more advanced use cases, such as controlled state,
-delays, arrows, portals and better browser support, use the [Tooltip](/core/tooltip) component.
+Note that this approach uses newer CSS Anchor Positioning features such as `anchor-name`,
+`position-anchor` and `position-try-fallbacks`, which may not be supported in all browsers yet.
+
+For more advanced use cases, such as controlled state, delays, arrows, portals and better browser support,
+use the [Tooltip](/core/tooltip) component.
 
 <Demo data={ButtonDemos.nativeTooltip} />
 

--- a/packages/@docs/demos/src/demos/core/Button/Button.demo.nativeTooltip.tsx
+++ b/packages/@docs/demos/src/demos/core/Button/Button.demo.nativeTooltip.tsx
@@ -1,0 +1,86 @@
+import { Box, Button } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+import classes from './Button.demo.nativeTooltipStyles.module.css';
+
+const code = `
+import { Box, Button } from '@mantine/core';
+import classes from './Demo.module.css';
+
+function Demo() {
+  return (
+    <>
+      <Button aria-describedby="btn-tooltip" className={classes.button}>
+        Button with tooltip
+      </Button>
+      <Box id="btn-tooltip" role="tooltip" className={classes.tooltip}>
+        Tooltip for button
+      </Box>
+    </>
+  );
+}
+`;
+
+const cssCode = `
+.button {
+  anchor-name: --btn;
+}
+
+.tooltip {
+  --tooltip-radius: var(--mantine-radius-default);
+
+  position-anchor: --btn;
+  bottom: anchor(top);
+  margin-bottom: 5px;
+  justify-self: anchor-center;
+  position-try-fallbacks: flip-block;
+
+  position: absolute;
+  padding: calc(var(--mantine-spacing-xs) / 2) var(--mantine-spacing-xs);
+  pointer-events: none;
+  font-size: var(--mantine-font-size-sm);
+  white-space: nowrap;
+  border-radius: var(--tooltip-radius);
+
+  @mixin where-light {
+    background-color: var(--tooltip-bg, var(--mantine-color-gray-9));
+    color: var(--tooltip-color, var(--mantine-color-white));
+  }
+
+  @mixin where-dark {
+    background-color: var(--tooltip-bg, var(--mantine-color-gray-2));
+    color: var(--tooltip-color, var(--mantine-color-black));
+  }
+
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 100ms ease;
+}
+
+.button:hover + .tooltip {
+  opacity: 1;
+  visibility: visible;
+}
+`;
+
+function Demo() {
+  return (
+    <>
+      <Button aria-describedby="btn-tooltip" className={classes.button}>
+        Button with tooltip
+      </Button>
+      <Box id="btn-tooltip" role="tooltip" className={classes.tooltip}>
+        Tooltip for button
+      </Box>
+    </>
+  );
+}
+
+export const nativeTooltip: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  centered: true,
+  code: [
+    { fileName: 'Demo.tsx', code, language: 'tsx' },
+    { fileName: 'Demo.module.css', code: cssCode, language: 'scss' },
+  ],
+};

--- a/packages/@docs/demos/src/demos/core/Button/Button.demo.nativeTooltipStyles.module.css
+++ b/packages/@docs/demos/src/demos/core/Button/Button.demo.nativeTooltipStyles.module.css
@@ -1,0 +1,39 @@
+.button {
+  anchor-name: --btn;
+}
+
+.tooltip {
+  --tooltip-radius: var(--mantine-radius-default);
+
+  position-anchor: --btn;
+  bottom: anchor(top);
+  margin-bottom: 5px;
+  justify-self: anchor-center;
+  position-try-fallbacks: flip-block;
+
+  position: absolute;
+  padding: calc(var(--mantine-spacing-xs) / 2) var(--mantine-spacing-xs);
+  pointer-events: none;
+  font-size: var(--mantine-font-size-sm);
+  white-space: nowrap;
+  border-radius: var(--tooltip-radius);
+
+  @mixin where-light {
+    background-color: var(--tooltip-bg, var(--mantine-color-gray-9));
+    color: var(--tooltip-color, var(--mantine-color-white));
+  }
+
+  @mixin where-dark {
+    background-color: var(--tooltip-bg, var(--mantine-color-gray-2));
+    color: var(--tooltip-color, var(--mantine-color-black));
+  }
+
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 100ms ease;
+}
+
+.button:hover + .tooltip {
+  opacity: 1;
+  visibility: visible;
+}

--- a/packages/@docs/demos/src/demos/core/Button/Button.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/core/Button/Button.demos.story.tsx
@@ -48,6 +48,11 @@ export const Demo_group = {
   render: renderDemo(demos.group),
 };
 
+export const Demo_nativeTooltip = {
+  name: '⭐ Demo: nativeTooltip',
+  render: renderDemo(demos.nativeTooltip),
+};
+
 export const Demo_disabledTooltip = {
   name: '⭐ Demo: disabledTooltip',
   render: renderDemo(demos.disabledTooltip),

--- a/packages/@docs/demos/src/demos/core/Button/index.ts
+++ b/packages/@docs/demos/src/demos/core/Button/index.ts
@@ -15,3 +15,4 @@ export { disabledLink } from './Button.demo.disabledLink';
 export { stylesApi } from './Button.demo.stylesApi';
 export { autoContrast } from './Button.demo.autoContrast';
 export { groupSection } from './Button.demo.groupSection';
+export { nativeTooltip } from './Button.demo.nativeTooltip';


### PR DESCRIPTION
This pull request introduces a new demo showcasing how to implement a native CSS tooltip for a button using modern CSS Anchor Positioning features. The new example is integrated into the documentation, complete with both TypeScript and CSS code, and is now available in the Button component demos. This provides users with an alternative to JavaScript-based tooltips, while also explaining browser support caveats.

**New Native CSS Tooltip Demo:**

* Added a new demo component, `Button.demo.nativeTooltip.tsx`, which demonstrates a tooltip positioned with CSS Anchor Positioning and includes both the React and CSS code needed for the example.
* Created a corresponding CSS module, `Button.demo.nativeTooltipStyles.module.css`, defining the tooltip's positioning, appearance, and show/hide behavior on hover using anchor positioning properties.

**Documentation and Integration:**

* Updated the Button documentation (`button.mdx`) to include a new section explaining the native CSS tooltip approach, its limitations, and when to use the built-in Tooltip component instead.
* Registered the new demo in the Button demos story file, making it available in the demo explorer.
* Exported the new demo from the Button demos index for use in documentation and stories.