### PR TITLE
fix(dates): preserve time format on paste

### DIFF
--- a/packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx
@@ -280,6 +280,20 @@ describe('@mantine/dates/TimePicker', () => {
     expect(spy).toHaveBeenLastCalledWith('13:34:00');
   });
 
+  it('does not include seconds in pasted value when withSeconds is false', async () => {
+    const spy = jest.fn();
+    render(<TimePicker {...defaultProps} format="24h" onChange={spy} />);
+
+    await userEvent.click(screen.getByLabelText('test-hours'));
+    expect(screen.getByLabelText('test-hours')).toHaveFocus();
+
+    await userEvent.paste('13:34:56');
+
+    expect(screen.getByLabelText('test-hours')).toHaveValue('13');
+    expect(screen.getByLabelText('test-minutes')).toHaveValue('34');
+    expect(spy).toHaveBeenLastCalledWith('13:34');
+  });
+
   it('calls onChange function when the value is valid (24h format)', async () => {
     const spy = jest.fn();
     render(<TimePicker {...defaultProps} withSeconds format="24h" onChange={spy} />);

--- a/packages/@mantine/dates/src/components/TimePicker/use-time-picker.ts
+++ b/packages/@mantine/dates/src/components/TimePicker/use-time-picker.ts
@@ -194,7 +194,9 @@ export function useTimePicker({
       acceptChange.current = false;
       const defaultMax = type === 'duration' ? undefined : '23:59:59';
       const clamped = clampTime(timeString.value, min || '00:00:00', max || defaultMax);
-      onChange?.(clamped.timeString);
+      onChange?.(
+        withSeconds ? clamped.timeString : clamped.timeString.split(':').slice(0, 2).join(':')
+      );
       setHours(parsedTime.hours);
       setMinutes(parsedTime.minutes);
       setSeconds(parsedTime.seconds);


### PR DESCRIPTION


Fixes #9041.

When `withSeconds={false}`, typing a time emits values in `HH:MM` format, but pasting a time emitted `HH:MM:00` because the paste handler forwarded the clamped value from `clampTime`, which always includes seconds.

This change preserves the expected value format by removing the seconds segment from the pasted value when `withSeconds` is disabled, while keeping the existing behavior unchanged when `withSeconds` is enabled.

## What changed

- Preserve `HH:MM` format for pasted values when `withSeconds={false}`.
- Keep existing `HH:MM:SS` behavior when `withSeconds={true}`.
- Add a regression test covering the paste behavior.