### PR TITLE
[@mantine/dates] DatePicker: Add quick year controls

### DIFF
--- a/apps/mantine.dev/src/pages/dates/date-picker.mdx
+++ b/apps/mantine.dev/src/pages/dates/date-picker.mdx
@@ -119,6 +119,13 @@ then the corresponding control will be disabled.
 
 <Demo data={DatePickerDemos.minMax} />
 
+## Quick year controls
+
+Set the `withYearControls` prop to display additional previous and next year controls in the month view.
+These controls allow users to navigate by one year at a time without switching to the year or decade level.
+
+<Demo data={DatePickerDemos.withYearControls} />
+
 ## Change header controls order
 
 Use the `headerControlsOrder` prop to change the order of header controls. The prop accepts an array of

--- a/packages/@docs/demos/src/demos/dates/DatePicker/DatePicker.demo.withYearControls.tsx
+++ b/packages/@docs/demos/src/demos/dates/DatePicker/DatePicker.demo.withYearControls.tsx
@@ -1,0 +1,26 @@
+import { DatePicker } from '@mantine/dates';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { DatePicker } from '@mantine/dates';
+
+function Demo() {
+  return (
+    <DatePicker
+      defaultDate="2022-02-01"
+      withYearControls
+    />
+  );
+}
+`;
+
+function Demo() {
+  return <DatePicker defaultDate="2022-02-01" withYearControls />;
+}
+
+export const withYearControls: MantineDemo = {
+  type: 'code',
+  centered: true,
+  component: Demo,
+  code,
+};

--- a/packages/@docs/demos/src/demos/dates/DatePicker/DatePicker.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/dates/DatePicker/DatePicker.demos.story.tsx
@@ -133,6 +133,11 @@ export const Demo_headerControlsOrder = {
   render: renderDemo(demos.headerControlsOrder),
 };
 
+export const Demo_withYearControls = {
+  name: '⭐ Demo: withYearControls',
+  render: renderDemo(demos.withYearControls),
+};
+
 export const Demo_fullWidth = {
   name: '⭐ Demo: fullWidth',
   render: renderDemo(demos.fullWidth),

--- a/packages/@docs/demos/src/demos/dates/DatePicker/index.ts
+++ b/packages/@docs/demos/src/demos/dates/DatePicker/index.ts
@@ -23,4 +23,5 @@ export { withWeekNumbers } from './DatePicker.demo.withWeekNumbers';
 export { presets } from './DatePicker.demo.presets';
 export { presetsRange } from './DatePicker.demo.presetsRange';
 export { headerControlsOrder } from './DatePicker.demo.headerControlsOrder';
+export { withYearControls } from './DatePicker.demo.withYearControls';
 export { fullWidth } from './DatePicker.demo.fullWidth';

--- a/packages/@mantine/dates/src/components/Calendar/Calendar.story.tsx
+++ b/packages/@mantine/dates/src/components/Calendar/Calendar.story.tsx
@@ -45,6 +45,14 @@ export function MinLevel() {
   );
 }
 
+export function WithYearsControl() {
+  return (
+    <div style={{ padding: 40 }}>
+      <Calendar withYearControls maxDate="2032-04-11" />
+    </div>
+  );
+}
+
 export function NumberOfColumns() {
   return (
     <div style={{ padding: 40 }}>

--- a/packages/@mantine/dates/src/components/Calendar/Calendar.tsx
+++ b/packages/@mantine/dates/src/components/Calendar/Calendar.tsx
@@ -44,11 +44,17 @@ export interface CalendarAriaLabels {
 type OmittedSettings =
   | 'onNext'
   | 'onPrevious'
+  | 'onNextYear'
+  | 'onPreviousYear'
   | 'onLevelClick'
   | 'withNext'
   | 'withPrevious'
+  | 'withNextYear'
+  | 'withPreviousYear'
   | 'nextDisabled'
   | 'previousDisabled'
+  | 'nextYearDisabled'
+  | 'previousYearDisabled'
   | 'hasNextLevel';
 
 export interface CalendarSettings
@@ -140,6 +146,9 @@ export interface CalendarBaseProps {
 
   /** Called when the previous month button is clicked */
   onPreviousMonth?: (date: DateStringValue) => void;
+
+  /** Enables previous and next year navigation controls in the month view. @default false */
+  withYearControls?: boolean;
 }
 
 export interface CalendarProps
@@ -174,6 +183,7 @@ const defaultProps = {
   __updateDateOnYearSelect: true,
   __updateDateOnMonthSelect: true,
   enableKeyboardNavigation: true,
+  withYearControls: false,
 } satisfies Partial<CalendarProps>;
 
 export const Calendar = factory<CalendarFactory>((_props) => {
@@ -193,7 +203,9 @@ export const Calendar = factory<CalendarFactory>((_props) => {
     columnsToScroll,
     ariaLabels,
     nextLabel,
+    nextYearLabel,
     previousLabel,
+    previousYearLabel,
     onYearSelect,
     onMonthSelect,
     onYearMouseEnter,
@@ -216,7 +228,9 @@ export const Calendar = factory<CalendarFactory>((_props) => {
     getDayAriaLabel,
     monthLabelFormat,
     nextIcon,
+    nextYearIcon,
     previousIcon,
+    previousYearIcon,
     __onDayClick,
     __onDayMouseEnter,
     withCellSpacing,
@@ -240,6 +254,7 @@ export const Calendar = factory<CalendarFactory>((_props) => {
     minDate,
     maxDate,
     locale,
+    withYearControls,
     __staticSelector,
     size,
     __preventFocus,
@@ -324,10 +339,36 @@ export const Calendar = factory<CalendarFactory>((_props) => {
     setDate(nextDate);
   };
 
+  const handleMonthLevelNextYear = () => {
+    let nextDate = dayjs(currentDate).add(1, 'year');
+
+    if (maxDate && nextDate.isAfter(dayjs(maxDate))) {
+      nextDate = dayjs(maxDate);
+    }
+
+    const formattedDate = nextDate.format('YYYY-MM-DD');
+
+    onNextYear?.(formattedDate);
+    setDate(formattedDate);
+  };
+
   const handlePreviousYear = () => {
     const nextDate = dayjs(currentDate).subtract(_columnsToScroll, 'year').format('YYYY-MM-DD');
     onPreviousYear?.(nextDate);
     setDate(nextDate);
+  };
+
+  const handleMonthLevelPreviousYear = () => {
+    let nextDate = dayjs(currentDate).subtract(1, 'year');
+
+    if (minDate && nextDate.isBefore(dayjs(minDate))) {
+      nextDate = dayjs(minDate);
+    }
+
+    const formattedDate = nextDate.format('YYYY-MM-DD');
+
+    onPreviousYear?.(formattedDate);
+    setDate(formattedDate);
   };
 
   const handleNextDecade = () => {
@@ -417,6 +458,8 @@ export const Calendar = factory<CalendarFactory>((_props) => {
     >
       {_level === 'month' && (
         <MonthLevelGroup
+          withPreviousYear={withYearControls}
+          withNextYear={withYearControls}
           month={currentDate}
           minDate={minDate}
           maxDate={maxDate}
@@ -430,16 +473,22 @@ export const Calendar = factory<CalendarFactory>((_props) => {
           hideWeekdays={hideWeekdays}
           getDayAriaLabel={getDayAriaLabel}
           onNext={handleNextMonth}
+          onNextYear={handleMonthLevelNextYear}
           onPrevious={handlePreviousMonth}
+          onPreviousYear={handleMonthLevelPreviousYear}
           hasNextLevel={maxLevel !== 'month'}
           onLevelClick={() => setLevel('year')}
           numberOfColumns={numberOfColumns}
           locale={locale}
           levelControlAriaLabel={ariaLabels?.monthLevelControl}
           nextLabel={ariaLabels?.nextMonth ?? nextLabel}
+          nextYearLabel={ariaLabels?.nextYear ?? nextYearLabel}
           nextIcon={nextIcon}
+          nextYearIcon={nextYearIcon}
           previousLabel={ariaLabels?.previousMonth ?? previousLabel}
+          previousYearLabel={ariaLabels?.previousYear ?? previousYearLabel}
           previousIcon={previousIcon}
+          previousYearIcon={previousYearIcon}
           monthLabelFormat={monthLabelFormat}
           __onDayClick={__onDayClick}
           __onDayMouseEnter={__onDayMouseEnter}

--- a/packages/@mantine/dates/src/components/Calendar/pick-calendar-levels-props/pick-calendar-levels-props.ts
+++ b/packages/@mantine/dates/src/components/Calendar/pick-calendar-levels-props/pick-calendar-levels-props.ts
@@ -6,7 +6,9 @@ export function pickCalendarProps<T extends Record<string, any>>(props: T) {
     level,
     onLevelChange,
     nextIcon,
+    nextYearIcon,
     previousIcon,
+    previousYearIcon,
     date,
     defaultDate,
     onDateChange,
@@ -15,6 +17,8 @@ export function pickCalendarProps<T extends Record<string, any>>(props: T) {
     ariaLabels,
     nextLabel,
     previousLabel,
+    nextYearLabel,
+    previousYearLabel,
     onYearSelect,
     onMonthSelect,
     onYearMouseEnter,
@@ -32,6 +36,7 @@ export function pickCalendarProps<T extends Record<string, any>>(props: T) {
     __setDateRef,
     __setLevelRef,
     withWeekNumbers,
+    withYearControls,
     headerControlsOrder,
 
     // MonthLevelGroup props
@@ -75,7 +80,9 @@ export function pickCalendarProps<T extends Record<string, any>>(props: T) {
       level,
       onLevelChange,
       nextIcon,
+      nextYearIcon,
       previousIcon,
+      previousYearIcon,
       date,
       defaultDate,
       onDateChange,
@@ -100,6 +107,7 @@ export function pickCalendarProps<T extends Record<string, any>>(props: T) {
       __updateDateOnMonthSelect,
       __setDateRef,
       withWeekNumbers,
+      withYearControls,
       headerControlsOrder,
 
       // MonthLevelGroup props

--- a/packages/@mantine/dates/src/components/CalendarHeader/CalendarHeader.story.tsx
+++ b/packages/@mantine/dates/src/components/CalendarHeader/CalendarHeader.story.tsx
@@ -58,6 +58,30 @@ export function WithoutNextAndPrevious() {
   );
 }
 
+export function WithNextYearControl() {
+  return (
+    <div style={{ padding: 40, width: 320 }}>
+      <CalendarHeader label="March 2022" withNextYear />
+    </div>
+  );
+}
+
+export function WithPreviousYearControl() {
+  return (
+    <div style={{ padding: 40, width: 320 }}>
+      <CalendarHeader label="March 2022" withPreviousYear />
+    </div>
+  );
+}
+
+export function WithNextAndPreviousYearControls() {
+  return (
+    <div style={{ padding: 40, width: 320 }}>
+      <CalendarHeader label="March 2022" withPreviousYear withNextYear />
+    </div>
+  );
+}
+
 export function Sizes() {
   const sizes = (['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
     <CalendarHeader label="January" size={size} key={size} mt="xl" />

--- a/packages/@mantine/dates/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/@mantine/dates/src/components/CalendarHeader/CalendarHeader.tsx
@@ -15,6 +15,7 @@ import {
   useStyles,
 } from '@mantine/core';
 import classes from './CalendarHeader.module.css';
+import { CalendarHeaderYearChevrons } from './CalendarHeaderYearChevrons';
 
 export type CalendarHeaderStylesNames =
   | 'calendarHeader'
@@ -37,17 +38,35 @@ export interface CalendarHeaderSettings {
   /** Change previous icon */
   previousIcon?: React.ReactNode;
 
+  /** Change next year icon */
+  nextYearIcon?: React.ReactNode;
+
+  /** Change previous year icon */
+  previousYearIcon?: React.ReactNode;
+
   /** Next button `aria-label` */
   nextLabel?: string;
 
+  /** Next year button `aria-label` */
+  nextYearLabel?: string;
+
   /** Previous button `aria-label` */
   previousLabel?: string;
+
+  /** Previous year button `aria-label` */
+  previousYearLabel?: string;
 
   /** Called when the next button is clicked */
   onNext?: () => void;
 
   /** Called when the previous button is clicked */
   onPrevious?: () => void;
+
+  /** Called when the next year button is clicked */
+  onNextYear?: () => void;
+
+  /** Called when the previous year button is clicked */
+  onPreviousYear?: () => void;
 
   /** Called when the level button is clicked */
   onLevelClick?: () => void;
@@ -58,6 +77,12 @@ export interface CalendarHeaderSettings {
   /** Disables previous control */
   previousDisabled?: boolean;
 
+  /** Disables next year control */
+  nextYearDisabled?: boolean;
+
+  /** Disables previous year control */
+  previousYearDisabled?: boolean;
+
   /** Determines whether next level button should be enabled @default true */
   hasNextLevel?: boolean;
 
@@ -67,11 +92,17 @@ export interface CalendarHeaderSettings {
   /** Determines whether previous control should be rendered @default true */
   withPrevious?: boolean;
 
+  /** Determines whether next control should be rendered @default false */
+  withNextYear?: boolean;
+
+  /** Determines whether previous control should be rendered @default false */
+  withPreviousYear?: boolean;
+
   /** Component size */
   size?: MantineSize;
 
-  /** Controls order @default ['previous', 'level', 'next'] */
-  headerControlsOrder?: ('previous' | 'next' | 'level')[];
+  /** Controls order @default ['previous-year', 'previous', 'level', 'next', 'next-year'] */
+  headerControlsOrder?: ('previous' | 'previous-year' | 'next-year' | 'next' | 'level')[];
 
   /** Determines whether the header should take the full width of its container @default false */
   fullWidth?: boolean;
@@ -103,7 +134,9 @@ const defaultProps = {
   hasNextLevel: true,
   withNext: true,
   withPrevious: true,
-  headerControlsOrder: ['previous', 'level', 'next'],
+  withNextYear: false,
+  withPreviousYear: false,
+  headerControlsOrder: ['previous-year', 'previous', 'level', 'next', 'next-year'],
 } satisfies Partial<CalendarHeaderProps>;
 
 const varsResolver = createVarsResolver<CalendarHeaderFactory>((_, { size }) => ({
@@ -123,19 +156,29 @@ export const CalendarHeader = factory<CalendarHeaderFactory>((_props) => {
     unstyled,
     vars,
     nextIcon,
+    nextYearIcon,
     previousIcon,
+    previousYearIcon,
     nextLabel,
+    nextYearLabel,
     previousLabel,
+    previousYearLabel,
     onNext,
+    onNextYear,
     onPrevious,
+    onPreviousYear,
     onLevelClick,
     label,
     nextDisabled,
+    nextYearDisabled,
     previousDisabled,
+    previousYearDisabled,
     hasNextLevel,
     levelControlAriaLabel,
     withNext,
+    withNextYear,
     withPrevious,
+    withPreviousYear,
     headerControlsOrder,
     fullWidth,
     __staticSelector,
@@ -188,6 +231,32 @@ export const CalendarHeader = factory<CalendarHeaderFactory>((_props) => {
     </UnstyledButton>
   );
 
+  const previousYearControl = withPreviousYear && (
+    <UnstyledButton
+      {...getStyles('calendarHeaderControl')}
+      key="previous-year"
+      data-direction="previous"
+      aria-label={previousYearLabel}
+      onClick={onPreviousYear}
+      unstyled={unstyled}
+      onMouseDown={preventFocus}
+      disabled={previousYearDisabled}
+      data-disabled={previousYearDisabled || undefined}
+      tabIndex={__preventFocus || previousYearDisabled ? -1 : 0}
+      data-mantine-stop-propagation={__stopPropagation || undefined}
+    >
+      {previousYearIcon || (
+        <>
+          <CalendarHeaderYearChevrons
+            {...getStyles('calendarHeaderControlIcon')}
+            data-direction="previous"
+            size="45%"
+          />
+        </>
+      )}
+    </UnstyledButton>
+  );
+
   const levelControl = (
     <UnstyledButton
       component={hasNextLevel ? 'button' : 'div'}
@@ -230,15 +299,45 @@ export const CalendarHeader = factory<CalendarHeaderFactory>((_props) => {
     </UnstyledButton>
   );
 
+  const nextYearControl = withNextYear && (
+    <UnstyledButton
+      {...getStyles('calendarHeaderControl')}
+      key="next-year"
+      data-direction="next"
+      aria-label={nextYearLabel}
+      onClick={onNextYear}
+      unstyled={unstyled}
+      onMouseDown={preventFocus}
+      disabled={nextYearDisabled}
+      data-disabled={nextYearDisabled || undefined}
+      tabIndex={__preventFocus || nextYearDisabled ? -1 : 0}
+      data-mantine-stop-propagation={__stopPropagation || undefined}
+    >
+      {nextYearIcon || (
+        <CalendarHeaderYearChevrons
+          {...getStyles('calendarHeaderControlIcon')}
+          data-direction="next"
+          size="45%"
+        />
+      )}
+    </UnstyledButton>
+  );
+
   const controls = headerControlsOrder.map((control) => {
     if (control === 'previous') {
       return previousControl;
+    }
+    if (control === 'previous-year') {
+      return previousYearControl;
     }
     if (control === 'level') {
       return levelControl;
     }
     if (control === 'next') {
       return nextControl;
+    }
+    if (control === 'next-year') {
+      return nextYearControl;
     }
     return null;
   });

--- a/packages/@mantine/dates/src/components/CalendarHeader/CalendarHeaderYearChevrons.tsx
+++ b/packages/@mantine/dates/src/components/CalendarHeader/CalendarHeaderYearChevrons.tsx
@@ -1,0 +1,41 @@
+import { rem } from '@mantine/core';
+
+export interface CalendarHeaderYearChevronsProps extends React.ComponentProps<'svg'> {
+  /** Controls `width` and `height` of the icon, `16` by default */
+  size?: number | string;
+}
+
+export function CalendarHeaderYearChevrons({
+  style,
+  size = 16,
+  ...others
+}: CalendarHeaderYearChevronsProps) {
+  return (
+    <svg
+      viewBox="0 0 15 15"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ ...style, width: rem(size), height: rem(size), display: 'block' }}
+      {...others}
+    >
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M3.135 7.278a.5.5 0 0 1 .707-.023l3.658 3.43 3.658-3.43a.5.5 0 0 1 .684.73l-4 3.75a.5.5 0 0 1-.684 0l-4-3.75a.5.5 0 0 1-.023-.707Z"
+        clipRule="evenodd"
+      />
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M3.135 3.278a.5.5 0 0 1 .707-.023L7.5 6.685l3.658-3.43a.5.5 0 0 1 .684.73l-4 3.75a.5.5 0 0 1-.684 0l-4-3.75a.5.5 0 0 1-.023-.707Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+CalendarHeaderYearChevrons.displayName = '@mantine/core/CalendarHeaderYearChevrons';
+
+export namespace CalendarHeaderYearChevrons {
+  export type Props = CalendarHeaderYearChevronsProps;
+}

--- a/packages/@mantine/dates/src/components/DateInput/DateInput.tsx
+++ b/packages/@mantine/dates/src/components/DateInput/DateInput.tsx
@@ -49,7 +49,7 @@ export interface DateInputProps
     CalendarBaseProps,
     DecadeLevelSettings,
     YearLevelSettings,
-    MonthLevelSettings,
+    Omit<MonthLevelSettings, 'onNextYear' | 'onPreviousYear'>,
     StylesApiProps<DateInputFactory>,
     ElementProps<'input', 'size' | 'value' | 'defaultValue' | 'onChange'> {
   /** A function to parse user input and convert it to date string value */

--- a/packages/@mantine/dates/src/components/DecadeLevel/DecadeLevel.tsx
+++ b/packages/@mantine/dates/src/components/DecadeLevel/DecadeLevel.tsx
@@ -28,7 +28,23 @@ export interface DecadeLevelBaseSettings extends YearsListSettings {
 }
 
 export interface DecadeLevelSettings
-  extends DecadeLevelBaseSettings, Omit<CalendarHeaderSettings, 'onLevelClick' | 'hasNextLevel'> {}
+  extends
+    DecadeLevelBaseSettings,
+    Omit<
+      CalendarHeaderSettings,
+      | 'previousYearLabel'
+      | 'nextYearLabel'
+      | 'onNextYear'
+      | 'onPreviousYear'
+      | 'nextYearDisabled'
+      | 'previousYearDisabled'
+      | 'nextYearIcon'
+      | 'previousYearIcon'
+      | 'withNextYear'
+      | 'withPreviousYear'
+      | 'onLevelClick'
+      | 'hasNextLevel'
+    > {}
 
 export interface DecadeLevelProps
   extends

--- a/packages/@mantine/dates/src/components/MonthLevel/MonthLevel.story.tsx
+++ b/packages/@mantine/dates/src/components/MonthLevel/MonthLevel.story.tsx
@@ -14,9 +14,21 @@ function Wrapper(props: Partial<MonthLevelProps>) {
   const onPrevMonth = () =>
     setMonth((current) => dayjs(current).subtract(1, 'month').format('YYYY-MM-DD'));
 
+  const onNextYear = () =>
+    setMonth((current) => dayjs(current).add(1, 'year').format('YYYY-MM-DD'));
+  const onPrevYear = () =>
+    setMonth((current) => dayjs(current).subtract(1, 'year').format('YYYY-MM-DD'));
+
   return (
     <div>
-      <MonthLevel month={month} onNext={onNextMonth} onPrevious={onPrevMonth} {...props} />
+      <MonthLevel
+        month={month}
+        onNextYear={onNextYear}
+        onPreviousYear={onPrevYear}
+        onNext={onNextMonth}
+        onPrevious={onPrevMonth}
+        {...props}
+      />
     </div>
   );
 }
@@ -43,6 +55,14 @@ export function MinDate() {
 
 export function MaxDate() {
   return <Wrapper maxDate="2022-04-11" />;
+}
+
+export function MinDateYearsControl() {
+  return <Wrapper withNextYear withPreviousYear minDate="2022-04-11" />;
+}
+
+export function MaxDateYearsControl() {
+  return <Wrapper withNextYear withPreviousYear maxDate="2022-04-11" />;
 }
 
 export function Sizes() {

--- a/packages/@mantine/dates/src/components/MonthLevel/MonthLevel.tsx
+++ b/packages/@mantine/dates/src/components/MonthLevel/MonthLevel.tsx
@@ -88,18 +88,28 @@ export const MonthLevel = factory<MonthLevelFactory>((_props) => {
     __preventFocus,
     __stopPropagation,
     nextIcon,
+    nextYearIcon,
     previousIcon,
+    previousYearIcon,
     nextLabel,
+    nextYearLabel,
     previousLabel,
+    previousYearLabel,
     onNext,
+    onNextYear,
     onPrevious,
+    onPreviousYear,
     onLevelClick,
     nextDisabled,
+    nextYearDisabled,
     previousDisabled,
+    previousYearDisabled,
     hasNextLevel,
     levelControlAriaLabel,
     withNext,
+    withNextYear,
     withPrevious,
+    withPreviousYear,
     headerControlsOrder,
 
     // Other props
@@ -133,11 +143,25 @@ export const MonthLevel = factory<MonthLevelFactory>((_props) => {
         ? !dayjs(month).endOf('month').isBefore(maxDate)
         : false;
 
+  const _nextYearDisabled =
+    typeof nextYearDisabled === 'boolean'
+      ? nextYearDisabled
+      : maxDate
+        ? !dayjs(month).endOf('year').isBefore(maxDate)
+        : false;
+
   const _previousDisabled =
     typeof previousDisabled === 'boolean'
       ? previousDisabled
       : minDate
         ? !dayjs(month).startOf('month').isAfter(minDate)
+        : false;
+
+  const _previousYearDisabled =
+    typeof previousYearDisabled === 'boolean'
+      ? previousYearDisabled
+      : minDate
+        ? !dayjs(month).startOf('year').isAfter(minDate)
         : false;
 
   return (
@@ -153,18 +177,28 @@ export const MonthLevel = factory<MonthLevelFactory>((_props) => {
         __preventFocus={__preventFocus}
         __stopPropagation={__stopPropagation}
         nextIcon={nextIcon}
+        nextYearIcon={nextYearIcon}
         previousIcon={previousIcon}
+        previousYearIcon={previousYearIcon}
         nextLabel={nextLabel}
+        nextYearLabel={nextYearLabel}
         previousLabel={previousLabel}
+        previousYearLabel={previousYearLabel}
         onNext={onNext}
+        onNextYear={onNextYear}
         onPrevious={onPrevious}
+        onPreviousYear={onPreviousYear}
         onLevelClick={onLevelClick}
         nextDisabled={_nextDisabled}
+        nextYearDisabled={_nextYearDisabled}
         previousDisabled={_previousDisabled}
+        previousYearDisabled={_previousYearDisabled}
         hasNextLevel={hasNextLevel}
         levelControlAriaLabel={levelControlAriaLabel}
         withNext={withNext}
+        withNextYear={withNextYear}
         withPrevious={withPrevious}
+        withPreviousYear={withPreviousYear}
         headerControlsOrder={headerControlsOrder}
         fullWidth={fullWidth}
         {...stylesApiProps}

--- a/packages/@mantine/dates/src/components/MonthLevelGroup/MonthLevelGroup.story.tsx
+++ b/packages/@mantine/dates/src/components/MonthLevelGroup/MonthLevelGroup.story.tsx
@@ -17,6 +17,35 @@ export function Usage() {
   );
 }
 
+export function WithYearControls() {
+  return (
+    <div style={{ padding: 40 }}>
+      <div>1 month</div>
+      <MonthLevelGroup withNextYear withPreviousYear month="2022-04-11" mb={50} mt="xs" />
+
+      <div>2 months</div>
+      <MonthLevelGroup
+        withNextYear
+        withPreviousYear
+        numberOfColumns={2}
+        month="2022-04-11"
+        mb={50}
+        mt="xs"
+      />
+
+      <div>3 months</div>
+      <MonthLevelGroup
+        withNextYear
+        withPreviousYear
+        numberOfColumns={3}
+        month="2022-04-11"
+        mb={50}
+        mt="xs"
+      />
+    </div>
+  );
+}
+
 export function Sizes() {
   const sizes = (['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
     <MonthLevelGroup numberOfColumns={3} size={size} key={size} mt="xl" month="2022-04-11" />

--- a/packages/@mantine/dates/src/components/MonthLevelGroup/MonthLevelGroup.tsx
+++ b/packages/@mantine/dates/src/components/MonthLevelGroup/MonthLevelGroup.tsx
@@ -70,16 +70,26 @@ export const MonthLevelGroup = factory<MonthLevelGroupFactory>((_props) => {
     // CalendarHeader settings
     __preventFocus,
     nextIcon,
+    nextYearIcon,
     previousIcon,
+    previousYearIcon,
     nextLabel,
+    nextYearLabel,
     previousLabel,
+    previousYearLabel,
     onNext,
+    onNextYear,
     onPrevious,
+    onPreviousYear,
     onLevelClick,
     nextDisabled,
+    nextYearDisabled,
     previousDisabled,
+    previousYearDisabled,
     hasNextLevel,
     headerControlsOrder,
+    withNextYear,
+    withPreviousYear,
 
     // Other settings
     classNames,
@@ -111,6 +121,8 @@ export const MonthLevelGroup = factory<MonthLevelGroupFactory>((_props) => {
           month={currentMonth}
           withNext={monthIndex === numberOfColumns - 1}
           withPrevious={monthIndex === 0}
+          withNextYear={withNextYear && monthIndex === numberOfColumns - 1}
+          withPreviousYear={withPreviousYear && monthIndex === 0}
           monthLabelFormat={monthLabelFormat}
           __stopPropagation={__stopPropagation}
           __onDayClick={__onDayClick}
@@ -154,14 +166,22 @@ export const MonthLevelGroup = factory<MonthLevelGroupFactory>((_props) => {
           getDayAriaLabel={getDayAriaLabel}
           __preventFocus={__preventFocus}
           nextIcon={nextIcon}
+          nextYearIcon={nextYearIcon}
           previousIcon={previousIcon}
+          previousYearIcon={previousYearIcon}
           nextLabel={nextLabel}
+          nextYearLabel={nextYearLabel}
           previousLabel={previousLabel}
+          previousYearLabel={previousYearLabel}
           onNext={onNext}
+          onNextYear={onNextYear}
           onPrevious={onPrevious}
+          onPreviousYear={onPreviousYear}
           onLevelClick={onLevelClick}
           nextDisabled={nextDisabled}
+          nextYearDisabled={nextYearDisabled}
           previousDisabled={previousDisabled}
+          previousYearDisabled={previousYearDisabled}
           hasNextLevel={hasNextLevel}
           classNames={classNames}
           styles={styles}

--- a/packages/@mantine/dates/src/components/MonthPicker/MonthPicker.tsx
+++ b/packages/@mantine/dates/src/components/MonthPicker/MonthPicker.tsx
@@ -56,7 +56,10 @@ export interface MonthPickerBaseProps<Type extends DatePickerType = 'default'>
     PickerBaseProps<Type>,
     DecadeLevelBaseSettings,
     YearLevelBaseSettings,
-    Omit<CalendarBaseProps, 'onNextMonth' | 'onPreviousMonth' | 'hasNextLevel'> {
+    Omit<
+      CalendarBaseProps,
+      'withYearControls' | 'onNextMonth' | 'onPreviousMonth' | 'hasNextLevel'
+    > {
   /** Max level that user can go up to @default 'decade' */
   maxLevel?: CalendarLevel;
 

--- a/packages/@mantine/dates/src/components/YearLevel/YearLevel.tsx
+++ b/packages/@mantine/dates/src/components/YearLevel/YearLevel.tsx
@@ -24,7 +24,22 @@ export interface YearLevelBaseSettings extends MonthsListSettings {
   yearLabelFormat?: DateLabelFormat;
 }
 
-export interface YearLevelSettings extends YearLevelBaseSettings, CalendarHeaderSettings {}
+export interface YearLevelSettings
+  extends
+    YearLevelBaseSettings,
+    Omit<
+      CalendarHeaderSettings,
+      | 'previousYearLabel'
+      | 'nextYearLabel'
+      | 'onNextYear'
+      | 'onPreviousYear'
+      | 'nextYearDisabled'
+      | 'previousYearDisabled'
+      | 'nextYearIcon'
+      | 'previousYearIcon'
+      | 'withNextYear'
+      | 'withPreviousYear'
+    > {}
 
 export interface YearLevelProps
   extends

--- a/packages/@mantine/dates/src/components/YearPicker/YearPicker.tsx
+++ b/packages/@mantine/dates/src/components/YearPicker/YearPicker.tsx
@@ -52,7 +52,12 @@ export interface YearPickerBaseProps<Type extends DatePickerType = 'default'>
     DecadeLevelBaseSettings,
     Omit<
       CalendarBaseProps,
-      'onNextYear' | 'onPreviousYear' | 'onNextMonth' | 'onPreviousMonth' | 'hasNextLevel'
+      | 'withYearControls'
+      | 'onNextYear'
+      | 'onPreviousYear'
+      | 'onNextMonth'
+      | 'onPreviousMonth'
+      | 'hasNextLevel'
     > {
   /** Predefined values to pick from */
   presets?: YearPickerPreset<Type>[];


### PR DESCRIPTION
**Summary**
Adds quick previous/next year controls to @mantine/dates month view and exposes them through DatePicker docs/demos.

**Changes**
- Added withYearControls support for month-level calendar navigation
- Added year-control icons, labels, disabled states, and header ordering support
- Forwarded year-control props through picker wrappers
- Added docs and Storybook demos for the new controls

**Screenshots**

<img width="875" height="632" alt="image" src="https://github.com/user-attachments/assets/160284bc-399a-4a23-bc25-a8e142e8e09a" />