### PR TITLE
[@mantine/core] Tooltip: Rename `interactive` prop to `hoverable` and fix interactive-content guidance

### DIFF
--- a/apps/mantine.dev/src/pages/changelog/9-5-0.mdx
+++ b/apps/mantine.dev/src/pages/changelog/9-5-0.mdx
@@ -156,4 +156,4 @@ the tooltip contains content that the user must be able to reach with a pointer,
 It is also required by [WCAG 2.1 success criterion 1.4.13](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html),
 which states that content that appears on hover must remain visible while the pointer is over it.
 
-<Demo data={TooltipDemos.interactive} />
+<Demo data={TooltipDemos.hoverable} />

--- a/apps/mantine.dev/src/pages/core/tooltip.mdx
+++ b/apps/mantine.dev/src/pages/core/tooltip.mdx
@@ -170,7 +170,9 @@ By default, the tooltip closes as soon as the pointer leaves the target element,
 
 <Demo data={TooltipDemos.interactive} />
 
-Set `interactive` if the tooltip contains content that the user must be able to reach with a pointer, for example a link. It is also required by [WCAG 2.1 success criterion 1.4.13: Content on Hover or Focus](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html), which states that content that appears on hover must remain visible while the pointer is over it.
+The `interactive` prop satisfies the _hoverable_ condition of [WCAG 2.1 success criterion 1.4.13: Content on Hover or Focus](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html), so the pointer can reach the tooltip body without dismissing it, for example to read or select its content.
+
+Do not put interactive or focusable content (links, buttons, inputs) inside a tooltip. Interactive content should be put in a [Popover](/core/popover) instead, which is reachable by mouse, keyboard, and touch.
 
 Note that an interactive tooltip receives pointer events, which means that while it is open, it intercepts clicks and hover events of the elements that it overlaps. The tooltip stops receiving pointer events as soon as it starts closing. The `interactive` prop is not supported by `Tooltip.Floating`, which always follows the mouse.
 

--- a/apps/mantine.dev/src/pages/core/tooltip.mdx
+++ b/apps/mantine.dev/src/pages/core/tooltip.mdx
@@ -164,17 +164,17 @@ function Demo() {
 }
 ```
 
-## Interactive tooltip
+## Hoverable tooltip
 
-By default, the tooltip closes as soon as the pointer leaves the target element, and the tooltip body ignores pointer events. Set the `interactive` prop to keep the tooltip open while the pointer travels from the target to the tooltip and rests over its content:
+By default, the tooltip closes as soon as the pointer leaves the target element, and the tooltip body ignores pointer events. Set the `hoverable` prop to keep the tooltip open while the pointer travels from the target to the tooltip and rests over its content:
 
-<Demo data={TooltipDemos.interactive} />
+<Demo data={TooltipDemos.hoverable} />
 
-The `interactive` prop satisfies the _hoverable_ condition of [WCAG 2.1 success criterion 1.4.13: Content on Hover or Focus](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html), so the pointer can reach the tooltip body without dismissing it, for example to read or select its content.
+The `hoverable` prop satisfies the _hoverable_ condition of [WCAG 2.1 success criterion 1.4.13: Content on Hover or Focus](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html), so the pointer can reach the tooltip body without dismissing it, for example to read or select its content.
 
 Do not put interactive or focusable content (links, buttons, inputs) inside a tooltip. Interactive content should be put in a [Popover](/core/popover) instead, which is reachable by mouse, keyboard, and touch.
 
-Note that an interactive tooltip receives pointer events, which means that while it is open, it intercepts clicks and hover events of the elements that it overlaps. The tooltip stops receiving pointer events as soon as it starts closing. The `interactive` prop is not supported by `Tooltip.Floating`, which always follows the mouse.
+Note that a hoverable tooltip receives pointer events, which means that while it is open, it intercepts clicks and hover events of the elements that it overlaps. The tooltip stops receiving pointer events as soon as it starts closing. The `hoverable` prop is not supported by `Tooltip.Floating`, which always follows the mouse.
 
 ## Multiline
 
@@ -262,8 +262,8 @@ function Demo() {
 additionally requires content that appears on hover to be dismissable, hoverable and persistent.
 Tooltip is persistent out of the box and dismissable if its opened state is not controlled
 (`Escape` closes it without moving the pointer – if you control the `opened` prop, you are responsible
-for handling `Escape` yourself). Tooltip is not hoverable by default – set the
-[interactive](#interactive-tooltip) prop to make the tooltip body hoverable:
+for handling `Escape` yourself). Tooltip is not hoverable by default. Set the
+[hoverable](#hoverable-tooltip) prop to change that:
 
 ```tsx
 import { Button, Tooltip } from '@mantine/core';
@@ -271,7 +271,7 @@ import { Button, Tooltip } from '@mantine/core';
 // Tooltip stays open while the pointer is over its content
 function Demo() {
   return (
-    <Tooltip label="Tooltip" interactive>
+    <Tooltip label="Tooltip" hoverable>
       <Button>Button with tooltip</Button>
     </Tooltip>
   );

--- a/packages/@docs/demos/src/demos/core/Tooltip/Tooltip.demo.hoverable.tsx
+++ b/packages/@docs/demos/src/demos/core/Tooltip/Tooltip.demo.hoverable.tsx
@@ -7,7 +7,7 @@ import { Button, Tooltip } from '@mantine/core';
 function Demo() {
   return (
     <Tooltip
-      interactive
+      hoverable
       withArrow
       multiline
       w={220}
@@ -22,7 +22,7 @@ function Demo() {
 function Demo() {
   return (
     <Tooltip
-      interactive
+      hoverable
       withArrow
       multiline
       w={220}
@@ -33,7 +33,7 @@ function Demo() {
   );
 }
 
-export const interactive: MantineDemo = {
+export const hoverable: MantineDemo = {
   type: 'code',
   code,
   centered: true,

--- a/packages/@docs/demos/src/demos/core/Tooltip/Tooltip.demo.interactive.tsx
+++ b/packages/@docs/demos/src/demos/core/Tooltip/Tooltip.demo.interactive.tsx
@@ -1,8 +1,8 @@
-import { Anchor, Button, Tooltip } from '@mantine/core';
+import { Button, Tooltip } from '@mantine/core';
 import { MantineDemo } from '@mantinex/demo';
 
 const code = `
-import { Anchor, Button, Tooltip } from '@mantine/core';
+import { Button, Tooltip } from '@mantine/core';
 
 function Demo() {
   return (
@@ -11,16 +11,9 @@ function Demo() {
       withArrow
       multiline
       w={220}
-      label={
-        <>
-          Tooltip content can be hovered, for example to follow{' '}
-          <Anchor href="https://mantine.dev" target="_blank" inherit>
-            this link
-          </Anchor>
-        </>
-      }
+      label="This tooltip stays open while you move the pointer onto it, so you can read or select its full contents without it closing."
     >
-      <Button>Interactive tooltip</Button>
+      <Button>Hover to read the tooltip</Button>
     </Tooltip>
   );
 }
@@ -33,16 +26,9 @@ function Demo() {
       withArrow
       multiline
       w={220}
-      label={
-        <>
-          Tooltip content can be hovered, for example to follow{' '}
-          <Anchor href="https://mantine.dev" target="_blank" inherit>
-            this link
-          </Anchor>
-        </>
-      }
+      label="This tooltip stays open while you move the pointer onto it, so you can read or select its full contents without it closing."
     >
-      <Button>Interactive tooltip</Button>
+      <Button>Hover to read the tooltip</Button>
     </Tooltip>
   );
 }

--- a/packages/@docs/demos/src/demos/core/Tooltip/Tooltip.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/core/Tooltip/Tooltip.demos.story.tsx
@@ -23,9 +23,9 @@ export const Demo_multiline = {
   render: renderDemo(demos.multiline),
 };
 
-export const Demo_interactive = {
-  name: '⭐ Demo: interactive',
-  render: renderDemo(demos.interactive),
+export const Demo_hoverable = {
+  name: '⭐ Demo: hoverable',
+  render: renderDemo(demos.hoverable),
 };
 
 export const Demo_transitions = {

--- a/packages/@docs/demos/src/demos/core/Tooltip/index.ts
+++ b/packages/@docs/demos/src/demos/core/Tooltip/index.ts
@@ -2,7 +2,7 @@ export { configurator } from './Tooltip.demo.configurator';
 export { controlled } from './Tooltip.demo.controlled';
 export { arrow } from './Tooltip.demo.arrow';
 export { multiline } from './Tooltip.demo.multiline';
-export { interactive } from './Tooltip.demo.interactive';
+export { hoverable } from './Tooltip.demo.hoverable';
 export { transitions } from './Tooltip.demo.transitions';
 export { delay } from './Tooltip.demo.delay';
 export { floating } from './Tooltip.demo.floating';

--- a/packages/@mantine/core/src/components/Tooltip/Tooltip.module.css
+++ b/packages/@mantine/core/src/components/Tooltip/Tooltip.module.css
@@ -26,7 +26,7 @@
     position: fixed;
   }
 
-  &:where([data-interactive]) {
+  &:where([data-hoverable]) {
     pointer-events: auto;
   }
 }

--- a/packages/@mantine/core/src/components/Tooltip/Tooltip.story.tsx
+++ b/packages/@mantine/core/src/components/Tooltip/Tooltip.story.tsx
@@ -6,7 +6,7 @@ export default { title: 'Tooltip' };
 export function Usage() {
   return (
     <div style={{ padding: 40 }}>
-      <Tooltip position="bottom" interactive label="Tooltip label">
+      <Tooltip position="bottom" hoverable label="Tooltip label">
         <button>target</button>
       </Tooltip>
     </div>
@@ -278,7 +278,7 @@ export function Fixed() {
   );
 }
 
-export function Interactive() {
+export function Hoverable() {
   return (
     <div style={{ padding: 40 }}>
       <button type="button" style={{ position: 'fixed', top: 40, left: 200, width: 300 }}>
@@ -288,7 +288,7 @@ export function Interactive() {
       <Tooltip
         position="top"
         offset={20}
-        interactive
+        hoverable
         withArrow
         label={
           <span>
@@ -300,7 +300,7 @@ export function Interactive() {
         }
       >
         <button type="button" style={{ position: 'fixed', top: 160, left: 200 }}>
-          Interactive tooltip
+          Hoverable tooltip
         </button>
       </Tooltip>
     </div>

--- a/packages/@mantine/core/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/@mantine/core/src/components/Tooltip/Tooltip.test.tsx
@@ -39,24 +39,24 @@ describe('@mantine/core/Tooltip', () => {
     expect(screen.queryAllByText('test-tooltip')).toHaveLength(0);
   });
 
-  it('does not set data-interactive attribute by default', () => {
+  it('does not set data-hoverable attribute by default', () => {
     render(<Tooltip {...defaultProps} />);
-    expect(screen.getByRole('tooltip')).not.toHaveAttribute('data-interactive');
+    expect(screen.getByRole('tooltip')).not.toHaveAttribute('data-hoverable');
   });
 
-  it('sets data-interactive attribute when tooltip is opened with interactive prop', () => {
-    render(<Tooltip {...defaultProps} interactive />);
-    expect(screen.getByRole('tooltip')).toHaveAttribute('data-interactive');
+  it('sets data-hoverable attribute when tooltip is opened with hoverable prop', () => {
+    render(<Tooltip {...defaultProps} hoverable />);
+    expect(screen.getByRole('tooltip')).toHaveAttribute('data-hoverable');
   });
 
-  it('does not set data-interactive attribute on a hidden tooltip with keepMounted prop', () => {
-    render(<Tooltip {...defaultProps} interactive opened={false} keepMounted />);
-    expect(screen.getByRole('tooltip', { hidden: true })).not.toHaveAttribute('data-interactive');
+  it('does not set data-hoverable attribute on a hidden tooltip with keepMounted prop', () => {
+    render(<Tooltip {...defaultProps} hoverable opened={false} keepMounted />);
+    expect(screen.getByRole('tooltip', { hidden: true })).not.toHaveAttribute('data-hoverable');
   });
 
-  it('does not set data-interactive attribute on a disabled tooltip', () => {
-    render(<Tooltip {...defaultProps} interactive disabled keepMounted />);
-    expect(screen.getByRole('tooltip', { hidden: true })).not.toHaveAttribute('data-interactive');
+  it('does not set data-hoverable attribute on a disabled tooltip', () => {
+    render(<Tooltip {...defaultProps} hoverable disabled keepMounted />);
+    expect(screen.getByRole('tooltip', { hidden: true })).not.toHaveAttribute('data-hoverable');
   });
 
   it('exposes TooltipGroup and TooltipFloating as static properties', () => {

--- a/packages/@mantine/core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/@mantine/core/src/components/Tooltip/Tooltip.tsx
@@ -74,8 +74,8 @@ export interface TooltipProps extends TooltipBaseProps {
   /** Determines which events will be used to show tooltip @default { hover: true, focus: false, touch: false } */
   events?: { hover: boolean; focus: boolean; touch: boolean };
 
-  /** If set, the tooltip stays open while the pointer moves from the target to the tooltip and remains over it. Required by [WCAG 1.4.13](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html). Note that an interactive tooltip intercepts pointer events of the content it overlaps @default false */
-  interactive?: boolean;
+  /** If set, the tooltip stays open while the pointer moves from the target to the tooltip and remains over it. Required by [WCAG 1.4.13](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html). Note that a hoverable tooltip intercepts pointer events of the content it overlaps @default false */
+  hoverable?: boolean;
 
   /** Must be set if the tooltip target is an inline element */
   inline?: boolean;
@@ -167,7 +167,7 @@ export const Tooltip = factory<TooltipFactory>((_props) => {
     transitionProps,
     multiline,
     events,
-    interactive,
+    hoverable,
     zIndex,
     disabled,
     onClick,
@@ -199,7 +199,7 @@ export const Tooltip = factory<TooltipFactory>((_props) => {
     opened,
     defaultOpened,
     events,
-    interactive,
+    hoverable,
     arrowRef,
     arrowOffset,
     offset: typeof offset === 'number' ? offset + (withArrow ? arrowSize / 2 : 0) : offset,
@@ -244,7 +244,7 @@ export const Tooltip = factory<TooltipFactory>((_props) => {
   }
 
   const tooltipStyles = getStyles('tooltip');
-  const interactiveMod = interactive && !disabled && !!tooltip.opened;
+  const hoverableMod = hoverable && !disabled && !!tooltip.opened;
   const mergeStyles =
     arrowPosition === 'merge' && withArrow
       ? getArrowMergeDropdownStyles({ position: tooltip.placement, dir })
@@ -266,7 +266,7 @@ export const Tooltip = factory<TooltipFactory>((_props) => {
                 {...others}
                 data-fixed={floatingStrategy === 'fixed' || undefined}
                 variant={variant}
-                mod={[{ multiline, interactive: interactiveMod }, mod]}
+                mod={[{ multiline, hoverable: hoverableMod }, mod]}
                 {...tooltipStyles}
                 {...tooltip.getFloatingProps({
                   ref: tooltip.floating,
@@ -321,7 +321,7 @@ export const Tooltip = factory<TooltipFactory>((_props) => {
               {...others}
               data-fixed={floatingStrategy === 'fixed' || undefined}
               variant={variant}
-              mod={[{ multiline, interactive: interactiveMod }, mod]}
+              mod={[{ multiline, hoverable: hoverableMod }, mod]}
               {...tooltip.getFloatingProps({
                 ref: tooltip.floating,
                 className: getStyles('tooltip').className,

--- a/packages/@mantine/core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/@mantine/core/src/components/Tooltip/Tooltip.tsx
@@ -74,7 +74,7 @@ export interface TooltipProps extends TooltipBaseProps {
   /** Determines which events will be used to show tooltip @default { hover: true, focus: false, touch: false } */
   events?: { hover: boolean; focus: boolean; touch: boolean };
 
-  /** If set, the tooltip stays open while the pointer moves from the target to the tooltip and remains over it. Required by [WCAG 1.4.13](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) if the tooltip contains interactive content. Note that an interactive tooltip intercepts pointer events of the content it overlaps @default false */
+  /** If set, the tooltip stays open while the pointer moves from the target to the tooltip and remains over it. Required by [WCAG 1.4.13](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html). Note that an interactive tooltip intercepts pointer events of the content it overlaps @default false */
   interactive?: boolean;
 
   /** Must be set if the tooltip target is an inline element */

--- a/packages/@mantine/core/src/components/Tooltip/use-tooltip.ts
+++ b/packages/@mantine/core/src/components/Tooltip/use-tooltip.ts
@@ -32,7 +32,7 @@ interface UseTooltip {
   arrowRef?: React.RefObject<HTMLDivElement | null>;
   arrowOffset?: number;
   events?: { hover: boolean; focus: boolean; touch: boolean };
-  interactive?: boolean;
+  hoverable?: boolean;
   inline?: boolean;
   strategy?: FloatingStrategy;
   middlewares?: TooltipMiddlewares;
@@ -129,7 +129,7 @@ export function useTooltip(settings: UseTooltip) {
       enabled: settings.events?.hover,
       delay: withinGroup ? groupDelay : { open: settings.openDelay, close: settings.closeDelay },
       mouseOnly: !settings.events?.touch,
-      handleClose: settings.interactive ? safePolygon() : null,
+      handleClose: settings.hoverable ? safePolygon() : null,
     }),
     useFocus(context, { enabled: settings.events?.focus, visibleOnly: true }),
     useRole(context, { role: 'tooltip' }),


### PR DESCRIPTION
Follow-up to #9072 / the `interactive` prop shipped in 9.5.1.

@rtivital I'm sorry if there was confusion or I could have been more clear in [my original issue description](https://github.com/mantinedev/mantine/issues/9072), but the goal of #9072 was only to make the tooltip **hoverable** — so the pointer can travel from the target onto the tooltip without it closing (WCAG 2.1 SC 1.4.13, _Hoverable_). And at the very most, allow users to select/copy the contents of the tooltip, not to enable users to put interactive content in there. We obviously can't stop them but we shouldn't encourage them either.

### 1. The docs encourage putting interactive content in a tooltip

[The updated docs](https://mantine.dev/core/tooltip/#interactive-tooltip) say 

> Set `interactive` if the tooltip contains content that the user must be able to reach with a pointer, for example a link.

and the demo renders an `<Anchor href>` inside the tooltip. 

However that wasn't the intent of the original fix because interactive/focusable content in a tooltip isn't accessible: a tooltip is exposed to assistive technology only as an `aria-describedby` description, isn't in the focus order, and is dismissed on `Escape`, so keyboard and screen-reader users can't reliably reach it. 

Example guidance against interactive tooltip content:
- [Inclusive Components](https://inclusive-components.design/tooltips-toggletips/) — "Don't put interactive content such as close and confirm buttons or links in tooltips or toggletips."
- [Sarah Higley, _Tooltips in the time of WCAG 2.1_](https://sarahmhigley.com/writing/tooltips-in-wcag-21/#best-practices-summary) — "No interactive content."
- [CSS-Tricks - _Tooltips Best Practices_](https://css-tricks.com/tooltip-best-practices/) — "Tooltips must not contain interactive content."

This PR updates the docs to make that more clear, suggesting that interactive content be put in a `Popover` instead (an accessible non-modal dialog reachable by mouse, keyboard, and touch — which is what the WAI-ARIA APG recommends). It also updates the demo and also corrects a wording bug: 1.4.13 was described as applying _only_ when the tooltip contains interactive content, but it applies to any content shown on hover (and a tooltip should never contain interactive content).

### 2. The prop name `interactive` contradicts that guidance

Naming the prop `interactive` is slightly misleading because it sounds like it's recommending the thing the accessibility guidance says not to do — the docs for `interactive` have to warn against interactive content, which feels odd. This PR renames the prop to **`hoverable`**, which names the actual behavior (and matches the WCAG 1.4.13 _hoverable_ condition it satisfies). Default stays `false` for smallest impact on users, even  though I think you could make a case it should default to `true`. Renaming the prop now, about a week after it shipped, keeps the breaking change as small as possible.

### Commits (intentionally separable)

1. **Clarify that tooltips must not contain interactive content** — docs/demo/JSDoc guidance fix. Non-breaking. Stands on its own.
2. **Rename `interactive` prop to `hoverable`** — breaking rename on top, so it can be `git revert`ed independently if you'd prefer to keep only the guidance fix, or take the guidance now and rename later.

The 9.5.0 changelog prose is left as the historical record of that release; only its live `<Demo>` reference was updated to the renamed export.

Happy to adjust the name, split differently, or drop the rename commit — whatever you prefer.
