### PR TITLE
[@mantine/schedule] Multi-hour intervalMinutes and align time grid to…

### DIFF
--- a/packages/@mantine/schedule/src/components/DayView/DayView.tsx
+++ b/packages/@mantine/schedule/src/components/DayView/DayView.tsx
@@ -108,7 +108,7 @@ export interface DayViewProps
   /** Time slots end time in `HH:mm:ss` format @default 23:59:59 */
   endTime?: string;
 
-  /** Number of minutes for each time slot @default 15 */
+  /** Number of minutes for each time slot. Must divide evenly into an hour (e.g. `15`, `30`) or be a whole number of hours (e.g. `120`, `240`) @default 15 */
   intervalMinutes?: number;
 
   /** If set, grid lines are displayed for intervals smaller than one hour, for example 15 and 30 minutes intervals @default true */

--- a/packages/@mantine/schedule/src/components/ResourcesDayView/ResourcesDayView.story.tsx
+++ b/packages/@mantine/schedule/src/components/ResourcesDayView/ResourcesDayView.story.tsx
@@ -101,6 +101,51 @@ export function IntervalMinutes() {
   );
 }
 
+export function IntervalTwoHours() {
+  const [date, setDate] = useState(toDateString(new Date()));
+  return (
+    <ResourcesDayView
+      date={date}
+      onDateChange={setDate}
+      resources={resources}
+      events={regularEvents}
+      startTime="08:00:00"
+      endTime="20:00:00"
+      intervalMinutes={120}
+    />
+  );
+}
+
+export function IntervalFourHours() {
+  const [date, setDate] = useState(toDateString(new Date()));
+  return (
+    <ResourcesDayView
+      date={date}
+      onDateChange={setDate}
+      resources={resources}
+      events={regularEvents}
+      startTime="08:00:00"
+      endTime="20:00:00"
+      intervalMinutes={240}
+    />
+  );
+}
+
+export function IntervalTwoHoursOddStart() {
+  const [date, setDate] = useState(toDateString(new Date()));
+  return (
+    <ResourcesDayView
+      date={date}
+      onDateChange={setDate}
+      resources={resources}
+      events={regularEvents}
+      startTime="07:00:00"
+      endTime="19:00:00"
+      intervalMinutes={120}
+    />
+  );
+}
+
 export function SlotWidth() {
   const [date, setDate] = useState(toDateString(new Date()));
   return (

--- a/packages/@mantine/schedule/src/components/ResourcesDayView/ResourcesDayView.tsx
+++ b/packages/@mantine/schedule/src/components/ResourcesDayView/ResourcesDayView.tsx
@@ -114,7 +114,7 @@ export interface ResourcesDayViewProps
   /** End time for the day view, in `HH:mm:ss` format @default 23:59:59 */
   endTime?: string;
 
-  /** Number of minutes for each interval in the day view @default 60 */
+  /** Number of minutes for each interval in the day view. Must divide evenly into an hour (e.g. `15`, `30`) or be a whole number of hours (e.g. `120`, `240`) @default 60 */
   intervalMinutes?: number;
 
   /** Dayjs format for slot labels or a callback function that returns formatted value @default HH:mm */
@@ -553,8 +553,9 @@ export const ResourcesDayView = factory<ResourcesDayViewFactory>((_props) => {
         resources,
         startTime,
         endTime,
+        intervalMinutes,
       }),
-    [date, expandedEvents, resources, startTime, endTime]
+    [date, expandedEvents, resources, startTime, endTime, intervalMinutes]
   );
 
   const timeLabels = slots.map((interval) => {

--- a/packages/@mantine/schedule/src/components/ResourcesDayView/get-resources-day-view-events/get-resources-day-view-events.ts
+++ b/packages/@mantine/schedule/src/components/ResourcesDayView/get-resources-day-view-events/get-resources-day-view-events.ts
@@ -14,6 +14,7 @@ interface GetResourcesDayViewEventsInput {
   date: AnyDateValue;
   startTime?: string;
   endTime?: string;
+  intervalMinutes?: number;
 }
 
 export interface ResourcesDayViewEventsResult {
@@ -29,6 +30,7 @@ export function getResourcesDayViewEvents({
   date,
   startTime,
   endTime,
+  intervalMinutes,
 }: GetResourcesDayViewEventsInput): ResourcesDayViewEventsResult {
   const result: ResourcesDayViewEventsResult = {
     regularEvents: {},
@@ -118,6 +120,7 @@ export function getResourcesDayViewEvents({
       startTime,
       endTime,
       date,
+      intervalMinutes,
     });
 
     for (const event of positioned) {
@@ -156,7 +159,12 @@ export function getResourcesDayViewEvents({
           },
         });
       } else {
-        const { top, height } = getDayPosition({ event: clippedEvent, startTime, endTime });
+        const { top, height } = getDayPosition({
+          event: clippedEvent,
+          startTime,
+          endTime,
+          intervalMinutes,
+        });
         if (height <= 0) {
           continue;
         }

--- a/packages/@mantine/schedule/src/components/ResourcesWeekView/ResourcesWeekView.tsx
+++ b/packages/@mantine/schedule/src/components/ResourcesWeekView/ResourcesWeekView.tsx
@@ -111,6 +111,7 @@ export interface ResourcesWeekViewProps
   resources: ScheduleResourceData[];
   startTime?: string;
   endTime?: string;
+  /** Number of minutes for each interval in the week view. Must divide evenly into an hour (e.g. `15`, `30`) or be a whole number of hours (e.g. `120`, `240`) @default 60 */
   intervalMinutes?: number;
   slotLabelFormat?: DateLabelFormat;
   radius?: MantineRadius;
@@ -520,9 +521,10 @@ export const ResourcesWeekView = factory<ResourcesWeekViewFactory>((_props) => {
         weekdays,
         startTime,
         endTime,
+        intervalMinutes,
         expansionLimit: recurrenceExpansionLimit,
       }),
-    [events, resources, weekdays, startTime, endTime, recurrenceExpansionLimit]
+    [events, resources, weekdays, startTime, endTime, intervalMinutes, recurrenceExpansionLimit]
   );
 
   const dayLabels = weekdays.map((day) => {

--- a/packages/@mantine/schedule/src/components/ResourcesWeekView/get-resources-week-view-events/get-resources-week-view-events.ts
+++ b/packages/@mantine/schedule/src/components/ResourcesWeekView/get-resources-week-view-events/get-resources-week-view-events.ts
@@ -56,6 +56,7 @@ interface GetResourcesWeekViewEventsInput {
   weekdays: string[];
   startTime?: string;
   endTime?: string;
+  intervalMinutes?: number;
   expansionLimit?: number;
 }
 
@@ -65,6 +66,7 @@ export function getResourcesWeekViewEvents({
   weekdays,
   startTime,
   endTime,
+  intervalMinutes,
   expansionLimit,
 }: GetResourcesWeekViewEventsInput): ResourcesWeekViewEventsResult {
   const rangeStart = dayjs(weekdays[0]).startOf('day').toDate();
@@ -132,6 +134,7 @@ export function getResourcesWeekViewEvents({
       date: day,
       startTime,
       endTime,
+      intervalMinutes,
     });
   }
 

--- a/packages/@mantine/schedule/src/components/WeekView/WeekView.tsx
+++ b/packages/@mantine/schedule/src/components/WeekView/WeekView.tsx
@@ -114,7 +114,7 @@ export interface WeekViewProps
   /** End time for the day view, in `HH:mm:ss` format @default 23:59:59 */
   endTime?: string;
 
-  /** Number of minutes for each interval in the day view @default 60 */
+  /** Number of minutes for each interval in the day view. Must divide evenly into an hour (e.g. `15`, `30`) or be a whole number of hours (e.g. `120`, `240`) @default 60 */
   intervalMinutes?: number;
 
   /** If set, grid lines are displayed for intervals smaller than one hour, for example 15 and 30 minutes intervals @default true */

--- a/packages/@mantine/schedule/src/utils/align-time-to-interval/align-time-to-interval.test.ts
+++ b/packages/@mantine/schedule/src/utils/align-time-to-interval/align-time-to-interval.test.ts
@@ -1,0 +1,27 @@
+import { alignTimeToInterval } from './align-time-to-interval';
+
+describe('@mantine/schedule/align-time-to-interval', () => {
+  it('leaves times already on the interval grid unchanged', () => {
+    expect(alignTimeToInterval('08:00:00', 120)).toBe('08:00:00');
+    expect(alignTimeToInterval('00:00:00', 240)).toBe('00:00:00');
+    expect(alignTimeToInterval('09:30:00', 30)).toBe('09:30:00');
+  });
+
+  it('floors multi-hour intervals to the nearest clock boundary', () => {
+    expect(alignTimeToInterval('07:00:00', 120)).toBe('06:00:00');
+    expect(alignTimeToInterval('07:00:00', 240)).toBe('04:00:00');
+    expect(alignTimeToInterval('11:00:00', 240)).toBe('08:00:00');
+    expect(alignTimeToInterval('23:00:00', 120)).toBe('22:00:00');
+  });
+
+  it('floors sub-hour intervals to the nearest boundary', () => {
+    expect(alignTimeToInterval('09:15:00', 30)).toBe('09:00:00');
+    expect(alignTimeToInterval('09:20:00', 15)).toBe('09:15:00');
+    expect(alignTimeToInterval('09:45:00', 60)).toBe('09:00:00');
+  });
+
+  it('uses the clamped interval for alignment', () => {
+    // 90 is not a whole number of hours, so it clamps to 60 and floors to the hour.
+    expect(alignTimeToInterval('09:45:00', 90)).toBe('09:00:00');
+  });
+});

--- a/packages/@mantine/schedule/src/utils/align-time-to-interval/align-time-to-interval.ts
+++ b/packages/@mantine/schedule/src/utils/align-time-to-interval/align-time-to-interval.ts
@@ -1,0 +1,23 @@
+import { clampIntervalMinutes } from '../clamp-interval-minutes/clamp-interval-minutes';
+import { parseTimeString } from '../parse-time-string/parse-time-string';
+import { toTimeString } from '../to-time-string/to-time-string';
+
+/**
+ * Floors a time down to the nearest interval boundary anchored at the start of the day (`00:00:00`).
+ *
+ * This keeps the time grid aligned to the clock: a 2-hour interval always lands on even hours
+ * (`00:00`, `02:00`, …) and a 4-hour interval on `00:00`, `04:00`, … regardless of the provided
+ * start time. For example `align('07:00:00', 120)` returns `'06:00:00'`.
+ */
+export function alignTimeToInterval(time: string, intervalMinutes: number): string {
+  const intervalSeconds = clampIntervalMinutes(intervalMinutes) * 60;
+  const { hours, minutes, seconds } = parseTimeString(time);
+  const totalSeconds = hours * 3600 + minutes * 60 + seconds;
+  const floored = Math.floor(totalSeconds / intervalSeconds) * intervalSeconds;
+
+  return toTimeString({
+    hours: Math.floor(floored / 3600),
+    minutes: Math.floor((floored % 3600) / 60),
+    seconds: floored % 60,
+  });
+}

--- a/packages/@mantine/schedule/src/utils/clamp-interval-minutes/clamp-interval-minutes.test.ts
+++ b/packages/@mantine/schedule/src/utils/clamp-interval-minutes/clamp-interval-minutes.test.ts
@@ -29,4 +29,25 @@ describe('@mantine/schedule/clamp-interval-minutes', () => {
     expect(clampIntervalMinutes(29.4)).toBe(60);
     expect(clampIntervalMinutes(-5.5)).toBe(1);
   });
+
+  it('allows intervals longer than an hour when they are whole hours', () => {
+    const wholeHourIntervals = [120, 180, 240, 360, 480, 720, 1440];
+
+    wholeHourIntervals.forEach((interval) => {
+      expect(clampIntervalMinutes(interval)).toBe(interval);
+    });
+  });
+
+  it('defaults to 60 for values above an hour that are not whole hours', () => {
+    const partialHourIntervals = [61, 90, 100, 150, 200];
+
+    partialHourIntervals.forEach((interval) => {
+      expect(clampIntervalMinutes(interval)).toBe(60);
+    });
+  });
+
+  it('caps intervals at a full day', () => {
+    expect(clampIntervalMinutes(1440)).toBe(1440);
+    expect(clampIntervalMinutes(2000)).toBe(1440);
+  });
 });

--- a/packages/@mantine/schedule/src/utils/clamp-interval-minutes/clamp-interval-minutes.ts
+++ b/packages/@mantine/schedule/src/utils/clamp-interval-minutes/clamp-interval-minutes.ts
@@ -1,6 +1,19 @@
-/** Clamp interval minutes to valid values (1-60) and ensure it divides evenly into 60 */
+/**
+ * Clamps interval minutes to a value that keeps the time grid consistent:
+ *
+ * - Values of 60 or less must divide evenly into an hour (e.g. `15`, `20`, `30`, `60`).
+ * - Values above an hour must be a whole number of hours (e.g. `120`, `240`) so that
+ *   slots still start on hour boundaries.
+ *
+ * Values that don't satisfy these rules fall back to `60`. The result is capped to a
+ * single day (`1440`).
+ */
 export function clampIntervalMinutes(intervalMinutes: number): number {
-  let clamped = Math.round(Math.max(1, Math.min(60, intervalMinutes)));
-  clamped = 60 % clamped === 0 ? clamped : 60;
-  return clamped;
+  const rounded = Math.round(Math.max(1, Math.min(1440, intervalMinutes)));
+
+  if (rounded <= 60) {
+    return 60 % rounded === 0 ? rounded : 60;
+  }
+
+  return rounded % 60 === 0 ? rounded : 60;
 }

--- a/packages/@mantine/schedule/src/utils/get-current-time-position/get-current-time-position.ts
+++ b/packages/@mantine/schedule/src/utils/get-current-time-position/get-current-time-position.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import { AnyDateValue } from '../../types';
+import { alignTimeToInterval } from '../align-time-to-interval/align-time-to-interval';
 import { clampIntervalMinutes } from '../clamp-interval-minutes/clamp-interval-minutes';
 
 interface GetCurrentTimePositionInput {
@@ -20,7 +21,12 @@ export function getCurrentTimePosition(input?: GetCurrentTimePositionInput) {
     return (diffInMinutes / 1440) * 100;
   }
 
-  const [startHour, startMinute, startSecond = 0] = input.startTime.split(':').map(Number);
+  const alignedStartTime =
+    input.intervalMinutes !== undefined
+      ? alignTimeToInterval(input.startTime, input.intervalMinutes)
+      : input.startTime;
+
+  const [startHour, startMinute, startSecond = 0] = alignedStartTime.split(':').map(Number);
   const [endHour, endMinute, endSecond = 0] = input.endTime.split(':').map(Number);
 
   const startOfDay = now.startOf('date');

--- a/packages/@mantine/schedule/src/utils/get-day-position/get-day-position.ts
+++ b/packages/@mantine/schedule/src/utils/get-day-position/get-day-position.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import { ScheduleEventData } from '../../types';
+import { alignTimeToInterval } from '../align-time-to-interval/align-time-to-interval';
 import { clampIntervalMinutes } from '../clamp-interval-minutes/clamp-interval-minutes';
 import { parseTimeString } from '../parse-time-string/parse-time-string';
 
@@ -27,7 +28,7 @@ export function getDayPosition({
   const eventStart = dayjs(event.start);
   const eventEnd = dayjs(event.end);
 
-  const parsedStartTime = parseTimeString(startTime);
+  const parsedStartTime = parseTimeString(alignTimeToInterval(startTime, intervalMinutes));
   const parsedEndTime = parseTimeString(endTime);
 
   const startOfDay = eventStart.startOf('date');

--- a/packages/@mantine/schedule/src/utils/get-day-time-intervals/get-day-time-intervals.ts
+++ b/packages/@mantine/schedule/src/utils/get-day-time-intervals/get-day-time-intervals.ts
@@ -1,3 +1,4 @@
+import { alignTimeToInterval } from '../align-time-to-interval/align-time-to-interval';
 import { clampIntervalMinutes } from '../clamp-interval-minutes/clamp-interval-minutes';
 import { parseTimeString } from '../parse-time-string/parse-time-string';
 import { toTimeString } from '../to-time-string/to-time-string';
@@ -34,7 +35,7 @@ export function getDayTimeIntervals({
 }: GetDayTimeIntervalsInput): DayTimeInterval[] {
   const intervalMinutes = clampIntervalMinutes(_intervalMinutes);
 
-  const start = parseTimeString(startTime);
+  const start = parseTimeString(alignTimeToInterval(startTime, intervalMinutes));
   const end = endTime ? parseTimeString(endTime) : { hours: 23, minutes: 59, seconds: 59 };
 
   const startSeconds = start.hours * 3600 + start.minutes * 60 + start.seconds;

--- a/packages/@mantine/schedule/src/utils/index.ts
+++ b/packages/@mantine/schedule/src/utils/index.ts
@@ -16,6 +16,7 @@ export { toDateString } from './to-date-string/to-date-string';
 export { nextWeek } from './next-week/next-week';
 export { previousWeek } from './previous-week/previous-week';
 export { clampIntervalMinutes } from './clamp-interval-minutes/clamp-interval-minutes';
+export { alignTimeToInterval } from './align-time-to-interval/align-time-to-interval';
 export { getCurrentTimePosition } from './get-current-time-position/get-current-time-position';
 export { isInTimeRange } from './is-in-time-range/is-in-time-range';
 export { isAllDayEvent } from './is-all-day-event/is-all-day-event';


### PR DESCRIPTION
… whole hours

Allow whole-hour intervals >60 and floor startTime to the interval grid so slots, events and the time indicator stay clock-aligned.