### PR TITLE
[@mantine/core] NumberInput: Fix thousand separator being replaced with decimal separator in pasted values

### DIFF
--- a/packages/@mantine/core/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/@mantine/core/src/components/NumberInput/NumberInput.test.tsx
@@ -651,4 +651,46 @@ describe('@mantine/core/NumberInput', () => {
     expect(spy).toHaveBeenLastCalledWith(25.5);
     expectValue('25,5');
   });
+
+  // jsdom does not insert clipboard text on paste, so these tests assert that the
+  // paste event is not intercepted (value/onChange untouched) — in the browser the
+  // native paste then goes through react-number-format, which handles grouping
+  it('does not treat thousandSeparator as a decimal separator in pasted values', () => {
+    const spy = jest.fn();
+    render(<NumberInput onChange={spy} thousandSeparator="," />);
+
+    focusInput();
+    fireEvent.paste(getInput(), {
+      clipboardData: { getData: () => '1,234,567' },
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+    expectValue('');
+  });
+
+  it('does not treat thousandSeparator={true} as a decimal separator in pasted values', () => {
+    const spy = jest.fn();
+    render(<NumberInput onChange={spy} thousandSeparator />);
+
+    focusInput();
+    fireEvent.paste(getInput(), {
+      clipboardData: { getData: () => '1,234,567' },
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+    expectValue('');
+  });
+
+  it('converts allowed decimal separators in pasted values when thousandSeparator is a different character', () => {
+    const spy = jest.fn();
+    render(<NumberInput onChange={spy} thousandSeparator=" " allowedDecimalSeparators={[',']} />);
+
+    focusInput();
+    fireEvent.paste(getInput(), {
+      clipboardData: { getData: () => '25,5' },
+    });
+
+    expect(spy).toHaveBeenLastCalledWith(25.5);
+    expectValue('25.5');
+  });
 });

--- a/packages/@mantine/core/src/components/NumberInput/NumberInput.tsx
+++ b/packages/@mantine/core/src/components/NumberInput/NumberInput.tsx
@@ -645,8 +645,13 @@ export const NumberInput = genericFactory<NumberInputFactory>(
     const handlePaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
       const pastedText = event.clipboardData.getData('text');
       const _decimalSeparator = others.decimalSeparator || '.';
+      // `thousandSeparator: true` enables the default ',' separator in react-number-format
+      const _thousandSeparator = others.thousandSeparator === true ? ',' : others.thousandSeparator;
+      // The thousand separator cannot act as a decimal separator: values like 1,234,567
+      // must keep their grouping (react-number-format strips it on its own) instead of
+      // being rewritten to 1.234.567
       const separatorsToReplace = (allowedDecimalSeparators || ['.', ',']).filter(
-        (s) => s !== _decimalSeparator
+        (s) => s !== _decimalSeparator && s !== _thousandSeparator
       );
 
       if (separatorsToReplace.some((s) => pastedText.includes(s))) {


### PR DESCRIPTION
## Bug

Pasting a value that contains thousand separators into a `NumberInput` with `thousandSeparator=","` corrupts the value:

```tsx
<NumberInput thousandSeparator="," />
```

Paste `1,234,567` → input shows `1.234` (value `1.234`), instead of `1,234,567` (value `1234567`).

This makes copy/paste lossy even for the input's **own displayed value**: copying `1,234,567` out of the input and pasting it back produces a different number.

Regression introduced in 8.3.16 ("NumberInput: Fix incorrect decimal separator parsing in `onPaste`") — versions ≤ 8.3.15 had no paste handler and pasted grouped values correctly via react-number-format.

## Root cause

`handlePaste` replaces every character in `allowedDecimalSeparators` (default `['.', ',']`) with the decimal separator, filtering out only the `decimalSeparator` itself — it never checks whether the character is also the `thousandSeparator`. With the default configuration, `,` is simultaneously the thousand separator and an "allowed decimal separator", so `1,234,567` is rewritten to `1.234.567` before being handed to react-number-format.

## Fix

Exclude the effective thousand separator (handling `thousandSeparator: true` → `','`) from the set of separators rewritten on paste. When the pasted text contains no other convertible separator, the paste is no longer intercepted and react-number-format handles the grouping natively (it strips thousand separators on its own).

Decimal-separator conversion on paste is unchanged in every configuration where the two separators are distinct characters (e.g. `decimalSeparator=","` + default thousand grouping, or `thousandSeparator=" "` + `allowedDecimalSeparators={[',']}`).

## Tests

- `does not treat thousandSeparator as a decimal separator in pasted values` — fails on master, passes with the fix
- `does not treat thousandSeparator={true} as a decimal separator in pasted values` — fails on master, passes with the fix
- `converts allowed decimal separators in pasted values when thousandSeparator is a different character` — guards that the 8.3.16 conversion behaviour is preserved when the separators don't collide

All 112 NumberInput tests pass.
