### PR TITLE
fix(@mantine/schedule): preserve local wall-clock time in rrule dtstart to prevent DST drift

### DIFF
--- a/packages/@mantine/schedule/src/utils/expand-recurring-events/expand-recurring-events.ts
+++ b/packages/@mantine/schedule/src/utils/expand-recurring-events/expand-recurring-events.ts
@@ -71,12 +71,47 @@ function getOccurrenceStartsInRange(
 
   try {
     const options = RRule.parseString(getRRuleString(event.recurrence.rrule));
-    options.dtstart = dtstart.toDate();
+    options.dtstart = new Date(Date.UTC(
+      dtstart.year(),
+      dtstart.month(),
+      dtstart.date(),
+      dtstart.hour(),
+      dtstart.minute(),
+      dtstart.second()
+    ));
     const rule = new RRule(options);
 
-    const searchStart = rangeStart.subtract(Math.max(0, durationMs), 'millisecond').toDate();
-    const results = rule.between(searchStart, rangeEnd.toDate(), true);
-    return results.slice(0, expansionLimit).map((value) => dayjs(value));
+    const searchStart = new Date(Date.UTC(
+      rangeStart.year(),
+      rangeStart.month(),
+      rangeStart.date(),
+      rangeStart.hour(),
+      rangeStart.minute(),
+      rangeStart.second()
+    )).valueOf();
+    const searchEnd = new Date(Date.UTC(
+      rangeEnd.year(),
+      rangeEnd.month(),
+      rangeEnd.date(),
+      rangeEnd.hour(),
+      rangeEnd.minute(),
+      rangeEnd.second()
+    )).valueOf();
+    const results = rule.between(
+      new Date(searchStart - Math.max(0, durationMs)),
+      new Date(searchEnd),
+      true
+    );
+    return results.slice(0, expansionLimit).map((value) =>
+      dayjs(new Date(
+        value.getUTCFullYear(),
+        value.getUTCMonth(),
+        value.getUTCDate(),
+        value.getUTCHours(),
+        value.getUTCMinutes(),
+        value.getUTCSeconds()
+      ))
+    );
   } catch {
     return [];
   }


### PR DESCRIPTION
## Description

Fixes #9112

The  function uses  to pass the rrule dtstart as a JavaScript Fri Aug 14 00:22:24 CST 2026 object. The  library reads UTC getters from this Date to advance occurrences by fixed 86,400,000ms (24h) increments. When the expansion range crosses a DST transition, the fixed UTC-ms increments no longer land on the same local wall-clock time, causing permanent drift.

## Fix

1. Use  to create a  Date whose UTC getters match the local wall-clock time values
2. Apply the same UTC-based approach to  and  for consistency
3. Convert rrule output Dates back to local time using  — the Date constructor interprets these components as local time

This ensures that all occurrences preserve the correct local wall-clock time regardless of DST transitions.