### PR TITLE
[@mantine/core] Menubar: Fix menu requiring two clicks to dismiss after switching menus with hover

### DIFF
--- a/packages/@mantine/core/src/components/Menubar/Menubar.test.tsx
+++ b/packages/@mantine/core/src/components/Menubar/Menubar.test.tsx
@@ -107,12 +107,14 @@ describe('@mantine/core/Menubar', () => {
     expectAllClosed();
   });
 
-  it('keeps only one menu open at a time and switches on click', async () => {
+  it('keeps only one menu open at a time and switches on click', () => {
     render(<TestContainer />);
-    await userEvent.click(getTarget('File'));
+    // fireEvent.click does not fire mouseover: covers clicks that are not
+    // preceded by hover (keyboard/assistive technology activation)
+    fireEvent.click(getTarget('File'));
     expectMenuOpen('New file');
 
-    await userEvent.click(getTarget('Edit'));
+    fireEvent.click(getTarget('Edit'));
     expectMenuOpen('Undo');
     expect(screen.queryByText('New file')).not.toBeInTheDocument();
     expect(screen.queryAllByRole('menu')).toHaveLength(1);
@@ -126,6 +128,18 @@ describe('@mantine/core/Menubar', () => {
     await userEvent.hover(getTarget('Edit'));
     expectMenuOpen('Undo');
     expect(screen.queryByText('New file')).not.toBeInTheDocument();
+  });
+
+  it('closes the menu on the first target click after switching menus with hover (trigger="click")', async () => {
+    render(<TestContainer />);
+    await userEvent.click(getTarget('File'));
+    expectMenuOpen('New file');
+
+    await userEvent.hover(getTarget('Edit'));
+    expectMenuOpen('Undo');
+
+    await userEvent.click(getTarget('Edit'));
+    expectAllClosed();
   });
 
   it('does not open a menu on hover when all menus are closed (trigger="click")', async () => {

--- a/packages/@mantine/core/src/components/Menubar/MenubarTarget/MenubarTarget.tsx
+++ b/packages/@mantine/core/src/components/Menubar/MenubarTarget/MenubarTarget.tsx
@@ -127,7 +127,10 @@ export function MenubarTarget(props: MenubarTargetProps) {
       ctx.openMenu(menuCtx.index, 'hover');
       ctx.setActiveIndex(menuCtx.index);
     } else if (ctx.openIndex !== null && ctx.openIndex !== menuCtx.index) {
-      ctx.openMenu(menuCtx.index, 'hover');
+      // Hover-switching with trigger="click" continues a click-driven interaction:
+      // keep 'click' as the open source so that the next click on the target
+      // closes the menu, same as a click-opened menu (desktop application pattern)
+      ctx.openMenu(menuCtx.index, 'click');
       ctx.setActiveIndex(menuCtx.index);
     }
   });


### PR DESCRIPTION
Fixes #9037

With `trigger="click"`, after opening a menu with a click and switching to a sibling menu by hovering its target, clicking that target did not dismiss the menu — a second click was required. Desktop menubars (e.g. macOS) dismiss on the first click.

**Root cause:** `MenubarTarget` skips closing on target click when the open source is `'hover'` — the guard exists so that with `trigger="hover"` the click that usually follows a hover-open does not immediately close the menu. But hover-switching between menus with `trigger="click"` also recorded `'hover'` as the open source, so the first click on the switched-open target fell into the reopen branch (only re-marking the source as `'click'`) and the second click closed it.

**Fix:** hover-switching with `trigger="click"` continues a click-driven interaction, so record `'click'` as the open source. The next click on the open target now closes the menu. `trigger="hover"` behavior is unchanged.

Note on the existing test: `userEvent.click` fires hover before clicking, like a real pointer, so in "keeps only one menu open at a time and switches on click" the second click now dismisses the menus (same as macOS: click File, move to Edit, click Edit — the menubar closes). Updated that test to use `fireEvent.click` so it still covers switching for clicks without a preceding hover (keyboard/assistive technology activation), and added a regression test for the hover-then-click dismissal.