### PR TITLE
fix(TooltipFloating): guard against NaN in top/left position style

### DIFF
--- a/packages/@mantine/core/src/components/Tooltip/TooltipFloating/TooltipFloating.test.tsx
+++ b/packages/@mantine/core/src/components/Tooltip/TooltipFloating/TooltipFloating.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, userEvent } from '@mantine-tests/core';
+import { TooltipFloating } from './TooltipFloating';
+
+function TargetWithoutMouseCoordinates({ onMouseEnter, ...others }: any) {
+  return (
+    <button {...others} type="button" onClick={() => onMouseEnter({ chartX: 10, chartY: 20 })}>
+      target
+    </button>
+  );
+}
+
+describe('@mantine/core/TooltipFloating', () => {
+  it('does not set NaN position when children call onMouseEnter without mouse coordinates', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <TooltipFloating label="test-tooltip" withinPortal={false}>
+        <TargetWithoutMouseCoordinates />
+      </TooltipFloating>
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    const nanWarnings = spy.mock.calls.filter((call) => String(call[0]).includes('NaN'));
+    spy.mockRestore();
+
+    expect(nanWarnings).toHaveLength(0);
+    expect(screen.getByText('test-tooltip').getAttribute('style')).not.toContain('NaN');
+  });
+});

--- a/packages/@mantine/core/src/components/Tooltip/TooltipFloating/TooltipFloating.tsx
+++ b/packages/@mantine/core/src/components/Tooltip/TooltipFloating/TooltipFloating.tsx
@@ -132,8 +132,8 @@ export const TooltipFloating = factory<TooltipFloatingFactory>((_props) => {
               ...getStyleObject(style, theme),
               zIndex: zIndex as React.CSSProperties['zIndex'],
               display: !disabled && opened ? 'block' : 'none',
-              top: (y && Math.round(y)) ?? '',
-              left: (x && Math.round(x)) ?? '',
+              top: Number.isFinite(y) ? Math.round(y!) : '',
+              left: Number.isFinite(x) ? Math.round(x!) : '',
             },
           })}
           variant={variant}

--- a/packages/@mantine/core/src/components/Tooltip/TooltipFloating/TooltipFloating.tsx
+++ b/packages/@mantine/core/src/components/Tooltip/TooltipFloating/TooltipFloating.tsx
@@ -132,8 +132,8 @@ export const TooltipFloating = factory<TooltipFloatingFactory>((_props) => {
               ...getStyleObject(style, theme),
               zIndex: zIndex as React.CSSProperties['zIndex'],
               display: !disabled && opened ? 'block' : 'none',
-              top: Number.isFinite(y) ? Math.round(y!) : '',
-              left: Number.isFinite(x) ? Math.round(x!) : '',
+              top: Number.isFinite(y) ? Math.round(y) : '',
+              left: Number.isFinite(x) ? Math.round(x) : '',
             },
           })}
           variant={variant}

--- a/packages/@mantine/core/src/components/Tooltip/TooltipFloating/use-floating-tooltip.ts
+++ b/packages/@mantine/core/src/components/Tooltip/TooltipFloating/use-floating-tooltip.ts
@@ -40,6 +40,10 @@ export function useFloatingTooltip<T extends HTMLElement = any>({
 
   const handleMouseMove = useCallback(
     ({ clientX, clientY }: MouseEvent | React.MouseEvent<T, MouseEvent>) => {
+      if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) {
+        return;
+      }
+
       refs.setPositionReference({
         getBoundingClientRect() {
           return {


### PR DESCRIPTION
## Problem

`Tooltip.Floating` sets `top: NaN` on the tooltip element when `useFloating` returns `NaN` for `x`/`y`, triggering a React warning:

```
NaN is an invalid value for the `top` css style property.
```

This happens on **mobile/touch devices** where the synthesized `mouseenter` event can have `clientX`/`clientY` as `undefined`. In `use-floating-tooltip.ts`, `handleMouseMove` uses these to build a virtual bounding rect — `undefined + offset = NaN` — so floating-ui computes `y = NaN`.

The existing guard in `TooltipFloating.tsx` does not catch this:

```ts
top: (y && Math.round(y)) ?? '',
```

- `NaN` is **falsy**, so `NaN && Math.round(NaN)` → `NaN`
- `NaN` is **not** `null`/`undefined`, so `NaN ?? ''` → `NaN`
- Result: `top: NaN` on the DOM element

## Fix

Replace the falsy check with `Number.isFinite`, which correctly rejects `null`, `undefined`, `NaN`, and `Infinity` while preserving `0` (which `||` would incorrectly coerce to `''`):

```ts
// before
top: (y && Math.round(y)) ?? '',
left: (x && Math.round(x)) ?? '',

// after
top: Number.isFinite(y) ? Math.round(y!) : '',
left: Number.isFinite(x) ? Math.round(x!) : '',
```

Closes #9130