### PR TITLE
[mantine.dev] Add AdaptTable community extension

### DIFF
--- a/apps/mantine.dev/src/pages/x/extensions.mdx
+++ b/apps/mantine.dev/src/pages/x/extensions.mdx
@@ -35,6 +35,7 @@ Mantine packages and extensions.
 
 Community extensions list:
 
+- [AdaptTable](https://orwa-mahmoud.github.io/adapttable/demo/?kit=mantine) – data table with a headless core, Mantine-native UI, server data, virtualization, and responsive mobile cards
 - [BlockNote](https://www.blocknotejs.org/) – block-based rich text editor
 - [ContextMenu](https://icflorescu.github.io/mantine-contextmenu/) – context menu component
 - [DataTable](https://icflorescu.github.io/mantine-datatable/) – data table component without dependencies


### PR DESCRIPTION
Adds AdaptTable to the community extensions list.

`@adapttable/mantine` is a published, independently maintained Mantine data-table adapter with a headless core, Mantine-native controls, client and server data, virtualization, RTL, and responsive mobile cards.

- Demo: https://orwa-mahmoud.github.io/adapttable/demo/?kit=mantine
- npm: https://www.npmjs.com/package/@adapttable/mantine
- Source: https://github.com/orwa-mahmoud/adapttable/tree/main/packages/adapter-mantine