### PR TITLE
[@mantine/core] Modal/Drawer: Add keepMountedMode prop

### DIFF
--- a/packages/@mantine/core/src/components/Drawer/Drawer.story.tsx
+++ b/packages/@mantine/core/src/components/Drawer/Drawer.story.tsx
@@ -1,8 +1,10 @@
+import { useEffect, useRef, useState } from 'react';
 import { useDisclosure } from '@mantine/hooks';
 import { Button } from '../Button';
 import { useModalsStack } from '../Modal';
 import { ScrollArea } from '../ScrollArea';
 import { Tabs } from '../Tabs';
+import { Stack as MantineStack } from '../Stack';
 import { Drawer } from './Drawer';
 
 export default { title: 'Drawer' };
@@ -197,6 +199,86 @@ export function Stack() {
           </Button>
         </Drawer>
       </Drawer.Stack>
+    </div>
+  );
+}
+
+function Timer() {
+  const [seconds, setSeconds] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => setSeconds((s) => s + 1), 1000);
+    return () => clearInterval(interval);
+  }, []);
+  return (
+    <div style={{ padding: 10, background: 'rgba(0,0,0,0.05)', borderRadius: 4 }}>
+      Timer running: {seconds}s
+    </div>
+  );
+}
+
+export function KeepMountedMode() {
+  const [displayNoneOpened, setDisplayNoneOpened] = useState(false);
+  const [activityOpened, setActivityOpened] = useState(false);
+  const refDisplayNone = useRef<HTMLInputElement>(null);
+  const refActivity = useRef<HTMLInputElement>(null);
+  const [refDisplayNoneVal, setRefDisplayNoneVal] = useState<string>('null');
+  const [refActivityVal, setRefActivityVal] = useState<string>('null');
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setRefDisplayNoneVal(refDisplayNone.current ? 'active input ref' : 'null');
+      setRefActivityVal(refActivity.current ? 'active input ref' : 'null');
+    }, 100);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div style={{ padding: 40, maxWidth: 600 }}>
+      <h3>keepMountedMode="display-none"</h3>
+      <p style={{ fontSize: 13, color: 'gray' }}>
+        Timer keeps running and refs remain active when the drawer is closed.
+      </p>
+      <Button onClick={() => setDisplayNoneOpened(true)}>Open display-none Drawer</Button>
+      <div style={{ marginTop: 10, fontSize: 14 }}>
+        <strong>Current ref state:</strong> {refDisplayNoneVal}
+      </div>
+
+      <Drawer
+        opened={displayNoneOpened}
+        onClose={() => setDisplayNoneOpened(false)}
+        title="keepMountedMode='display-none'"
+        keepMounted
+        keepMountedMode="display-none"
+      >
+        <MantineStack>
+          <Timer />
+          <input ref={refDisplayNone} placeholder="Type here..." />
+        </MantineStack>
+      </Drawer>
+
+      <hr style={{ margin: '40px 0', border: 'none', borderTop: '1px solid #ccc' }} />
+
+      <h3>keepMountedMode="activity" (default)</h3>
+      <p style={{ fontSize: 13, color: 'gray' }}>
+        Timer pauses/resets and refs are set to null when the drawer is closed.
+      </p>
+      <Button onClick={() => setActivityOpened(true)}>Open activity Drawer</Button>
+      <div style={{ marginTop: 10, fontSize: 14 }}>
+        <strong>Current ref state:</strong> {refActivityVal}
+      </div>
+
+      <Drawer
+        opened={activityOpened}
+        onClose={() => setActivityOpened(false)}
+        title="keepMountedMode='activity'"
+        keepMounted
+        keepMountedMode="activity"
+      >
+        <MantineStack>
+          <Timer />
+          <input ref={refActivity} placeholder="Type here..." />
+        </MantineStack>
+      </Drawer>
     </div>
   );
 }

--- a/packages/@mantine/core/src/components/Drawer/Drawer.test.tsx
+++ b/packages/@mantine/core/src/components/Drawer/Drawer.test.tsx
@@ -72,6 +72,24 @@ describe('@mantine/core/Drawer', () => {
     expect(Drawer.Title).toBe(DrawerTitle);
     expect(Drawer.CloseButton).toBe(DrawerCloseButton);
   });
+
+  it('applies display: none style when keepMountedMode is display-none and opened is false (transitionDuration is 0)', () => {
+    const { container } = render(
+      <Drawer
+        {...defaultProps}
+        opened={false}
+        keepMounted
+        keepMountedMode="display-none"
+        transitionProps={{ duration: 0 }}
+      >
+        test-drawer
+      </Drawer>
+    );
+
+    expect(container.querySelector('.mantine-Drawer-content')).toHaveStyle({
+      display: 'none',
+    });
+  });
 });
 
 describe('@mantine/core/DrawerRoot', () => {

--- a/packages/@mantine/core/src/components/Drawer/Drawer.test.tsx
+++ b/packages/@mantine/core/src/components/Drawer/Drawer.test.tsx
@@ -81,12 +81,30 @@ describe('@mantine/core/Drawer', () => {
         keepMounted
         keepMountedMode="display-none"
         transitionProps={{ duration: 0 }}
-      >
-        test-drawer
-      </Drawer>
+      />,
+      undefined,
+      { env: 'default' }
     );
 
     expect(container.querySelector('.mantine-Drawer-content')).toHaveStyle({
+      display: 'none',
+    });
+  });
+
+  it('does not apply display: none style when keepMountedMode is activity and opened is false (transitionDuration is 0)', () => {
+    const { container } = render(
+      <Drawer
+        {...defaultProps}
+        opened={false}
+        keepMounted
+        keepMountedMode="activity"
+        transitionProps={{ duration: 0 }}
+      />,
+      undefined,
+      { env: 'default' }
+    );
+
+    expect(container.querySelector('.mantine-Drawer-content')).not.toHaveStyle({
       display: 'none',
     });
   });

--- a/packages/@mantine/core/src/components/Modal/Modal.story.tsx
+++ b/packages/@mantine/core/src/components/Modal/Modal.story.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import { useDisclosure } from '@mantine/hooks';
 import { Button } from '../Button';
 import { Card } from '../Card';
@@ -335,5 +336,85 @@ export function WithScrollArea() {
         Open modal
       </Button>
     </>
+  );
+}
+
+function Timer() {
+  const [seconds, setSeconds] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => setSeconds((s) => s + 1), 1000);
+    return () => clearInterval(interval);
+  }, []);
+  return (
+    <div style={{ padding: 10, background: 'rgba(0,0,0,0.05)', borderRadius: 4 }}>
+      Timer running: {seconds}s
+    </div>
+  );
+}
+
+export function KeepMountedMode() {
+  const [displayNoneOpened, setDisplayNoneOpened] = useState(false);
+  const [activityOpened, setActivityOpened] = useState(false);
+  const refDisplayNone = useRef<HTMLInputElement>(null);
+  const refActivity = useRef<HTMLInputElement>(null);
+  const [refDisplayNoneVal, setRefDisplayNoneVal] = useState<string>('null');
+  const [refActivityVal, setRefActivityVal] = useState<string>('null');
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setRefDisplayNoneVal(refDisplayNone.current ? 'active input ref' : 'null');
+      setRefActivityVal(refActivity.current ? 'active input ref' : 'null');
+    }, 100);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div style={{ padding: 40, maxWidth: 600 }}>
+      <h3>keepMountedMode="display-none"</h3>
+      <p style={{ fontSize: 13, color: 'gray' }}>
+        Timer keeps running and refs remain active when the modal is closed.
+      </p>
+      <Button onClick={() => setDisplayNoneOpened(true)}>Open display-none Modal</Button>
+      <div style={{ marginTop: 10, fontSize: 14 }}>
+        <strong>Current ref state:</strong> {refDisplayNoneVal}
+      </div>
+
+      <Modal
+        opened={displayNoneOpened}
+        onClose={() => setDisplayNoneOpened(false)}
+        title="keepMountedMode='display-none'"
+        keepMounted
+        keepMountedMode="display-none"
+      >
+        <Stack>
+          <Timer />
+          <input ref={refDisplayNone} placeholder="Type here..." />
+        </Stack>
+      </Modal>
+
+      <hr style={{ margin: '40px 0', border: 'none', borderTop: '1px solid #ccc' }} />
+
+      <h3>keepMountedMode="activity" (default)</h3>
+      <p style={{ fontSize: 13, color: 'gray' }}>
+        Timer pauses/resets and refs are set to null when the modal is closed.
+      </p>
+      <Button onClick={() => setActivityOpened(true)}>Open activity Modal</Button>
+      <div style={{ marginTop: 10, fontSize: 14 }}>
+        <strong>Current ref state:</strong> {refActivityVal}
+      </div>
+
+      <Modal
+        opened={activityOpened}
+        onClose={() => setActivityOpened(false)}
+        title="keepMountedMode='activity'"
+        keepMounted
+        keepMountedMode="activity"
+      >
+        <Stack>
+          <Timer />
+          <input ref={refActivity} placeholder="Type here..." />
+        </Stack>
+      </Modal>
+    </div>
   );
 }

--- a/packages/@mantine/core/src/components/Modal/Modal.test.tsx
+++ b/packages/@mantine/core/src/components/Modal/Modal.test.tsx
@@ -88,6 +88,24 @@ describe('@mantine/core/Modal', () => {
     expect(Modal.Title).toBe(ModalTitle);
     expect(Modal.CloseButton).toBe(ModalCloseButton);
   });
+
+  it('applies display: none style when keepMountedMode is display-none and opened is false (transitionDuration is 0)', () => {
+    const { container } = render(
+      <Modal
+        {...defaultProps}
+        opened={false}
+        keepMounted
+        keepMountedMode="display-none"
+        transitionProps={{ duration: 0 }}
+      >
+        test-modal
+      </Modal>
+    );
+
+    expect(container.querySelector('.mantine-Modal-content')).toHaveStyle({
+      display: 'none',
+    });
+  });
 });
 
 describe('@mantine/core/ModalRoot', () => {

--- a/packages/@mantine/core/src/components/Modal/Modal.test.tsx
+++ b/packages/@mantine/core/src/components/Modal/Modal.test.tsx
@@ -97,12 +97,30 @@ describe('@mantine/core/Modal', () => {
         keepMounted
         keepMountedMode="display-none"
         transitionProps={{ duration: 0 }}
-      >
-        test-modal
-      </Modal>
+      />,
+      undefined,
+      { env: 'default' }
     );
 
     expect(container.querySelector('.mantine-Modal-content')).toHaveStyle({
+      display: 'none',
+    });
+  });
+
+  it('does not apply display: none style when keepMountedMode is activity and opened is false (transitionDuration is 0)', () => {
+    const { container } = render(
+      <Modal
+        {...defaultProps}
+        opened={false}
+        keepMounted
+        keepMountedMode="activity"
+        transitionProps={{ duration: 0 }}
+      />,
+      undefined,
+      { env: 'default' }
+    );
+
+    expect(container.querySelector('.mantine-Modal-content')).not.toHaveStyle({
       display: 'none',
     });
   });

--- a/packages/@mantine/core/src/components/ModalBase/ModalBase.tsx
+++ b/packages/@mantine/core/src/components/ModalBase/ModalBase.tsx
@@ -23,6 +23,13 @@ export interface ModalBaseProps extends BoxProps, ElementProps<'div', 'title'> {
   /** If set modal/drawer is not unmounted from the DOM when hidden. `display: none` styles are applied instead. @default false */
   keepMounted?: boolean;
 
+  /** Controls how the modal/drawer is hidden when `keepMounted` is set:
+   * `'activity'` - hidden with React 19 `Activity` component,
+   * `'display-none'` - hidden with `display: none` styles
+   * @default 'activity'
+   */
+  keepMountedMode?: 'activity' | 'display-none';
+
   /** Controls opened state */
   opened: boolean;
 
@@ -83,6 +90,7 @@ export interface ModalBaseProps extends BoxProps, ElementProps<'div', 'title'> {
 
 export function ModalBase({
   keepMounted,
+  keepMountedMode = 'activity',
   opened,
   onClose,
   id,
@@ -119,7 +127,7 @@ export function ModalBase({
           closeOnClickOutside,
           onExitTransitionEnd,
           onEnterTransitionEnd,
-          transitionProps: { ...transitionProps, keepMounted },
+          transitionProps: { ...transitionProps, keepMounted, keepMountedMode },
           getTitleId: () => `${_id}-title`,
           getBodyId: () => `${_id}-body`,
           titleMounted,

--- a/packages/@mantine/core/src/components/Transition/Transition.tsx
+++ b/packages/@mantine/core/src/components/Transition/Transition.tsx
@@ -10,8 +10,8 @@ export interface TransitionProps {
 
   /**
    * Controls how the element is hidden when `keepMounted` is set:
-   * `'activity'` – hidden with React 19 `Activity` component,
-   * `'display-none'` – hidden with `display: none` styles
+   * `'activity'` - hidden with React 19 `Activity` component,
+   * `'display-none'` - hidden with `display: none` styles
    * @default 'activity'
    */
   keepMountedMode?: 'activity' | 'display-none';


### PR DESCRIPTION
### Problem

[Issue #8934](https://github.com/mantinedev/mantine/issues/8934) was closed by the merge of [PR #9021](https://github.com/mantinedev/mantine/pull/9021), which introduced the `keepMountedMode` prop to Accordion and Collapse. However, the issue was closed prematurely since `Modal` and `Drawer` were not yet updated with the new prop and still had no option to bypass React 19's `<Activity>` component. 

As a result, refs referring to elements within `Modal` and `Drawer` components with `keepMounted` still get torn down and set to `null` when closed, and background side-effects inside them are paused/reset.

### Solution

Extended the `keepMountedMode` prop with values `"activity" | "display-none"` (defaulting to `"activity"`) to `ModalBase` and propagated it to `ModalRoot`, `Modal`, `DrawerRoot`, and `Drawer`.

* `keepMountedMode="activity"` (default): Hides the content using React 19's `<Activity>` component, preserving performance by pausing hidden effects.
* `keepMountedMode="display-none"`: Hides the content using standard CSS `display: none` styling instead. This keeps the React component tree fully active in the reconciliation cycle, preventing refs from being set to `null` and allowing all background effects and processes to run normally when closed.

### Tests

* Added unit tests to `Modal.test.tsx` and `Drawer.test.tsx` asserting that setting `keepMounted={true}` and `keepMountedMode="display-none"` correctly applies the CSS `display: none` style on the content wrapper when closed.
* Added comparative storybook demos to `Modal.story.tsx` and `Drawer.story.tsx` featuring active timers and ref state counters to easily verify both modes visually.
* All tests compile, formatting and typechecking are clean, and the complete verification suite passes successfully.

Refers to [issue #8934](https://github.com/mantinedev/mantine/issues/8934).