### PR TITLE
fix(ScrollArea): replace useEffectEvent with useCallbackRef to prevent React 19.2 rAF crash (Fixes #9113)

### DIFF
--- a/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollArea.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffectEvent, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useMergeRefs } from '@floating-ui/react';
-import { useIsomorphicEffect } from '@mantine/hooks';
+import { useCallbackRef, useIsomorphicEffect } from '@mantine/hooks';
 import {
   Box,
   BoxProps,
@@ -387,7 +387,7 @@ export const ScrollAreaAutosize = factory<ScrollAreaAutosizeFactory>((props) => 
   const overflowingRef = useRef(false);
   const didMountRef = useRef(false);
 
-  const handleOverflowCheck = useEffectEvent(() => {
+  const handleOverflowCheck = useCallbackRef(() => {
     const el = viewportObserverRef.current;
     if (!el || !onOverflowChange) {
       return;

--- a/packages/@mantine/core/src/components/ScrollArea/ScrollAreaScrollbar/Scrollbar.tsx
+++ b/packages/@mantine/core/src/components/ScrollArea/ScrollAreaScrollbar/Scrollbar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useCallbackRef, useDebouncedCallback, useMergedRef } from '@mantine/hooks';
 import { useScrollAreaContext } from '../ScrollArea.context';
 import { Sizes } from '../ScrollArea.types';
@@ -42,7 +42,7 @@ export function Scrollbar(props: ScrollbarProps) {
   const prevWebkitUserSelectRef = useRef<string>('');
   const { viewport } = context;
   const maxScrollPos = sizes.content - sizes.viewport;
-  const handleWheelScroll = useEffectEvent(onWheelScroll);
+  const handleWheelScroll = useCallbackRef(onWheelScroll);
   const handleThumbPositionChange = useCallbackRef(onThumbPositionChange);
   const handleResize = useDebouncedCallback(onResize, 10);
 

--- a/packages/@mantine/core/src/components/ScrollArea/use-resize-observer.ts
+++ b/packages/@mantine/core/src/components/ScrollArea/use-resize-observer.ts
@@ -1,8 +1,8 @@
-import { useEffectEvent } from 'react';
+import { useCallbackRef } from '@mantine/hooks';
 import { useIsomorphicEffect } from '@mantine/hooks';
 
 export function useResizeObserver(element: HTMLElement | null, onResize: () => void) {
-  const handleResize = useEffectEvent(onResize);
+  const handleResize = useCallbackRef(onResize);
 
   useIsomorphicEffect(() => {
     let rAF = 0;


### PR DESCRIPTION
## Description

`ScrollArea` passes React 19.2's strict `useEffectEvent` trampolines to `requestAnimationFrame` and to a `document` wheel listener. Neither is an effect, so React throws error #440 — *"A function wrapped in useEffectEvent can't be called during rendering"* — whenever one of those callbacks lands while React has `executionContext & RenderContext` set.

The consequence is worse than a single caught error. Throwing mid-render leaves React's `executionContext` dirty, so the *next* scheduler task fails its entry guard with **"Should not already be working."** That second throw happens outside any component render, so no error boundary can catch it — the React root stops updating and the tab is stuck until the user reloads.

## Changes

Replace `useEffectEvent` with `useCallbackRef` from `@mantine/hooks` at all three sites:

1. **`use-resize-observer.ts`** — `handleResize` was passed to `requestAnimationFrame`
2. **`ScrollArea.tsx`** — `handleOverflowCheck` (itself a `useEffectEvent`) was passed into `useResizeObserver`, which then wraps it a second time
3. **`Scrollbar.tsx`** — `handleWheelScroll` was a `document` `wheel` listener

`Scrollbar.tsx` already uses `useCallbackRef` for its four sibling handlers (`onThumbChange`, `onThumbPointerUp`, `onThumbPositionChange`, `onThumbPointerDown`) — `onWheelScroll` was the odd one out, so this also makes the component internally consistent.

Fixes #9113