### PR TITLE
[@mantine/core] RollingNumber: Fix off-screen digits captured on copy

### DIFF
--- a/packages/@mantine/core/src/components/RollingNumber/DigitColumn.tsx
+++ b/packages/@mantine/core/src/components/RollingNumber/DigitColumn.tsx
@@ -34,7 +34,7 @@ export function DigitColumn({
   const columnStyles = getStyles('digitColumn');
 
   return (
-    <span {...digitStyles} data-empty={empty || undefined} aria-hidden="true">
+    <span {...digitStyles} data-empty={empty || undefined}>
       <span
         key={digit}
         {...columnStyles}
@@ -46,9 +46,14 @@ export function DigitColumn({
         }}
         data-direction={direction}
       >
-        {STRIP_CELLS.map((d, i) => (
-          <span key={i}>{d}</span>
-        ))}
+        {STRIP_CELLS.map((d, i) => {
+          const isActive = !empty && i === digitIndex;
+          return (
+            <span key={i} data-value={isActive ? undefined : d}>
+              {isActive ? d : null}
+            </span>
+          );
+        })}
       </span>
     </span>
   );

--- a/packages/@mantine/core/src/components/RollingNumber/RollingNumber.module.css
+++ b/packages/@mantine/core/src/components/RollingNumber/RollingNumber.module.css
@@ -34,6 +34,10 @@
     align-items: center;
     justify-content: center;
     height: 1em;
+
+    &::before {
+      content: attr(data-value);
+    }
   }
 }
 

--- a/packages/@mantine/core/src/components/RollingNumber/RollingNumber.test.tsx
+++ b/packages/@mantine/core/src/components/RollingNumber/RollingNumber.test.tsx
@@ -126,7 +126,9 @@ describe('@mantine/core/RollingNumber', () => {
     const { container } = render(<RollingNumber value={5} />);
     const column = container.querySelector('.mantine-RollingNumber-digitColumn');
     expect(column!.children).toHaveLength(12);
-    const cells = Array.from(column!.children).map((c) => c.textContent);
+    const cells = Array.from(column!.children).map(
+      (c) => c.textContent || c.getAttribute('data-value')
+    );
     expect(cells).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '1']);
   });
 
@@ -192,5 +194,13 @@ describe('@mantine/core/RollingNumber', () => {
       'aria-label',
       '$ 1,000,000 USD'
     );
+  });
+
+  it('renders clean textContent matching formatted value without off-screen digits', () => {
+    const { container } = render(
+      <RollingNumber value={1234.56} thousandSeparator prefix="$ " suffix=" USD" />
+    );
+    const root = container.querySelector('.mantine-RollingNumber-root');
+    expect(root?.textContent).toBe('$ 1,234.56 USD');
   });
 });

--- a/packages/@mantine/core/src/components/RollingNumber/RollingNumber.tsx
+++ b/packages/@mantine/core/src/components/RollingNumber/RollingNumber.tsx
@@ -158,31 +158,28 @@ export const RollingNumber = factory<RollingNumberFactory>((_props) => {
       aria-label={accessibleValue}
       {...others}
     >
-      {slots.map((slot) => {
-        if (slot.type === 'digit') {
-          return (
-            <DigitColumn
-              key={slot.key}
-              digit={slot.digit}
-              previousDigit={slot.previousDigit}
-              getStyles={getStyles}
-              empty={slot.empty}
-              valueDirection={valueDirection}
-            />
-          );
-        }
+      <span style={{ display: 'inline-flex', alignItems: 'baseline' }}>
+        {slots.map((slot) => {
+          if (slot.type === 'digit') {
+            return (
+              <DigitColumn
+                key={slot.key}
+                digit={slot.digit}
+                previousDigit={slot.previousDigit}
+                getStyles={getStyles}
+                empty={slot.empty}
+                valueDirection={valueDirection}
+              />
+            );
+          }
 
-        return (
-          <span
-            key={slot.key}
-            {...getStyles('char')}
-            data-empty={slot.empty || undefined}
-            aria-hidden="true"
-          >
-            {slot.char}
-          </span>
-        );
-      })}
+          return (
+            <span key={slot.key} {...getStyles('char')} data-empty={slot.empty || undefined}>
+              {slot.empty ? null : slot.char}
+            </span>
+          );
+        })}
+      </span>
     </Box>
   );
 });


### PR DESCRIPTION
Fixes #9132

### Summary of changes
- Only render real DOM `#text` nodes for active digits in `DigitColumn`; inactive/off-screen strip cells receive `data-value` attributes without child text nodes.
- Render off-screen strip digits via CSS `&::before { content: attr(data-value); }`, preserving smooth vertical roll animations while preventing browser clipboard serialization of off-screen numbers.
- Removed duplicate `<VisuallyHidden>` text nodes and suppressed empty/collapsed char slots.
- Added unit test asserting clean rendered `textContent` on formatted numbers.