### PR TITLE
[@mantine/core] Stepper: Make stepper composite

### DIFF
--- a/apps/mantine.dev/src/mdx/data/mdx-core-data.ts
+++ b/apps/mantine.dev/src/mdx/data/mdx-core-data.ts
@@ -1118,7 +1118,7 @@ export const MDX_CORE_DATA: Record<string, Frontmatter> = {
     title: 'Stepper',
     package: '@mantine/core',
     slug: '/core/stepper',
-    props: ['Stepper', 'StepperStep'],
+    props: ['Stepper', 'StepperStep', 'StepperRoot', 'StepperSteps', 'StepperContent'],
     styles: ['Stepper'],
     componentPrefix: 'Stepper',
     description: 'Display content divided into a steps sequence',

--- a/apps/mantine.dev/src/pages/core/stepper.mdx
+++ b/apps/mantine.dev/src/pages/core/stepper.mdx
@@ -8,6 +8,25 @@ export default Layout(MDX_DATA.Stepper);
 
 <Demo data={StepperDemos.usage} />
 
+## Compound components
+
+`Stepper` component children must follow a strict structure: `Stepper.Step` and `Stepper.Completed`
+components must be direct children of the `Stepper` component. If you need full control over the layout,
+use compound components instead:
+
+- `Stepper.Root` accepts the same props as `Stepper` and renders its children as is
+- `Stepper.Steps` renders the steps list, `Stepper.Step` components must be its direct children
+- `Stepper.Content` renders its children when the step with the associated 0-based `step` index is active
+- `Stepper.Completed` renders its children when `active` is greater than or equal to its `step` prop; `step` is required with `Stepper.Root` and set automatically by `Stepper`
+
+<Demo data={StepperDemos.compound} />
+
+Unlike the `Stepper` component, compound components do not restrict the layout structure –
+you can wrap them with any elements. For example, you can pin step indicators to the top of
+the screen while the content below is scrolled independently:
+
+<Demo data={StepperDemos.compoundSticky} />
+
 ## Allow step select
 
 To disable step selection, set the `allowStepSelect` prop on the `Stepper.Step` component.

--- a/apps/mantine.dev/src/pages/core/stepper.mdx
+++ b/apps/mantine.dev/src/pages/core/stepper.mdx
@@ -21,6 +21,10 @@ use compound components instead:
 
 <Demo data={StepperDemos.compound} />
 
+`useStepperContext` hook provides the current step index and the total number of steps. The `stepsCount`
+value is detected automatically from `Stepper.Steps` children in client-side applications. Set the
+`stepsCount` prop on `Stepper.Root` only when server-side rendering the step count.
+
 Unlike the `Stepper` component, compound components do not restrict the layout structure –
 you can wrap them with any elements. For example, you can pin step indicators to the top of
 the screen while the content below is scrolled independently:

--- a/packages/@docs/demos/src/demos/core/Stepper/Stepper.demo.compound.tsx
+++ b/packages/@docs/demos/src/demos/core/Stepper/Stepper.demo.compound.tsx
@@ -1,10 +1,15 @@
 import { useState } from 'react';
-import { Button, Group, Stepper } from '@mantine/core';
+import { Button, Group, Stepper, Text, useStepperContext } from '@mantine/core';
 import { MantineDemo } from '@mantinex/demo';
 
 const code = `
 import { useState } from 'react';
-import { Stepper, Button, Group } from '@mantine/core';
+import { Stepper, Button, Group, Text, useStepperContext } from '@mantine/core';
+
+function StepCount() {
+  const { active, stepsCount } = useStepperContext();
+  return <Text>Step {Math.min(active + 1, stepsCount)} of {stepsCount}</Text>;
+}
 
 function Demo() {
   const [active, setActive] = useState(0);
@@ -14,6 +19,7 @@ function Demo() {
   return (
     <>
       <Stepper.Root active={active} onStepClick={setActive}>
+        <StepCount />
         <Stepper.Steps>
           <Stepper.Step label="First step" description="Create an account" />
           <Stepper.Step label="Second step" description="Verify email" />
@@ -45,6 +51,15 @@ function Demo() {
 }
 `;
 
+function StepCount() {
+  const { active, stepsCount } = useStepperContext();
+  return (
+    <Text>
+      Step {Math.min(active + 1, stepsCount)} of {stepsCount}
+    </Text>
+  );
+}
+
 function Demo() {
   const [active, setActive] = useState(0);
   const nextStep = () => setActive((current) => (current < 3 ? current + 1 : current));
@@ -53,6 +68,7 @@ function Demo() {
   return (
     <>
       <Stepper.Root active={active} onStepClick={setActive}>
+        <StepCount />
         <Stepper.Steps>
           <Stepper.Step label="First step" description="Create an account" />
           <Stepper.Step label="Second step" description="Verify email" />

--- a/packages/@docs/demos/src/demos/core/Stepper/Stepper.demo.compound.tsx
+++ b/packages/@docs/demos/src/demos/core/Stepper/Stepper.demo.compound.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { Button, Group, Stepper } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { useState } from 'react';
+import { Stepper, Button, Group } from '@mantine/core';
+
+function Demo() {
+  const [active, setActive] = useState(0);
+  const nextStep = () => setActive((current) => (current < 3 ? current + 1 : current));
+  const prevStep = () => setActive((current) => (current > 0 ? current - 1 : current));
+
+  return (
+    <>
+      <Stepper.Root active={active} onStepClick={setActive}>
+        <Stepper.Steps>
+          <Stepper.Step label="First step" description="Create an account" />
+          <Stepper.Step label="Second step" description="Verify email" />
+          <Stepper.Step label="Final step" description="Get full access" />
+        </Stepper.Steps>
+
+        <Stepper.Content step={0}>
+          Step 1 content: Create an account
+        </Stepper.Content>
+        <Stepper.Content step={1}>
+          Step 2 content: Verify email
+        </Stepper.Content>
+        <Stepper.Content step={2}>
+          Step 3 content: Get full access
+        </Stepper.Content>
+        <Stepper.Completed step={3}>
+          Completed, click back button to get to previous step
+        </Stepper.Completed>
+      </Stepper.Root>
+
+      <Group justify="center" mt="xl">
+        <Button variant="default" onClick={prevStep}>
+          Back
+        </Button>
+        <Button onClick={nextStep}>Next step</Button>
+      </Group>
+    </>
+  );
+}
+`;
+
+function Demo() {
+  const [active, setActive] = useState(0);
+  const nextStep = () => setActive((current) => (current < 3 ? current + 1 : current));
+  const prevStep = () => setActive((current) => (current > 0 ? current - 1 : current));
+
+  return (
+    <>
+      <Stepper.Root active={active} onStepClick={setActive}>
+        <Stepper.Steps>
+          <Stepper.Step label="First step" description="Create an account" />
+          <Stepper.Step label="Second step" description="Verify email" />
+          <Stepper.Step label="Final step" description="Get full access" />
+        </Stepper.Steps>
+
+        <Stepper.Content step={0}>Step 1 content: Create an account</Stepper.Content>
+        <Stepper.Content step={1}>Step 2 content: Verify email</Stepper.Content>
+        <Stepper.Content step={2}>Step 3 content: Get full access</Stepper.Content>
+        <Stepper.Completed step={3}>
+          Completed, click back button to get to previous step
+        </Stepper.Completed>
+      </Stepper.Root>
+
+      <Group justify="center" mt="xl">
+        <Button variant="default" onClick={prevStep}>
+          Back
+        </Button>
+        <Button onClick={nextStep}>Next step</Button>
+      </Group>
+    </>
+  );
+}
+
+export const compound: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+};

--- a/packages/@docs/demos/src/demos/core/Stepper/Stepper.demo.compoundSticky.tsx
+++ b/packages/@docs/demos/src/demos/core/Stepper/Stepper.demo.compoundSticky.tsx
@@ -1,0 +1,160 @@
+import { useState } from 'react';
+import { Box, ScrollArea, Stack, Stepper, Text } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { useState } from 'react';
+import { Box, ScrollArea, Stack, Stepper, Text } from '@mantine/core';
+
+function Demo() {
+  const [active, setActive] = useState(0);
+
+  return (
+    <Stepper.Root active={active} onStepClick={setActive}>
+      <Box pos="sticky" top={0}>
+        <Stepper.Steps>
+          <Stepper.Step label="Step 1" />
+          <Stepper.Step label="Step 2" />
+          <Stepper.Step label="Step 3" />
+        </Stepper.Steps>
+      </Box>
+
+      <ScrollArea h={100}>
+        <Stepper.Content step={0}>
+          <Stack p="md">
+            <Text>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </Text>
+            <Text>
+              Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+            </Text>
+            <Text>
+              Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            </Text>
+            <Text>
+              Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </Text>
+          </Stack>
+        </Stepper.Content>
+        <Stepper.Content step={1}>
+          <Stack p="md">
+            <Text>
+              Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.
+            </Text>
+            <Text>
+              Totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+            </Text>
+            <Text>
+              Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores.
+            </Text>
+            <Text>
+              Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.
+            </Text>
+          </Stack>
+        </Stepper.Content>
+        <Stepper.Content step={2}>
+          <Stack p="md">
+            <Text>
+              At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti.
+            </Text>
+            <Text>
+              Et harum quidem rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae itaque earum.
+            </Text>
+            <Text>
+              Rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.
+            </Text>
+            <Text>
+              Sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.
+            </Text>
+          </Stack>
+        </Stepper.Content>
+      </ScrollArea>
+    </Stepper.Root>
+  );
+}
+`;
+
+function Demo() {
+  const [active, setActive] = useState(0);
+
+  return (
+    <Stepper.Root active={active} onStepClick={setActive}>
+      <Box pos="sticky" top={0}>
+        <Stepper.Steps>
+          <Stepper.Step label="Step 1" />
+          <Stepper.Step label="Step 2" />
+          <Stepper.Step label="Step 3" />
+        </Stepper.Steps>
+      </Box>
+
+      <ScrollArea h={100}>
+        <Stepper.Content step={0}>
+          <Stack p="md">
+            <Text>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+              incididunt ut labore et dolore magna aliqua.
+            </Text>
+            <Text>
+              Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+              ea commodo consequat.
+            </Text>
+            <Text>
+              Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+              nulla pariatur.
+            </Text>
+            <Text>
+              Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+              mollit anim id est laborum.
+            </Text>
+          </Stack>
+        </Stepper.Content>
+        <Stepper.Content step={1}>
+          <Stack p="md">
+            <Text>
+              Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque
+              laudantium.
+            </Text>
+            <Text>
+              Totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto
+              beatae vitae dicta sunt explicabo.
+            </Text>
+            <Text>
+              Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia
+              consequuntur magni dolores.
+            </Text>
+            <Text>
+              Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci
+              velit.
+            </Text>
+          </Stack>
+        </Stepper.Content>
+        <Stepper.Content step={2}>
+          <Stack p="md">
+            <Text>
+              At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium
+              voluptatum deleniti atque corrupti.
+            </Text>
+            <Text>
+              Et harum quidem rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint
+              et molestiae non recusandae itaque earum.
+            </Text>
+            <Text>
+              Rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias
+              consequatur aut perferendis doloribus asperiores repellat.
+            </Text>
+            <Text>
+              Sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam
+              quaerat voluptatem.
+            </Text>
+          </Stack>
+        </Stepper.Content>
+      </ScrollArea>
+    </Stepper.Root>
+  );
+}
+
+export const compoundSticky: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+};

--- a/packages/@docs/demos/src/demos/core/Stepper/Stepper.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/core/Stepper/Stepper.demos.story.tsx
@@ -8,6 +8,16 @@ export const Demo_usage = {
   render: renderDemo(demos.usage),
 };
 
+export const Demo_compound = {
+  name: '⭐ Demo: compound',
+  render: renderDemo(demos.compound),
+};
+
+export const Demo_compoundSticky = {
+  name: '⭐ Demo: compoundSticky',
+  render: renderDemo(demos.compoundSticky),
+};
+
 export const Demo_configurator = {
   name: '⭐ Demo: configurator',
   render: renderDemo(demos.configurator),

--- a/packages/@docs/demos/src/demos/core/Stepper/index.ts
+++ b/packages/@docs/demos/src/demos/core/Stepper/index.ts
@@ -1,4 +1,6 @@
 export { usage } from './Stepper.demo.usage';
+export { compound } from './Stepper.demo.compound';
+export { compoundSticky } from './Stepper.demo.compoundSticky';
 export { configurator } from './Stepper.demo.configurator';
 export { icons } from './Stepper.demo.icons';
 export { iconSizeConfigurator } from './Stepper.demo.iconSizeConfigurator';

--- a/packages/@mantine/core/src/components/Stepper/Stepper.context.ts
+++ b/packages/@mantine/core/src/components/Stepper/Stepper.context.ts
@@ -7,6 +7,9 @@ export interface StepperContextValue {
   orientation: 'horizontal' | 'vertical' | undefined;
   iconPosition: 'left' | 'right' | undefined;
   active: number;
+  stepsCount: number;
+  /** @internal */
+  setStepsCount: (count: number) => void;
   onStepClick?: (stepIndex: number) => void;
   allowNextStepsSelect: boolean | undefined;
   icon: React.ReactNode | StepFragmentComponent;

--- a/packages/@mantine/core/src/components/Stepper/Stepper.context.ts
+++ b/packages/@mantine/core/src/components/Stepper/Stepper.context.ts
@@ -1,12 +1,27 @@
-import { createSafeContext, GetStylesApi } from '../../core';
-import type { StepperFactory } from './Stepper';
+import { use } from 'react';
+import { createSafeContext, GetStylesApi, MantineColor } from '../../core';
+import type { StepFragmentComponent, StepperRootFactory } from './StepperRoot/StepperRoot';
 
 export interface StepperContextValue {
-  getStyles: GetStylesApi<StepperFactory>;
+  getStyles: GetStylesApi<StepperRootFactory>;
   orientation: 'horizontal' | 'vertical' | undefined;
   iconPosition: 'left' | 'right' | undefined;
+  active: number;
+  onStepClick?: (stepIndex: number) => void;
+  allowNextStepsSelect: boolean | undefined;
+  icon: React.ReactNode | StepFragmentComponent;
+  completedIcon: React.ReactNode | StepFragmentComponent;
+  progressIcon: React.ReactNode | StepFragmentComponent;
+  color: MantineColor | undefined;
+  iconSize: number | string | undefined;
+  wrap: boolean | undefined;
+  keepMounted: boolean | undefined;
 }
 
 export const [StepperProvider, useStepperContext] = createSafeContext<StepperContextValue>(
   'Stepper component was not found in tree'
 );
+
+export function useOptionalStepperContext() {
+  return use(StepperProvider);
+}

--- a/packages/@mantine/core/src/components/Stepper/Stepper.context.ts
+++ b/packages/@mantine/core/src/components/Stepper/Stepper.context.ts
@@ -12,9 +12,9 @@ export interface StepperContextValue {
   setStepsCount: (count: number) => void;
   onStepClick?: (stepIndex: number) => void;
   allowNextStepsSelect: boolean | undefined;
-  icon: React.ReactNode | StepFragmentComponent;
-  completedIcon: React.ReactNode | StepFragmentComponent;
-  progressIcon: React.ReactNode | StepFragmentComponent;
+  icon?: React.ReactNode | StepFragmentComponent;
+  completedIcon?: React.ReactNode | StepFragmentComponent;
+  progressIcon?: React.ReactNode | StepFragmentComponent;
   color: MantineColor | undefined;
   iconSize: number | string | undefined;
   wrap: boolean | undefined;

--- a/packages/@mantine/core/src/components/Stepper/Stepper.story.tsx
+++ b/packages/@mantine/core/src/components/Stepper/Stepper.story.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { NumberInput, Stack, Text } from '../..';
+import { Box, NumberInput, ScrollArea, Stack, Text } from '../..';
 import { Button } from '../Button';
 import { Group } from '../Group';
 import { Stepper } from './Stepper';
@@ -200,5 +200,82 @@ export function RightIconPosition() {
         <Button onClick={nextStep}>Next step</Button>
       </Group>
     </>
+  );
+}
+
+export function CompoundComponents() {
+  const [active, setActive] = useState(0);
+  const nextStep = () => setActive((current) => (current < 3 ? current + 1 : current));
+  const prevStep = () => setActive((current) => (current > 0 ? current - 1 : current));
+
+  return (
+    <div style={{ padding: 40 }}>
+      <Stepper.Root active={active} onStepClick={setActive}>
+        <Stepper.Steps>
+          <Stepper.Step label="First step" description="Create an account" />
+          <Stepper.Step label="Second step" description="Verify email" />
+          <Stepper.Step label="Final step" description="Get full access" />
+        </Stepper.Steps>
+
+        <Stepper.Content step={0}>Step 1 content: Create an account</Stepper.Content>
+        <Stepper.Content step={1}>Step 2 content: Verify email</Stepper.Content>
+        <Stepper.Content step={2}>Step 3 content: Get full access</Stepper.Content>
+        <Stepper.Completed step={3}>
+          Completed, click back button to get to previous step
+        </Stepper.Completed>
+      </Stepper.Root>
+
+      <Group justify="center" mt="xl">
+        <Button variant="default" onClick={prevStep}>
+          Back
+        </Button>
+        <Button onClick={nextStep}>Next step</Button>
+      </Group>
+    </div>
+  );
+}
+
+export function CompoundStickySteps() {
+  const [active, setActive] = useState(0);
+  const nextStep = () => setActive((current) => (current < 3 ? current + 1 : current));
+  const prevStep = () => setActive((current) => (current > 0 ? current - 1 : current));
+
+  const content = (step: number) =>
+    Array(20)
+      .fill(0)
+      .map((_, index) => (
+        <Text key={index} my="md">
+          Step {step + 1} scrollable content, paragraph {index + 1}
+        </Text>
+      ));
+
+  return (
+    <Box p={40}>
+      <Stepper.Root active={active} onStepClick={setActive}>
+        <Box pos="sticky" top={0} pb="md">
+          <Stepper.Steps>
+            <Stepper.Step label="First step" description="Create an account" />
+            <Stepper.Step label="Second step" description="Verify email" />
+            <Stepper.Step label="Final step" description="Get full access" />
+          </Stepper.Steps>
+        </Box>
+
+        <ScrollArea h={100}>
+          <Stepper.Content step={0}>{content(0)}</Stepper.Content>
+          <Stepper.Content step={1}>{content(1)}</Stepper.Content>
+          <Stepper.Content step={2}>{content(2)}</Stepper.Content>
+          <Stepper.Completed step={3}>
+            Completed, click back button to get to previous step
+          </Stepper.Completed>
+        </ScrollArea>
+      </Stepper.Root>
+
+      <Group justify="center" mt="xl">
+        <Button variant="default" onClick={prevStep}>
+          Back
+        </Button>
+        <Button onClick={nextStep}>Next step</Button>
+      </Group>
+    </Box>
   );
 }

--- a/packages/@mantine/core/src/components/Stepper/Stepper.test.tsx
+++ b/packages/@mantine/core/src/components/Stepper/Stepper.test.tsx
@@ -7,6 +7,7 @@ import { StepperContent } from './StepperContent/StepperContent';
 import { StepperRoot, StepperRootProps } from './StepperRoot/StepperRoot';
 import { StepperStep } from './StepperStep/StepperStep';
 import { StepperSteps } from './StepperSteps/StepperSteps';
+import { useStepperContext } from './Stepper.context';
 
 const defaultProps: StepperProps = {
   active: 1,
@@ -26,6 +27,11 @@ const defaultProps: StepperProps = {
     <Stepper.Completed key="4">test-step-completed</Stepper.Completed>,
   ],
 };
+
+function StepCount() {
+  const { stepsCount } = useStepperContext();
+  return <div data-testid="steps-count">{stepsCount}</div>;
+}
 
 describe('@mantine/core/Stepper', () => {
   tests.axe([<Stepper {...defaultProps} key="1" />]);
@@ -67,6 +73,20 @@ describe('@mantine/core/Stepper', () => {
     expect(screen.getByText('test-step-completed')).toBeInTheDocument();
     rerender(<Stepper {...defaultProps} active={100} />);
     expect(screen.getByText('test-step-completed')).toBeInTheDocument();
+  });
+
+  it('sets stepsCount in context', () => {
+    render(
+      <Stepper active={0}>
+        <Stepper.Step label="0">
+          <StepCount />
+        </Stepper.Step>
+        <Stepper.Step label="1" />
+        <Stepper.Completed>Completed</Stepper.Completed>
+      </Stepper>
+    );
+
+    expect(screen.getByTestId('steps-count')).toHaveTextContent('2');
   });
 
   it('exposes Stepper.Step and Stepper.Completed components', () => {
@@ -186,6 +206,73 @@ describe('@mantine/core/Stepper compound components', () => {
   it('renders completed content during server-side rendering', () => {
     const html = renderToString(<MantineProvider>{getCompound({ active: 3 })}</MantineProvider>);
     expect(html).toContain('test-step-completed');
+  });
+
+  it('sets stepsCount in context', () => {
+    render(
+      <Stepper.Root active={0}>
+        <StepCount />
+        <Stepper.Steps>
+          <Stepper.Step label="0" />
+          <Stepper.Step label="1" />
+          <Stepper.Completed>Completed</Stepper.Completed>
+        </Stepper.Steps>
+      </Stepper.Root>
+    );
+
+    expect(screen.getByTestId('steps-count')).toHaveTextContent('2');
+  });
+
+  it('updates stepsCount when steps change', () => {
+    const { rerender } = render(
+      <Stepper.Root active={0}>
+        <StepCount />
+        <Stepper.Steps>
+          <Stepper.Step label="0" />
+        </Stepper.Steps>
+      </Stepper.Root>
+    );
+
+    expect(screen.getByTestId('steps-count')).toHaveTextContent('1');
+
+    rerender(
+      <Stepper.Root active={0}>
+        <StepCount />
+        <Stepper.Steps>
+          <Stepper.Step label="0" />
+          <Stepper.Step label="1" />
+        </Stepper.Steps>
+      </Stepper.Root>
+    );
+
+    expect(screen.getByTestId('steps-count')).toHaveTextContent('2');
+  });
+
+  it('supports stepsCount during server-side rendering', () => {
+    const compoundHtml = renderToString(
+      <MantineProvider>
+        <Stepper.Root active={0} stepsCount={2}>
+          <StepCount />
+          <Stepper.Steps>
+            <Stepper.Step label="0" />
+            <Stepper.Step label="1" />
+          </Stepper.Steps>
+        </Stepper.Root>
+      </MantineProvider>
+    );
+    const stepperHtml = renderToString(
+      <MantineProvider>
+        <Stepper active={0}>
+          <Stepper.Step label="0">
+            <StepCount />
+          </Stepper.Step>
+          <Stepper.Step label="1" />
+        </Stepper>
+      </MantineProvider>
+    );
+
+    expect(compoundHtml).toContain('>2<');
+    expect(stepperHtml).toContain('>2<');
   });
 
   it('renders nothing when Stepper.Completed is used outside Stepper', () => {

--- a/packages/@mantine/core/src/components/Stepper/Stepper.test.tsx
+++ b/packages/@mantine/core/src/components/Stepper/Stepper.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen, tests, userEvent } from '@mantine-tests/core';
+import { renderToString } from 'react-dom/server';
+import { MantineProvider } from '../../core';
 import { Stepper, StepperProps, StepperStylesNames } from './Stepper';
 import { StepperCompleted } from './StepperCompleted/StepperCompleted';
+import { StepperContent } from './StepperContent/StepperContent';
+import { StepperRoot, StepperRootProps } from './StepperRoot/StepperRoot';
 import { StepperStep } from './StepperStep/StepperStep';
+import { StepperSteps } from './StepperSteps/StepperSteps';
 
 const defaultProps: StepperProps = {
   active: 1,
@@ -130,5 +135,121 @@ describe('@mantine/core/Stepper', () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(2);
+  });
+});
+
+describe('@mantine/core/Stepper compound components', () => {
+  const getCompound = (props: Partial<StepperRootProps> = {}) => (
+    <Stepper.Root active={1} {...props}>
+      <Stepper.Steps>
+        <Stepper.Step label="0" description="0" />
+        <Stepper.Step label="1" description="1" />
+        <Stepper.Step label="2" description="2" />
+      </Stepper.Steps>
+      <Stepper.Content step={0}>test-step-content-0</Stepper.Content>
+      <Stepper.Content step={1}>test-step-content-1</Stepper.Content>
+      <Stepper.Content step={2}>test-step-content-2</Stepper.Content>
+      <Stepper.Completed step={3}>test-step-completed</Stepper.Completed>
+    </Stepper.Root>
+  );
+
+  tests.axe([getCompound()]);
+
+  it('exposes Stepper.Root, Stepper.Steps and Stepper.Content components', () => {
+    expect(Stepper.Root).toBe(StepperRoot);
+    expect(Stepper.Steps).toBe(StepperSteps);
+    expect(Stepper.Content).toBe(StepperContent);
+  });
+
+  it('renders content of active step', () => {
+    const { rerender } = render(getCompound({ active: 1 }));
+    expect(screen.getByText('test-step-content-1')).toBeInTheDocument();
+    expect(screen.queryByText('test-step-content-0')).not.toBeInTheDocument();
+    expect(screen.queryByText('test-step-completed')).not.toBeInTheDocument();
+
+    rerender(getCompound({ active: 2 }));
+    expect(screen.getByText('test-step-content-2')).toBeInTheDocument();
+    expect(screen.queryByText('test-step-content-1')).not.toBeInTheDocument();
+  });
+
+  it('renders completed content when active is beyond the last step', () => {
+    const { rerender } = render(getCompound({ active: 3 }));
+    expect(screen.getByText('test-step-completed')).toBeInTheDocument();
+
+    rerender(getCompound({ active: 100 }));
+    expect(screen.getByText('test-step-completed')).toBeInTheDocument();
+
+    rerender(getCompound({ active: 1 }));
+    expect(screen.queryByText('test-step-completed')).not.toBeInTheDocument();
+  });
+
+  it('renders completed content during server-side rendering', () => {
+    const html = renderToString(<MantineProvider>{getCompound({ active: 3 })}</MantineProvider>);
+    expect(html).toContain('test-step-completed');
+  });
+
+  it('renders nothing when Stepper.Completed is used outside Stepper', () => {
+    render(<Stepper.Completed>test-step-completed</Stepper.Completed>);
+    expect(screen.queryByText('test-step-completed')).not.toBeInTheDocument();
+  });
+
+  it('calls onStepClick with clicked step index', async () => {
+    const spy = jest.fn();
+    render(getCompound({ onStepClick: spy }));
+    await userEvent.click(screen.getAllByRole('button')[2]);
+    expect(spy).toHaveBeenCalledWith(2);
+  });
+
+  it('only allows selecting previous steps when allowNextStepsSelect is false', async () => {
+    const spy = jest.fn();
+    render(getCompound({ onStepClick: spy, allowNextStepsSelect: false }));
+
+    const stepButtons = screen.getAllByRole('button');
+
+    await userEvent.click(stepButtons[2]);
+    expect(spy).not.toHaveBeenCalled();
+
+    await userEvent.click(stepButtons[0]);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(0);
+  });
+
+  it('supports Styles API selectors through Stepper.Root classNames', () => {
+    const { container } = render(
+      getCompound({
+        classNames: {
+          steps: 'test-steps',
+          separator: 'test-separator',
+          step: 'test-step',
+          content: 'test-content',
+        },
+      })
+    );
+
+    expect(container.querySelector('.test-steps')).toBeInTheDocument();
+    expect(container.querySelector('.test-separator')).toBeInTheDocument();
+    expect(container.querySelector('.test-step')).toBeInTheDocument();
+    expect(container.querySelector('.test-content')).toBeInTheDocument();
+  });
+
+  it('supports steps rendered inside custom wrapper elements', () => {
+    render(
+      <Stepper.Root active={2}>
+        <div data-testid="sticky-wrapper">
+          <Stepper.Steps>
+            <Stepper.Step label="0" />
+            <Stepper.Step label="1" />
+          </Stepper.Steps>
+        </div>
+        <div data-testid="scroll-wrapper">
+          <Stepper.Content step={0}>test-step-content-0</Stepper.Content>
+          <Stepper.Content step={1}>test-step-content-1</Stepper.Content>
+          <Stepper.Completed step={2}>test-step-completed</Stepper.Completed>
+        </div>
+      </Stepper.Root>
+    );
+
+    expect(screen.getByText('test-step-completed')).toBeInTheDocument();
+    expect(screen.queryByText('test-step-content-0')).not.toBeInTheDocument();
   });
 });

--- a/packages/@mantine/core/src/components/Stepper/Stepper.tsx
+++ b/packages/@mantine/core/src/components/Stepper/Stepper.tsx
@@ -47,8 +47,15 @@ export type StepperFactory = Factory<{
   };
 }>;
 
+const defaultProps = {
+  orientation: 'horizontal',
+  iconPosition: 'left',
+  allowNextStepsSelect: true,
+  wrap: true,
+} satisfies Partial<StepperProps>;
+
 export const Stepper = factory<StepperFactory>((_props) => {
-  const props = useProps('Stepper', null, _props);
+  const props = useProps('Stepper', defaultProps, _props);
   const { children, classNames, styles, vars, ...others } = props;
 
   const { resolvedClassNames, resolvedStyles } = useResolvedStylesApi<StepperFactory>({

--- a/packages/@mantine/core/src/components/Stepper/Stepper.tsx
+++ b/packages/@mantine/core/src/components/Stepper/Stepper.tsx
@@ -1,112 +1,36 @@
-import { Activity, Children, cloneElement } from 'react';
-import {
-  Box,
-  BoxProps,
-  createVarsResolver,
-  ElementProps,
-  factory,
-  Factory,
-  getAutoContrastValue,
-  getContrastColor,
-  getFontSize,
-  getRadius,
-  getSize,
-  getSpacing,
-  getThemeColor,
-  MantineColor,
-  MantineRadius,
-  MantineSize,
-  MantineSpacing,
-  rem,
-  StylesApiProps,
-  useProps,
-  useStyles,
-} from '../../core';
-import { StepperProvider, type StepperContextValue } from './Stepper.context';
+import { Children, cloneElement } from 'react';
+import { factory, Factory, useProps, useResolvedStylesApi } from '../../core';
+import type { StepperContextValue } from './Stepper.context';
 import { StepperCompleted, StepperCompletedProps } from './StepperCompleted/StepperCompleted';
+import {
+  StepperContent,
+  type StepperContentProps,
+  type StepperContentStylesNames,
+} from './StepperContent/StepperContent';
+import {
+  StepperRoot,
+  varsResolver,
+  type StepFragmentComponent,
+  type StepperRootCssVariables,
+  type StepperRootProps,
+  type StepperRootStylesNames,
+} from './StepperRoot/StepperRoot';
 import { StepperStep, StepperStepProps } from './StepperStep/StepperStep';
+import {
+  StepperSteps,
+  type StepperStepsProps,
+  type StepperStepsStylesNames,
+} from './StepperSteps/StepperSteps';
 import classes from './Stepper.module.css';
-export type StepFragmentComponent = React.FC<{ step: number }>;
 
-export type StepperStylesNames =
-  | 'root'
-  | 'separator'
-  | 'steps'
-  | 'content'
-  | 'step'
-  | 'stepLoader'
-  | 'verticalSeparator'
-  | 'stepWrapper'
-  | 'stepIcon'
-  | 'stepCompletedIcon'
-  | 'stepIconContent'
-  | 'stepBody'
-  | 'stepLabel'
-  | 'stepDescription';
+export type { StepFragmentComponent };
 
-export type StepperCssVariables = {
-  root:
-    | '--stepper-color'
-    | '--stepper-icon-color'
-    | '--stepper-icon-size'
-    | '--stepper-content-padding'
-    | '--stepper-radius'
-    | '--stepper-fz'
-    | '--stepper-spacing';
-};
+export type StepperStylesNames = StepperRootStylesNames;
+export type StepperCssVariables = StepperRootCssVariables;
 
-export interface StepperProps
-  extends BoxProps, StylesApiProps<StepperFactory>, ElementProps<'div'> {
+export interface StepperProps extends StepperRootProps {
   /** `Stepper.Step` components */
   children: React.ReactNode;
-
-  /** Called when a clickable step is clicked with its 0-based index. Not called for the currently active step. */
-  onStepClick?: (stepIndex: number) => void;
-
-  /** Index of the active step */
-  active: number;
-
-  /** Step icon @default step index + 1 */
-  icon?: React.ReactNode | StepFragmentComponent;
-
-  /** Step icon displayed when step is completed @default CheckIcon */
-  completedIcon?: React.ReactNode | StepFragmentComponent;
-
-  /** Step icon displayed when step is in progress @default step index + 1 */
-  progressIcon?: React.ReactNode | StepFragmentComponent;
-
-  /** Key of `theme.colors` or any valid CSS color, controls colors of active and progress steps @default theme.primaryColor */
-  color?: MantineColor;
-
-  /** Controls size of the step icon, by default icon size is inferred from `size` prop */
-  iconSize?: number | string;
-
-  /** Key of `theme.spacing` or any valid CSS value to set `padding-top` of the content @default 'md' */
-  contentPadding?: MantineSpacing;
-
-  /** Stepper orientation @default 'horizontal' */
-  orientation?: 'vertical' | 'horizontal';
-
-  /** Icon position relative to the step body @default 'left' */
-  iconPosition?: 'right' | 'left';
-
-  /** Controls size of various Stepper elements */
-  size?: MantineSize;
-
-  /** Key of `theme.radius` or any valid CSS value to set steps border-radius @default "xl" */
-  radius?: MantineRadius;
-
-  /** When true, users can click and jump to any step. When false, users can only navigate to completed steps @default true */
-  allowNextStepsSelect?: boolean;
-
-  /** Determines whether steps should wrap to the next line if no space is available @default true */
-  wrap?: boolean;
-
-  /** When true, automatically adjusts the icon color in completed steps to ensure sufficient contrast against the step background color */
-  autoContrast?: boolean;
-
-  /** If set, all step content is kept mounted. React 19 `Activity` is used to preserve state while content is hidden. @default false */
-  keepMounted?: boolean;
 }
 
 export type StepperFactory = Factory<{
@@ -117,174 +41,40 @@ export type StepperFactory = Factory<{
   staticComponents: {
     Step: typeof StepperStep;
     Completed: typeof StepperCompleted;
+    Root: typeof StepperRoot;
+    Steps: typeof StepperSteps;
+    Content: typeof StepperContent;
   };
 }>;
 
-const defaultProps = {
-  orientation: 'horizontal',
-  iconPosition: 'left',
-  allowNextStepsSelect: true,
-  wrap: true,
-} satisfies Partial<StepperProps>;
-
-const varsResolver = createVarsResolver<StepperFactory>(
-  (theme, { color, iconSize, size, contentPadding, radius, autoContrast }) => ({
-    root: {
-      '--stepper-color': color ? getThemeColor(color, theme) : undefined,
-      '--stepper-icon-color': getAutoContrastValue(autoContrast, theme)
-        ? getContrastColor({ color, theme, autoContrast })
-        : undefined,
-      '--stepper-icon-size':
-        iconSize === undefined ? getSize(size, 'stepper-icon-size') : rem(iconSize),
-      '--stepper-content-padding': getSpacing(contentPadding),
-      '--stepper-radius': radius === undefined ? undefined : getRadius(radius),
-      '--stepper-fz': getFontSize(size),
-      '--stepper-spacing': getSpacing(size),
-    },
-  })
-);
-
 export const Stepper = factory<StepperFactory>((_props) => {
-  const props = useProps('Stepper', defaultProps, _props);
-  const {
-    classNames,
-    className,
-    style,
-    styles,
-    unstyled,
-    vars,
-    children,
-    onStepClick,
-    active,
-    icon,
-    completedIcon,
-    progressIcon,
-    color,
-    iconSize,
-    contentPadding,
-    orientation,
-    iconPosition,
-    size,
-    radius,
-    allowNextStepsSelect,
-    wrap,
-    autoContrast,
-    keepMounted,
-    attributes,
-    ...others
-  } = props;
+  const props = useProps('Stepper', null, _props);
+  const { children, classNames, styles, vars, ...others } = props;
 
-  const getStyles = useStyles<StepperFactory>({
-    name: 'Stepper',
-    classes,
-    props,
-    className,
-    style,
+  const { resolvedClassNames, resolvedStyles } = useResolvedStylesApi<StepperFactory>({
     classNames,
     styles,
-    unstyled,
-    attributes,
-    vars,
-    varsResolver,
+    props,
   });
 
   const convertedChildren = Children.toArray(children) as React.ReactElement[];
   const _children = convertedChildren.filter(
     (child) => child.type !== StepperCompleted
   ) as React.ReactElement<StepperStepProps>[];
-  const completedStep = convertedChildren.find(
-    (item) => item.type === StepperCompleted
-  ) as React.ReactElement<StepperCompletedProps>;
-
-  const items = _children.reduce<React.ReactElement<StepperStepProps>[]>(
-    (acc, item: React.ReactElement<StepperStepProps>, index) => {
-      const state =
-        active === index ? 'stepProgress' : active > index ? 'stepCompleted' : 'stepInactive';
-
-      const shouldAllowSelect = () => {
-        if (typeof onStepClick !== 'function') {
-          return false;
-        }
-
-        if (typeof item.props.allowStepSelect === 'boolean') {
-          return item.props.allowStepSelect;
-        }
-
-        return state === 'stepCompleted' || allowNextStepsSelect;
-      };
-
-      const isStepSelectionEnabled = shouldAllowSelect();
-
-      acc.push(
-        cloneElement(item, {
-          icon: item.props.icon || icon || index + 1,
-          key: index,
-          step: index,
-          state,
-          onClick: () => isStepSelectionEnabled && onStepClick?.(index),
-          allowStepClick: isStepSelectionEnabled,
-          completedIcon: item.props.completedIcon || completedIcon,
-          progressIcon: item.props.progressIcon || progressIcon,
-          color: item.props.color || color,
-          iconSize,
-          iconPosition: item.props.iconPosition || iconPosition,
-          orientation,
-        })
-      );
-
-      if (orientation === 'horizontal' && index !== _children.length - 1) {
-        acc.push(
-          <div
-            {...getStyles('separator')}
-            data-active={index < active || undefined}
-            data-orientation={orientation}
-            key={`separator-${index}`}
-          />
-        );
-      }
-
-      return acc;
-    },
-    []
-  );
-
-  const stepContent = _children[active]?.props?.children;
-  const completedContent = completedStep?.props?.children;
-  const content = active > _children.length - 1 ? completedContent : stepContent;
-
-  const contentSection = keepMounted ? (
-    <>
-      {_children.map((child, index) => (
-        <Activity key={index} mode={active === index ? 'visible' : 'hidden'}>
-          <div {...getStyles('content')}>{child.props.children}</div>
-        </Activity>
-      ))}
-      {completedStep && (
-        <Activity mode={active > _children.length - 1 ? 'visible' : 'hidden'}>
-          <div {...getStyles('content')}>{completedStep.props.children}</div>
-        </Activity>
-      )}
-    </>
-  ) : (
-    content && <div {...getStyles('content')}>{content}</div>
-  );
+  const completedStep = convertedChildren.find((item) => item.type === StepperCompleted) as
+    | React.ReactElement<StepperCompletedProps>
+    | undefined;
 
   return (
-    <StepperProvider value={{ getStyles, orientation, iconPosition }}>
-      <Box {...getStyles('root')} size={size} {...others}>
-        <Box
-          {...getStyles('steps')}
-          mod={{
-            orientation,
-            'icon-position': iconPosition,
-            wrap: wrap && orientation !== 'vertical',
-          }}
-        >
-          {items}
-        </Box>
-        {contentSection}
-      </Box>
-    </StepperProvider>
+    <StepperRoot classNames={resolvedClassNames} styles={resolvedStyles} vars={vars} {...others}>
+      <StepperSteps>{_children}</StepperSteps>
+      {_children.map((child, index) => (
+        <StepperContent step={index} key={index}>
+          {child.props.children}
+        </StepperContent>
+      ))}
+      {completedStep && cloneElement(completedStep, { step: _children.length })}
+    </StepperRoot>
   );
 });
 
@@ -293,6 +83,9 @@ Stepper.varsResolver = varsResolver;
 Stepper.displayName = '@mantine/core/Stepper';
 Stepper.Completed = StepperCompleted;
 Stepper.Step = StepperStep;
+Stepper.Root = StepperRoot;
+Stepper.Steps = StepperSteps;
+Stepper.Content = StepperContent;
 
 export namespace Stepper {
   export type Props = StepperProps;
@@ -308,5 +101,21 @@ export namespace Stepper {
 
   export namespace Completed {
     export type Props = StepperCompletedProps;
+  }
+
+  export namespace Root {
+    export type Props = StepperRootProps;
+    export type StylesNames = StepperRootStylesNames;
+    export type CssVariables = StepperRootCssVariables;
+  }
+
+  export namespace Steps {
+    export type Props = StepperStepsProps;
+    export type StylesNames = StepperStepsStylesNames;
+  }
+
+  export namespace Content {
+    export type Props = StepperContentProps;
+    export type StylesNames = StepperContentStylesNames;
   }
 }

--- a/packages/@mantine/core/src/components/Stepper/Stepper.tsx
+++ b/packages/@mantine/core/src/components/Stepper/Stepper.tsx
@@ -56,7 +56,7 @@ const defaultProps = {
 
 export const Stepper = factory<StepperFactory>((_props) => {
   const props = useProps('Stepper', defaultProps, _props);
-  const { children, classNames, styles, vars, ...others } = props;
+  const { children, classNames, styles, vars, stepsCount, ...others } = props;
 
   const { resolvedClassNames, resolvedStyles } = useResolvedStylesApi<StepperFactory>({
     classNames,
@@ -73,7 +73,13 @@ export const Stepper = factory<StepperFactory>((_props) => {
     | undefined;
 
   return (
-    <StepperRoot classNames={resolvedClassNames} styles={resolvedStyles} vars={vars} {...others}>
+    <StepperRoot
+      classNames={resolvedClassNames}
+      styles={resolvedStyles}
+      vars={vars}
+      {...others}
+      stepsCount={stepsCount ?? _children.length}
+    >
       <StepperSteps>{_children}</StepperSteps>
       {_children.map((child, index) => (
         <StepperContent step={index} key={index}>

--- a/packages/@mantine/core/src/components/Stepper/StepperCompleted/StepperCompleted.tsx
+++ b/packages/@mantine/core/src/components/Stepper/StepperCompleted/StepperCompleted.tsx
@@ -1,7 +1,32 @@
+import { Activity } from 'react';
+import { useOptionalStepperContext } from '../Stepper.context';
+
 export interface StepperCompletedProps {
-  /** Label content */
+  /** Content displayed when all steps are completed */
   children: React.ReactNode;
+
+  /** 0-based index at which completed content is displayed. Required with `Stepper.Root`, automatically set by `Stepper`. */
+  step?: number;
 }
 
-export const StepperCompleted: React.FC<StepperCompletedProps> = () => null;
+export const StepperCompleted: React.FC<StepperCompletedProps> = ({ children, step }) => {
+  const ctx = useOptionalStepperContext();
+
+  if (!ctx || step === undefined) {
+    return null;
+  }
+
+  const active = ctx.active >= step;
+
+  if (ctx.keepMounted) {
+    return (
+      <Activity mode={active ? 'visible' : 'hidden'}>
+        <div {...ctx.getStyles('content')}>{children}</div>
+      </Activity>
+    );
+  }
+
+  return active ? <div {...ctx.getStyles('content')}>{children}</div> : null;
+};
+
 StepperCompleted.displayName = '@mantine/core/StepperCompleted';

--- a/packages/@mantine/core/src/components/Stepper/StepperCompleted/StepperCompleted.tsx
+++ b/packages/@mantine/core/src/components/Stepper/StepperCompleted/StepperCompleted.tsx
@@ -1,7 +1,8 @@
+import { Box, type BoxProps, type ElementProps } from '@mantine/core';
 import { Activity } from 'react';
 import { useOptionalStepperContext } from '../Stepper.context';
 
-export interface StepperCompletedProps {
+export interface StepperCompletedProps extends BoxProps, ElementProps<'div'> {
   /** Content displayed when all steps are completed */
   children: React.ReactNode;
 
@@ -9,7 +10,7 @@ export interface StepperCompletedProps {
   step?: number;
 }
 
-export const StepperCompleted: React.FC<StepperCompletedProps> = ({ children, step }) => {
+export const StepperCompleted: React.FC<StepperCompletedProps> = ({ children, step, className, style, ...others }) => {
   const ctx = useOptionalStepperContext();
 
   if (!ctx || step === undefined) {
@@ -17,16 +18,17 @@ export const StepperCompleted: React.FC<StepperCompletedProps> = ({ children, st
   }
 
   const active = ctx.active >= step;
-
+  const content = (
+    <Box {...ctx.getStyles('content', { className, style })} {...others}>
+      {children}
+    </Box>
+  );
   if (ctx.keepMounted) {
-    return (
-      <Activity mode={active ? 'visible' : 'hidden'}>
-        <div {...ctx.getStyles('content')}>{children}</div>
-      </Activity>
-    );
+    return <Activity mode={active ? 'visible' : 'hidden'}>{content}</Activity>;
   }
 
-  return active ? <div {...ctx.getStyles('content')}>{children}</div> : null;
+  return active ? content : null;
+
 };
 
 StepperCompleted.displayName = '@mantine/core/StepperCompleted';

--- a/packages/@mantine/core/src/components/Stepper/StepperContent/StepperContent.tsx
+++ b/packages/@mantine/core/src/components/Stepper/StepperContent/StepperContent.tsx
@@ -1,0 +1,66 @@
+import { Activity } from 'react';
+import {
+  Box,
+  BoxProps,
+  CompoundStylesApiProps,
+  ElementProps,
+  factory,
+  Factory,
+  useProps,
+} from '../../../core';
+import { useStepperContext } from '../Stepper.context';
+import classes from '../Stepper.module.css';
+
+export type StepperContentStylesNames = 'content';
+
+export interface StepperContentProps
+  extends BoxProps, CompoundStylesApiProps<StepperContentFactory>, ElementProps<'div'> {
+  /** Content displayed when the associated step is active */
+  children?: React.ReactNode;
+
+  /** 0-based index of the associated `Stepper.Step` component */
+  step: number;
+
+  /** If set, the content is kept mounted, even if `keepMounted` is not set on the parent `Stepper.Root` component */
+  keepMounted?: boolean;
+}
+
+export type StepperContentFactory = Factory<{
+  props: StepperContentProps;
+  ref: HTMLDivElement;
+  stylesNames: StepperContentStylesNames;
+  compound: true;
+}>;
+
+export const StepperContent = factory<StepperContentFactory>((_props) => {
+  const props = useProps('StepperContent', null, _props);
+  const { children, className, style, classNames, styles, mod, step, keepMounted, ...others } =
+    props;
+
+  const ctx = useStepperContext();
+  const active = ctx.active === step;
+  const shouldKeepMounted = ctx.keepMounted || keepMounted;
+
+  if (!shouldKeepMounted && (!active || children == null)) {
+    return null;
+  }
+
+  const content = (
+    <Box
+      {...ctx.getStyles('content', { className, style, classNames, styles, props })}
+      mod={mod}
+      {...others}
+    >
+      {children}
+    </Box>
+  );
+
+  if (shouldKeepMounted) {
+    return <Activity mode={active ? 'visible' : 'hidden'}>{content}</Activity>;
+  }
+
+  return content;
+});
+
+StepperContent.classes = classes;
+StepperContent.displayName = '@mantine/core/StepperContent';

--- a/packages/@mantine/core/src/components/Stepper/StepperRoot/StepperRoot.tsx
+++ b/packages/@mantine/core/src/components/Stepper/StepperRoot/StepperRoot.tsx
@@ -1,0 +1,210 @@
+import {
+  Box,
+  BoxProps,
+  createVarsResolver,
+  ElementProps,
+  factory,
+  Factory,
+  getAutoContrastValue,
+  getContrastColor,
+  getFontSize,
+  getRadius,
+  getSize,
+  getSpacing,
+  getThemeColor,
+  MantineColor,
+  MantineRadius,
+  MantineSize,
+  MantineSpacing,
+  rem,
+  StylesApiProps,
+  useProps,
+  useStyles,
+} from '../../../core';
+import { StepperProvider } from '../Stepper.context';
+import classes from '../Stepper.module.css';
+
+export type StepFragmentComponent = React.FC<{ step: number }>;
+
+export type StepperRootStylesNames =
+  | 'root'
+  | 'separator'
+  | 'steps'
+  | 'content'
+  | 'step'
+  | 'stepLoader'
+  | 'verticalSeparator'
+  | 'stepWrapper'
+  | 'stepIcon'
+  | 'stepCompletedIcon'
+  | 'stepIconContent'
+  | 'stepBody'
+  | 'stepLabel'
+  | 'stepDescription';
+
+export type StepperRootCssVariables = {
+  root:
+    | '--stepper-color'
+    | '--stepper-icon-color'
+    | '--stepper-icon-size'
+    | '--stepper-content-padding'
+    | '--stepper-radius'
+    | '--stepper-fz'
+    | '--stepper-spacing';
+};
+
+export interface __StepperRootProps extends BoxProps, ElementProps<'div'> {
+  /** Called when a clickable step is clicked with its 0-based index. Not called for the currently active step. */
+  onStepClick?: (stepIndex: number) => void;
+
+  /** Index of the active step */
+  active: number;
+
+  /** Step icon @default step index + 1 */
+  icon?: React.ReactNode | StepFragmentComponent;
+
+  /** Step icon displayed when step is completed @default CheckIcon */
+  completedIcon?: React.ReactNode | StepFragmentComponent;
+
+  /** Step icon displayed when step is in progress @default step index + 1 */
+  progressIcon?: React.ReactNode | StepFragmentComponent;
+
+  /** Key of `theme.colors` or any valid CSS color, controls colors of active and progress steps @default theme.primaryColor */
+  color?: MantineColor;
+
+  /** Controls size of the step icon, by default icon size is inferred from `size` prop */
+  iconSize?: number | string;
+
+  /** Key of `theme.spacing` or any valid CSS value to set `padding-top` of the content @default 'md' */
+  contentPadding?: MantineSpacing;
+
+  /** Stepper orientation @default 'horizontal' */
+  orientation?: 'vertical' | 'horizontal';
+
+  /** Icon position relative to the step body @default 'left' */
+  iconPosition?: 'right' | 'left';
+
+  /** Controls size of various Stepper elements */
+  size?: MantineSize;
+
+  /** Key of `theme.radius` or any valid CSS value to set steps border-radius @default "xl" */
+  radius?: MantineRadius;
+
+  /** When true, users can click and jump to any step. When false, users can only navigate to completed steps @default true */
+  allowNextStepsSelect?: boolean;
+
+  /** Determines whether steps should wrap to the next line if no space is available @default true */
+  wrap?: boolean;
+
+  /** When true, automatically adjusts the icon color in completed steps to ensure sufficient contrast against the step background color */
+  autoContrast?: boolean;
+
+  /** If set, all step content is kept mounted. React 19 `Activity` is used to preserve state while content is hidden. @default false */
+  keepMounted?: boolean;
+}
+
+export interface StepperRootProps extends __StepperRootProps, StylesApiProps<StepperRootFactory> {}
+
+export type StepperRootFactory = Factory<{
+  props: StepperRootProps;
+  ref: HTMLDivElement;
+  stylesNames: StepperRootStylesNames;
+  vars: StepperRootCssVariables;
+}>;
+
+const defaultProps = {
+  orientation: 'horizontal',
+  iconPosition: 'left',
+  allowNextStepsSelect: true,
+  wrap: true,
+} satisfies Partial<StepperRootProps>;
+
+export const varsResolver = createVarsResolver<StepperRootFactory>(
+  (theme, { color, iconSize, size, contentPadding, radius, autoContrast }) => ({
+    root: {
+      '--stepper-color': color ? getThemeColor(color, theme) : undefined,
+      '--stepper-icon-color': getAutoContrastValue(autoContrast, theme)
+        ? getContrastColor({ color, theme, autoContrast })
+        : undefined,
+      '--stepper-icon-size':
+        iconSize === undefined ? getSize(size, 'stepper-icon-size') : rem(iconSize),
+      '--stepper-content-padding': getSpacing(contentPadding),
+      '--stepper-radius': radius === undefined ? undefined : getRadius(radius),
+      '--stepper-fz': getFontSize(size),
+      '--stepper-spacing': getSpacing(size),
+    },
+  })
+);
+
+export const StepperRoot = factory<StepperRootFactory>((_props) => {
+  const props = useProps('StepperRoot', defaultProps, _props);
+  const {
+    classNames,
+    className,
+    style,
+    styles,
+    unstyled,
+    vars,
+    children,
+    onStepClick,
+    active,
+    icon,
+    completedIcon,
+    progressIcon,
+    color,
+    iconSize,
+    contentPadding,
+    orientation,
+    iconPosition,
+    size,
+    radius,
+    allowNextStepsSelect,
+    wrap,
+    autoContrast,
+    keepMounted,
+    attributes,
+    ...others
+  } = props;
+
+  const getStyles = useStyles<StepperRootFactory>({
+    name: 'Stepper',
+    classes,
+    props,
+    className,
+    style,
+    classNames,
+    styles,
+    unstyled,
+    attributes,
+    vars,
+    varsResolver,
+  });
+
+  return (
+    <StepperProvider
+      value={{
+        getStyles,
+        orientation,
+        iconPosition,
+        active,
+        onStepClick,
+        allowNextStepsSelect,
+        icon,
+        completedIcon,
+        progressIcon,
+        color,
+        iconSize,
+        wrap,
+        keepMounted,
+      }}
+    >
+      <Box {...getStyles('root')} size={size} {...others}>
+        {children}
+      </Box>
+    </StepperProvider>
+  );
+});
+
+StepperRoot.classes = classes;
+StepperRoot.varsResolver = varsResolver;
+StepperRoot.displayName = '@mantine/core/StepperRoot';

--- a/packages/@mantine/core/src/components/Stepper/StepperRoot/StepperRoot.tsx
+++ b/packages/@mantine/core/src/components/Stepper/StepperRoot/StepperRoot.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   Box,
   BoxProps,
@@ -59,6 +60,9 @@ export interface __StepperRootProps extends BoxProps, ElementProps<'div'> {
 
   /** Index of the active step */
   active: number;
+
+  /** Number of steps, overrides the value detected from `Stepper.Steps` children. Set for correct value during server-side rendering. */
+  stepsCount?: number;
 
   /** Step icon @default step index + 1 */
   icon?: React.ReactNode | StepFragmentComponent;
@@ -148,6 +152,7 @@ export const StepperRoot = factory<StepperRootFactory>((_props) => {
     children,
     onStepClick,
     active,
+    stepsCount,
     icon,
     completedIcon,
     progressIcon,
@@ -165,6 +170,8 @@ export const StepperRoot = factory<StepperRootFactory>((_props) => {
     attributes,
     ...others
   } = props;
+
+  const [detectedStepsCount, setStepsCount] = useState(0);
 
   const getStyles = useStyles<StepperRootFactory>({
     name: 'Stepper',
@@ -187,6 +194,8 @@ export const StepperRoot = factory<StepperRootFactory>((_props) => {
         orientation,
         iconPosition,
         active,
+        stepsCount: stepsCount ?? detectedStepsCount,
+        setStepsCount,
         onStepClick,
         allowNextStepsSelect,
         icon,

--- a/packages/@mantine/core/src/components/Stepper/StepperStep/StepperStep.tsx
+++ b/packages/@mantine/core/src/components/Stepper/StepperStep/StepperStep.tsx
@@ -13,8 +13,8 @@ import { CheckIcon } from '../../Checkbox';
 import { Loader } from '../../Loader';
 import { Transition } from '../../Transition';
 import { UnstyledButton } from '../../UnstyledButton';
-import type { StepFragmentComponent } from '../Stepper';
 import { useStepperContext } from '../Stepper.context';
+import type { StepFragmentComponent } from '../StepperRoot/StepperRoot';
 import classes from '../Stepper.module.css';
 
 const getStepFragment = (

--- a/packages/@mantine/core/src/components/Stepper/StepperSteps/StepperSteps.tsx
+++ b/packages/@mantine/core/src/components/Stepper/StepperSteps/StepperSteps.tsx
@@ -1,0 +1,122 @@
+import { Children, cloneElement } from 'react';
+import {
+  Box,
+  BoxProps,
+  CompoundStylesApiProps,
+  ElementProps,
+  factory,
+  Factory,
+  useProps,
+} from '../../../core';
+import { useStepperContext } from '../Stepper.context';
+import { StepperCompleted } from '../StepperCompleted/StepperCompleted';
+import type { StepperStepProps } from '../StepperStep/StepperStep';
+import classes from '../Stepper.module.css';
+
+export type StepperStepsStylesNames = 'steps' | 'separator';
+
+export interface StepperStepsProps
+  extends BoxProps, CompoundStylesApiProps<StepperStepsFactory>, ElementProps<'div'> {
+  /** `Stepper.Step` components */
+  children: React.ReactNode;
+}
+
+export type StepperStepsFactory = Factory<{
+  props: StepperStepsProps;
+  ref: HTMLDivElement;
+  stylesNames: StepperStepsStylesNames;
+  compound: true;
+}>;
+
+export const StepperSteps = factory<StepperStepsFactory>((_props) => {
+  const props = useProps('StepperSteps', null, _props);
+  const { children, className, style, classNames, styles, mod, ...others } = props;
+
+  const ctx = useStepperContext();
+  const stylesApiProps = { classNames, styles, props };
+
+  const convertedChildren = Children.toArray(children) as React.ReactElement[];
+  const _children = convertedChildren.filter(
+    (child) => child.type !== StepperCompleted
+  ) as React.ReactElement<StepperStepProps>[];
+
+  const items = _children.reduce<React.ReactElement<StepperStepProps>[]>(
+    (acc, item: React.ReactElement<StepperStepProps>, index) => {
+      const state =
+        ctx.active === index
+          ? 'stepProgress'
+          : ctx.active > index
+            ? 'stepCompleted'
+            : 'stepInactive';
+
+      const shouldAllowSelect = () => {
+        if (typeof ctx.onStepClick !== 'function') {
+          return false;
+        }
+
+        if (ctx.active === index) {
+          return false;
+        }
+
+        if (typeof item.props.allowStepSelect === 'boolean') {
+          return item.props.allowStepSelect;
+        }
+
+        return state === 'stepCompleted' || ctx.allowNextStepsSelect;
+      };
+
+      const isStepSelectionEnabled = shouldAllowSelect();
+
+      acc.push(
+        cloneElement(item, {
+          icon: item.props.icon || ctx.icon || index + 1,
+          key: index,
+          step: index,
+          state,
+          onClick: () => isStepSelectionEnabled && ctx.onStepClick?.(index),
+          allowStepClick: isStepSelectionEnabled,
+          completedIcon: item.props.completedIcon || ctx.completedIcon,
+          progressIcon: item.props.progressIcon || ctx.progressIcon,
+          color: item.props.color || ctx.color,
+          iconSize: ctx.iconSize,
+          iconPosition: item.props.iconPosition || ctx.iconPosition,
+          orientation: ctx.orientation,
+        })
+      );
+
+      if (ctx.orientation === 'horizontal' && index !== _children.length - 1) {
+        acc.push(
+          <div
+            {...ctx.getStyles('separator', stylesApiProps)}
+            data-active={index < ctx.active || undefined}
+            data-orientation={ctx.orientation}
+            key={`separator-${index}`}
+          />
+        );
+      }
+
+      return acc;
+    },
+    []
+  );
+
+  return (
+    <Box
+      {...ctx.getStyles('steps', { className, style, ...stylesApiProps })}
+      mod={[
+        {
+          orientation: ctx.orientation,
+          'icon-position': ctx.iconPosition,
+          wrap: ctx.wrap && ctx.orientation !== 'vertical',
+        },
+        mod,
+      ]}
+      {...others}
+    >
+      {items}
+    </Box>
+  );
+});
+
+StepperSteps.classes = classes;
+StepperSteps.displayName = '@mantine/core/StepperSteps';

--- a/packages/@mantine/core/src/components/Stepper/StepperSteps/StepperSteps.tsx
+++ b/packages/@mantine/core/src/components/Stepper/StepperSteps/StepperSteps.tsx
@@ -1,3 +1,4 @@
+import { useIsomorphicEffect } from '@mantine/hooks';
 import { Children, cloneElement } from 'react';
 import {
   Box,
@@ -39,6 +40,10 @@ export const StepperSteps = factory<StepperStepsFactory>((_props) => {
   const _children = convertedChildren.filter(
     (child) => child.type !== StepperCompleted
   ) as React.ReactElement<StepperStepProps>[];
+
+  useIsomorphicEffect(() => {
+    ctx.setStepsCount(_children.length);
+  }, [_children.length]);
 
   const items = _children.reduce<React.ReactElement<StepperStepProps>[]>(
     (acc, item: React.ReactElement<StepperStepProps>, index) => {

--- a/packages/@mantine/core/src/components/Stepper/index.ts
+++ b/packages/@mantine/core/src/components/Stepper/index.ts
@@ -7,12 +7,21 @@ import type {
 } from './Stepper';
 import type { StepperContextValue } from './Stepper.context';
 import type { StepperCompletedProps } from './StepperCompleted/StepperCompleted';
+import type {
+  StepperContentProps,
+  StepperContentStylesNames,
+} from './StepperContent/StepperContent';
+import type { StepperRootProps } from './StepperRoot/StepperRoot';
 import type { StepperStepProps } from './StepperStep/StepperStep';
+import type { StepperStepsProps, StepperStepsStylesNames } from './StepperSteps/StepperSteps';
 
 export { Stepper } from './Stepper';
-export { StepperStep } from './StepperStep/StepperStep';
-export { StepperCompleted } from './StepperCompleted/StepperCompleted';
 export { useStepperContext } from './Stepper.context';
+export { StepperCompleted } from './StepperCompleted/StepperCompleted';
+export { StepperContent } from './StepperContent/StepperContent';
+export { StepperRoot } from './StepperRoot/StepperRoot';
+export { StepperStep } from './StepperStep/StepperStep';
+export { StepperSteps } from './StepperSteps/StepperSteps';
 
 export type {
   StepperProps,
@@ -22,5 +31,10 @@ export type {
   StepFragmentComponent,
   StepperStepProps,
   StepperCompletedProps,
+  StepperContentProps,
+  StepperContentStylesNames,
+  StepperRootProps,
+  StepperStepsProps,
+  StepperStepsStylesNames,
   StepperContextValue,
 };

--- a/scripts/docgen/docgen-paths.ts
+++ b/scripts/docgen/docgen-paths.ts
@@ -110,6 +110,9 @@ const FILES_PATHS = getPaths([
 
   // Stepper
   'packages/@mantine/core/src/components/Stepper/StepperStep/StepperStep.tsx',
+  'packages/@mantine/core/src/components/Stepper/StepperRoot/StepperRoot.tsx',
+  'packages/@mantine/core/src/components/Stepper/StepperSteps/StepperSteps.tsx',
+  'packages/@mantine/core/src/components/Stepper/StepperContent/StepperContent.tsx',
 
   // Timeline
   'packages/@mantine/core/src/components/Timeline/TimelineItem/TimelineItem.tsx',


### PR DESCRIPTION
This refactors `@mantine/core`'s Stepper into a compound component API (`Stepper.Root`, `Stepper.Steps`, `Stepper.Content`, `Stepper.Completed`) while keeping `Stepper` as a convenience wrapper, and updates docs/demos/tests accordingly.

This change is backwards-compatible, and all current usages of the `Stepper` component should continue to work as expected.

**Changes:**
- Added new compound components (`StepperRoot`, `StepperSteps`, `StepperContent`) and refactored `Stepper` to use them.
- Updated the `StepperCompleted` component to render the completed content, and added optional context access.
- Added coverage and documentation for compound usage, plus new demos/stories and docs updates.

This fixes https://github.com/orgs/mantinedev/discussions/8562