### PR TITLE
[@mantine/form] Fix async validation with debounce on initial keystroke of empty input

### DIFF
--- a/packages/@mantine/form/src/stories/Form.validateOnChange.story.tsx
+++ b/packages/@mantine/form/src/stories/Form.validateOnChange.story.tsx
@@ -81,3 +81,39 @@ export function ValidateOnChangeUncontrolled() {
     </FormBase>
   );
 }
+
+import { useState } from 'react';
+import { Button } from '@mantine/core';
+
+export function ValidateDebounce() {
+  const [requestCount, setRequestCount] = useState(0);
+
+  const form = useForm({
+    mode: 'uncontrolled',
+    validateInputOnChange: true,
+    validateDebounce: 500,
+    initialValues: {
+      name: '',
+    },
+    validate: {
+      name: async (value) => {
+        if (value.trim().length === 0) {
+          return 'Name is required';
+        }
+        setRequestCount((c) => c + 1);
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        return value.length < 5 ? 'Must be at least 5 characters' : null;
+      },
+    },
+  });
+
+  return (
+    <FormBase form={form}>
+      <div>Request Count: {requestCount}</div>
+      <TextInput label="Name" {...form.getInputProps('name')} />
+      <Button onClick={() => setRequestCount(0)} mt="xs">
+        Reset Count
+      </Button>
+    </FormBase>
+  );
+}

--- a/packages/@mantine/form/src/stories/Form.validateOnChange.story.tsx
+++ b/packages/@mantine/form/src/stories/Form.validateOnChange.story.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, TextInput } from '@mantine/core';
+import { Button, Checkbox, TextInput } from '@mantine/core';
 import { FORM_INDEX } from '../form-index';
 import { useForm } from '../use-form';
 import { FormBase } from './_base';
@@ -83,7 +83,6 @@ export function ValidateOnChangeUncontrolled() {
 }
 
 import { useState } from 'react';
-import { Button } from '@mantine/core';
 
 export function ValidateDebounce() {
   const [requestCount, setRequestCount] = useState(0);

--- a/packages/@mantine/form/src/tests/use-form/validateDebounce.test.ts
+++ b/packages/@mantine/form/src/tests/use-form/validateDebounce.test.ts
@@ -1,0 +1,61 @@
+import { act, renderHook } from '@testing-library/react';
+import { useForm } from '../../use-form';
+
+describe('@mantine/form/validateDebounce', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('correctly debounces validation and clears previous timer on rapid value changes', () => {
+    const validateSpy = jest.fn().mockReturnValue(null);
+
+    const hook = renderHook(() =>
+      useForm({
+        initialValues: { name: '' },
+        validateInputOnChange: true,
+        validateDebounce: 100,
+        validate: {
+          name: validateSpy,
+        },
+      })
+    );
+
+    act(() => {
+      hook.result.current.setFieldValue('name', 'a');
+    });
+
+    // Advance time slightly, but not enough to trigger validation
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+    expect(validateSpy).not.toHaveBeenCalled();
+
+    // Type a second character - this should clear the first timer
+    act(() => {
+      hook.result.current.setFieldValue('name', 'ab');
+    });
+
+    // Advance time past the original 100ms mark from the first keystroke (total time: 110ms)
+    act(() => {
+      jest.advanceTimersByTime(60);
+    });
+    // If the debounce failed to clear the timer, the validation for 'a' would have fired here.
+    expect(validateSpy).not.toHaveBeenCalled();
+
+    // Now advance time fully past the second keystroke's debounce window (total time: 150ms)
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+    expect(validateSpy).toHaveBeenLastCalledWith(
+      'ab',
+      expect.anything(),
+      'name',
+      expect.anything()
+    );
+  });
+});

--- a/packages/@mantine/form/src/use-form.ts
+++ b/packages/@mantine/form/src/use-form.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFormActions } from './actions';
 import { getInputOnChange } from './get-input-on-change';
 import { useFormErrors } from './hooks/use-form-errors/use-form-errors';
@@ -86,6 +86,13 @@ export function useForm<
   const [fieldKeys, setFieldKeys] = useState<Record<string, number>>({});
   const [submitting, setSubmitting] = useState(false);
   const validateGeneration = useRef(0);
+  const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  useEffect(() => {
+    return () => {
+      Object.values(timers.current).forEach(clearTimeout);
+    };
+  }, []);
 
   const reset: Reset = useCallback(() => {
     $values.resetValues();
@@ -115,8 +122,6 @@ export function useForm<
   );
 
   const debouncedValidateField = useMemo(() => {
-    const timers: Record<string, ReturnType<typeof setTimeout>> = {};
-
     const handleValidation = (path: string) => {
       const signal = $validating.getAbortSignal(path);
       const result = validateFieldValue(
@@ -153,9 +158,9 @@ export function useForm<
     };
 
     return (path: string) => {
-      clearTimeout(timers[path]);
+      clearTimeout(timers.current[path]);
       if (validateDebounce > 0) {
-        timers[path] = setTimeout(() => handleValidation(path), validateDebounce);
+        timers.current[path] = setTimeout(() => handleValidation(path), validateDebounce);
       } else {
         handleValidation(path);
       }


### PR DESCRIPTION
### Problem
When using `validateDebounce` with async validation on change (`validateInputOnChange: true`), the debounce mechanism fails to cancel/clear the initial validation timer on subsequent rapid keystrokes if typing started from an empty input.
This occurs because:
* On the first keystroke of an empty input, the field transitions from clean to dirty.
* This transition triggers a state update (`setDirtyState`) that causes the component to re-render.
* During the re-render, if the `validate` rules are defined as an inline object (common practice), the `useMemo` for `debouncedValidateField` in `use-form.ts` re-runs because its dependencies changed.
* Re-running the `useMemo` discards the local `timers` object and creates a new one, leaving the first timer ($T_1$) orphaned in the old object.
* On subsequent rapid keystrokes (which do not trigger re-renders since the field is already dirty), the new `debouncedValidateField` attempts to clear the previous timer but looks in the new, empty `timers` object, failing to clear $T_1$.
* Consequently, both the initial keystroke's timer and the final keystroke's timer execute, resulting in duplicate/unwanted API requests.


### Solution
Refactored the validation timer management in `packages/@mantine/form/src/use-form.ts`:
* Moved the `timers` dictionary from a local variable inside the `useMemo` callback of `debouncedValidateField` into a shared React `useRef` (`timers.current`) at the `useForm` hook level.
* Storing timers in a ref ensures that the timer references survive any re-renders or `useMemo` updates, allowing subsequent keystrokes to successfully locate and clear previous timers.
* Added a `useEffect` cleanup hook to clear all active validation timers on unmount.
* Added a new story `ValidateDebounce` to `packages/@mantine/form/src/stories/Form.validateOnChange.story.tsx` to showcase and easily test debounced change validations.


### Tests
* **Automated Tests**: Added a new test suite `packages/@mantine/form/src/tests/use-form/validateDebounce.test.ts` to verify that rapid value changes within the debounce window correctly clear preceding timers. Verified that all `@mantine/form` tests pass successfully (`npm run jest packages/@mantine/form`).
* **Build & Typecheck**: Successfully verified that the codebase typechecks (`npm run typecheck`) and builds without errors (`npm run build`).
* **Manual Verification**: Verified visually using the new `ValidateDebounce` story in Storybook.


Resolves [#9067](https://github.com/mantinedev/mantine/issues/9067)