### PR TITLE
[@mantine/core] Transition: Resolve useTransition synchronously in test env

### DIFF
--- a/packages/@mantine/core/src/components/Transition/Transition.test.tsx
+++ b/packages/@mantine/core/src/components/Transition/Transition.test.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { act, fireEvent } from '@testing-library/react';
+import { render, screen } from '@mantine-tests/core';
+import { Transition, TransitionProps } from './Transition';
+
+function getHandlers() {
+  return {
+    onEnter: jest.fn(),
+    onEntered: jest.fn(),
+    onExit: jest.fn(),
+    onExited: jest.fn(),
+  };
+}
+
+function TestContainer(props: Partial<TransitionProps>) {
+  const [mounted, setMounted] = useState(false);
+
+  return (
+    <>
+      <button type="button" onClick={() => setMounted((m) => !m)}>
+        toggle
+      </button>
+      <Transition duration={400} exitDuration={400} transition="fade" mounted={mounted} {...props}>
+        {(styles) => <div style={styles}>test-child</div>}
+      </Transition>
+    </>
+  );
+}
+
+describe('@mantine/core/Transition', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('completes enter and exit transitions synchronously in test env', () => {
+    const handlers = getHandlers();
+    render(<TestContainer {...handlers} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(handlers.onEnter).toHaveBeenCalledTimes(1);
+    expect(handlers.onEntered).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('test-child')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(handlers.onExit).toHaveBeenCalledTimes(1);
+    expect(handlers.onExited).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('test-child')).not.toBeInTheDocument();
+  });
+
+  it('does not schedule timers or animation frames in test env', () => {
+    jest.useFakeTimers();
+    render(<TestContainer enterDelay={100} exitDelay={100} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('runs enter transition asynchronously when env is not test', () => {
+    jest.useFakeTimers();
+    const handlers = getHandlers();
+    render(<TestContainer {...handlers} />, undefined, { env: 'default' });
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(handlers.onEntered).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(handlers.onEnter).toHaveBeenCalledTimes(1);
+    expect(handlers.onEntered).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@mantine/core/src/components/Transition/use-transition.ts
+++ b/packages/@mantine/core/src/components/Transition/use-transition.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { useDidUpdate, useReducedMotion } from '@mantine/hooks';
-import { useMantineTheme } from '../../core';
+import { useMantineEnv, useMantineTheme } from '../../core';
 
 export type TransitionStatus =
   | 'entered'
@@ -36,10 +36,12 @@ export function useTransition({
   enterDelay,
   exitDelay,
 }: UseTransition) {
+  const env = useMantineEnv();
   const theme = useMantineTheme();
   const shouldReduceMotion = useReducedMotion();
-  const reduceMotion = theme.respectReducedMotion ? shouldReduceMotion : false;
-  const [transitionDuration, setTransitionDuration] = useState(reduceMotion ? 0 : duration);
+  const skipTransition =
+    env === 'test' || (theme.respectReducedMotion ? shouldReduceMotion : false);
+  const [transitionDuration, setTransitionDuration] = useState(skipTransition ? 0 : duration);
   const [transitionStatus, setStatus] = useState<TransitionStatus>(mounted ? 'entered' : 'exited');
   const transitionTimeoutRef = useRef<number>(-1);
   const delayTimeoutRef = useRef<number>(-1);
@@ -55,7 +57,7 @@ export function useTransition({
     clearAllTimeouts();
     const preHandler = shouldMount ? onEnter : onExit;
     const handler = shouldMount ? onEntered : onExited;
-    const newTransitionDuration = reduceMotion ? 0 : shouldMount ? duration : exitDuration;
+    const newTransitionDuration = skipTransition ? 0 : shouldMount ? duration : exitDuration;
     setTransitionDuration(newTransitionDuration);
 
     if (newTransitionDuration === 0) {
@@ -82,7 +84,7 @@ export function useTransition({
   const handleTransitionWithDelay = (shouldMount: boolean) => {
     clearAllTimeouts();
     const delay = shouldMount ? enterDelay : exitDelay;
-    if (typeof delay !== 'number') {
+    if (env === 'test' || typeof delay !== 'number') {
       handleStateChange(shouldMount);
       return;
     }


### PR DESCRIPTION
Fixes #9105

`MantineProvider env="test"` is documented as disabling transitions, but it only skipped `getTransitionStyles()` in `Transition`'s output — `useTransition` still ran its full `requestAnimationFrame → flushSync → requestAnimationFrame → setTimeout(duration)` chain on real timers, firing `onEnter` / `onEntered` / `onExit` / `onExited` on the production schedule. In test suites this causes act() warnings and, when a component is unmounted mid-chain, orphaned timers that fire during later unrelated tests.

### Changes

- `useTransition` now reads `useMantineEnv()`: `env === 'test'` routes through the existing synchronous `duration === 0` fast path (the one used for `respectReducedMotion`) and skips the `enterDelay` / `exitDelay` timers, so the hook resolves synchronously with no raf/timeout scheduled.
- `Transition.tsx` is unchanged — its `env === 'test'` render branch keeps working as before; callbacks now fire synchronously to match it.
- Added `Transition.test.tsx`: enter/exit callbacks fire synchronously in test env, no timers or animation frames are scheduled (including with `enterDelay`/`exitDelay`), and non-test env keeps the async timer-driven behavior.

### Checks

- `npm run jest` — all 655 suites / 15,945 tests pass
- `tsc --noEmit` and `npm run lint` pass
