### PR TITLE
fix(@mantine/hooks): useDebouncedValue with leading:true emits stale values (#9119)

### DIFF
--- a/packages/@mantine/hooks/src/use-debounced-value/use-debounced-value.test.ts
+++ b/packages/@mantine/hooks/src/use-debounced-value/use-debounced-value.test.ts
@@ -126,5 +126,81 @@ describe('useDebouncedValue', () => {
       rerender({ value: 'c' });
       expect(result.current[0]).toBe('c');
     });
+
+    test('emits only the leading and the final value during a long burst', () => {
+      const emitted: string[] = [];
+      const { rerender } = renderHook(
+        ({ value }) => {
+          const [debounced] = useDebouncedValue(value, 500, { leading: true });
+          if (emitted[emitted.length - 1] !== debounced) {
+            emitted.push(debounced);
+          }
+          return debounced;
+        },
+        {
+          initialProps: { value: '' },
+        }
+      );
+
+      ['a', 'ab', 'abc', 'abcd', 'abcde'].forEach((value) => {
+        rerender({ value });
+        act(() => jest.advanceTimersByTime(100));
+      });
+
+      act(() => jest.advanceTimersByTime(500));
+
+      // the leading edge must not re-fire mid-burst, and the trailing edge
+      // must emit the latest value rather than a superseded one
+      expect(emitted).toEqual(['', 'a', 'abcde']);
+    });
+
+    test('the trailing update is scheduled from the last change', () => {
+      const { result, rerender } = renderHook(
+        ({ value }) => useDebouncedValue(value, 200, { leading: true }),
+        {
+          initialProps: { value: 'a' },
+        }
+      );
+
+      rerender({ value: 'b' });
+      expect(result.current[0]).toBe('b');
+
+      act(() => jest.advanceTimersByTime(150));
+      rerender({ value: 'c' });
+
+      act(() => jest.advanceTimersByTime(199));
+      expect(result.current[0]).toBe('b');
+
+      act(() => jest.advanceTimersByTime(1));
+      expect(result.current[0]).toBe('c');
+    });
+
+    test('flush is not followed by a stale update', () => {
+      const emitted: string[] = [];
+      const { result, rerender } = renderHook(
+        ({ value }) => {
+          const debounced = useDebouncedValue(value, 200, { leading: true });
+          if (emitted[emitted.length - 1] !== debounced[0]) {
+            emitted.push(debounced[0]);
+          }
+          return debounced;
+        },
+        {
+          initialProps: { value: '' },
+        }
+      );
+
+      rerender({ value: 'a' });
+      rerender({ value: 'ab' });
+      rerender({ value: 'abc' });
+
+      act(() => {
+        result.current[2].flush();
+      });
+      expect(result.current[0]).toBe('abc');
+
+      act(() => jest.advanceTimersByTime(1000));
+      expect(emitted).toEqual(['', 'a', 'abc']);
+    });
   });
 });

--- a/packages/@mantine/hooks/src/use-debounced-value/use-debounced-value.ts
+++ b/packages/@mantine/hooks/src/use-debounced-value/use-debounced-value.ts
@@ -43,11 +43,16 @@ export function useDebouncedValue<T = any>(
       if (!cooldownRef.current && options.leading) {
         cooldownRef.current = true;
         setValue(value);
+        // Clear any lingering trailing timer before starting the cooldown
+        // window, so an orphaned timer cannot later fire with a stale value.
+        window.clearTimeout(timeoutRef.current!);
         timeoutRef.current = window.setTimeout(() => {
           cooldownRef.current = false;
         }, wait);
       } else {
-        cancel();
+        // Only clear the timer — do not reset cooldownRef, so the
+        // leading edge does not re-fire mid-burst (see #9119).
+        window.clearTimeout(timeoutRef.current!);
         timeoutRef.current = window.setTimeout(() => {
           cooldownRef.current = false;
           setValue(value);

--- a/packages/@mantine/hooks/src/use-debounced-value/use-debounced-value.ts
+++ b/packages/@mantine/hooks/src/use-debounced-value/use-debounced-value.ts
@@ -24,9 +24,13 @@ export function useDebouncedValue<T = any>(
   const latestValueRef = useRef(value);
   latestValueRef.current = value;
 
-  const cancel = useCallback(() => {
+  const clearTimer = useCallback(() => {
     window.clearTimeout(timeoutRef.current!);
     timeoutRef.current = null;
+  }, []);
+
+  const cancel = useCallback(() => {
+    clearTimer();
     cooldownRef.current = false;
   }, []);
 
@@ -40,19 +44,15 @@ export function useDebouncedValue<T = any>(
 
   useEffect(() => {
     if (mountedRef.current) {
+      clearTimer();
+
       if (!cooldownRef.current && options.leading) {
         cooldownRef.current = true;
         setValue(value);
-        // Clear any lingering trailing timer before starting the cooldown
-        // window, so an orphaned timer cannot later fire with a stale value.
-        window.clearTimeout(timeoutRef.current!);
         timeoutRef.current = window.setTimeout(() => {
           cooldownRef.current = false;
         }, wait);
       } else {
-        // Only clear the timer — do not reset cooldownRef, so the
-        // leading edge does not re-fire mid-burst (see #9119).
-        window.clearTimeout(timeoutRef.current!);
         timeoutRef.current = window.setTimeout(() => {
           cooldownRef.current = false;
           setValue(value);


### PR DESCRIPTION
## Problem
When `useDebouncedValue` is used with `{ leading: true }`, a single burst of rapid value changes produces more than the expected two emissions (one leading, one trailing), and the final emission can be a stale, out-of-order value.

Typing `abc` — three changes, each 100ms apart, with `wait: 500` — emits `'a' → 'abc' → 'ab'`. The last emission is `'ab'`, a value that was superseded.

## Root Cause
Two defects in `use-debounced-value.ts`:

1. **`cancel()` resets `cooldownRef`.** The trailing branch reused `cancel()` just to clear the timer, but as a side effect it cleared the cooldown flag — the only thing preventing the leading edge from re-firing mid-burst.

2. **The leading branch overwrites `timeoutRef.current` without clearing it first.** Once the cooldown is cleared, the pending trailing timer is orphaned and later fires `setValue()` with a stale `value` from an earlier render.

## Fix
- Replace `cancel()` in the trailing branch with `window.clearTimeout()` only — do not reset `cooldownRef`, so the leading edge does not re-fire mid-burst.
- Also clear any lingering timeout in the leading branch before setting a new one, so an orphaned timer cannot later fire with a stale value.
- `cancel()` is unchanged for its unmount/abort/`flush` role.

Fixes #9119