### PR TITLE
[@mantine/notifications] Add stacked notifications

### DIFF
--- a/apps/mantine.dev/src/pages/x/notifications.mdx
+++ b/apps/mantine.dev/src/pages/x/notifications.mdx
@@ -184,6 +184,27 @@ function Demo() {
 }
 ```
 
+## Stacked notifications
+
+Set `stacked` on the `Notifications` component to display notifications in a compact stack.
+The front notification remains visible, older notifications are shown as previews behind it,
+and the stack expands on hover or focus.
+
+```tsx
+import { Notifications } from '@mantine/notifications';
+
+function Demo() {
+  return <Notifications stacked />;
+}
+```
+
+Stacked notifications work with all supported positions. Top positions expand down,
+bottom positions expand up. In stacked mode, new notifications are displayed immediately
+at the front of the stack instead of waiting in the queue; older notifications move behind the
+front notification and fade out when they are too deep in the stack.
+
+<Demo data={NotificationsDemos.stacked} />
+
 ## Limit and queue
 
 You can limit the maximum number of notifications that are displayed at a time by setting

--- a/packages/@docs/demos/src/demos/notifications/Notifications.demo.stacked.tsx
+++ b/packages/@docs/demos/src/demos/notifications/Notifications.demo.stacked.tsx
@@ -1,0 +1,78 @@
+import { Button, Group } from '@mantine/core';
+import { createNotificationsStore, notifications, Notifications } from '@mantine/notifications';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { Button, Group } from '@mantine/core';
+import { createNotificationsStore, notifications, Notifications } from '@mantine/notifications';
+
+const store = createNotificationsStore();
+
+function Demo() {
+  return (
+    <>
+      <Notifications store={store} position="top-right" stacked autoClose={false} />
+
+      <Group justify="center">
+        <Button
+          onClick={() => {
+            Array(8)
+              .fill(0)
+              .forEach((_, index) => {
+                setTimeout(() => {
+                  notifications.show(
+                    {
+                      title: \`Notification \${index + 1}\`,
+                      message: 'Hover the stack to expand notifications',
+                    },
+                    store
+                  );
+                }, index * 150);
+              });
+          }}
+        >
+          Show stacked notifications
+        </Button>
+      </Group>
+    </>
+  );
+}`;
+
+const store = createNotificationsStore();
+
+function Demo() {
+  return (
+    <>
+      <Notifications store={store} position="top-right" stacked autoClose={false} />
+
+      <Group justify="center">
+        <Button
+          onClick={() => {
+            Array(8)
+              .fill(0)
+              .forEach((_, index) => {
+                setTimeout(() => {
+                  notifications.show(
+                    {
+                      title: `Notification ${index + 1}`,
+                      message: 'Hover the stack to expand notifications',
+                    },
+                    store
+                  );
+                }, index * 150);
+              });
+          }}
+        >
+          Show stacked notifications
+        </Button>
+      </Group>
+    </>
+  );
+}
+
+export const stacked: MantineDemo = {
+  type: 'code',
+  code,
+  centered: true,
+  component: Demo,
+};

--- a/packages/@docs/demos/src/demos/notifications/Notifications.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/notifications/Notifications.demos.story.tsx
@@ -28,6 +28,11 @@ export const Demo_priority = {
   render: renderDemo(demos.priority),
 };
 
+export const Demo_stacked = {
+  name: '⭐ Demo: stacked',
+  render: renderDemo(demos.stacked),
+};
+
 export const Demo_update = {
   name: '⭐ Demo: update',
   render: renderDemo(demos.update),

--- a/packages/@docs/demos/src/demos/notifications/index.ts
+++ b/packages/@docs/demos/src/demos/notifications/index.ts
@@ -3,6 +3,7 @@ export { base } from './Notifications.demo.base';
 export { clean } from './Notifications.demo.clean';
 export { limit } from './Notifications.demo.limit';
 export { priority } from './Notifications.demo.priority';
+export { stacked } from './Notifications.demo.stacked';
 export { update } from './Notifications.demo.update';
 export { customize } from './Notifications.demo.customize';
 export { position } from './Notifications.demo.position';

--- a/packages/@mantine/notifications/src/NotificationContainer.tsx
+++ b/packages/@mantine/notifications/src/NotificationContainer.tsx
@@ -16,6 +16,7 @@ interface NotificationContainerProps extends NotificationProps {
   paused: boolean;
   onHoverStart?: () => void;
   onHoverEnd?: () => void;
+  onHeightChange?: (id: string, height: number | null) => void;
   ref?: React.Ref<HTMLDivElement>;
 }
 
@@ -29,6 +30,7 @@ export function NotificationContainer({
   paused,
   onHoverStart,
   onHoverEnd,
+  onHeightChange,
   ref,
   style,
   ...others
@@ -168,6 +170,7 @@ export function NotificationContainer({
   const resolvedStyle = getStyleObject(style, theme);
   const resolvedDataStyle = getStyleObject(dataStyle, theme);
   const baseStyle = { ...resolvedStyle, ...resolvedDataStyle };
+  const baseCssVariables = baseStyle as Record<string, string | number | undefined>;
   const baseOpacity = typeof baseStyle.opacity === 'number' ? baseStyle.opacity : 1;
   const swipeOpacity = dismissed ? 0 : 1 - Math.min(Math.abs(offset) / 200, 1) * 0.6;
   const resolvedTransitionDuration =
@@ -178,11 +181,16 @@ export function NotificationContainer({
     ['--notifications-state-transform' as string]:
       typeof baseStyle.transform === 'string' ? baseStyle.transform : 'translateX(0)',
     ['--notifications-state-opacity' as string]: String(baseOpacity),
+    ['--notifications-stack-transform' as string]:
+      baseCssVariables['--notifications-stack-transform'] ?? 'translate3d(0, 0, 0)',
+    ['--notifications-stack-opacity' as string]:
+      baseCssVariables['--notifications-stack-opacity'] ?? '1',
     ['--notifications-swipe-offset' as string]: `${offset}px`,
     ['--notifications-swipe-opacity' as string]: String(swipeOpacity),
     transform:
-      'var(--notifications-state-transform) translate3d(var(--notifications-swipe-offset), 0, 0)',
-    opacity: 'calc(var(--notifications-state-opacity) * var(--notifications-swipe-opacity))',
+      'var(--notifications-state-transform) var(--notifications-stack-transform) translate3d(var(--notifications-swipe-offset), 0, 0)',
+    opacity:
+      'calc(var(--notifications-state-opacity) * var(--notifications-stack-opacity) * var(--notifications-swipe-opacity))',
     transitionDuration:
       active || scrollDismissActive ? '0ms, 0ms, 0ms' : resolvedTransitionDuration,
     cursor: 'default',
@@ -279,6 +287,37 @@ export function NotificationContainer({
       cancelScrollDismissReset();
     };
   }, []);
+
+  useEffect(() => {
+    if (!data.id || !onHeightChange) {
+      return undefined;
+    }
+
+    const node = notificationRef.current;
+    if (!node) {
+      return undefined;
+    }
+
+    const updateHeight = () => {
+      const originalHeight = node.style.height;
+      node.style.height = 'auto';
+      onHeightChange(data.id!, node.offsetHeight);
+      node.style.height = originalHeight;
+    };
+    updateHeight();
+
+    if (typeof ResizeObserver === 'undefined') {
+      return () => onHeightChange(data.id!, null);
+    }
+
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+      onHeightChange(data.id!, null);
+    };
+  }, [data.id, onHeightChange]);
 
   useEffect(() => {
     data.onOpen?.(data);

--- a/packages/@mantine/notifications/src/Notifications.module.css
+++ b/packages/@mantine/notifications/src/Notifications.module.css
@@ -35,6 +35,65 @@
     bottom: var(--mantine-spacing-md);
     right: var(--mantine-spacing-md);
   }
+
+  &:where([data-stacked]) {
+    height: var(--notifications-stack-height);
+    transition-property: height;
+    transition-duration: var(--notifications-stack-transition-duration);
+    transition-timing-function: ease;
+
+    & .notification {
+      --notifications-stack-content-opacity: 1;
+
+      position: absolute;
+      left: 0;
+      right: 0;
+      margin-top: 0;
+      transform-origin: center;
+      will-change: transform, opacity;
+
+      &::before {
+        transition-property: opacity;
+        transition-duration: var(--notifications-stack-transition-duration);
+        transition-timing-function: ease;
+      }
+
+      & > * {
+        opacity: var(--notifications-stack-content-opacity);
+        transition-property: opacity;
+        transition-duration: var(--notifications-stack-transition-duration);
+        transition-timing-function: ease;
+      }
+    }
+
+    & .notification[data-stack-preview] {
+      pointer-events: none;
+
+      &::before {
+        opacity: 0;
+      }
+    }
+
+    & .notification + .notification {
+      margin-top: 0;
+    }
+  }
+
+  &:where([data-stacked][data-position='top-center']),
+  &:where([data-stacked][data-position='top-left']),
+  &:where([data-stacked][data-position='top-right']) {
+    & .notification {
+      top: 0;
+    }
+  }
+
+  &:where([data-stacked][data-position='bottom-center']),
+  &:where([data-stacked][data-position='bottom-left']),
+  &:where([data-stacked][data-position='bottom-right']) {
+    & .notification {
+      bottom: 0;
+    }
+  }
 }
 
 .notification {

--- a/packages/@mantine/notifications/src/Notifications.test.tsx
+++ b/packages/@mantine/notifications/src/Notifications.test.tsx
@@ -402,6 +402,329 @@ describe('@mantine/core/Notifications', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  describe('stacked', () => {
+    function getPositionRoot(container: HTMLElement, position: string) {
+      return container.querySelector(`[data-position="${position}"]`) as HTMLElement;
+    }
+
+    function getStackTransform(notification: HTMLElement) {
+      return notification.style.getPropertyValue('--notifications-stack-transform');
+    }
+
+    it('does not enable stacked layout by default', () => {
+      const store = createNotificationsStore();
+      const { container } = render(
+        <Notifications store={store} withinPortal={false} autoClose={false} />
+      );
+
+      act(() => {
+        notifications.show({ id: 'default-stacked', message: 'Default layout' }, store);
+      });
+
+      expect(getPositionRoot(container, 'bottom-right')).not.toHaveAttribute('data-stacked');
+    });
+
+    it('enables stacked layout with stacked prop', () => {
+      const store = createNotificationsStore();
+      const { container } = render(
+        <Notifications store={store} withinPortal={false} autoClose={false} stacked />
+      );
+
+      act(() => {
+        notifications.show({ id: 'stacked-prop', message: 'Stacked prop' }, store);
+      });
+
+      expect(getPositionRoot(container, 'bottom-right')).toHaveAttribute('data-stacked');
+    });
+
+    it('renders the newest equal-priority notification as the front item', () => {
+      const store = createNotificationsStore();
+      render(<Notifications store={store} withinPortal={false} autoClose={false} stacked />);
+
+      act(() => {
+        notifications.show({ id: 'first', message: 'First notification' }, store);
+        notifications.show({ id: 'second', message: 'Second notification' }, store);
+      });
+
+      expect(
+        screen.getAllByRole('alert', { hidden: true }).map((item) => item.textContent)
+      ).toEqual(['Second notification', 'First notification']);
+    });
+
+    it('keeps higher priority notifications in front of newer lower priority notifications', () => {
+      const store = createNotificationsStore();
+      render(<Notifications store={store} withinPortal={false} autoClose={false} stacked />);
+
+      act(() => {
+        notifications.show({ id: 'high', message: 'High priority', priority: 10 }, store);
+        notifications.show({ id: 'low', message: 'Low priority', priority: 0 }, store);
+      });
+
+      expect(
+        screen.getAllByRole('alert', { hidden: true }).map((item) => item.textContent)
+      ).toEqual(['High priority', 'Low priority']);
+    });
+
+    it('expands top-positioned stacks downward on hover', () => {
+      const store = createNotificationsStore();
+      const { container } = render(
+        <Notifications
+          store={store}
+          withinPortal={false}
+          autoClose={false}
+          stacked
+          position="top-right"
+        />
+      );
+
+      act(() => {
+        notifications.show({ id: 'older', message: 'Older' }, store);
+        notifications.show({ id: 'newer', message: 'Newer' }, store);
+      });
+
+      const root = getPositionRoot(container, 'top-right');
+      const olderNotification = screen.getByText('Older').closest('[role="alert"]') as HTMLElement;
+      const newerNotification = screen.getByText('Newer').closest('[role="alert"]') as HTMLElement;
+
+      expect(root).toHaveAttribute('data-stacked');
+      expect(root.style.getPropertyValue('--notifications-stack-height')).toBe('88px');
+      expect(newerNotification.style.getPropertyValue('--notifications-state-transform')).toBe(
+        'translateY(0)'
+      );
+      expect(getStackTransform(olderNotification)).toContain('8px');
+      expect(olderNotification).toHaveAttribute('data-stack-preview', 'true');
+      expect(olderNotification).toHaveAttribute('aria-hidden', 'true');
+      expect(olderNotification).toHaveAttribute('inert');
+      expect(
+        olderNotification.style.getPropertyValue('--notifications-stack-content-opacity')
+      ).toBe('0');
+      expect(olderNotification).toHaveStyle({ height: '80px', overflow: 'hidden' });
+
+      fireEvent.mouseEnter(root);
+
+      expect(root).toHaveAttribute('data-expanded');
+      expect(root.style.getPropertyValue('--notifications-stack-height')).toBe('174px');
+      expect(getStackTransform(olderNotification)).toContain('94px');
+      expect(olderNotification).not.toHaveAttribute('data-stack-preview');
+      expect(olderNotification).not.toHaveAttribute('aria-hidden');
+      expect(olderNotification).not.toHaveAttribute('inert');
+      expect(
+        olderNotification.style.getPropertyValue('--notifications-stack-content-opacity')
+      ).toBe('1');
+
+      fireEvent.mouseLeave(root);
+
+      expect(root).not.toHaveAttribute('data-expanded');
+      expect(getStackTransform(olderNotification)).toContain('8px');
+    });
+
+    it('expands bottom-positioned stacks upward on hover', () => {
+      const store = createNotificationsStore();
+      const { container } = render(
+        <Notifications
+          store={store}
+          withinPortal={false}
+          autoClose={false}
+          stacked
+          position="bottom-right"
+        />
+      );
+
+      act(() => {
+        notifications.show({ id: 'older', message: 'Older bottom' }, store);
+        notifications.show({ id: 'newer', message: 'Newer bottom' }, store);
+      });
+
+      const root = getPositionRoot(container, 'bottom-right');
+      const olderNotification = screen
+        .getByText('Older bottom')
+        .closest('[role="alert"]') as HTMLElement;
+
+      expect(getStackTransform(olderNotification)).toContain('-8px');
+
+      fireEvent.mouseEnter(root);
+
+      expect(root).toHaveAttribute('data-expanded');
+      expect(getStackTransform(olderNotification)).toContain('-94px');
+    });
+
+    it('expands stack on focus and collapses on blur', () => {
+      const store = createNotificationsStore();
+      const { container } = render(
+        <Notifications store={store} withinPortal={false} autoClose={false} stacked />
+      );
+
+      act(() => {
+        notifications.show({ id: 'older-focus', message: 'Older focus' }, store);
+        notifications.show({ id: 'newer-focus', message: 'Newer focus' }, store);
+      });
+
+      const root = getPositionRoot(container, 'bottom-right');
+
+      fireEvent.focus(root);
+      expect(root).toHaveAttribute('data-expanded');
+
+      fireEvent.blur(root, { relatedTarget: document.body });
+      expect(root).not.toHaveAttribute('data-expanded');
+    });
+
+    it('keeps stack expanded on mouse leave when focus remains inside', () => {
+      const store = createNotificationsStore();
+      const { container } = render(
+        <Notifications store={store} withinPortal={false} autoClose={false} stacked />
+      );
+
+      act(() => {
+        notifications.show({ id: 'older-focused', message: 'Older focused' }, store);
+        notifications.show({ id: 'newer-focused', message: 'Newer focused' }, store);
+      });
+
+      const root = getPositionRoot(container, 'bottom-right');
+      const closeButton = root.querySelector('button')!;
+
+      act(() => {
+        closeButton.focus();
+        fireEvent.mouseLeave(root);
+      });
+
+      expect(root).toHaveAttribute('data-expanded');
+    });
+
+    it('composes forwarded root handlers with stacked expansion handlers', () => {
+      const store = createNotificationsStore();
+      const onMouseEnter = jest.fn();
+      const { container } = render(
+        <Notifications
+          store={store}
+          withinPortal={false}
+          autoClose={false}
+          stacked
+          onMouseEnter={onMouseEnter}
+        />
+      );
+
+      act(() => {
+        notifications.show({ id: 'older-handler', message: 'Older handler' }, store);
+        notifications.show({ id: 'newer-handler', message: 'Newer handler' }, store);
+      });
+
+      const root = getPositionRoot(container, 'bottom-right');
+
+      fireEvent.mouseEnter(root);
+
+      expect(onMouseEnter).toHaveBeenCalledTimes(1);
+      expect(root).toHaveAttribute('data-expanded');
+    });
+
+    it('resumes auto close when stacked is disabled while expanded', () => {
+      jest.useFakeTimers();
+      const store = createNotificationsStore();
+      const { container, rerender } = render(
+        <Notifications
+          store={store}
+          withinPortal={false}
+          autoClose={100}
+          transitionDuration={10}
+          stacked
+        />
+      );
+
+      act(() => {
+        notifications.show({ id: 'older-toggle', message: 'Older toggle' }, store);
+        notifications.show({ id: 'newer-toggle', message: 'Newer toggle' }, store);
+      });
+
+      fireEvent.mouseEnter(getPositionRoot(container, 'bottom-right'));
+
+      rerender(
+        <Notifications store={store} withinPortal={false} autoClose={100} transitionDuration={10} />
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(125);
+      });
+
+      expect(store.getState().notifications).toHaveLength(0);
+    });
+
+    it('displays new notifications in the stack immediately instead of queueing them', () => {
+      const store = createNotificationsStore();
+      render(
+        <Notifications store={store} withinPortal={false} autoClose={false} stacked limit={1} />
+      );
+
+      act(() => {
+        notifications.show({ id: 'older-visible', message: 'Older visible notification' }, store);
+        notifications.show({ id: 'newer-visible', message: 'Newer visible notification' }, store);
+      });
+
+      expect(screen.getByText('Older visible notification')).toBeInTheDocument();
+      expect(screen.getByText('Newer visible notification')).toBeInTheDocument();
+      expect(store.getState().queue).toEqual([]);
+    });
+
+    it('moves deep collapsed notifications farther into the stack and fades them out', () => {
+      const store = createNotificationsStore();
+      const { container } = render(
+        <Notifications store={store} withinPortal={false} autoClose={false} stacked />
+      );
+
+      act(() => {
+        Array(5)
+          .fill(0)
+          .forEach((_, index) => {
+            notifications.show({ id: `deep-${index}`, message: `Deep ${index}` }, store);
+          });
+      });
+
+      const deepestNotification = screen
+        .getByText('Deep 0')
+        .closest('[role="alert"]') as HTMLElement;
+
+      expect(getStackTransform(deepestNotification)).toContain('32px');
+      expect(deepestNotification.style.getPropertyValue('--notifications-stack-opacity')).toBe('0');
+      expect(deepestNotification).toHaveAttribute('aria-hidden', 'true');
+      expect(deepestNotification).toHaveAttribute('inert');
+
+      fireEvent.mouseEnter(getPositionRoot(container, 'bottom-right'));
+
+      expect(deepestNotification.style.getPropertyValue('--notifications-stack-opacity')).toBe('0');
+      expect(deepestNotification).toHaveAttribute('aria-hidden', 'true');
+      expect(deepestNotification).toHaveAttribute('inert');
+    });
+
+    it('allows dismissing the front stacked notification by dragging', () => {
+      jest.useFakeTimers();
+      const store = createNotificationsStore();
+
+      render(
+        <Notifications
+          store={store}
+          withinPortal={false}
+          autoClose={false}
+          stacked
+          transitionDuration={10}
+        />
+      );
+
+      act(() => {
+        notifications.show({ id: 'older-drag', message: 'Older drag' }, store);
+        notifications.show({ id: 'newer-drag', message: 'Newer drag' }, store);
+      });
+
+      const notification = screen.getByText('Newer drag').closest('[role="alert"]')!;
+
+      act(() => {
+        pointerDown(notification, { clientX: 0, clientY: 0 });
+        pointerMove({ clientX: 200, clientY: 0 });
+        pointerUp({ clientX: 200, clientY: 0 });
+        jest.advanceTimersByTime(425);
+      });
+
+      expect(store.getState().notifications.map((item) => item.id)).toEqual(['older-drag']);
+    });
+  });
+
   describe('priority', () => {
     function createStoreWithLimit(limit: number) {
       const store = createNotificationsStore();

--- a/packages/@mantine/notifications/src/Notifications.tsx
+++ b/packages/@mantine/notifications/src/Notifications.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Transition as _Transition,
   TransitionGroup,
@@ -30,15 +30,24 @@ import { getNotificationStateStyles } from './get-notification-state-styles';
 import { NotificationContainer } from './NotificationContainer';
 import {
   hideNotification,
+  NotificationData,
   NotificationPosition,
   notifications,
   NotificationsStore,
   notificationsStore,
+  updateNotificationsState,
   useNotifications,
 } from './notifications.store';
 import classes from './Notifications.module.css';
 
 const Transition: any = _Transition;
+const STACKED_NOTIFICATION_OFFSET = 8;
+const STACKED_NOTIFICATION_GAP = 14;
+const STACKED_NOTIFICATION_SCALE_STEP = 0.05;
+const STACKED_NOTIFICATION_MAX_VISIBLE_PREVIEWS = 3;
+const STACKED_NOTIFICATION_FALLBACK_HEIGHT = 80;
+const STACKED_NOTIFICATION_TRANSITION_DURATION = 400;
+const STACKED_NOTIFICATIONS_LIMIT = Number.MAX_SAFE_INTEGER;
 
 export type NotificationsStylesNames = 'root' | 'notification';
 export type NotificationsCssVariables = {
@@ -85,6 +94,9 @@ export interface NotificationsProps
 
   /** Determines which notifications should pause auto close on hover, `'all'` – pauses auto close for all notifications when any notification is hovered, `'notification'` – pauses auto close only for the hovered notification @default 'all' */
   pauseResetOnHover?: 'all' | 'notification';
+
+  /** Determines whether notifications should be stacked and expanded on hover/focus @default false */
+  stacked?: boolean;
 }
 
 export type NotificationsFactory = Factory<{
@@ -115,7 +127,160 @@ const defaultProps = {
   store: notificationsStore,
   withinPortal: true,
   pauseResetOnHover: 'all',
+  stacked: false,
 } satisfies Partial<NotificationsProps>;
+
+interface SequencedNotificationData extends NotificationData {
+  __sequence?: number;
+}
+
+function isTopPosition(position: NotificationPosition) {
+  return position.startsWith('top');
+}
+
+function getStackedNotifications(notifications: NotificationData[]) {
+  return [...(notifications as SequencedNotificationData[])].sort(
+    (a, b) => (b.priority ?? 0) - (a.priority ?? 0) || (b.__sequence ?? 0) - (a.__sequence ?? 0)
+  );
+}
+
+function getNotificationHeight(
+  heights: Record<string, number>,
+  notification: NotificationData | undefined
+) {
+  if (!notification?.id) {
+    return STACKED_NOTIFICATION_FALLBACK_HEIGHT;
+  }
+
+  return heights[notification.id] || STACKED_NOTIFICATION_FALLBACK_HEIGHT;
+}
+
+function getExpandedOffset(
+  notifications: NotificationData[],
+  heights: Record<string, number>,
+  index: number
+) {
+  return notifications
+    .slice(0, index)
+    .reduce(
+      (acc, notification) =>
+        acc + getNotificationHeight(heights, notification) + STACKED_NOTIFICATION_GAP,
+      0
+    );
+}
+
+function getStackedNotificationStateStyles({
+  state,
+  maxHeight,
+  position,
+  transitionDuration,
+}: {
+  state: TransitionStatus;
+  maxHeight: number | string;
+  position: NotificationPosition;
+  transitionDuration: number;
+}) {
+  const transform = isTopPosition(position) ? 'translateY(-100%)' : 'translateY(100%)';
+  const commonStyles: React.CSSProperties = {
+    opacity: 0,
+    maxHeight,
+    transform,
+    transitionDuration: `${transitionDuration}ms, ${transitionDuration}ms, ${transitionDuration}ms`,
+    transitionTimingFunction: 'cubic-bezier(.21,1.02,.73,1), cubic-bezier(.21,1.02,.73,1), linear',
+    transitionProperty: 'opacity, transform, max-height',
+  };
+  const inState: React.CSSProperties = {
+    opacity: 1,
+    transform: 'translateY(0)',
+  };
+  const outState: React.CSSProperties = {
+    opacity: 0,
+    maxHeight: 0,
+    transform,
+  };
+  const transitionStyles = {
+    entering: inState,
+    entered: inState,
+    exiting: outState,
+    exited: outState,
+  };
+
+  return { ...commonStyles, ...transitionStyles[state as keyof typeof transitionStyles] };
+}
+
+function getStackHeight(
+  notifications: NotificationData[],
+  heights: Record<string, number>,
+  expanded: boolean
+) {
+  if (notifications.length === 0) {
+    return 0;
+  }
+
+  if (!expanded) {
+    return (
+      getNotificationHeight(heights, notifications[0]) +
+      Math.min(notifications.length - 1, STACKED_NOTIFICATION_MAX_VISIBLE_PREVIEWS) *
+        STACKED_NOTIFICATION_OFFSET
+    );
+  }
+
+  const visibleNotifications = notifications.slice(
+    0,
+    STACKED_NOTIFICATION_MAX_VISIBLE_PREVIEWS + 1
+  );
+
+  return (
+    visibleNotifications.reduce(
+      (acc, notification) => acc + getNotificationHeight(heights, notification),
+      0
+    ) +
+    (visibleNotifications.length - 1) * STACKED_NOTIFICATION_GAP
+  );
+}
+
+function getStackedNotificationStyle({
+  notifications,
+  heights,
+  index,
+  position,
+  expanded,
+  transitionDuration,
+}: {
+  notifications: NotificationData[];
+  heights: Record<string, number>;
+  index: number;
+  position: NotificationPosition;
+  expanded: boolean;
+  transitionDuration: number;
+}) {
+  const direction = isTopPosition(position) ? 1 : -1;
+  const visiblePreviewIndex = Math.min(index, STACKED_NOTIFICATION_MAX_VISIBLE_PREVIEWS + 1);
+  const collapsedOffset = visiblePreviewIndex * STACKED_NOTIFICATION_OFFSET;
+  const expandedOffset = getExpandedOffset(notifications, heights, index);
+  const offset = expanded ? expandedOffset : collapsedOffset;
+  const frontNotificationHeight = getNotificationHeight(heights, notifications[0]);
+  const scale =
+    expanded || index > STACKED_NOTIFICATION_MAX_VISIBLE_PREVIEWS
+      ? 1
+      : 1 - visiblePreviewIndex * STACKED_NOTIFICATION_SCALE_STEP;
+  const isVisible = index <= STACKED_NOTIFICATION_MAX_VISIBLE_PREVIEWS;
+
+  return {
+    ['--notifications-stack-transform' as string]: `translate3d(0, ${
+      direction * offset
+    }px, 0) scale(${scale})`,
+    ['--notifications-stack-opacity' as string]: isVisible ? '1' : '0',
+    ['--notifications-stack-content-opacity' as string]:
+      (expanded && isVisible) || index === 0 ? '1' : '0',
+    zIndex: notifications.length - index,
+    pointerEvents: isVisible && (index === 0 || expanded) ? 'auto' : 'none',
+    height: !expanded && index > 0 ? frontNotificationHeight : undefined,
+    overflow: !expanded && index > 0 ? 'hidden' : undefined,
+    transitionDuration: `${transitionDuration}ms, ${transitionDuration}ms, ${transitionDuration}ms`,
+    transitionTimingFunction: 'cubic-bezier(.21,1.02,.73,1), cubic-bezier(.21,1.02,.73,1), linear',
+  } as React.CSSProperties;
+}
 
 const varsResolver = createVarsResolver<NotificationsFactory>((_, { zIndex, containerWidth }) => ({
   root: {
@@ -147,6 +312,11 @@ export const Notifications = factory<NotificationsFactory>((_props) => {
     portalProps,
     withinPortal,
     pauseResetOnHover,
+    stacked,
+    onMouseEnter,
+    onMouseLeave,
+    onFocus,
+    onBlur,
     ...others
   } = props;
 
@@ -157,12 +327,45 @@ export const Notifications = factory<NotificationsFactory>((_props) => {
   const refs = useRef<Record<string, HTMLDivElement>>({});
   const previousLength = useRef<number>(0);
   const [hoveredCount, setHoveredCount] = useState(0);
+  const [notificationHeights, setNotificationHeights] = useState<Record<string, number>>({});
+  const [expandedPositions, setExpandedPositions] = useState<Record<NotificationPosition, boolean>>(
+    {} as Record<NotificationPosition, boolean>
+  );
 
   const handleHoverStart = useCallback(() => setHoveredCount((c) => c + 1), []);
   const handleHoverEnd = useCallback(() => setHoveredCount((c) => Math.max(0, c - 1)), []);
+  const handleHeightChange = useCallback((id: string, height: number | null) => {
+    setNotificationHeights((current) => {
+      if (height === null) {
+        const next = { ...current };
+        delete next[id];
+        return next;
+      }
+
+      if (current[id] === height) {
+        return current;
+      }
+
+      return { ...current, [id]: height };
+    });
+  }, []);
+
+  const setPositionExpanded = useCallback((pos: NotificationPosition, expanded: boolean) => {
+    setExpandedPositions((current) => {
+      if ((current[pos] ?? false) === expanded) {
+        return current;
+      }
+
+      return { ...current, [pos]: expanded };
+    });
+  }, []);
 
   const reduceMotion = theme.respectReducedMotion ? shouldReduceMotion : false;
   const duration = reduceMotion ? 1 : transitionDuration;
+  const isStacked = stacked;
+  const stackDuration = reduceMotion
+    ? 1
+    : Math.max(duration, STACKED_NOTIFICATION_TRANSITION_DURATION);
 
   const getStyles = useStyles<NotificationsFactory>({
     name: 'Notifications',
@@ -179,12 +382,19 @@ export const Notifications = factory<NotificationsFactory>((_props) => {
   });
 
   useEffect(() => {
+    const nextLimit = isStacked ? STACKED_NOTIFICATIONS_LIMIT : limit || 5;
+    const shouldRedistribute = store?.getState().limit !== nextLimit;
+
     store?.updateState((current) => ({
       ...current,
-      limit: limit || 5,
+      limit: nextLimit,
       defaultPosition: position,
     }));
-  }, [limit, position]);
+
+    if (store && shouldRedistribute) {
+      updateNotificationsState(store, (current) => current);
+    }
+  }, [isStacked, limit, position, store]);
 
   useDidUpdate(() => {
     if (data.notifications.length > previousLength.current) {
@@ -194,85 +404,210 @@ export const Notifications = factory<NotificationsFactory>((_props) => {
   }, [data.notifications]);
 
   const grouped = getGroupedNotifications(data.notifications, position);
+  const expandedStackCount = useMemo(
+    () => Object.values(expandedPositions).filter(Boolean).length,
+    [expandedPositions]
+  );
   const groupedComponents = positions.reduce(
     (acc, pos) => {
-      acc[pos] = grouped[pos].map(({ style: notificationStyle, ...notification }) => (
-        <Transition
-          key={notification.id}
-          timeout={duration}
-          onEnter={() => refs.current[notification.id!].offsetHeight}
-          nodeRef={{ current: refs.current[notification.id!] }}
-        >
-          {(state: TransitionStatus) => (
-            <NotificationContainer
-              ref={(node) => {
-                if (node) {
-                  refs.current[notification.id!] = node;
-                } else {
-                  delete refs.current[notification.id!];
+      const currentGroup = isStacked ? getStackedNotifications(grouped[pos]) : grouped[pos];
+      const stackExpanded = expandedPositions[pos] ?? false;
+
+      acc[pos] = currentGroup.map(({ style: notificationStyle, ...notification }, index) => {
+        const hiddenFromAccessibility =
+          isStacked &&
+          (stackExpanded ? index > STACKED_NOTIFICATION_MAX_VISIBLE_PREVIEWS : index > 0);
+
+        return (
+          <Transition
+            key={notification.id}
+            timeout={isStacked ? stackDuration : duration}
+            onEnter={() => refs.current[notification.id!].offsetHeight}
+            nodeRef={{ current: refs.current[notification.id!] }}
+          >
+            {(state: TransitionStatus) => (
+              <NotificationContainer
+                ref={(node) => {
+                  if (node) {
+                    refs.current[notification.id!] = node;
+                  } else {
+                    delete refs.current[notification.id!];
+                  }
+                }}
+                data={notification}
+                onHide={(id) => hideNotification(id, store)}
+                autoClose={autoClose}
+                transitionDuration={isStacked ? stackDuration : duration}
+                allowDragDismiss={allowDragDismiss}
+                allowScrollDismiss={allowScrollDismiss}
+                paused={
+                  pauseResetOnHover === 'all'
+                    ? hoveredCount > 0 || (isStacked && expandedStackCount > 0)
+                    : false
                 }
-              }}
-              data={notification}
-              onHide={(id) => hideNotification(id, store)}
-              autoClose={autoClose}
-              transitionDuration={duration}
-              allowDragDismiss={allowDragDismiss}
-              allowScrollDismiss={allowScrollDismiss}
-              paused={pauseResetOnHover === 'all' ? hoveredCount > 0 : false}
-              onHoverStart={handleHoverStart}
-              onHoverEnd={handleHoverEnd}
-              {...getStyles('notification', {
-                style: {
-                  ...getNotificationStateStyles({
-                    state,
-                    position: pos,
-                    transitionDuration: duration,
-                    maxHeight: notificationMaxHeight,
-                  }),
-                  ...notificationStyle,
-                },
-              })}
-            />
-          )}
-        </Transition>
-      ));
+                onHoverStart={handleHoverStart}
+                onHoverEnd={handleHoverEnd}
+                onHeightChange={isStacked ? handleHeightChange : undefined}
+                {...getStyles('notification', {
+                  style: {
+                    ...getNotificationStateStyles({
+                      state,
+                      position: pos,
+                      transitionDuration: duration,
+                      maxHeight: notificationMaxHeight,
+                    }),
+                    ...(isStacked
+                      ? getStackedNotificationStateStyles({
+                          state,
+                          position: pos,
+                          transitionDuration: stackDuration,
+                          maxHeight: notificationMaxHeight,
+                        })
+                      : null),
+                    ...(isStacked
+                      ? getStackedNotificationStyle({
+                          notifications: currentGroup,
+                          heights: notificationHeights,
+                          index,
+                          position: pos,
+                          expanded: stackExpanded,
+                          transitionDuration: stackDuration,
+                        })
+                      : null),
+                    ...notificationStyle,
+                  },
+                })}
+                data-stack-preview={isStacked && !stackExpanded && index > 0 ? true : undefined}
+                aria-hidden={hiddenFromAccessibility ? true : undefined}
+                inert={hiddenFromAccessibility ? true : undefined}
+              />
+            )}
+          </Transition>
+        );
+      });
 
       return acc;
     },
     {} as Record<NotificationPosition, React.ReactNode>
   );
 
+  const getRootProps = (pos: NotificationPosition) => {
+    const stackExpanded = expandedPositions[pos] ?? false;
+
+    return {
+      ...(isStacked
+        ? {
+            'data-stacked': true,
+            'data-expanded': stackExpanded || undefined,
+          }
+        : null),
+      onMouseEnter: (event: React.MouseEvent<HTMLDivElement>) => {
+        onMouseEnter?.(event);
+        if (isStacked) {
+          setPositionExpanded(pos, true);
+        }
+      },
+      onMouseLeave: (event: React.MouseEvent<HTMLDivElement>) => {
+        onMouseLeave?.(event);
+        if (
+          isStacked &&
+          !event.currentTarget.contains(event.currentTarget.ownerDocument.activeElement)
+        ) {
+          setPositionExpanded(pos, false);
+        }
+      },
+      onFocus: (event: React.FocusEvent<HTMLDivElement>) => {
+        onFocus?.(event);
+        if (isStacked) {
+          setPositionExpanded(pos, true);
+        }
+      },
+      onBlur: (event: React.FocusEvent<HTMLDivElement>) => {
+        onBlur?.(event);
+        if (isStacked && !event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          setPositionExpanded(pos, false);
+        }
+      },
+    };
+  };
+
+  const getRootStyle = (pos: NotificationPosition) => {
+    if (!isStacked) {
+      return undefined;
+    }
+
+    const currentGroup = getStackedNotifications(grouped[pos]);
+    const stackExpanded = expandedPositions[pos] ?? false;
+
+    return {
+      ['--notifications-stack-height' as string]: `${getStackHeight(
+        currentGroup,
+        notificationHeights,
+        stackExpanded
+      )}px`,
+      ['--notifications-stack-transition-duration' as string]: `${stackDuration}ms`,
+    } as React.CSSProperties;
+  };
+
   return (
     <OptionalPortal withinPortal={withinPortal} {...portalProps}>
-      <Box {...getStyles('root')} data-position="top-center" {...others}>
+      <Box
+        {...getStyles('root', { style: getRootStyle('top-center') })}
+        data-position="top-center"
+        {...getRootProps('top-center')}
+        {...others}
+      >
         <TransitionGroup>{groupedComponents['top-center']}</TransitionGroup>
       </Box>
 
-      <Box {...getStyles('root')} data-position="top-left" {...others}>
+      <Box
+        {...getStyles('root', { style: getRootStyle('top-left') })}
+        data-position="top-left"
+        {...getRootProps('top-left')}
+        {...others}
+      >
         <TransitionGroup>{groupedComponents['top-left']}</TransitionGroup>
       </Box>
 
       <Box
-        {...getStyles('root', { className: RemoveScroll.classNames.fullWidth })}
+        {...getStyles('root', {
+          className: RemoveScroll.classNames.fullWidth,
+          style: getRootStyle('top-right'),
+        })}
         data-position="top-right"
+        {...getRootProps('top-right')}
         {...others}
       >
         <TransitionGroup>{groupedComponents['top-right']}</TransitionGroup>
       </Box>
 
       <Box
-        {...getStyles('root', { className: RemoveScroll.classNames.fullWidth })}
+        {...getStyles('root', {
+          className: RemoveScroll.classNames.fullWidth,
+          style: getRootStyle('bottom-right'),
+        })}
         data-position="bottom-right"
+        {...getRootProps('bottom-right')}
         {...others}
       >
         <TransitionGroup>{groupedComponents['bottom-right']}</TransitionGroup>
       </Box>
 
-      <Box {...getStyles('root')} data-position="bottom-left" {...others}>
+      <Box
+        {...getStyles('root', { style: getRootStyle('bottom-left') })}
+        data-position="bottom-left"
+        {...getRootProps('bottom-left')}
+        {...others}
+      >
         <TransitionGroup>{groupedComponents['bottom-left']}</TransitionGroup>
       </Box>
 
-      <Box {...getStyles('root')} data-position="bottom-center" {...others}>
+      <Box
+        {...getStyles('root', { style: getRootStyle('bottom-center') })}
+        data-position="bottom-center"
+        {...getRootProps('bottom-center')}
+        {...others}
+      >
         <TransitionGroup>{groupedComponents['bottom-center']}</TransitionGroup>
       </Box>
     </OptionalPortal>


### PR DESCRIPTION
## What changed

- Added `stacked` prop to `Notifications` for Sonner-style stacked notification layout.
- Stacked notifications show the front notification with compact previews behind it and expand on hover/focus.
- Supported all notification positions: top stacks expand downward, bottom stacks expand upward.
- New stacked notifications are displayed immediately at the front instead of waiting in the queue.
- Preserved existing priority, auto-close, drag dismiss, scroll dismiss, and close-disabled behavior.
- Added documentation, Storybook demo, and focused tests for the new mode.

## Testing

- npm run typecheck
- npx oxlint -c oxlint.config.mjs packages/@mantine/notifications/src packages/@docs/demos/src/demos/notifications apps/mantine.dev/src/pages/x/notifications.mdx
- npm run format:write:files ...
- npm run jest packages/@mantine/notifications/src/Notifications.test.tsx -- --runInBand --watchman=false
- npm run stylelint
- npm run build

This pull request introduces a new "stacked notifications" feature to the `@mantine/notifications` package, allowing notifications to be displayed in a compact stack with previews of older notifications behind the front notification. The stack expands on hover or focus, and the implementation includes new CSS, demo, and comprehensive tests. Several internal changes support this feature, including new props, event handling, and style variables.

**Stacked Notifications Feature:**

* Added a `stacked` prop to the `Notifications` component, enabling a compact stacked layout where the newest notification is shown in front and older notifications appear as previews behind it. The stack expands on hover or focus, and works with all supported positions. [[1]](diffhunk://#diff-5959375f81e06fe82c32091455b8d9c89f1e44d4e3afe90816a5ca35abb51b34R187-R207) [[2]](diffhunk://#diff-19259eed2a270e8b33dfe9258176f124ac0fa337e085f102654860b92dc774c7R33-R50) [[3]](diffhunk://#diff-934a543b50beb8ceabe1dc4a8a627bb404f5d1d3014bed357b4ef57e15735eecR38-R96)

**Implementation and API Changes:**

* Updated `NotificationContainer` to accept an `onHeightChange` prop and manage CSS variables for stacking, opacity, and transforms. Added logic to measure notification heights and handle dynamic stacking transitions. [[1]](diffhunk://#diff-b01b073698bac2f0ad2092a6f6377e2c478134edc9f3bf0a48849f0b0e044193R19) [[2]](diffhunk://#diff-b01b073698bac2f0ad2092a6f6377e2c478134edc9f3bf0a48849f0b0e044193R33) [[3]](diffhunk://#diff-b01b073698bac2f0ad2092a6f6377e2c478134edc9f3bf0a48849f0b0e044193R173) [[4]](diffhunk://#diff-b01b073698bac2f0ad2092a6f6377e2c478134edc9f3bf0a48849f0b0e044193R184-R193) [[5]](diffhunk://#diff-b01b073698bac2f0ad2092a6f6377e2c478134edc9f3bf0a48849f0b0e044193R291-R321)
* Added new constants for stacked notification layout and animation, and updated notification state management to support immediate display of new notifications in stacked mode.

**Documentation and Demos:**

* Added a new section to the documentation describing stacked notifications, and created a new interactive demo (`Notifications.demo.stacked.tsx`) to showcase the feature. [[1]](diffhunk://#diff-5959375f81e06fe82c32091455b8d9c89f1e44d4e3afe90816a5ca35abb51b34R187-R207) [[2]](diffhunk://#diff-e6e517359f3e04413a54db545671da184478a859087a309612e60eb96bda04d0R1-R78)
* Registered the new stacked demo in the storybook and export indexes. [[1]](diffhunk://#diff-74a98f6a2053915641bb4c907e57b2ad37db473e27eff12d9d583343758015aeR31-R35) [[2]](diffhunk://#diff-8d4e8ee690d1a9b66ff871c6242abbff96a013eaff1d1b80a557e44d55c1af25R6)

**Styling:**

* Added CSS for the stacked notifications layout, including transitions, positioning, and preview/fade-out effects for older notifications.

**Testing:**

* Added a comprehensive test suite for stacked notifications, covering layout, stacking order, expansion/collapse behavior, keyboard/mouse interaction, queue handling, and drag-to-dismiss.