### PR TITLE
fix(Calendar): always use current date as fallback month instead of minDate

### DIFF
--- a/packages/@mantine/dates/src/components/Calendar/Calendar.tsx
+++ b/packages/@mantine/dates/src/components/Calendar/Calendar.tsx
@@ -304,9 +304,7 @@ export const Calendar = factory<CalendarFactory>((_props) => {
   const fallbackDateRef = useRef<DateStringValue | null>(null);
   if (fallbackDateRef.current === null) {
     const now = new Date();
-    fallbackDateRef.current = (
-      minDate && dayjs(now).isAfter(minDate) ? minDate : dayjs(now).format('YYYY-MM-DD')
-    ) as DateStringValue;
+    fallbackDateRef.current = dayjs(now).format('YYYY-MM-DD') as DateStringValue;
   }
   const currentDate = _date || fallbackDateRef.current;
 


### PR DESCRIPTION
## Summary

In Mantine v7, `DatePicker` (and other date-based components built on `Calendar`) defaulted to the current date (`new Date()`) when no `date`/`defaultDate` was provided. Since v8, when a `minDate` is set and today is after `minDate`, the fallback displayed date incorrectly uses `minDate` instead of the current date — so the calendar opens showing a different month than expected.

### Root cause

In `packages/@mantine/dates/src/components/Calendar/Calendar.tsx`, the fallback date ref was built as:

```ts
fallbackDateRef.current =
  minDate && dayjs(now).isAfter(minDate) ? minDate : dayjs(now).format('YYYY-MM-DD');
```

This picks `minDate` whenever it is in the past, which is the common case for date inputs with `minDate` set (e.g. "select a future date"). The displayed month then jumps to `minDate`'s month instead of the current month.

### Fix

Always use the current date as the fallback, matching v7 behavior:

```ts
fallbackDateRef.current = dayjs(now).format('YYYY-MM-DD');
```

### Test plan

- Existing `Calendar.test.tsx` suite still passes (fallback date assertions unchanged for the no-`minDate` case).
- Manual: render `<DatePicker minDate={dayjs().subtract(1, 'year').toDate()} />` with no `date` — the calendar now opens on the current month, as in v7, and `minDate` is still respected for selection boundaries.

Fixes #9117