### PR TITLE
[@mantine/schedule] ScheduleEvent: Fix short event edge alignment

### DIFF
--- a/packages/@mantine/schedule/src/components/ResourcesDayView/ResourcesDayView.module.css
+++ b/packages/@mantine/schedule/src/components/ResourcesDayView/ResourcesDayView.module.css
@@ -392,6 +392,7 @@
 .resourcesDayViewEventWrapper {
   position: absolute;
   z-index: 3;
+  overflow: hidden;
 
   &:hover .resourcesDayViewResizeHandle {
     opacity: 0.5;

--- a/packages/@mantine/schedule/src/components/ResourcesWeekView/ResourcesWeekView.module.css
+++ b/packages/@mantine/schedule/src/components/ResourcesWeekView/ResourcesWeekView.module.css
@@ -365,6 +365,7 @@
 .resourcesWeekViewEventWrapper {
   position: absolute;
   z-index: 3;
+  overflow: hidden;
 
   &:hover .resourcesWeekViewResizeHandle {
     opacity: 0.5;

--- a/packages/@mantine/schedule/src/components/ScheduleEvent/ScheduleEvent.module.css
+++ b/packages/@mantine/schedule/src/components/ScheduleEvent/ScheduleEvent.module.css
@@ -9,6 +9,18 @@
 
   &:where([data-auto-size]) {
     container-type: size;
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+
+    @container (max-width: 8px) {
+      padding: 0;
+    }
+
+    @container (min-width: 9px) {
+      padding: 1px;
+    }
   }
 
   &:where([data-draggable]) .eventInner {
@@ -157,6 +169,12 @@
       display: flex;
       flex-direction: column;
       justify-content: center;
+    }
+
+    @container (max-width: 8px) {
+      padding-inline: 0;
+      padding-block: 0;
+      border-radius: 1px;
     }
   }
 

--- a/packages/@mantine/schedule/src/utils/get-time-axis-event-style/get-time-axis-event-style.test.ts
+++ b/packages/@mantine/schedule/src/utils/get-time-axis-event-style/get-time-axis-event-style.test.ts
@@ -1,32 +1,33 @@
 import { getTimeAxisEventStyle } from './get-time-axis-event-style';
 
 describe('@mantine/schedule/get-time-axis-event-style', () => {
-  it('renders a normal event with a 1px gap on each side', () => {
+  it('renders a normal horizontal event with exact start and span percentages', () => {
     const result = getTimeAxisEventStyle({ start: 10, span: 20 });
 
-    expect(result.right).toBe('calc(70% + 1px)');
-    expect(result.width).toBe('max(1px, calc(20% - 2px))');
+    expect(result.left).toBe('10%');
+    expect(result.width).toBe('20%');
   });
 
-  it('anchors the trailing edge so events ending at the same time align regardless of duration', () => {
+  it('anchors the leading edge so events starting at the same time align regardless of duration', () => {
+    const short = getTimeAxisEventStyle({ start: 10, span: 1 });
     const long = getTimeAxisEventStyle({ start: 10, span: 20 });
-    const short = getTimeAxisEventStyle({ start: 29, span: 1 });
 
-    // Both events end at 30% — their trailing edges must resolve identically
-    expect(long.right).toBe('calc(70% + 1px)');
-    expect(short.right).toBe('calc(70% + 1px)');
+    expect(short.left).toBe('10%');
+    expect(long.left).toBe('10%');
   });
 
-  it('floors the visible width so very short events do not collapse to zero', () => {
-    const result = getTimeAxisEventStyle({ start: 29, span: 1 });
+  it('uses exact span percentages so events ending at the same time align', () => {
+    const first = getTimeAxisEventStyle({ start: 10, span: 5 });
+    const second = getTimeAxisEventStyle({ start: 12, span: 3 });
 
-    expect(result.width).toBe('max(1px, calc(1% - 2px))');
+    expect(first.width).toBe('5%');
+    expect(second.width).toBe('3%');
   });
 
-  it('never sets a left inset (the box is anchored from the trailing edge)', () => {
+  it('never sets a trailing inset on the horizontal axis', () => {
     const result = getTimeAxisEventStyle({ start: 10, span: 20 });
 
-    expect(result).not.toHaveProperty('left');
+    expect(result).not.toHaveProperty('right');
   });
 
   it('returns bottom/height for the vertical axis', () => {
@@ -46,7 +47,7 @@ describe('@mantine/schedule/get-time-axis-event-style', () => {
     expect(short.bottom).toBe('calc(70% + 1px)');
   });
 
-  it('supports a single-sided gap (gap without a trailing portion)', () => {
+  it('supports a single-sided gap (gap without a trailing portion) on the vertical axis', () => {
     const result = getTimeAxisEventStyle({
       start: 10,
       span: 20,

--- a/packages/@mantine/schedule/src/utils/get-time-axis-event-style/get-time-axis-event-style.ts
+++ b/packages/@mantine/schedule/src/utils/get-time-axis-event-style/get-time-axis-event-style.ts
@@ -8,15 +8,15 @@ export interface GetTimeAxisEventStyleInput {
   /** Axis along which time flows @default 'horizontal' */
   axis?: 'horizontal' | 'vertical';
 
-  /** Total gap subtracted from the visible size, in px @default 2 */
+  /** Total gap subtracted from the visible size on the vertical axis, in px @default 2 */
   gap?: number;
 
-  /** Portion of the gap placed after the trailing edge, in px @default 1 */
+  /** Portion of the gap placed after the trailing edge on the vertical axis, in px @default 1 */
   trailingGap?: number;
 }
 
 export interface HorizontalEventStyle {
-  right: string;
+  left: string;
   width: string;
 }
 
@@ -38,10 +38,16 @@ export function getTimeAxisEventStyle({
   gap = 2,
   trailingGap = 1,
 }: GetTimeAxisEventStyleInput): HorizontalEventStyle | VerticalEventStyle {
-  const end = start + span;
+  if (axis === 'horizontal') {
+    return {
+      left: `${start}%`,
+      width: `${span}%`,
+    };
+  }
 
+  const end = start + span;
   const inset = trailingGap ? `calc(${100 - end}% + ${trailingGap}px)` : `${100 - end}%`;
   const size = `max(1px, calc(${span}% - ${gap}px))`;
 
-  return axis === 'vertical' ? { bottom: inset, height: size } : { right: inset, width: size };
+  return { bottom: inset, height: size };
 }


### PR DESCRIPTION
### Problem

When displaying events horizontally in `ResourcesDayView` or `ResourcesWeekView` at varying zoom levels (`intervalMinutes`), the start/end edges of short events did not align properly:
1. The horizontal positioning layout calculated boundaries with hardcoded pixel-gap offsets (`calc(${span}% - ${gap}px)`), leading to uneven sub-pixel rounding mismatches as viewport/scale settings changed.
2. Very short events had their width clamped to `1px`. Because they were anchored from the right edge, this clamping displaced their starting boundary, preventing them from aligning correctly with other events starting at the same time.

### Solution

*   Refactored `getTimeAxisEventStyle` for the horizontal axis to position events using exact, unaltered start and span percentages (`left: start%`, `width: span%`), guaranteeing precise vertical alignment of event edges across all zoom settings.
*   Delegated the event spacing (visual gaps) entirely to CSS padding in `ScheduleEvent.module.css` using container queries, decoupling visual gutters from layout positioning bounds.
*   Added `overflow: hidden` to the event wrappers in `ResourcesDayView.module.css` and `ResourcesWeekView.module.css` to clean up text rendering on thin slots.

### Tests

*   **Unit Tests**: Updated `get-time-axis-event-style.test.ts` to assert layout constraints on exact start and span percentages for the horizontal time axis.
*   **Visual Stories**: Verified edge alignment using the `ShortEvents` story in `ResourcesDayView.story.tsx` across different viewport widths and at all zoom settings (`intervalMinutes` settings of `1`, `5`, `10`, `15`, `30`, `60`, and `120`).


Resolves [9057](https://github.com/mantinedev/mantine/issues/9057)