### PR TITLE
Fix appshell breakpoint 0

### DIFF
--- a/packages/@mantine/core/src/components/AppShell/AppShellMediaStyles/assign-aside-variables/assign-aside-variables.test.ts
+++ b/packages/@mantine/core/src/components/AppShell/AppShellMediaStyles/assign-aside-variables/assign-aside-variables.test.ts
@@ -2,7 +2,7 @@ import { DEFAULT_THEME, px, rem } from '../../../../core';
 import { AppShellProps } from '../../AppShell';
 import { assignAsideVariables } from './assign-aside-variables';
 
-function getTestObject(aside: AppShellProps['aside']) {
+function getTestObject(aside: AppShellProps['aside'], mode: 'fixed' | 'static' = 'fixed') {
   const baseStyles = {};
   const minMediaStyles = {};
   const maxMediaStyles = {};
@@ -13,7 +13,7 @@ function getTestObject(aside: AppShellProps['aside']) {
     maxMediaStyles,
     theme: DEFAULT_THEME,
     aside,
-    mode: 'fixed',
+    mode,
   });
 
   return { baseStyles, minMediaStyles, maxMediaStyles };
@@ -78,6 +78,17 @@ describe('@mantine/core/AppShell/assign-aside-variables', () => {
         lg: {
           '--app-shell-aside-width': rem(300),
           '--app-shell-aside-offset': rem(300),
+        },
+      });
+    });
+
+    it('supports breakpoint=0 in static mode', () => {
+      expect(getTestObject({ width: 100, breakpoint: 0 }, 'static').minMediaStyles).toStrictEqual({
+        0: {
+          '--app-shell-aside-position': 'sticky',
+          '--app-shell-aside-grid-row': '2',
+          '--app-shell-aside-grid-column': '3',
+          '--app-shell-main-column-end': '3',
         },
       });
     });

--- a/packages/@mantine/core/src/components/AppShell/AppShellMediaStyles/assign-aside-variables/assign-aside-variables.ts
+++ b/packages/@mantine/core/src/components/AppShell/AppShellMediaStyles/assign-aside-variables/assign-aside-variables.ts
@@ -26,7 +26,7 @@ export function assignAsideVariables({
   const collapsedAsideTransform = 'translateX(var(--app-shell-aside-width))';
   const collapsedAsideTransformRtl = 'translateX(calc(var(--app-shell-aside-width) * -1))';
 
-  if (aside?.breakpoint && !aside?.collapsed?.mobile) {
+  if (aside?.breakpoint !== undefined && !aside?.collapsed?.mobile) {
     maxMediaStyles[aside?.breakpoint] = maxMediaStyles[aside?.breakpoint] || {};
     if (mode === 'fixed') {
       maxMediaStyles[aside?.breakpoint]['--app-shell-aside-width'] = '100%';
@@ -58,7 +58,7 @@ export function assignAsideVariables({
     });
   }
 
-  if (aside?.breakpoint && mode === 'static') {
+  if (aside?.breakpoint !== undefined && mode === 'static') {
     minMediaStyles[aside.breakpoint] = minMediaStyles[aside.breakpoint] || {};
     minMediaStyles[aside.breakpoint]['--app-shell-aside-position'] = 'sticky';
     minMediaStyles[aside.breakpoint]['--app-shell-aside-grid-row'] = '2';

--- a/packages/@mantine/core/src/components/AppShell/AppShellMediaStyles/assign-navbar-variables/assign-navbar-variables.test.ts
+++ b/packages/@mantine/core/src/components/AppShell/AppShellMediaStyles/assign-navbar-variables/assign-navbar-variables.test.ts
@@ -2,7 +2,7 @@ import { DEFAULT_THEME, px, rem } from '../../../../core';
 import { AppShellProps } from '../../AppShell';
 import { assignNavbarVariables } from './assign-navbar-variables';
 
-function getTestObject(navbar: AppShellProps['navbar']) {
+function getTestObject(navbar: AppShellProps['navbar'], mode: 'fixed' | 'static' = 'fixed') {
   const baseStyles = {};
   const minMediaStyles = {};
   const maxMediaStyles = {};
@@ -13,7 +13,7 @@ function getTestObject(navbar: AppShellProps['navbar']) {
     maxMediaStyles,
     theme: DEFAULT_THEME,
     navbar,
-    mode: 'fixed',
+    mode,
   });
 
   return { baseStyles, minMediaStyles, maxMediaStyles };
@@ -77,6 +77,17 @@ describe('@mantine/core/AppShell/assign-navbar-variables', () => {
         lg: {
           '--app-shell-navbar-width': rem(300),
           '--app-shell-navbar-offset': rem(300),
+        },
+      });
+    });
+
+    it('supports breakpoint=0 in static mode', () => {
+      expect(getTestObject({ width: 100, breakpoint: 0 }, 'static').minMediaStyles).toStrictEqual({
+        0: {
+          '--app-shell-navbar-position': 'sticky',
+          '--app-shell-navbar-grid-row': '2',
+          '--app-shell-navbar-grid-column': '1',
+          '--app-shell-main-column-start': '2',
         },
       });
     });

--- a/packages/@mantine/core/src/components/AppShell/AppShellMediaStyles/assign-navbar-variables/assign-navbar-variables.ts
+++ b/packages/@mantine/core/src/components/AppShell/AppShellMediaStyles/assign-navbar-variables/assign-navbar-variables.ts
@@ -26,7 +26,7 @@ export function assignNavbarVariables({
   const collapsedNavbarTransform = 'translateX(calc(var(--app-shell-navbar-width) * -1))';
   const collapsedNavbarTransformRtl = 'translateX(var(--app-shell-navbar-width))';
 
-  if (navbar?.breakpoint && !navbar?.collapsed?.mobile) {
+  if (navbar?.breakpoint !== undefined && !navbar?.collapsed?.mobile) {
     maxMediaStyles[navbar?.breakpoint] = maxMediaStyles[navbar?.breakpoint] || {};
     maxMediaStyles[navbar?.breakpoint]['--app-shell-navbar-offset'] = '0px';
     maxMediaStyles[navbar?.breakpoint]['--app-shell-navbar-width'] = '100%';
@@ -65,7 +65,7 @@ export function assignNavbarVariables({
     });
   }
 
-  if (navbar?.breakpoint && mode === 'static') {
+  if (navbar?.breakpoint !== undefined && mode === 'static') {
     minMediaStyles[navbar.breakpoint] = minMediaStyles[navbar.breakpoint] || {};
     minMediaStyles[navbar.breakpoint]['--app-shell-navbar-position'] = 'sticky';
     minMediaStyles[navbar.breakpoint]['--app-shell-navbar-grid-row'] = '2';


### PR DESCRIPTION


Fixes #9039.

`breakpoint={0}` is a valid value, but it was ignored because `assignNavbarVariables` and `assignAsideVariables` used truthiness checks (`if (breakpoint)`) before generating CSS variables. As a result, in `mode="static"` the navbar/aside did not switch to the static layout and overlapped the main content.

This PR replaces those truthiness checks with explicit `undefined` checks so that `breakpoint={0}` is handled correctly while preserving the existing behavior for all other breakpoint values.

## Changes

* Replace truthiness checks with `breakpoint !== undefined` in:

  * `assignNavbarVariables`
  * `assignAsideVariables`
* Add regression tests for both navbar and aside to verify that `breakpoint={0}` generates the expected static layout CSS variables.

## Testing

* Added regression tests covering `breakpoint={0}` in static mode for:

  * `assign-navbar-variables.test.ts`
  * `assign-aside-variables.test.ts`
* Ran:

  * `yarn jest packages/@mantine/core/src/components/AppShell/AppShellMediaStyles/assign-navbar-variables/assign-navbar-variables.test.ts`
  * `yarn jest packages/@mantine/core/src/components/AppShell/AppShellMediaStyles/assign-aside-variables/assign-aside-variables.test.ts`
