### PR TITLE
[@mantine/core] Input: Lighter placeholder color for error state

### DIFF
--- a/packages/@mantine/core/src/components/Input/Input.module.css
+++ b/packages/@mantine/core/src/components/Input/Input.module.css
@@ -146,7 +146,7 @@
     }
 
     --input-color: var(--mantine-color-error);
-    --input-placeholder-color: var(--mantine-color-error);
+    --input-placeholder-color: var(--mantine-color-placeholder-error);
     --input-section-color: var(--mantine-color-error);
   }
 

--- a/packages/@mantine/core/src/components/Tree/TreeNode.tsx
+++ b/packages/@mantine/core/src/components/Tree/TreeNode.tsx
@@ -20,7 +20,7 @@ function getValuesRange(anchor: string | null, value: string | undefined, flatVa
 }
 
 function isVisibleTreeNode(node: HTMLElement, root: Element) {
-  for (let current: HTMLElement | null = node; current && current !== root;) {
+  for (let current: HTMLElement | null = node; current && current !== root; ) {
     if (current.style.display === 'none') {
       return false;
     }

--- a/packages/@mantine/core/src/core/MantineProvider/default-css-variables.css
+++ b/packages/@mantine/core/src/core/MantineProvider/default-css-variables.css
@@ -270,6 +270,7 @@
   --mantine-color-error: var(--mantine-color-red-8);
   --mantine-color-success: var(--mantine-color-teal-8);
   --mantine-color-placeholder: var(--mantine-color-dark-3);
+  --mantine-color-placeholder-error: alpha(var(--mantine-color-error), 0.65);
   --mantine-color-anchor: var(--mantine-color-blue-4);
   --mantine-color-default: var(--mantine-color-dark-6);
   --mantine-color-default-hover: var(--mantine-color-dark-5);
@@ -403,6 +404,7 @@
   --mantine-color-error: var(--mantine-color-red-6);
   --mantine-color-success: var(--mantine-color-teal-8);
   --mantine-color-placeholder: var(--mantine-color-gray-5);
+  --mantine-color-placeholder-error: alpha(var(--mantine-color-error), 0.65);
   --mantine-color-anchor: var(--mantine-color-blue-6);
   --mantine-color-default: var(--mantine-color-white);
   --mantine-color-default-hover: var(--mantine-color-gray-0);


### PR DESCRIPTION
**Summary**
When an input is in an error state, the placeholder and an actual invalid value are displayed in the same red color. This makes an empty field with a placeholder look very similar to a field that contains an invalid value, which can be confusing.

https://discord.com/channels/854810300876062770/861521000985264138/1525067554891104267

**Changes**
- New css variable: --mantine-color-placeholder-error
- Placeholder color is set to var(--mantine-color-placeholder-error) when data-error is present. 

**Considerations**
As the documentation states: 
```
If it is not possible to convert the color to rgba format (for example, if the color is a CSS variable), the function will use [color-mix](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix). Note that color-mix is not supported in some older browsers.
``` 

**Screenshots**
<img width="394" height="138" alt="image" src="https://github.com/user-attachments/assets/ed40231e-edea-4c63-b951-de3d890a2726" />
<img width="397" height="136" alt="image" src="https://github.com/user-attachments/assets/aae3a8e6-120b-4ce8-90e0-70f8b87317a2" />
