### PR TITLE
[@mantine/core] Tree: Fix keyboard navigation highlight on Safari

### DIFF
--- a/packages/@mantine/core/src/components/Tree/FlatTreeNode.tsx
+++ b/packages/@mantine/core/src/components/Tree/FlatTreeNode.tsx
@@ -99,7 +99,9 @@ export const FlatTreeNode = memo(function FlatTreeNode({
           : [];
         const index = nodes.indexOf(event.currentTarget as HTMLElement);
         if (index !== -1) {
-          nodes[index + 1]?.focus();
+          const nextNode = nodes[index + 1];
+          nextNode?.setAttribute('data-focus-ring', 'true');
+          nextNode?.focus();
         }
       } else if (hasChildren) {
         tree.expand(node.value);
@@ -117,6 +119,7 @@ export const FlatTreeNode = memo(function FlatTreeNode({
         const parentElement = root?.querySelector<HTMLElement>(
           `[role=treeitem][data-value="${CSS.escape(parent)}"]`
         );
+        parentElement?.setAttribute('data-focus-ring', 'true');
         parentElement?.focus();
       }
     }
@@ -140,7 +143,9 @@ export const FlatTreeNode = memo(function FlatTreeNode({
       }
 
       const nextIndex = event.nativeEvent.code === 'ArrowDown' ? index + 1 : index - 1;
-      nodes[nextIndex]?.focus();
+      const nextNode = nodes[nextIndex];
+      nextNode?.setAttribute('data-focus-ring', 'true');
+      nextNode?.focus();
     }
 
     if (event.nativeEvent.code === 'Space') {
@@ -188,6 +193,9 @@ export const FlatTreeNode = memo(function FlatTreeNode({
       data-level={level}
       tabIndex={tabIndex}
       onKeyDown={handleKeyDown}
+      onBlur={(event) => {
+        event.currentTarget.removeAttribute('data-focus-ring');
+      }}
     >
       {linesPath?.map((state, idx) => {
         if (state === 'none') {

--- a/packages/@mantine/core/src/components/Tree/FlatTreeNode.tsx
+++ b/packages/@mantine/core/src/components/Tree/FlatTreeNode.tsx
@@ -194,7 +194,9 @@ export const FlatTreeNode = memo(function FlatTreeNode({
       tabIndex={tabIndex}
       onKeyDown={handleKeyDown}
       onBlur={(event) => {
-        event.currentTarget.removeAttribute('data-focus-ring');
+        if (!event.currentTarget.contains(event.relatedTarget as HTMLElement)) {
+          event.currentTarget.removeAttribute('data-focus-ring');
+        }
       }}
     >
       {linesPath?.map((state, idx) => {

--- a/packages/@mantine/core/src/components/Tree/Tree.module.css
+++ b/packages/@mantine/core/src/components/Tree/Tree.module.css
@@ -22,7 +22,8 @@
   padding: 0;
   outline: 0;
 
-  &:focus-visible {
+  &:focus-visible,
+  &[data-focus-ring]:focus {
     > .label {
       outline: 2px solid var(--mantine-primary-color-filled);
       outline-offset: 2px;

--- a/packages/@mantine/core/src/components/Tree/TreeNode.tsx
+++ b/packages/@mantine/core/src/components/Tree/TreeNode.tsx
@@ -237,7 +237,9 @@ export function TreeNode({
       tabIndex={rootIndex === 0 ? 0 : -1}
       onKeyDown={handleKeyDown}
       onBlur={(event) => {
-        event.currentTarget.removeAttribute('data-focus-ring');
+        if (!event.currentTarget.contains(event.relatedTarget as HTMLElement)) {
+          event.currentTarget.removeAttribute('data-focus-ring');
+        }
       }}
       ref={ref}
     >

--- a/packages/@mantine/core/src/components/Tree/TreeNode.tsx
+++ b/packages/@mantine/core/src/components/Tree/TreeNode.tsx
@@ -20,7 +20,7 @@ function getValuesRange(anchor: string | null, value: string | undefined, flatVa
 }
 
 function isVisibleTreeNode(node: HTMLElement, root: Element) {
-  for (let current: HTMLElement | null = node; current && current !== root;) {
+  for (let current: HTMLElement | null = node; current && current !== root; ) {
     if (current.style.display === 'none') {
       return false;
     }
@@ -123,7 +123,9 @@ export function TreeNode({
       event.preventDefault();
 
       if (isExpanded) {
-        event.currentTarget.querySelector<HTMLLIElement>('[role=treeitem]')?.focus();
+        const nextNode = event.currentTarget.querySelector<HTMLLIElement>('[role=treeitem]');
+        nextNode?.setAttribute('data-focus-ring', 'true');
+        nextNode?.focus();
       } else {
         controller.expand(node.value);
       }
@@ -135,7 +137,12 @@ export function TreeNode({
       if (isExpanded && hasChildren) {
         controller.collapse(node.value);
       } else if (isSubtree) {
-        findElementAncestor(event.currentTarget as HTMLElement, '[role=treeitem]')?.focus();
+        const parentNode = findElementAncestor(
+          event.currentTarget as HTMLElement,
+          '[role=treeitem]'
+        );
+        parentNode?.setAttribute('data-focus-ring', 'true');
+        parentNode?.focus();
       }
     }
 
@@ -158,7 +165,9 @@ export function TreeNode({
       }
 
       const nextIndex = event.nativeEvent.code === 'ArrowDown' ? index + 1 : index - 1;
-      nodes[nextIndex]?.focus();
+      const nextNode = nodes[nextIndex];
+      nextNode?.setAttribute('data-focus-ring', 'true');
+      nextNode?.focus();
 
       if (event.shiftKey) {
         const selectNode = nodes[nextIndex];
@@ -227,6 +236,9 @@ export function TreeNode({
       data-level={level}
       tabIndex={rootIndex === 0 ? 0 : -1}
       onKeyDown={handleKeyDown}
+      onBlur={(event) => {
+        event.currentTarget.removeAttribute('data-focus-ring');
+      }}
       ref={ref}
     >
       {typeof renderNode === 'function' ? (


### PR DESCRIPTION
### Problem

On Safari, the focus ring outline on tree nodes does not display correctly during keyboard navigation. This is because Safari does not trigger the `:focus-visible` pseudo-class for programmatically focused (`.focus()`) elements that have `tabIndex={-1}`. Safari only triggers the focus ring programmatically for elements that are part of the tab order (`tabIndex >= 0`).

Additionally, since child tree nodes are DOM descendants of parent tree nodes (residing inside nested `<ul>` groups), moving focus from a child node back up to its parent triggers a bubbling `blur` event on the parent node. This causes the parent's `onBlur` handler to trigger and prematurely clear its focus ring state.

### Solution

Implemented a target-focused custom attribute style polyfill to resolve the Safari focus ring styling quirk:
- Prior to calling `.focus()` on a node during keyboard events, we set the custom attribute `data-focus-ring="true"`.
- Updated the styles in `Tree.module.css` to render the outline ring when the node matches `:focus-visible` OR when it matches `[data-focus-ring]:focus`. Scoping the selector with `:focus` guarantees only the active focused element shows the highlight.
- Managed the `onBlur` handler to only remove `data-focus-ring` when focus actually leaves the node's bounds (`!event.currentTarget.contains(event.relatedTarget)`), resolving the child-to-parent focus bubbling issue.

### Tests

- **Unit Tests**: All 63 tests in `Tree.test.tsx` pass successfully.
- **Manual Verification**: Verified inside Safari using Storybook that the focus ring moves continuously and matches expected `:focus-visible` behavior (hidden on mouse click, visible on arrow key navigation, only one active highlighted node, handles parent node focus transitions correctly).

This resolves [issue 9045.](https://github.com/mantinedev/mantine/issues/9045)