### PR TITLE
fix(mantine.dev): prevent desktop navbar focus outline from being clipped by ScrollArea viewport (Fixes #9108)

### DIFF
--- a/apps/mantine.dev/src/components/Shell/DocsNavbar/DocsNavbar.module.css
+++ b/apps/mantine.dev/src/components/Shell/DocsNavbar/DocsNavbar.module.css
@@ -14,6 +14,7 @@
 
 .categories {
   padding-inline-end: var(--mantine-spacing-md);
+  padding-inline-start: 4px;
 
   &:first-of-type {
     padding-top: var(--mantine-spacing-xl);


### PR DESCRIPTION
### Problem

When navigating the desktop documentation navbar with the `Tab` key, the inline-start portion of the focused link's outline is clipped. This happens because the desktop navigation links inside `ScrollArea` are positioned directly against the viewport edge, which clips overflowing content.

### Fix

Added `padding-inline-start: 4px` to the `.categories` container in the desktop navbar. This gives the keyboard focus outline enough room to render fully without being clipped.

### Verification

- Desktop navbar: focus outline is fully visible
- Mobile/tablet navbar: unaffected (already has its own padding via separate styles)
- No visual regression — the 4px gutter is minimal and maintains the existing layout

Fixes #9108