### PR TITLE
[@mantine/core] ComboboxPopover: Fix incorrect @default JSDoc for maxDropdownHeight

### DIFF
--- a/packages/@mantine/core/src/components/ComboboxPopover/ComboboxPopover.tsx
+++ b/packages/@mantine/core/src/components/ComboboxPopover/ComboboxPopover.tsx
@@ -235,7 +235,7 @@ export interface ComboboxPopoverProps<
   /** Determines whether the options should be wrapped with ScrollArea.AutoSize @default true */
   withScrollArea?: boolean;
 
-  /** max-height of the dropdown @default 250 */
+  /** max-height of the dropdown @default 220 */
   maxDropdownHeight?: number | string;
 
   /** If set, the first option is selected when dropdown opens @default false */


### PR DESCRIPTION
## What

The `maxDropdownHeight` prop on `ComboboxPopover` documents `@default 250`, but the actual fallback used in the code is `220`:

```tsx
mah={maxDropdownHeight ?? 220}
```

For comparison, `TreeSelect` documents the same prop correctly as `@default 220`, matching its `?? 220` fallback.

## Changes

Updated the JSDoc from `@default 250` to `@default 220` so the generated props table on mantine.dev reflects the real default. Documentation-only change, no behavior affected.