### PR TITLE
[@mantine/core] MantineProvider: Fix topmost pixel click issue on active elements

### DIFF
--- a/packages/@mantine/core/src/core/MantineProvider/global.css
+++ b/packages/@mantine/core/src/core/MantineProvider/global.css
@@ -42,10 +42,25 @@
 .mantine-active {
   &:active {
     transform: translateY(rem(1px));
+    overflow: visible;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: rem(-1px);
+      left: 0;
+      right: 0;
+      height: rem(1px);
+      background-color: transparent;
+    }
   }
 
   fieldset:disabled &:active {
     transform: none;
+
+    &::after {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
### Problem

Clicking on the very topmost pixel of a button, action icon, or other interactive element using the `.mantine-active` class shows the pointer cursor, but fails to register a click event.

This occurs because:
* When active, `.mantine-active` applies `transform: translateY(rem(1px))` to visual elements to create a tactile "pressed" effect.
* Translating the element down shifts its bounding box 1px down.
* If a user initiates a click on the topmost pixel of the element, the translation moves the element's top boundary out from under the mouse cursor. 
* Upon `mouseup`, the cursor is no longer within the element's boundaries, causing the browser to abort the `click` event.


### Solution

Refactored the `.mantine-active` styles in `packages/@mantine/core/src/core/MantineProvider/global.css`:
* Temporarily allowed overflow (`overflow: visible`) during the `:active` state.
* Appended a `1px` tall transparent `::after` pseudo-element positioned at `top: rem(-1px)` spanning the full width of the element.
* This pseudo-element bridges the gap and keeps the hover/click target active relative to the cursor's original position when the element shifts down.
* Explicitly hidden/disabled the pseudo-element in `fieldset:disabled` to prevent unwanted interactions.


### Tests

* **Style Checks**: Verified CSS rules conform to style guidelines using `npm run stylelint` and formatted the file with `npm run format:write:files`.
* **Build & Typecheck**: Successfully verified that the codebase typechecks (`npm run typecheck`) and builds without errors (`npm run build`).
* **Manual Verification**: Tested on Storybook across `Button` and `ActionIcon` stories to verify that clicking the topmost pixel triggers events correctly and triggers the tactile visual press animation seamlessly.

Resolves [9064](https://github.com/mantinedev/mantine/issues/9064)