### PR TITLE
fix(Menu): add ARIA roles to MenuDivider and MenuLabel

### DIFF
--- a/packages/@mantine/core/src/components/Menu/MenuDivider/MenuDivider.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuDivider/MenuDivider.tsx
@@ -31,7 +31,7 @@ export const MenuDivider = factory<MenuDividerFactory>((props) => {
   const ctx = useMenuContext();
 
   return (
-    <Box {...ctx.getStyles('divider', { className, style, styles, classNames })} {...others} />
+    <Box {...ctx.getStyles('divider', { className, style, styles, classNames })} {...others} role="separator"/>
   );
 });
 

--- a/packages/@mantine/core/src/components/Menu/MenuDivider/MenuDivider.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuDivider/MenuDivider.tsx
@@ -31,7 +31,11 @@ export const MenuDivider = factory<MenuDividerFactory>((props) => {
   const ctx = useMenuContext();
 
   return (
-    <Box {...ctx.getStyles('divider', { className, style, styles, classNames })} {...others} role="separator"/>
+    <Box
+      {...ctx.getStyles('divider', { className, style, styles, classNames })}
+      {...others}
+      role="separator"
+    />
   );
 });
 

--- a/packages/@mantine/core/src/components/Menu/MenuLabel/MenuLabel.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuLabel/MenuLabel.tsx
@@ -30,7 +30,7 @@ export const MenuLabel = factory<MenuLabelFactory>((props) => {
   );
   const ctx = useMenuContext();
 
-  return <Box {...ctx.getStyles('label', { className, style, styles, classNames })} {...others} />;
+  return <Box {...ctx.getStyles('label', { className, style, styles, classNames })} {...others} role="presentation" />;
 });
 
 MenuLabel.classes = classes;

--- a/packages/@mantine/core/src/components/Menu/MenuLabel/MenuLabel.tsx
+++ b/packages/@mantine/core/src/components/Menu/MenuLabel/MenuLabel.tsx
@@ -30,7 +30,13 @@ export const MenuLabel = factory<MenuLabelFactory>((props) => {
   );
   const ctx = useMenuContext();
 
-  return <Box {...ctx.getStyles('label', { className, style, styles, classNames })} {...others} role="presentation" />;
+  return (
+    <Box
+      {...ctx.getStyles('label', { className, style, styles, classNames })}
+      {...others}
+      role="presentation"
+    />
+  );
 });
 
 MenuLabel.classes = classes;


### PR DESCRIPTION
## What this PR does

Fixes an accessibility issue where `Menu.Divider` and `Menu.Label` were rendered as direct children of the `role="menu"` container without any ARIA role. Per the WAI-ARIA spec, `menu` only permits children with roles `menuitem`, `menuitemcheckbox`, `menuitemradio`, `group`, or `separator` — plain unroled `<div>` children are flagged by accessibility checkers (e.g. axe) as invalid.

## Changes

- `MenuDivider.tsx`: added `role="separator"`, the correct ARIA role for a visual divider inside a menu
- `MenuLabel.tsx`: added `role="presentation"`, removing the non-interactive label from the accessibility tree so it's no longer counted as an invalid `menu` child

## Testing

Ran the full local test suite (`npm run lint`, `npm run jest`) — all checks pass, including `Menu.test.tsx`. Note: `npm run typecheck` fails on `apps/mantine.dev` independent of this change (confirmed by running it on a clean `master` checkout too).

Fixes #8971