### PR TITLE
[@mantine/core] FloatingWindow: Fix default z-index

### DIFF
--- a/packages/@mantine/core/src/components/FloatingWindow/FloatingWindow.story.tsx
+++ b/packages/@mantine/core/src/components/FloatingWindow/FloatingWindow.story.tsx
@@ -1,3 +1,4 @@
+import { Select } from '../Select';
 import { FloatingWindow } from './FloatingWindow';
 
 export default { title: 'FloatingWindow' };
@@ -25,6 +26,26 @@ export function Usage() {
       <p>{lorem}</p>
       <p>{lorem}</p>
     </div>
+  );
+}
+
+export function SelectDropdown() {
+  return (
+    <FloatingWindow
+      p="md"
+      w={320}
+      h={256}
+      withBorder
+      shadow="md"
+      initialPosition={{ top: 100, left: 100 }}
+    >
+      <Select
+        label="Your favorite library"
+        placeholder="Pick value"
+        data={['React', 'Angular', 'Vue', 'Svelte']}
+        defaultDropdownOpened
+      />
+    </FloatingWindow>
   );
 }
 

--- a/packages/@mantine/core/src/components/FloatingWindow/FloatingWindow.test.tsx
+++ b/packages/@mantine/core/src/components/FloatingWindow/FloatingWindow.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent } from '@testing-library/react';
 import { render, screen, tests } from '@mantine-tests/core';
+import { Select } from '../Select';
+import { Tooltip } from '../Tooltip';
 import { FloatingWindow, FloatingWindowProps, FloatingWindowStylesNames } from './FloatingWindow';
 
 const defaultProps: FloatingWindowProps = {};
@@ -13,6 +15,62 @@ describe('@mantine/core/FloatingWindow', () => {
     styleProps: false, // some style props are overridden internally
     displayName: '@mantine/core/FloatingWindow',
     stylesApiSelectors: ['root'],
+  });
+
+  it('renders portalled overlays above FloatingWindow by default', () => {
+    render(
+      <FloatingWindow data-testid="floating-window">
+        <Select
+          aria-label="Library"
+          data={['React', 'Angular']}
+          dropdownOpened
+          comboboxProps={{ transitionProps: { duration: 0 } }}
+        />
+
+        <Tooltip
+          opened
+          label="Tooltip content"
+          data-testid="tooltip"
+          transitionProps={{ duration: 0 }}
+        >
+          <button type="button">Tooltip target</button>
+        </Tooltip>
+
+        <Tooltip.Floating
+          defaultOpened
+          label="Floating tooltip content"
+          data-testid="floating-tooltip"
+        >
+          <button type="button">Floating tooltip target</button>
+        </Tooltip.Floating>
+      </FloatingWindow>,
+      undefined,
+      { env: 'default' }
+    );
+
+    const floatingWindow = screen.getByTestId('floating-window');
+    const floatingWindowZIndex = Number(
+      floatingWindow.style.getPropertyValue('--floating-window-z-index')
+    );
+    const selectDropdown = screen.getByRole('listbox').closest<HTMLElement>('[data-composed]')!;
+    const overlays = [
+      selectDropdown,
+      screen.getByTestId('tooltip'),
+      screen.getByTestId('floating-tooltip'),
+    ];
+
+    overlays.forEach((overlay) => {
+      expect(floatingWindow).not.toContainElement(overlay);
+      expect(overlay.parentElement).toBe(floatingWindow.parentElement);
+      expect(Number(overlay.style.zIndex)).toBeGreaterThan(floatingWindowZIndex);
+    });
+  });
+
+  it('supports custom z-index', () => {
+    render(<FloatingWindow data-testid="floating-window" zIndex={450} />);
+    expect(screen.getByTestId('floating-window')).toHaveStyle({
+      '--floating-window-z-index': '450',
+    });
   });
 
   it('renders ResizeHandle with correct ARIA attributes', () => {

--- a/packages/@mantine/core/src/components/FloatingWindow/FloatingWindow.tsx
+++ b/packages/@mantine/core/src/components/FloatingWindow/FloatingWindow.tsx
@@ -39,7 +39,7 @@ export interface FloatingWindowProps
   /** Props passed down to `Portal` component */
   portalProps?: Omit<PortalProps, 'children'>;
 
-  /** `z-index` of the root element @default 400 */
+  /** `z-index` of the root element @default 200 */
   zIndex?: React.CSSProperties['zIndex'];
 
   /** Dimensions configuration for resizable floating window */
@@ -57,7 +57,7 @@ export type FloatingWindowFactory = Factory<{
 
 const defaultProps = {
   constrainToViewport: true,
-  zIndex: getDefaultZIndex('overlay'),
+  zIndex: getDefaultZIndex('modal'),
 } satisfies Partial<FloatingWindowProps>;
 
 function clampDimension(value: number, min?: number, max?: number): number {


### PR DESCRIPTION
Fixes #8813

## Problem

`FloatingWindow` defaults to the overlay z-index tier (`400`), while portalled dropdowns and tooltips use the popover tier (`300`). Since the default portals share a body-level target, the window and its portalled overlays become sibling stacking contexts and the window covers the overlays.

This affects `Select` and every other Popover- or Tooltip-based surface rendered from a `FloatingWindow`.

## Solution

- change the default `FloatingWindow` z-index from the overlay tier (`400`) to the modal tier (`200`)
- preserve explicit `zIndex` overrides
- add real-portal regression coverage for `Select`, `Tooltip`, and `Tooltip.Floating`
- add a Storybook reproduction with an opened `Select` dropdown

This fixes the layer assignment at the container instead of coupling individual overlay components to `FloatingWindow`. It follows the existing hierarchy where application containers use the modal tier and transient floating surfaces use the popover tier.

The issue is labeled Deferred because changing the documented default is observable. This PR is intended for consideration with the next major release. Consumers that need the previous layer can continue to set `zIndex={400}` explicitly.

## Testing

- `npm run setup`
- `npm run build`
- `npm test` (647 suites, 15,788 tests, 1 snapshot)