### PR TITLE
[@mantine/core] ColorInput: Add support for fullWidth prop

### DIFF
--- a/packages/@mantine/core/src/components/ColorInput/ColorInput.story.tsx
+++ b/packages/@mantine/core/src/components/ColorInput/ColorInput.story.tsx
@@ -21,3 +21,11 @@ export function Unstyled() {
     </div>
   );
 }
+
+export function FullWidth() {
+  return (
+    <div style={{ padding: 40 }}>
+      <ColorInput label="Full width color picker" fullWidth popoverProps={{ opened: true }} />
+    </div>
+  );
+}

--- a/packages/@mantine/core/src/components/ColorInput/ColorInput.test.tsx
+++ b/packages/@mantine/core/src/components/ColorInput/ColorInput.test.tsx
@@ -1,4 +1,6 @@
+import { render } from '@testing-library/react';
 import { inputDefaultProps, inputStylesApiSelectors, tests } from '@mantine-tests/core';
+import { MantineProvider } from '../../core';
 import { __InputStylesNames } from '../Input';
 import { ColorInput, ColorInputProps } from './ColorInput';
 
@@ -33,5 +35,16 @@ describe('@mantine/core/ColorInput', () => {
     component: ColorInput,
     props: defaultProps,
     componentName: 'ColorInput',
+  });
+
+  it('passes fullWidth prop to ColorPicker', () => {
+    const { container } = render(
+      <MantineProvider>
+        <ColorInput popoverProps={{ opened: true, withinPortal: false }} fullWidth />
+      </MantineProvider>
+    );
+    expect(
+      container.querySelector('.mantine-ColorInput-dropdown [data-full-width]')
+    ).toBeInTheDocument();
   });
 });

--- a/packages/@mantine/core/src/components/ColorInput/ColorInput.tsx
+++ b/packages/@mantine/core/src/components/ColorInput/ColorInput.tsx
@@ -238,6 +238,7 @@ export const ColorInput = factory<ColorInputFactory>((_props) => {
         position="bottom-start"
         offset={5}
         opened={dropdownOpened}
+        width={fullWidth ? 'target' : undefined}
         {...popoverProps}
         classNames={resolvedClassNames}
         styles={resolvedStyles}

--- a/packages/@mantine/core/src/components/ColorInput/ColorInput.tsx
+++ b/packages/@mantine/core/src/components/ColorInput/ColorInput.tsx
@@ -139,6 +139,7 @@ export const ColorInput = factory<ColorInputFactory>((_props) => {
     leftSection,
     rightSection,
     swatchesPerRow,
+    fullWidth,
     ...others
   } = useInputProps('ColorInput', defaultProps, _props);
 
@@ -307,6 +308,7 @@ export const ColorInput = factory<ColorInputFactory>((_props) => {
             classNames={resolvedClassNames}
             onColorSwatchClick={() => closeOnColorSwatchClick && setDropdownOpened(false)}
             attributes={wrapperProps.attributes}
+            fullWidth={fullWidth}
           />
         </Popover.Dropdown>
       </Popover>

--- a/packages/@mantine/core/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/@mantine/core/src/components/ColorPicker/ColorPicker.tsx
@@ -77,6 +77,9 @@ export interface __ColorPickerProps {
 
   /** Component size @default 'md' */
   size?: MantineSize | (string & {});
+
+  /** If set, the component takes 100% width of its container @default false */
+  fullWidth?: boolean;
 }
 
 export interface ColorPickerProps
@@ -86,9 +89,6 @@ export interface ColorPickerProps
     StylesApiProps<ColorPickerFactory>,
     ElementProps<'div', 'onChange' | 'value' | 'defaultValue'> {
   __staticSelector?: string;
-
-  /** If set, the component takes 100% width of its container @default false */
-  fullWidth?: boolean;
 
   /** If set, interactive elements (sliders thumbs and swatches) are focusable with keyboard @default true */
   focusable?: boolean;


### PR DESCRIPTION
### Problem

The `ColorPicker` component supports taking 100% width of its container using the `fullWidth` prop. However, when rendering `ColorPicker` within a `ColorInput` dropdown, there was no way to pass the `fullWidth` prop from `ColorInput` down to the picker. Additionally, because the popover dropdown has `width: 'max-content'` by default, passing a 100% width constraint directly to the child color picker caused the layout to collapse.

### Solution

*   Moved the `fullWidth` prop from `ColorPickerProps` to `__ColorPickerProps` so that it is properly inherited by `ColorInputProps`.
*   Forwarded `fullWidth` from `ColorInput` to the internal `<ColorPicker />` component.
*   Passed `width={fullWidth ? 'target' : undefined}` to the `<Popover />` wrapper inside `ColorInput` so that the dropdown matches the target input's width and prevents the picker layout from collapsing.

### Tests

*   **Unit Tests**: Added a test case in `ColorInput.test.tsx` to verify that passing `fullWidth` to `ColorInput` correctly applies the `data-full-width` attribute to the underlying picker wrapper inside the dropdown.
*   **Visual Stories**: Added a `FullWidth` story in `ColorInput.story.tsx` with `popoverProps={{ opened: true }}` to demonstrate the color picker expanding to the full width of the input dropdown.

Resolves [#9060](https://github.com/mantinedev/mantine/issues/9060)