### PR TITLE
Add mantine-map into 3rd party extensions

### DIFF
--- a/apps/mantine.dev/src/pages/x/extensions.mdx
+++ b/apps/mantine.dev/src/pages/x/extensions.mdx
@@ -68,6 +68,7 @@ Community extensions list:
 - [Mantine Form Builder](https://pradip-v2.github.io/mantine-form-builder/) – form builder and viewer components
 - [Mantine Choropleth Map](https://maetes.github.io/mantine-choropleth/) - Choropleth Map component for GeoJson
 - [Lightbox](https://rilrom.github.io/mantine-bites/lightbox/) - Full-screen image lightbox built on top of @mantine/carousel
+- [Mantine Map](https://sarioglu.github.io/mantine-map) - Interactive maps for Mantine, powered by MapLibre GL
 
 ## Create your own extension
 


### PR DESCRIPTION
I recently created a map component based on my needs. This PR adds it into 3rd party extensions list so that more people can benefit from it