### PR TITLE
fix(PasswordInput): allow keyboard navigation for visibility toggle

### DIFF
--- a/packages/@mantine/core/src/components/PasswordInput/PasswordInput.test.tsx
+++ b/packages/@mantine/core/src/components/PasswordInput/PasswordInput.test.tsx
@@ -122,6 +122,22 @@ describe('@mantine/core/PasswordInput', () => {
     expect(input.type).toBe('password');
   });
 
+    it('allows visibility toggle button to be reached with keyboard navigation', async () => {
+    const user = userEvent.setup();
+    render(<PasswordInput label="Password" />);
+
+      await user.tab();
+      await user.tab();
+
+    const toggleButton = screen.getByRole('button', { name: 'Toggle password visibility' });
+
+    expect(toggleButton).toHaveFocus();
+
+    await user.keyboard(' ');
+    expect(toggleButton).toHaveAttribute('aria-pressed', 'true');
+  });
+
+
   it('supports controlled visible prop', async () => {
     const { rerender } = render(<PasswordInput label="Password" visible={false} />);
 

--- a/packages/@mantine/core/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/@mantine/core/src/components/PasswordInput/PasswordInput.tsx
@@ -165,7 +165,6 @@ export const PasswordInput = factory<PasswordInputFactory>((_props) => {
       disabled={disabled}
       radius={radius}
       aria-pressed={_visible}
-      tabIndex={-1}
       aria-label="Toggle password visibility"
       {...visibilityToggleButtonProps}
       variant={visibilityToggleButtonProps?.variant ?? 'subtle'}


### PR DESCRIPTION
Fixes #9090

Removed tabIndex={-1} from the PasswordInput visibility toggle button so it can be reached with keyboard navigation.

Added a regression test to verify the toggle button can be focused and activated with keyboard input.
