### PR TITLE
[@mantine/core] Rating: Fix allowClear not working on touch devices

### DIFF
--- a/packages/@mantine/core/src/components/Rating/Rating.test.tsx
+++ b/packages/@mantine/core/src/components/Rating/Rating.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, screen, tests } from '@mantine-tests/core';
 import { Rating, RatingProps, RatingStylesNames } from './Rating';
@@ -69,6 +70,29 @@ describe('@mantine/core/Rating', () => {
     const targetInput = inputs.find((input) => (input as HTMLInputElement).value === '2.5');
 
     await userEvent.click(targetInput!.nextElementSibling as HTMLElement);
+
+    expect(spy).toHaveBeenCalledWith(0);
+  });
+
+  it('clears rating on touch when tapping the same value with allowClear=true', () => {
+    const spy = jest.fn();
+    const { container } = render(<Rating allowClear onChange={spy} defaultValue={3} />);
+
+    const root = container.querySelector('[class*="root"]')!;
+    root.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        right: 500,
+        width: 500,
+        top: 0,
+        bottom: 0,
+        height: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    fireEvent.touchStart(root, { touches: [{ clientX: 250 }] });
 
     expect(spy).toHaveBeenCalledWith(0);
   });

--- a/packages/@mantine/core/src/components/Rating/Rating.tsx
+++ b/packages/@mantine/core/src/components/Rating/Rating.tsx
@@ -233,7 +233,7 @@ export const Rating = factory<RatingFactory>((_props) => {
 
     if (!readOnly) {
       const touch = touches[0];
-      setValue(getRatingFromCoordinates(touch.clientX));
+      handleChange(getRatingFromCoordinates(touch.clientX));
     }
 
     onTouchStart?.(event);


### PR DESCRIPTION
## Problem

On touch devices, tapping the same star does not clear the rating even with `allowClear` enabled, unlike mouse clicks. `handleTouchStart` calls `setValue` directly, bypassing the `allowClear` check.

Expected the same behavior on touch devices as on PC when `allowClear` is enabled.

https://github.com/user-attachments/assets/d65364ce-37d6-482a-9d95-44718c138616

## Solve

Use `handleChange` instead of `setValue` in `handleTouchStart` so touch goes through the same `allowClear` logic.

https://github.com/user-attachments/assets/270693fa-275b-44f0-b0be-a68f083e7ccc