### PR TITLE
[@mantine/core] Drawer/Modal: Add Footer components

### DIFF
--- a/packages/@docs/styles-api/src/data/Drawer.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/Drawer.styles-api.ts
@@ -11,6 +11,7 @@ export const DrawerStylesApi: StylesApiData<DrawerFactory> = {
     title: 'Drawer title (h2 tag), displayed in the header',
     body: 'Drawer body, displayed after header',
     close: 'Close button',
+    footer: 'Drawer footer, displayed after body',
   },
 
   vars: {

--- a/packages/@docs/styles-api/src/data/Modal.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/Modal.styles-api.ts
@@ -11,6 +11,7 @@ export const ModalStylesApi: StylesApiData<ModalFactory> = {
     title: 'Modal title (h2 tag), displayed in the header',
     body: 'Modal body, displayed after header',
     close: 'Close button',
+    footer: 'Modal footer, displayed after body',
   },
 
   vars: {

--- a/packages/@mantine/core/src/components/Drawer/Drawer.module.css
+++ b/packages/@mantine/core/src/components/Drawer/Drawer.module.css
@@ -12,6 +12,10 @@
   z-index: 1000;
 }
 
+.footer {
+  z-index: 1000;
+}
+
 .content {
   flex: var(--drawer-flex, 0 0 var(--drawer-size));
   height: var(--drawer-height, calc(100% - var(--drawer-offset) * 2));

--- a/packages/@mantine/core/src/components/Drawer/Drawer.story.tsx
+++ b/packages/@mantine/core/src/components/Drawer/Drawer.story.tsx
@@ -282,3 +282,28 @@ export function KeepMountedMode() {
     </div>
   );
 }
+
+export function WithFooter() {
+  const [opened, { open, close }] = useDisclosure(true);
+  return (
+    <div style={{ padding: 40 }}>
+      <Button onClick={open}>Open Drawer</Button>
+      <Drawer.Root opened={opened} onClose={close} size="md">
+        <Drawer.Overlay />
+        <Drawer.Content>
+          <Drawer.Header>
+            <Drawer.Title>Drawer with Footer</Drawer.Title>
+            <Drawer.CloseButton />
+          </Drawer.Header>
+          <Drawer.Body>{content}</Drawer.Body>
+          <Drawer.Footer style={{ borderTop: '1px solid var(--mantine-color-default-border)' }}>
+            <Button variant="default" onClick={close}>
+              Cancel
+            </Button>
+            <Button onClick={close}>Submit Action</Button>
+          </Drawer.Footer>
+        </Drawer.Content>
+      </Drawer.Root>
+    </div>
+  );
+}

--- a/packages/@mantine/core/src/components/Drawer/Drawer.tsx
+++ b/packages/@mantine/core/src/components/Drawer/Drawer.tsx
@@ -5,6 +5,7 @@ import { DrawerBody } from './DrawerBody';
 import { DrawerCloseButton } from './DrawerCloseButton';
 import { DrawerContent } from './DrawerContent';
 import { DrawerHeader } from './DrawerHeader';
+import { DrawerFooter } from './DrawerFooter';
 import { DrawerOverlay } from './DrawerOverlay';
 import {
   DrawerRoot,
@@ -53,6 +54,7 @@ export type DrawerFactory = Factory<{
     Content: typeof DrawerContent;
     Body: typeof DrawerBody;
     Header: typeof DrawerHeader;
+    Footer: typeof DrawerFooter;
     Title: typeof DrawerTitle;
     CloseButton: typeof DrawerCloseButton;
     Stack: typeof DrawerStack;
@@ -143,6 +145,7 @@ Drawer.Overlay = DrawerOverlay;
 Drawer.Content = DrawerContent;
 Drawer.Body = DrawerBody;
 Drawer.Header = DrawerHeader;
+Drawer.Footer = DrawerFooter;
 Drawer.Title = DrawerTitle;
 Drawer.CloseButton = DrawerCloseButton;
 Drawer.Stack = DrawerStack;

--- a/packages/@mantine/core/src/components/Drawer/DrawerFooter.tsx
+++ b/packages/@mantine/core/src/components/Drawer/DrawerFooter.tsx
@@ -1,0 +1,33 @@
+import { CompoundStylesApiProps, factory, Factory, useProps } from '../../core';
+import { ModalBaseFooter, ModalBaseFooterProps } from '../ModalBase';
+import { useDrawerContext } from './Drawer.context';
+import classes from './Drawer.module.css';
+
+export type DrawerFooterStylesNames = 'footer';
+
+export interface DrawerFooterProps
+  extends ModalBaseFooterProps, CompoundStylesApiProps<DrawerFooterFactory> {}
+
+export type DrawerFooterFactory = Factory<{
+  props: DrawerFooterProps;
+  ref: HTMLElement;
+  stylesNames: DrawerFooterStylesNames;
+  compound: true;
+}>;
+
+export const DrawerFooter = factory<DrawerFooterFactory>((_props) => {
+  const props = useProps('DrawerFooter', null, _props);
+  const { classNames, className, style, styles, vars, ...others } = props;
+
+  const ctx = useDrawerContext();
+
+  return (
+    <ModalBaseFooter
+      {...ctx.getStyles('footer', { classNames, style, styles, className })}
+      {...others}
+    />
+  );
+});
+
+DrawerFooter.classes = classes;
+DrawerFooter.displayName = '@mantine/core/DrawerFooter';

--- a/packages/@mantine/core/src/components/Drawer/index.ts
+++ b/packages/@mantine/core/src/components/Drawer/index.ts
@@ -4,6 +4,7 @@ import type { DrawerBodyProps } from './DrawerBody';
 import type { DrawerCloseButtonProps } from './DrawerCloseButton';
 import type { DrawerContentProps } from './DrawerContent';
 import type { DrawerHeaderProps } from './DrawerHeader';
+import type { DrawerFooterProps, DrawerFooterStylesNames } from './DrawerFooter';
 import type { DrawerOverlayProps } from './DrawerOverlay';
 import type { DrawerRootProps } from './DrawerRoot';
 import type { DrawerStackProps } from './DrawerStack';
@@ -15,6 +16,7 @@ export { DrawerBody } from './DrawerBody';
 export { DrawerCloseButton } from './DrawerCloseButton';
 export { DrawerContent } from './DrawerContent';
 export { DrawerHeader } from './DrawerHeader';
+export { DrawerFooter } from './DrawerFooter';
 export { DrawerOverlay } from './DrawerOverlay';
 export { DrawerTitle } from './DrawerTitle';
 export { DrawerStack, DrawerStackContext } from './DrawerStack';
@@ -30,6 +32,8 @@ export type {
   DrawerCloseButtonProps,
   DrawerContentProps,
   DrawerHeaderProps,
+  DrawerFooterProps,
+  DrawerFooterStylesNames,
   DrawerOverlayProps,
   DrawerTitleProps,
   DrawerStackProps,

--- a/packages/@mantine/core/src/components/Modal/Modal.module.css
+++ b/packages/@mantine/core/src/components/Modal/Modal.module.css
@@ -36,6 +36,11 @@
   border-start-end-radius: var(--modal-radius, var(--mantine-radius-default));
 }
 
+.footer {
+  border-end-start-radius: var(--modal-radius, var(--mantine-radius-default));
+  border-end-end-radius: var(--modal-radius, var(--mantine-radius-default));
+}
+
 .content {
   flex: var(--modal-content-flex, 0 0 var(--modal-size));
   max-width: 100%;

--- a/packages/@mantine/core/src/components/Modal/Modal.story.tsx
+++ b/packages/@mantine/core/src/components/Modal/Modal.story.tsx
@@ -418,3 +418,28 @@ export function KeepMountedMode() {
     </div>
   );
 }
+
+export function WithFooter() {
+  const [opened, { open, close }] = useDisclosure(true);
+  return (
+    <div style={{ padding: 40 }}>
+      <Button onClick={open}>Open Modal</Button>
+      <Modal.Root opened={opened} onClose={close} size="md">
+        <Modal.Overlay />
+        <Modal.Content>
+          <Modal.Header>
+            <Modal.Title>Modal with Footer</Modal.Title>
+            <Modal.CloseButton />
+          </Modal.Header>
+          <Modal.Body>{content}</Modal.Body>
+          <Modal.Footer style={{ borderTop: '1px solid var(--mantine-color-default-border)' }}>
+            <Button variant="default" onClick={close}>
+              Cancel
+            </Button>
+            <Button onClick={close}>Submit Action</Button>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal.Root>
+    </div>
+  );
+}

--- a/packages/@mantine/core/src/components/Modal/Modal.tsx
+++ b/packages/@mantine/core/src/components/Modal/Modal.tsx
@@ -5,6 +5,7 @@ import { ModalBody, type ModalBodyProps } from './ModalBody';
 import { ModalCloseButton, type ModalCloseButtonProps } from './ModalCloseButton';
 import { ModalContent, type ModalContentProps } from './ModalContent';
 import { ModalHeader, type ModalHeaderProps } from './ModalHeader';
+import { ModalFooter } from './ModalFooter';
 import { ModalOverlay, type ModalOverlayProps } from './ModalOverlay';
 import {
   ModalRoot,
@@ -54,6 +55,7 @@ export type ModalFactory = Factory<{
     Content: typeof ModalContent;
     Body: typeof ModalBody;
     Header: typeof ModalHeader;
+    Footer: typeof ModalFooter;
     Title: typeof ModalTitle;
     CloseButton: typeof ModalCloseButton;
     Stack: typeof ModalStack;
@@ -149,6 +151,7 @@ Modal.Overlay = ModalOverlay;
 Modal.Content = ModalContent;
 Modal.Body = ModalBody;
 Modal.Header = ModalHeader;
+Modal.Footer = ModalFooter;
 Modal.Title = ModalTitle;
 Modal.CloseButton = ModalCloseButton;
 Modal.Stack = ModalStack;

--- a/packages/@mantine/core/src/components/Modal/ModalFooter.tsx
+++ b/packages/@mantine/core/src/components/Modal/ModalFooter.tsx
@@ -1,0 +1,33 @@
+import { CompoundStylesApiProps, factory, Factory, useProps } from '../../core';
+import { ModalBaseFooter, ModalBaseFooterProps } from '../ModalBase';
+import { useModalContext } from './Modal.context';
+import classes from './Modal.module.css';
+
+export type ModalFooterStylesNames = 'footer';
+
+export interface ModalFooterProps
+  extends ModalBaseFooterProps, CompoundStylesApiProps<ModalFooterFactory> {}
+
+export type ModalFooterFactory = Factory<{
+  props: ModalFooterProps;
+  ref: HTMLElement;
+  stylesNames: ModalFooterStylesNames;
+  compound: true;
+}>;
+
+export const ModalFooter = factory<ModalFooterFactory>((_props) => {
+  const props = useProps('ModalFooter', null, _props);
+  const { classNames, className, style, styles, vars, ...others } = props;
+
+  const ctx = useModalContext();
+
+  return (
+    <ModalBaseFooter
+      {...ctx.getStyles('footer', { classNames, style, styles, className })}
+      {...others}
+    />
+  );
+});
+
+ModalFooter.classes = classes;
+ModalFooter.displayName = '@mantine/core/ModalFooter';

--- a/packages/@mantine/core/src/components/Modal/index.ts
+++ b/packages/@mantine/core/src/components/Modal/index.ts
@@ -4,6 +4,7 @@ import type { ModalBodyProps } from './ModalBody';
 import type { ModalCloseButtonProps } from './ModalCloseButton';
 import type { ModalContentProps } from './ModalContent';
 import type { ModalHeaderProps } from './ModalHeader';
+import type { ModalFooterProps, ModalFooterStylesNames } from './ModalFooter';
 import type { ModalOverlayProps } from './ModalOverlay';
 import type { ModalRootProps } from './ModalRoot';
 import type { ModalStackProps } from './ModalStack';
@@ -15,6 +16,7 @@ export { ModalBody } from './ModalBody';
 export { ModalCloseButton } from './ModalCloseButton';
 export { ModalContent } from './ModalContent';
 export { ModalHeader } from './ModalHeader';
+export { ModalFooter } from './ModalFooter';
 export { ModalOverlay } from './ModalOverlay';
 export { ModalTitle } from './ModalTitle';
 export { ModalStack, ModalStackContext } from './ModalStack';
@@ -31,6 +33,8 @@ export type {
   ModalCloseButtonProps,
   ModalContentProps,
   ModalHeaderProps,
+  ModalFooterProps,
+  ModalFooterStylesNames,
   ModalOverlayProps,
   ModalTitleProps,
   ModalStackProps,

--- a/packages/@mantine/core/src/components/ModalBase/ModalBase.module.css
+++ b/packages/@mantine/core/src/components/ModalBase/ModalBase.module.css
@@ -20,6 +20,18 @@
   transition: padding-inline-end 100ms;
 }
 
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--mantine-spacing-md);
+  padding: var(--mb-padding, var(--mantine-spacing-md));
+  position: sticky;
+  bottom: 0;
+  background-color: var(--mantine-color-body);
+  z-index: 1000;
+}
+
 .inner {
   position: fixed;
   width: 100%;

--- a/packages/@mantine/core/src/components/ModalBase/ModalBaseFooter.tsx
+++ b/packages/@mantine/core/src/components/ModalBase/ModalBaseFooter.tsx
@@ -1,0 +1,19 @@
+import cx from 'clsx';
+import { Box, BoxProps, ElementProps } from '../../core';
+import { useModalBaseContext } from './ModalBase.context';
+import classes from './ModalBase.module.css';
+
+export interface ModalBaseFooterProps extends BoxProps, ElementProps<'footer'> {}
+
+export function ModalBaseFooter({ className, ...others }: ModalBaseFooterProps) {
+  const ctx = useModalBaseContext();
+  return (
+    <Box
+      component="footer"
+      className={cx({ [classes.footer]: !ctx.unstyled }, className)}
+      {...others}
+    />
+  );
+}
+
+ModalBaseFooter.displayName = '@mantine/core/ModalBaseFooter';

--- a/packages/@mantine/core/src/components/ModalBase/index.ts
+++ b/packages/@mantine/core/src/components/ModalBase/index.ts
@@ -3,6 +3,7 @@ export { ModalBaseBody } from './ModalBaseBody';
 export { ModalBaseCloseButton } from './ModalBaseCloseButton';
 export { ModalBaseContent } from './ModalBaseContent';
 export { ModalBaseHeader } from './ModalBaseHeader';
+export { ModalBaseFooter } from './ModalBaseFooter';
 export { ModalBaseOverlay } from './ModalBaseOverlay';
 export { ModalBaseTitle } from './ModalBaseTitle';
 export { NativeScrollArea } from './NativeScrollArea';
@@ -12,12 +13,14 @@ export type { ModalBaseBodyProps } from './ModalBaseBody';
 export type { ModalBaseCloseButtonProps } from './ModalBaseCloseButton';
 export type { ModalBaseContentProps } from './ModalBaseContent';
 export type { ModalBaseHeaderProps } from './ModalBaseHeader';
+export type { ModalBaseFooterProps } from './ModalBaseFooter';
 export type { ModalBaseOverlayProps } from './ModalBaseOverlay';
 export type { ModalBaseTitleProps } from './ModalBaseTitle';
 
 export type ModalBaseStylesNames =
   | 'body'
   | 'header'
+  | 'footer'
   | 'title'
   | 'overlay'
   | 'root'


### PR DESCRIPTION
### Problem
Users currently struggle to implement fixed footer content (such as action buttons) at the bottom of a `Drawer` or `Modal` when the main body content (`Drawer.Body` / `Modal.Body`) is scrollable. 
Common workarounds (like reusing `<Drawer.Header bottom={0}>Footer</Drawer.Header>` or using custom absolutely positioned containers) are hacky, break HTML semantics (using a `<header>` tag for a footer), and require manual layout overrides that conflict with style rules. There was no native support for a sticky footer layout.
### Solution
* Introduced `ModalBaseFooter` in `packages/@mantine/core/src/components/ModalBase` rendering a semantic `<footer>` element.
* Added a `.footer` CSS class to `ModalBase.module.css` with sticky positioning (`position: sticky; bottom: 0;`), background color support, and standard padding spacing.
* Created and registered the `Drawer.Footer` component using `ModalBaseFooter` with support for Drawer styles API.
* Created and registered the `Modal.Footer` component using `ModalBaseFooter` with bottom corner border-radius variables (`border-end-start-radius` / `border-end-end-radius`) configured in `Modal.module.css`.
* Documented the `footer` selector inside the `Drawer` and `Modal` styles API definitions.
* Added `WithFooter` story test cases in both `Drawer.story.tsx` and `Modal.story.tsx` for easy manual verification.
### Tests
* **Automated tests**: Ran `npm run jest packages/@mantine/core/src/components/Drawer/Drawer.test.tsx packages/@mantine/core/src/components/Modal/Modal.test.tsx` — 556 tests passed successfully.
* **Build, typecheck & formatting**: Verified clean output for `npm run typecheck`, `npm run build`, `npm run oxlint`, and `npm run stylelint`.
* **Manual verification**: Checked Storybook → Drawer → With Footer and Storybook → Modal → With Footer.

Resolves [#4540](https://github.com/orgs/mantinedev/discussions/4540) and [#8680](https://github.com/orgs/mantinedev/discussions/8680)