### PR TITLE
[@mantine/hooks] use-scroll-spy: Accept a ref object for scrollHost option

### DIFF
--- a/packages/@mantine/hooks/src/use-scroll-spy/use-scroll-spy.test.ts
+++ b/packages/@mantine/hooks/src/use-scroll-spy/use-scroll-spy.test.ts
@@ -1,0 +1,34 @@
+import { renderHook } from '@testing-library/react';
+import { useScrollSpy } from './use-scroll-spy';
+
+describe('@mantine/hooks/use-scroll-spy', () => {
+  it('attaches scroll listener to window by default', () => {
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    renderHook(() => useScrollSpy());
+    expect(addSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+    addSpy.mockRestore();
+  });
+
+  it('attaches scroll listener to scrollHost element', () => {
+    const host = document.createElement('div');
+    const addSpy = jest.spyOn(host, 'addEventListener');
+    renderHook(() => useScrollSpy({ scrollHost: host }));
+    expect(addSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+  });
+
+  it('resolves scrollHost passed as a ref object', () => {
+    const host = document.createElement('div');
+    const addSpy = jest.spyOn(host, 'addEventListener');
+    const ref = { current: host };
+    renderHook(() => useScrollSpy({ scrollHost: ref }));
+    expect(addSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+  });
+
+  it('falls back to window when ref host is null', () => {
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const ref = { current: null };
+    renderHook(() => useScrollSpy({ scrollHost: ref }));
+    expect(addSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+    addSpy.mockRestore();
+  });
+});

--- a/packages/@mantine/hooks/src/use-scroll-spy/use-scroll-spy.ts
+++ b/packages/@mantine/hooks/src/use-scroll-spy/use-scroll-spy.ts
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useRef, useState } from 'react';
+import { RefObject, useEffect, useEffectEvent, useRef, useState } from 'react';
 import { randomId } from '../utils';
 
 function getHeadingsData(
@@ -75,8 +75,8 @@ export interface UseScrollSpyOptions {
   /** A function to retrieve heading value, by default `element.textContent` is used */
   getValue?: (element: HTMLElement) => string;
 
-  /** Host element to attach scroll event listener, if not provided, `window` is used */
-  scrollHost?: HTMLElement;
+  /** Host element (or a ref to it) to attach scroll event listener, if not provided, `window` is used */
+  scrollHost?: HTMLElement | RefObject<HTMLElement | null>;
 
   /** Offset from the top of the viewport to use when determining the active heading, `0` by default */
   offset?: number;
@@ -136,7 +136,8 @@ export function useScrollSpy({
 
   useEffect(() => {
     initialize();
-    const _scrollHost = scrollHost || window;
+    const resolvedHost = scrollHost && 'current' in scrollHost ? scrollHost.current : scrollHost;
+    const _scrollHost = resolvedHost || window;
     _scrollHost.addEventListener('scroll', handleScroll);
     return () => _scrollHost.removeEventListener('scroll', handleScroll);
   }, [scrollHost, selector, offset]);


### PR DESCRIPTION
## Closes #9025

Currently `useScrollSpy`'s `scrollHost` option only accepts a resolved `HTMLElement`. The idiomatic way to obtain a DOM node in React is a ref, but a ref's `.current` is `undefined` on first render, so users have to convert the element into state via a callback ref just to make the hook re-initialize once the host exists:

```tsx
const [scrollHost, setScrollHost] = useState<HTMLElement | null>(null);
useScrollSpy({ scrollHost: scrollHost ?? undefined, selector });
return <form ref={setScrollHost}>…</form>;
```

This change lets `scrollHost` accept either a resolved element **or** a ref object, collapsing the usage to the natural form:

```tsx
const scrollHostRef = useRef<HTMLDivElement>(null);
useScrollSpy({ scrollHost: scrollHostRef, selector });
return <div ref={scrollHostRef}>…</div>;
```

Because the listener is attached inside `useEffect` (which runs after the DOM is committed), `ref.current` is already populated by the time the host is resolved, so no extra state/re-render is required. This mirrors the existing pattern of other hooks such as `use-scroll-into-view`, which already accept a `RefObject`.

## Changes

- Widen `scrollHost` type to `HTMLElement | RefObject<HTMLElement | null>`.
- Resolve `.current` inside the effect when a ref object is passed; fall back to `window` when the resolved host is `null`/`undefined` (unchanged behavior for the existing `HTMLElement` and no-arg cases).
- Update the JSDoc for the option.

## Tests

Added `use-scroll-spy.test.ts` covering: default `window` host, a resolved `HTMLElement` host, a ref-object host, and a ref whose `current` is `null` (falls back to `window`).