### PR TITLE
[@mantine/core] Notification: Allow CloseButton props in closeButtonProps type

### DIFF
--- a/packages/@mantine/core/src/components/Notification/Notification.tsx
+++ b/packages/@mantine/core/src/components/Notification/Notification.tsx
@@ -14,7 +14,7 @@ import {
   useProps,
   useStyles,
 } from '../../core';
-import { CloseButton } from '../CloseButton';
+import { __CloseButtonProps, CloseButton } from '../CloseButton';
 import { Loader, LoaderProps } from '../Loader';
 import classes from './Notification.module.css';
 
@@ -60,7 +60,7 @@ export interface NotificationProps
   withCloseButton?: boolean;
 
   /** Props passed down to the close button */
-  closeButtonProps?: ElementProps<'button'> & DataAttributes;
+  closeButtonProps?: __CloseButtonProps & ElementProps<'button'> & DataAttributes;
 
   /** Props passed down to the `Loader` component */
   loaderProps?: LoaderProps;


### PR DESCRIPTION
Closes #9133

### Problem

`NotificationProps['closeButtonProps']` was typed as `ElementProps<'button'> & DataAttributes`, so `iconSize`, `size`, `radius` and `icon` were rejected by TypeScript despite working at runtime — `Notification` spreads `closeButtonProps` after its own `iconSize={16}` / `color="gray"` defaults, which is what #2205 made possible.

`Modal` and `Drawer` are not affected: both type the same prop as `ModalBaseCloseButtonProps`, which extends `__CloseButtonProps`.

### Solution

Add `__CloseButtonProps` (already exported from `@mantine/core`) to the intersection, matching how `Modal` and `Drawer` type the same prop:

```diff
- closeButtonProps?: ElementProps<'button'> & DataAttributes;
+ closeButtonProps?: __CloseButtonProps & ElementProps<'button'> & DataAttributes;
```

- Types only — no runtime, CSS, or export changes
- Not breaking — the type is strictly widened, every currently valid `closeButtonProps` object stays valid
- `ButtonHTMLAttributes` declares none of `iconSize`, `size`, `radius` or `icon`, and `__CloseButtonProps['data-disabled']` (`boolean`) is assignable to `DataAttributes`' `string | number | boolean | undefined` index signature, so no member of the intersection collides
- Verified that unknown props and `iconSize: true` are still rejected after the change, so this widens the type without loosening it

### Tests

Type-only change, no runtime behavior modified. `Notification.test.tsx` (48 tests) passes unchanged. Also verified locally: `npm run typecheck`, `npm run lint`, `npm run format:test`, `npm run syncpack` and `npm run docs:docgen` (no generated output changes).
