### PR TITLE
[@mantine/charts] PieChart: Fix incorrect @default JSDoc for withTooltip prop

### DIFF
--- a/packages/@mantine/charts/src/PieChart/PieChart.tsx
+++ b/packages/@mantine/charts/src/PieChart/PieChart.tsx
@@ -48,7 +48,7 @@ export interface PieChartProps
   /** Data used to render chart */
   data: PieChartCell[];
 
-  /** Determines whether the tooltip should be displayed when one of the section is hovered @default true */
+  /** Determines whether the tooltip should be displayed when one of the section is hovered @default false */
   withTooltip?: boolean;
 
   /** Determines whether the legend should be displayed @default false */


### PR DESCRIPTION
The `withTooltip` prop JSDoc documents `@default true`, but the component's `defaultProps` sets `withTooltip: false`.

```ts
// packages/@mantine/charts/src/PieChart/PieChart.tsx
const defaultProps = {
  withTooltip: false,
  // ...
} satisfies Partial<PieChartProps>;
```

The `@default` annotation feeds the auto-generated props table on mantine.dev, so this corrects the documented default to match the actual value (`false`). Docs-only change, no runtime behavior affected.