### PR TITLE
[mantine.dev] Fix prevent docs navbar focus outline clipping

### DIFF
--- a/apps/mantine.dev/src/components/Shell/DocsNavbar/DocsNavbar.module.css
+++ b/apps/mantine.dev/src/components/Shell/DocsNavbar/DocsNavbar.module.css
@@ -28,6 +28,10 @@
   }
 }
 
+.navbar .categories {
+  padding-inline-start: 4px;
+}
+
 .link {
   display: block;
   font-size: var(--mantine-font-size-sm);


### PR DESCRIPTION
Hello! Thanks for taking the time to review this PR.

If this approach doesn't match the intended direction for the project, I'm happy to adjust it or try an alternative approach based on your feedback.

Fixes #9108

## Description

Adds a small inline-start gutter to the desktop documentation navbar so keyboard focus outlines are not clipped by the `ScrollArea` viewport.

The change is scoped to the desktop navbar, leaving the existing mobile and tablet layout unchanged. It uses a logical CSS property to preserve RTL support.

## Testing

- `npm run stylelint`
- `npm run build`