### PR TITLE
[@mantine/hooks] Fix useEffectEvent-based hooks not updating inside forwardRef and memo components

### DIFF
--- a/packages/@mantine/hooks/src/use-click-outside/use-click-outside.test.tsx
+++ b/packages/@mantine/hooks/src/use-click-outside/use-click-outside.test.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { forwardRef, useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useClickOutside } from './use-click-outside';
@@ -239,5 +239,40 @@ describe('@mantine/hooks/use-click-outside', () => {
     const event = handler.mock.calls[0][0];
     expect(event).toHaveProperty('type', 'mousedown');
     expect(event).toHaveProperty('target', outsideTarget);
+  });
+
+  it('calls the latest handler after rerender inside a forwardRef component', async () => {
+    const ForwardedTarget = forwardRef<HTMLButtonElement, UseClickOutsideProps>(
+      ({ handler }, buttonRef) => {
+        const ref = useClickOutside<HTMLDivElement>(handler);
+        return (
+          <div data-testid="target" ref={ref}>
+            <button type="button" ref={buttonRef} />
+          </div>
+        );
+      }
+    );
+
+    const first = jest.fn();
+    const second = jest.fn();
+
+    const { rerender } = render(
+      <>
+        <ForwardedTarget handler={first} />
+        <div data-testid="outside-target" />
+      </>
+    );
+
+    rerender(
+      <>
+        <ForwardedTarget handler={second} />
+        <div data-testid="outside-target" />
+      </>
+    );
+
+    await userEvent.click(screen.getByTestId('outside-target'));
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/@mantine/hooks/src/use-click-outside/use-click-outside.ts
+++ b/packages/@mantine/hooks/src/use-click-outside/use-click-outside.ts
@@ -1,4 +1,5 @@
-import { useEffect, useEffectEvent, useRef } from 'react';
+import { useEffect, useRef } from 'react';
+import { useCallbackRef } from '../utils';
 
 type EventType = MouseEvent | TouchEvent;
 
@@ -13,7 +14,7 @@ export function useClickOutside<T extends HTMLElement = any>(
   const ref = useRef<T>(null);
   const eventsList = events || DEFAULT_EVENTS;
 
-  const listener = useEffectEvent((event: Event) => {
+  const listener = useCallbackRef((event: Event) => {
     const { target } = event ?? {};
     const shouldIgnore =
       !document.body.contains(target as Node) && (target as Element)?.tagName !== 'HTML';

--- a/packages/@mantine/hooks/src/use-collapse/use-collapse.ts
+++ b/packages/@mantine/hooks/src/use-collapse/use-collapse.ts
@@ -1,7 +1,8 @@
-import React, { CSSProperties, useEffectEvent, useRef, useState } from 'react';
+import React, { CSSProperties, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useDidUpdate } from '../use-did-update/use-did-update';
 import { mergeRefs } from '../use-merged-ref/use-merged-ref';
+import { useCallbackRef } from '../utils';
 
 function getAutoHeightDuration(height: number | string) {
   if (!height || typeof height === 'string') {
@@ -72,7 +73,7 @@ export function useCollapse({
     ...(keepMounted ? {} : { display: 'none' }),
   };
 
-  const onTransitionStartEvent = useEffectEvent(() => onTransitionStart?.());
+  const onTransitionStartEvent = useCallbackRef(() => onTransitionStart?.());
 
   const elementRef = useRef<HTMLElement>(null);
   const [styles, setStylesRaw] = useState<CSSProperties>(expanded ? {} : collapsedStyles);

--- a/packages/@mantine/hooks/src/use-collapse/use-horizontal-collapse.ts
+++ b/packages/@mantine/hooks/src/use-collapse/use-horizontal-collapse.ts
@@ -1,7 +1,8 @@
-import React, { CSSProperties, useEffectEvent, useRef, useState } from 'react';
+import React, { CSSProperties, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useDidUpdate } from '../use-did-update/use-did-update';
 import { mergeRefs } from '../use-merged-ref/use-merged-ref';
+import { useCallbackRef } from '../utils';
 
 function getAutoWidthDuration(width: number | string) {
   if (!width || typeof width === 'string') {
@@ -74,7 +75,7 @@ export function useHorizontalCollapse({
     ...(keepMounted ? {} : { display: 'none' }),
   };
 
-  const onTransitionStartEvent = useEffectEvent(() => onTransitionStart?.());
+  const onTransitionStartEvent = useCallbackRef(() => onTransitionStart?.());
 
   const elementRef = useRef<HTMLElement>(null);
   const [styles, setStylesRaw] = useState<CSSProperties>(expanded ? {} : collapsedStyles);

--- a/packages/@mantine/hooks/src/use-headroom/use-headroom.ts
+++ b/packages/@mantine/hooks/src/use-headroom/use-headroom.ts
@@ -1,7 +1,8 @@
-import { useEffectEvent, useRef } from 'react';
+import { useRef } from 'react';
 import { useIsomorphicEffect } from '../use-isomorphic-effect/use-isomorphic-effect';
 import { useScrollDirection } from '../use-scroll-direction/use-scroll-direction';
 import { useWindowScroll } from '../use-window-scroll/use-window-scroll';
+import { useCallbackRef } from '../utils';
 
 export { useScrollDirection } from '../use-scroll-direction/use-scroll-direction';
 
@@ -68,9 +69,9 @@ export function useHeadroom({
   const isScrollingUp = scrollDirection === 'up';
   const [{ y: scrollPosition }] = useWindowScroll();
 
-  const onPinEvent = useEffectEvent(() => onPin?.());
-  const onReleaseEvent = useEffectEvent(() => onRelease?.());
-  const onFixEvent = useEffectEvent(() => onFix?.());
+  const onPinEvent = useCallbackRef(() => onPin?.());
+  const onReleaseEvent = useCallbackRef(() => onRelease?.());
+  const onFixEvent = useCallbackRef(() => onFix?.());
 
   useIsomorphicEffect(() => {
     isPinnedOrReleased(

--- a/packages/@mantine/hooks/src/use-hotkeys/use-hotkeys.test.tsx
+++ b/packages/@mantine/hooks/src/use-hotkeys/use-hotkeys.test.tsx
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { forwardRef, memo } from 'react';
+import { act, render, renderHook } from '@testing-library/react';
 import { useHotkeys } from './use-hotkeys';
 
 const dispatchEvent = (data: any) => {
@@ -94,6 +95,48 @@ describe('@mantine/hooks/use-hotkey', () => {
     });
 
     rerender({ handler: second });
+
+    act(() => {
+      dispatchEvent({ ctrlKey: true, key: 'S' });
+    });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the latest handler after rerender inside a forwardRef component', () => {
+    const Forwarded = forwardRef<HTMLDivElement, { handler: (event: KeyboardEvent) => void }>(
+      ({ handler }, ref) => {
+        useHotkeys([['ctrl+S', handler]]);
+        return <div ref={ref} />;
+      }
+    );
+
+    const first = jest.fn();
+    const second = jest.fn();
+
+    const { rerender } = render(<Forwarded handler={first} />);
+    rerender(<Forwarded handler={second} />);
+
+    act(() => {
+      dispatchEvent({ ctrlKey: true, key: 'S' });
+    });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the latest handler after rerender inside a memo component', () => {
+    const Memoized = memo(({ handler }: { handler: (event: KeyboardEvent) => void }) => {
+      useHotkeys([['ctrl+S', handler]]);
+      return null;
+    });
+
+    const first = jest.fn();
+    const second = jest.fn();
+
+    const { rerender } = render(<Memoized handler={first} />);
+    rerender(<Memoized handler={second} />);
 
     act(() => {
       dispatchEvent({ ctrlKey: true, key: 'S' });

--- a/packages/@mantine/hooks/src/use-hotkeys/use-hotkeys.ts
+++ b/packages/@mantine/hooks/src/use-hotkeys/use-hotkeys.ts
@@ -1,4 +1,5 @@
-import { useEffect, useEffectEvent } from 'react';
+import { useEffect } from 'react';
+import { useCallbackRef } from '../utils';
 import { getHotkeyHandler, getHotkeyMatcher, HotkeyItemOptions } from './parse-hotkey';
 
 export type { HotkeyItemOptions };
@@ -27,7 +28,10 @@ export function useHotkeys(
   tagsToIgnore: string[] = ['INPUT', 'TEXTAREA', 'SELECT'],
   triggerOnContentEditable = false
 ) {
-  const handleKeydown = useEffectEvent((event: KeyboardEvent) => {
+  // useCallbackRef instead of React's useEffectEvent: effect event impls are not
+  // updated inside ForwardRef and SimpleMemoComponent fibers, so the handler would
+  // be pinned to the mount render there. See #9078
+  const handleKeydown = useCallbackRef((event: KeyboardEvent) => {
     hotkeys.forEach(
       ([hotkey, handler, options = { preventDefault: true, usePhysicalKeys: false }]) => {
         if (

--- a/packages/@mantine/hooks/src/use-page-leave/use-page-leave.ts
+++ b/packages/@mantine/hooks/src/use-page-leave/use-page-leave.ts
@@ -1,7 +1,8 @@
-import { useEffect, useEffectEvent } from 'react';
+import { useEffect } from 'react';
+import { useCallbackRef } from '../utils';
 
 export function usePageLeave(onPageLeave: () => void) {
-  const onPageLeaveEvent = useEffectEvent(onPageLeave);
+  const onPageLeaveEvent = useCallbackRef(onPageLeave);
 
   useEffect(() => {
     document.documentElement.addEventListener('mouseleave', onPageLeaveEvent);

--- a/packages/@mantine/hooks/src/use-scroll-direction/use-scroll-direction.ts
+++ b/packages/@mantine/hooks/src/use-scroll-direction/use-scroll-direction.ts
@@ -1,4 +1,5 @@
-import { useEffect, useEffectEvent, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useCallbackRef } from '../utils';
 
 export type ScrollDirection = 'up' | 'down' | 'unknown';
 
@@ -8,7 +9,7 @@ export function useScrollDirection(): ScrollDirection {
   const isResizingRef = useRef(false);
   const resizeTimerRef = useRef<number | undefined>(undefined);
 
-  const handleScroll = useEffectEvent(() => {
+  const handleScroll = useCallbackRef(() => {
     if (isResizingRef.current) {
       return;
     }

--- a/packages/@mantine/hooks/src/use-scroll-spy/use-scroll-spy.ts
+++ b/packages/@mantine/hooks/src/use-scroll-spy/use-scroll-spy.ts
@@ -1,5 +1,5 @@
-import { useEffect, useEffectEvent, useRef, useState } from 'react';
-import { randomId } from '../utils';
+import { useEffect, useRef, useState } from 'react';
+import { randomId, useCallbackRef } from '../utils';
 
 function getHeadingsData(
   headings: HTMLElement[],
@@ -108,7 +108,7 @@ export function useScrollSpy({
   const [data, setData] = useState<UseScrollSpyHeadingData[]>([]);
   const headingsRef = useRef<UseScrollSpyHeadingData[]>([]);
 
-  const handleScroll = useEffectEvent(() => {
+  const handleScroll = useCallbackRef(() => {
     setActive(
       getActiveElement(
         headingsRef.current.map((d) => d.getNode().getBoundingClientRect()),

--- a/packages/@mantine/hooks/src/use-text-selection/use-text-selection.ts
+++ b/packages/@mantine/hooks/src/use-text-selection/use-text-selection.ts
@@ -1,11 +1,12 @@
-import { useEffect, useEffectEvent, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForceUpdate } from '../use-force-update/use-force-update';
+import { useCallbackRef } from '../utils';
 
 export function useTextSelection(): Selection | null {
   const forceUpdate = useForceUpdate();
   const [selection, setSelection] = useState<Selection | null>(null);
 
-  const handleSelectionChange = useEffectEvent(() => {
+  const handleSelectionChange = useCallbackRef(() => {
     setSelection(document.getSelection());
     forceUpdate();
   });

--- a/packages/@mantine/hooks/src/use-window-event/use-window-event.ts
+++ b/packages/@mantine/hooks/src/use-window-event/use-window-event.ts
@@ -1,4 +1,5 @@
-import { useEffect, useEffectEvent } from 'react';
+import { useEffect } from 'react';
+import { useCallbackRef } from '../utils';
 
 export function useWindowEvent<K extends string>(
   type: K,
@@ -7,7 +8,7 @@ export function useWindowEvent<K extends string>(
     : (this: Window, ev: CustomEvent) => void,
   options?: boolean | AddEventListenerOptions
 ) {
-  const stableListener = useEffectEvent(listener);
+  const stableListener = useCallbackRef(listener);
 
   useEffect(() => {
     window.addEventListener(type as any, stableListener, options);

--- a/packages/@mantine/hooks/src/utils/use-callback-ref/use-callback-ref.ts
+++ b/packages/@mantine/hooks/src/utils/use-callback-ref/use-callback-ref.ts
@@ -1,9 +1,12 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
+import { useIsomorphicEffect } from '../../use-isomorphic-effect/use-isomorphic-effect';
 
 export function useCallbackRef<T extends (...args: any[]) => any>(callback: T | undefined): T {
   const callbackRef = useRef(callback);
 
-  useEffect(() => {
+  // Layout effect instead of useEffect so the ref is already fresh when other
+  // layout effects and event listeners run within the same commit
+  useIsomorphicEffect(() => {
     callbackRef.current = callback;
   });
 


### PR DESCRIPTION
Fixes #9078

## Problem

React only applies `useEffectEvent` implementation updates for plain function component fibers (tag 0). Inside `forwardRef` (tag 11) and `memo(fn)` (tag 15) the update is never applied, so any hook that pairs `useEffectEvent` with a subscribe-once effect keeps calling the closure from the first render. The listener still fires, but it always sees the initial props and state.

Reproduced with react-dom 19.2.7 in the browser and in jsdom. The regression tests in this PR fail on master.

Affected hooks: `use-hotkeys`, `use-window-event`, `use-click-outside`, `use-page-leave`, `use-headroom`, `use-scroll-direction`, `use-scroll-spy`, `use-text-selection`, `use-collapse`, `use-horizontal-collapse`.

## Solution

Replaced React's `useEffectEvent` with the existing `useCallbackRef` util in these hooks. It gives the same stable identity and single subscription, but keeps the callback fresh through a ref that is updated on every commit, and that works for all fiber types.

There is one supporting change: `useCallbackRef` now updates its ref in `useIsomorphicEffect` instead of `useEffect`. This matches the commit timing of `useEffectEvent` and is needed for `use-headroom`, which calls the wrapped callbacks inside layout effects. With a passive update those callbacks would be one commit behind.

## Tests

- `useHotkeys`: latest handler is called after rerender inside `forwardRef` and inside `memo` components, both fail on master
- `useClickOutside`: latest handler is called after rerender inside a `forwardRef` component, fails on master

`npm test` passes.

## Note

`useEffectEvent` from react is also imported in `@mantine/core` (ScrollArea), `@mantine/notifications` and `@mantine/schedule`, and those components are created with `forwardRef`, so the same staleness can happen there. I can send the same change for those packages in a separate PR if you prefer to keep this one scoped to `@mantine/hooks`.
