### PR TITLE
[@mantine/core] PinInput: Fix incorrect @default JSDoc for gap prop

### DIFF
--- a/packages/@mantine/core/src/components/PinInput/PinInput.tsx
+++ b/packages/@mantine/core/src/components/PinInput/PinInput.tsx
@@ -43,7 +43,7 @@ export interface PinInputProps
   /** Hidden input `form` attribute */
   form?: string;
 
-  /** Key of `theme.spacing` or any valid CSS value to set `gap` between inputs, numbers are converted to rem @default 'md' */
+  /** Key of `theme.spacing` or any valid CSS value to set `gap` between inputs, numbers are converted to rem @default 'sm' */
   gap?: MantineSpacing;
 
   /** Key of `theme.radius` or any valid CSS value to set `border-radius`, numbers are converted to rem @default theme.defaultRadius */


### PR DESCRIPTION
The `gap` prop JSDoc documents `@default 'md'`, but the component's `defaultProps` sets `gap: 'sm'`.

```ts
// packages/@mantine/core/src/components/PinInput/PinInput.tsx
const defaultProps = {
  gap: 'sm',
  // ...
} satisfies Partial<PinInputProps>;
```

The `@default` annotation feeds the auto-generated props table on mantine.dev, so this corrects the documented default to match the actual value (`'sm'`). Docs-only change, no runtime behavior affected.