### PR TITLE
[@mantine/core] Marquee: Fix duration default in JSDoc

### DIFF
--- a/packages/@mantine/core/src/components/Marquee/Marquee.tsx
+++ b/packages/@mantine/core/src/components/Marquee/Marquee.tsx
@@ -40,7 +40,7 @@ export interface MarqueeProps
   /** Number of times children are repeated inline for seamless scrolling @default 4 */
   repeat?: number;
 
-  /** Animation duration in ms @default 40000 */
+  /** Animation duration in ms @default 100000 */
   duration?: number;
 
   /** Gap between repeated children, key of `theme.spacing` or any valid CSS value @default 'md' */


### PR DESCRIPTION
The `duration` prop is documented as `@default 40000`, but the component applies `duration: 100_000` from its `defaultProps` (via `useProps`), so the effective default is `100000`ms. Updated the JSDoc `@default` to match `defaultProps`.
