### PR TITLE
[@mantine/hooks] Fix unstable `scrollIntoView` for some bundlers

### DIFF
--- a/packages/@mantine/hooks/src/use-scroll-into-view/use-scroll-into-view.ts
+++ b/packages/@mantine/hooks/src/use-scroll-into-view/use-scroll-into-view.ts
@@ -67,7 +67,7 @@ export function useScrollIntoView<
 
   const reducedMotion = useReducedMotion();
 
-  const _easing = easing ?? easeInOutQuad
+  const _easing = easing ?? easeInOutQuad;
 
   const cancel = (): void => {
     if (frameID.current) {

--- a/packages/@mantine/hooks/src/use-scroll-into-view/use-scroll-into-view.ts
+++ b/packages/@mantine/hooks/src/use-scroll-into-view/use-scroll-into-view.ts
@@ -52,7 +52,7 @@ export function useScrollIntoView<
   axis = 'y',
   onScrollFinish,
   onScrollCancel,
-  easing = easeInOutQuad,
+  easing,
   offset = 0,
   cancelable = true,
   isList = false,
@@ -66,6 +66,8 @@ export function useScrollIntoView<
   const targetRef = useRef<Target | null>(null);
 
   const reducedMotion = useReducedMotion();
+
+  const _easing = easing ?? easeInOutQuad
 
   const cancel = (): void => {
     if (frameID.current) {
@@ -108,7 +110,7 @@ export function useScrollIntoView<
         // Easing timing progress
         const t = reducedMotion || duration === 0 ? 1 : elapsed / duration;
 
-        const distance = start + change * easing(t);
+        const distance = start + change * _easing(t);
 
         setScrollParam({
           parent: scrollableRef.current,
@@ -132,7 +134,7 @@ export function useScrollIntoView<
       }
       animateScroll();
     },
-    [axis, duration, easing, isList, offset, onScrollFinish, onScrollCancel, reducedMotion]
+    [axis, duration, _easing, isList, offset, onScrollFinish, onScrollCancel, reducedMotion]
   );
 
   const handleStop = () => {


### PR DESCRIPTION
See discord discussion [here](https://discord.com/channels/854810300876062770/861521000985264138/1522580881938845756)

Assigning a default function value during destructuring leads to unstable references with certain bundlers, causing `scrollIntoView` to become unstable, which may cause errors for users that rely on this being stable, for example when it is used in dependency arrays of `useEffect`.