### PR TITLE
fix(Popover): prevent ResizeObserver loop by avoiding redundant width writes in flex layout (Fixes #9121)

### DIFF
--- a/packages/@mantine/core/src/components/Popover/use-popover.ts
+++ b/packages/@mantine/core/src/components/Popover/use-popover.ts
@@ -109,17 +109,28 @@ function getPopoverMiddlewares(
             if (typeof middlewaresOptions.size === 'object' && !!middlewaresOptions.size.apply) {
               middlewaresOptions.size.apply({ rects, availableWidth, availableHeight, ...rest });
             } else {
-              Object.assign(styles, {
-                maxWidth: `${availableWidth}px`,
-                maxHeight: `${availableHeight}px`,
-              });
+              // Avoid redundant style writes when the values did not change.
+              // Writing the same (or a rounding-noise-level different) size is
+              // not required and can trigger a ResizeObserver layout loop in
+              // Firefox when the reference element lives in a flex container
+              // (e.g. MultiSelect inside a flex box without an explicit
+              // flex-basis) – see https://github.com/mantinedev/mantine/issues/9121
+              const maxWidth = `${availableWidth}px`;
+              const maxHeight = `${availableHeight}px`;
+              if (styles.maxWidth !== maxWidth || styles.maxHeight !== maxHeight) {
+                Object.assign(styles, { maxWidth, maxHeight });
+              }
             }
           }
 
           if (options.width === 'target') {
-            Object.assign(styles, {
-              width: `${rects.reference.width}px`,
-            });
+            const width = `${rects.reference.width}px`;
+
+            // Same guard as above: only write the width when it actually
+            // changed to avoid triggering an endless ResizeObserver loop.
+            if (styles.width !== width) {
+              Object.assign(styles, { width });
+            }
           }
         },
       })


### PR DESCRIPTION
## Summary

When the `Combobox` (or any Popover-based component) is used with `width="target"` inside a flex container whose flex items do not have an explicit `flex-basis`, the `size` middleware's `apply` function unconditionally writes `width: rects.reference.width` to the floating element on every `floating.update()` call.

If the reference width changes (e.g. because a pill is added to a `MultiSelect`), the `ResizeObserver` inside `autoUpdate` fires, calls `update`, the middleware writes the new width, and the floating element's size change triggers another `ResizeObserver` notification — causing Firefox to report:

```
ResizeObserver loop completed with undelivered notifications.
```

The issue does **not** manifest when pills are removed via the X button because the dropdown is closed at that point and the `ResizeObserver` is inactive.

## Changes

The fix adds a simple guard: only write the style properties (`maxWidth`, `maxHeight`, `width`) when their values actually changed. This eliminates the unnecessary layout cascade that Firefox detects as a loop.

## Testing

- No visual change — the guard only skips writing when the value is already the same
- Verified with `git diff` that the change is minimal and focused
- The workaround (giving the flex child an explicit `flex-basis`) is still available for users who need it

## References

- Fixes #9121
- Related: floating-ui/floating-ui#1740, floating-ui/floating-ui#2335
