### PR TITLE
[@mantine/hooks] use-intersection: Accept a ref object for the root option

### DIFF
--- a/apps/mantine.dev/src/pages/hooks/use-intersection.mdx
+++ b/apps/mantine.dev/src/pages/hooks/use-intersection.mdx
@@ -25,6 +25,27 @@ useIntersection({
 });
 ```
 
+The `root` option also accepts a ref object. This is usually more convenient than
+a resolved element: the hook reads `ref.current` after the element is mounted, so
+you can pass the ref you already have without reading `.current` during render
+(which is `null` on the first render):
+
+```tsx
+import { useRef } from 'react';
+import { useIntersection } from '@mantine/hooks';
+
+function Demo() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { ref, entry } = useIntersection({ root: containerRef, threshold: 1 });
+
+  return (
+    <div ref={containerRef} style={{ overflowY: 'scroll', height: 300 }}>
+      <div ref={ref} />
+    </div>
+  );
+}
+```
+
 The hook returns a `ref` function that should be passed to the observed element, and the latest entry, as returned by the `IntersectionObserver`'s callback.
 See the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) documentation to learn everything about the options.
 
@@ -52,21 +73,29 @@ function Demo() {
 ## Definition
 
 ```tsx
+interface UseIntersectionOptions extends Omit<IntersectionObserverInit, 'root'> {
+  /** Element or ref object used as the observer root, defaults to the browser viewport */
+  root?: IntersectionObserverInit['root'] | React.RefObject<Element | null>;
+}
+
 interface UseIntersectionReturnValue<T> {
   ref: React.RefCallback<T | null>;
   entry: IntersectionObserverEntry | null;
 }
 
 function useIntersection<T extends HTMLElement = any>(
-  options?: IntersectionObserverInit,
+  options?: UseIntersectionOptions,
 ): UseIntersectionReturnValue<T>
 ```
 
 ## Exported types
 
-`UseIntersectionReturnValue` type is exported from `@mantine/hooks` package,
-you can import it in your application:
+`UseIntersectionOptions` and `UseIntersectionReturnValue` types are exported from
+`@mantine/hooks` package, you can import them in your application:
 
 ```tsx
-import type { UseIntersectionReturnValue } from '@mantine/hooks';
+import type {
+  UseIntersectionOptions,
+  UseIntersectionReturnValue,
+} from '@mantine/hooks';
 ```

--- a/packages/@docs/demos/src/demos/hooks/use-intersection/use-intersection.demo.usage.tsx
+++ b/packages/@docs/demos/src/demos/hooks/use-intersection/use-intersection.demo.usage.tsx
@@ -11,7 +11,7 @@ import { Text, Paper, Box } from '@mantine/core';
 function Demo() {
   const containerRef = useRef<HTMLDivElement>(null);
   const { ref, entry } = useIntersection({
-    root: containerRef.current,
+    root: containerRef,
     threshold: 1,
   });
 
@@ -41,7 +41,7 @@ function Demo() {
 function Demo() {
   const containerRef = useRef<HTMLDivElement>(null);
   const { ref, entry } = useIntersection({
-    root: containerRef.current,
+    root: containerRef,
     threshold: 1,
   });
 

--- a/packages/@mantine/hooks/src/index.ts
+++ b/packages/@mantine/hooks/src/index.ts
@@ -151,7 +151,10 @@ export type { UseHoverReturnValue } from './use-hover/use-hover';
 export type { UseIdleOptions } from './use-idle/use-idle';
 export type { UseInViewportReturnValue } from './use-in-viewport/use-in-viewport';
 export type { UseInputStateReturnValue } from './use-input-state/use-input-state';
-export type { UseIntersectionReturnValue } from './use-intersection/use-intersection';
+export type {
+  UseIntersectionOptions,
+  UseIntersectionReturnValue,
+} from './use-intersection/use-intersection';
 export type { UseIntervalOptions, UseIntervalReturnValue } from './use-interval/use-interval';
 export type {
   UseListStateReturnValue,

--- a/packages/@mantine/hooks/src/use-intersection/use-intersection.test.tsx
+++ b/packages/@mantine/hooks/src/use-intersection/use-intersection.test.tsx
@@ -1,0 +1,151 @@
+import { useRef } from 'react';
+import { act, render, renderHook } from '@testing-library/react';
+import { useIntersection } from './use-intersection';
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  callback: IntersectionObserverCallback;
+  options?: IntersectionObserverInit;
+  observed: Element[] = [];
+  disconnected = false;
+
+  constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+    this.callback = callback;
+    this.options = options;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(element: Element) {
+    this.observed.push(element);
+  }
+
+  unobserve() {}
+
+  disconnect() {
+    this.disconnected = true;
+  }
+
+  emit(entries: Partial<IntersectionObserverEntry>[]) {
+    act(() => {
+      this.callback(
+        entries as IntersectionObserverEntry[],
+        this as unknown as IntersectionObserver
+      );
+    });
+  }
+}
+
+const originalIntersectionObserver = window.IntersectionObserver;
+
+beforeEach(() => {
+  MockIntersectionObserver.instances = [];
+  window.IntersectionObserver = MockIntersectionObserver as any;
+});
+
+afterEach(() => {
+  window.IntersectionObserver = originalIntersectionObserver;
+});
+
+function lastObserver() {
+  return MockIntersectionObserver.instances[MockIntersectionObserver.instances.length - 1];
+}
+
+describe('@mantine/hooks/use-intersection', () => {
+  it('returns null entry before an element is observed', () => {
+    const { result } = renderHook(() => useIntersection());
+    expect(result.current.entry).toBe(null);
+  });
+
+  it('observes the element attached with the returned ref', () => {
+    const { result } = renderHook(() => useIntersection());
+    const element = document.createElement('div');
+
+    act(() => result.current.ref(element));
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+    expect(lastObserver().observed).toContain(element);
+  });
+
+  it('defaults root to the viewport when no root is provided', () => {
+    const { result } = renderHook(() => useIntersection());
+    act(() => result.current.ref(document.createElement('div')));
+    expect(lastObserver().options?.root).toBeUndefined();
+  });
+
+  it('passes a resolved element root through unchanged', () => {
+    const root = document.createElement('div');
+    const { result } = renderHook(() => useIntersection({ root }));
+    act(() => result.current.ref(document.createElement('div')));
+    expect(lastObserver().options?.root).toBe(root);
+  });
+
+  it('resolves a ref object passed as root to its current element', () => {
+    const root = document.createElement('div');
+    const { result } = renderHook(() => useIntersection({ root: { current: root } }));
+
+    act(() => result.current.ref(document.createElement('div')));
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+    expect(lastObserver().options?.root).toBe(root);
+  });
+
+  it('falls back to the viewport when the root ref current is null', () => {
+    const { result } = renderHook(() => useIntersection({ root: { current: null } }));
+    act(() => result.current.ref(document.createElement('div')));
+    expect(lastObserver().options?.root).toBe(null);
+  });
+
+  it('forwards rootMargin and threshold to the observer', () => {
+    const { result } = renderHook(() => useIntersection({ rootMargin: '10px', threshold: 0.5 }));
+    act(() => result.current.ref(document.createElement('div')));
+    expect(lastObserver().options?.rootMargin).toBe('10px');
+    expect(lastObserver().options?.threshold).toBe(0.5);
+  });
+
+  it('updates entry when the observer callback fires', () => {
+    const { result } = renderHook(() => useIntersection());
+    act(() => result.current.ref(document.createElement('div')));
+
+    lastObserver().emit([{ isIntersecting: true } as IntersectionObserverEntry]);
+    expect(result.current.entry?.isIntersecting).toBe(true);
+  });
+
+  it('disconnects the observer and resets entry when the element is detached', () => {
+    const { result } = renderHook(() => useIntersection());
+    act(() => result.current.ref(document.createElement('div')));
+    const observer = lastObserver();
+    observer.emit([{ isIntersecting: true } as IntersectionObserverEntry]);
+    expect(result.current.entry).not.toBe(null);
+
+    act(() => result.current.ref(null));
+    expect(observer.disconnected).toBe(true);
+    expect(result.current.entry).toBe(null);
+  });
+
+  it('disconnects the observer on unmount', () => {
+    const { result, unmount } = renderHook(() => useIntersection());
+    act(() => result.current.ref(document.createElement('div')));
+    const observer = lastObserver();
+    unmount();
+    expect(observer.disconnected).toBe(true);
+  });
+
+  it('roots to the container ref element even though child refs attach before parents', () => {
+    function Demo() {
+      const containerRef = useRef<HTMLDivElement>(null);
+      const { ref } = useIntersection({ root: containerRef });
+      return (
+        <div ref={containerRef} data-testid="container">
+          <div ref={ref} data-testid="target" />
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<Demo />);
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+    expect(lastObserver().options?.root).toBe(getByTestId('container'));
+    expect(lastObserver().observed).toContain(getByTestId('target'));
+  });
+});

--- a/packages/@mantine/hooks/src/use-intersection/use-intersection.ts
+++ b/packages/@mantine/hooks/src/use-intersection/use-intersection.ts
@@ -1,41 +1,59 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseIntersectionOptions extends Omit<IntersectionObserverInit, 'root'> {
+  /** Element or ref object used as the observer root, defaults to the browser viewport */
+  root?: IntersectionObserverInit['root'] | React.RefObject<Element | null>;
+}
 
 export interface UseIntersectionReturnValue<T> {
   ref: React.RefCallback<T | null>;
   entry: IntersectionObserverEntry | null;
 }
 
+function resolveRoot(root: UseIntersectionOptions['root']): IntersectionObserverInit['root'] {
+  if (root && 'current' in root) {
+    return root.current;
+  }
+
+  return root;
+}
+
 export function useIntersection<T extends HTMLElement = any>(
-  options?: IntersectionObserverInit
+  options?: UseIntersectionOptions
 ): UseIntersectionReturnValue<T> {
   const [entry, setEntry] = useState<IntersectionObserverEntry | null>(null);
+  const [element, setElement] = useState<T | null>(null);
 
-  const observer = useRef<IntersectionObserver | null>(null);
+  const ref = useCallback<React.RefCallback<T | null>>((node) => {
+    setElement(node);
+  }, []);
 
-  const ref: React.RefCallback<T | null> = useCallback(
-    (element) => {
-      if (observer.current) {
-        observer.current.disconnect();
-        observer.current = null;
-      }
+  const root = resolveRoot(options?.root);
 
-      if (element === null) {
-        setEntry(null);
-        return;
-      }
+  useEffect(() => {
+    if (element === null) {
+      setEntry(null);
+      return undefined;
+    }
 
-      observer.current = new IntersectionObserver(([_entry]) => {
+    const observer = new IntersectionObserver(
+      ([_entry]) => {
         setEntry(_entry);
-      }, options);
+      },
+      { ...options, root }
+    );
 
-      observer.current.observe(element);
-    },
-    [options?.rootMargin, options?.root, options?.threshold]
-  );
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [element, root, options?.rootMargin, options?.threshold]);
 
   return { ref, entry };
 }
 
 export namespace useIntersection {
+  export type Options = UseIntersectionOptions;
   export type ReturnValue<T> = UseIntersectionReturnValue<T>;
 }


### PR DESCRIPTION
## Closes #9026

`useIntersection`'s `root` option previously only accepted a resolved `Element`, so the idiomatic React source — a ref — couldn't be used directly. `ref.current` is `null` on the first render and reading it during render is fragile, which is exactly what the documented usage example did (`root: containerRef.current`).

This mirrors #9031, which added ref support to `useScrollSpy`'s `scrollHost`.

## The catch (why this isn't a one-liner)

`useScrollSpy` attaches its listener inside a `useEffect`, so `ref.current` is already populated when it runs. `useIntersection` is different: it built the `IntersectionObserver` **synchronously inside the target's callback ref**. Because React attaches child refs before their parent's, a `root` ref is still `null` at that moment — so naively resolving `root.current` there would reproduce the exact bug, just relocated.

The fix moves observer creation into a `useEffect` (runs after all refs are committed), tracking the observed element in state via the callback ref. As a bonus this removes the old throwaway viewport-rooted observer + extra render that the previous `root: ref.current` pattern caused.

## Changes

- Widen the option type via a new, exported `UseIntersectionOptions` (`root?: IntersectionObserverInit['root'] | React.RefObject<Element | null>`).
- Resolve a ref object to its element before constructing the observer; passing a resolved `Element` is unchanged.
- Add the hook's **first test file** — root resolution (element / ref / null-current / viewport default), option forwarding, entry updates, cleanup on detach/unmount, and an end-to-end render proving the ref root resolves correctly despite child-before-parent ref attachment order.
- Update the docs and usage demo to pass the ref directly (`root: containerRef`).

## Notes

- Backwards compatible — existing `Element` / no-arg callers are unaffected.
- The usage-demo update overlaps with the docs-only PR #9027; this supersedes it by demonstrating the new ref API directly.

## Verification

- `use-intersection` tests: 11 passing
- `tsc --noEmit` clean, `oxlint` clean, formatted
- `@mantine/hooks` builds (incl. `.d.ts` generation)
