### PR TITLE
[@mantine/notifications] NotificationContainer: Fix autoClose timer leak and pause-on-hover

### DIFF
--- a/packages/@mantine/core/src/components/Tree/TreeNode.tsx
+++ b/packages/@mantine/core/src/components/Tree/TreeNode.tsx
@@ -20,7 +20,7 @@ function getValuesRange(anchor: string | null, value: string | undefined, flatVa
 }
 
 function isVisibleTreeNode(node: HTMLElement, root: Element) {
-  for (let current: HTMLElement | null = node; current && current !== root;) {
+  for (let current: HTMLElement | null = node; current && current !== root; ) {
     if (current.style.display === 'none') {
       return false;
     }

--- a/packages/@mantine/notifications/src/NotificationContainer.tsx
+++ b/packages/@mantine/notifications/src/NotificationContainer.tsx
@@ -86,6 +86,7 @@ export function NotificationContainer({
       return;
     }
 
+    cancelAutoClose();
     autoCloseTimeout.current = window.setTimeout(handleHide, autoCloseDuration);
   };
 

--- a/packages/@mantine/notifications/src/Notifications.test.tsx
+++ b/packages/@mantine/notifications/src/Notifications.test.tsx
@@ -594,4 +594,43 @@ describe('@mantine/core/Notifications', () => {
       expect(state.queue).toEqual([]);
     });
   });
+
+  it('does not close notification on hover when autoClose is enabled', () => {
+    jest.useFakeTimers();
+    const store = createNotificationsStore();
+
+    render(
+      <Notifications store={store} withinPortal={false} autoClose={3000} transitionDuration={10} />
+    );
+
+    act(() => {
+      notifications.show(
+        { id: 'hover-prevent-close', message: 'Hover me to pause autoClose' },
+        store
+      );
+    });
+
+    const notification = screen.getByRole('alert');
+
+    // Simulate hover
+    fireEvent.mouseEnter(notification);
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    // Notification should still be present because it is hovered
+    expect(store.getState().notifications).toHaveLength(1);
+    expect(screen.getByText('Hover me to pause autoClose')).toBeInTheDocument();
+
+    // Simulate mouse leave
+    fireEvent.mouseLeave(notification);
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    // Notification should now be closed
+    expect(store.getState().notifications).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
### Problem

A notification with a numeric `autoClose` duration closes at `mount + autoClose` even while hovered, making the `pauseResetOnHover` (pause/reset on hover) feature have no effect. 

**Root cause:** 
In `NotificationContainer`, `handleAutoClose()` re-arms the timer without clearing the previous one. Multiple effects call `handleAutoClose()` on mount, leaving orphaned timers active in the browser/Jest event loop. Hovering on a notification triggers `cancelAutoClose()`, which only clears the single active timer tracked in `autoCloseTimeout.current`; the orphaned timers still fire and dismiss the notification anyway.

### Solution

Modified the `handleAutoClose` function in `NotificationContainer` to clear the current timer stored in `autoCloseTimeout.current` (by invoking `cancelAutoClose()`) before scheduling a new one.

### Tests

- **Unit Tests**: Added a regression unit test in `Notifications.test.tsx` to assert that:
  - Hovering (`mouseEnter`) on a notification halts the auto-close timer.
  - Moving the cursor away (`mouseLeave`) resumes the auto-close timer correctly.
  
All tests, typechecking, style guidelines, and formatting rules passed locally.

This resolves [issue 9046.](https://github.com/mantinedev/mantine/issues/9046)