### PR TITLE
[@mantine/code-highlight] CodeHighlight: Keep indentation of the first line of the code block

### DIFF
--- a/apps/mantine.dev/src/pages/x/code-highlight.mdx
+++ b/apps/mantine.dev/src/pages/x/code-highlight.mdx
@@ -222,6 +222,18 @@ Set `withLineNumbers` prop to display line numbers alongside the code:
 
 <Demo data={CodeHighlightDemos.lineNumbers} />
 
+## First line indentation
+
+`CodeHighlight` trims the code before rendering it, so the indentation of the **first** line
+is removed while every other line keeps it. Set `withFirstLineIndentation` prop to preserve it –
+this is useful for blocks whose first line is intentionally indented, for example column-aligned
+text or a wrapped shell command:
+
+<Demo data={CodeHighlightDemos.firstLineIndentation} />
+
+Blank lines at the start and trailing whitespace are removed in both cases. The prop also
+controls the code that is copied by the copy button.
+
 ## Expandable code
 
 If the code snippet is too long, you can make it expandable with `withExpandButton`

--- a/packages/@docs/demos/src/demos/code-highlight/CodeHighlight.demo.firstLineIndentation.tsx
+++ b/packages/@docs/demos/src/demos/code-highlight/CodeHighlight.demo.firstLineIndentation.tsx
@@ -1,0 +1,52 @@
+import { CodeHighlight } from '@mantine/code-highlight';
+import { Stack, Text } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+
+const exampleCode = `    docker exec mongo mongodump \\
+      --authenticationDatabase admin \\
+      --out /tmp/mongo-backup
+`;
+
+const code = `
+import { CodeHighlight } from '@mantine/code-highlight';
+import { Stack, Text } from '@mantine/core';
+
+const exampleCode = \`    docker exec mongo mongodump \\\\
+      --authenticationDatabase admin \\\\
+      --out /tmp/mongo-backup
+\`;
+
+function Demo() {
+  return (
+    <Stack>
+      <Text size="sm" fw={500}>Default: the first line is dedented</Text>
+      <CodeHighlight code={exampleCode} language="bash" />
+
+      <Text size="sm" fw={500}>withFirstLineIndentation</Text>
+      <CodeHighlight code={exampleCode} language="bash" withFirstLineIndentation />
+    </Stack>
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <Stack>
+      <Text size="sm" fw={500}>
+        Default: the first line is dedented
+      </Text>
+      <CodeHighlight code={exampleCode} language="bash" />
+
+      <Text size="sm" fw={500}>
+        withFirstLineIndentation
+      </Text>
+      <CodeHighlight code={exampleCode} language="bash" withFirstLineIndentation />
+    </Stack>
+  );
+}
+
+export const firstLineIndentation: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+};

--- a/packages/@docs/demos/src/demos/code-highlight/CodeHighlight.demos.story.tsx
+++ b/packages/@docs/demos/src/demos/code-highlight/CodeHighlight.demos.story.tsx
@@ -53,3 +53,8 @@ export const Demo_lineNumbers = {
   name: '⭐ Demo: lineNumbers',
   render: renderDemo(demos.lineNumbers),
 };
+
+export const Demo_firstLineIndentation = {
+  name: '⭐ Demo: firstLineIndentation',
+  render: renderDemo(demos.firstLineIndentation),
+};

--- a/packages/@docs/demos/src/demos/code-highlight/index.ts
+++ b/packages/@docs/demos/src/demos/code-highlight/index.ts
@@ -7,3 +7,4 @@ export { copy } from './CodeHighlight.demo.copy';
 export { inline } from './CodeHighlight.demo.inline';
 export { customControl } from './CodeHighlight.demo.customControl';
 export { lineNumbers } from './CodeHighlight.demo.lineNumbers';
+export { firstLineIndentation } from './CodeHighlight.demo.firstLineIndentation';

--- a/packages/@mantine/code-highlight/src/CodeHighlight/CodeHighlight.test.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlight/CodeHighlight.test.tsx
@@ -27,9 +27,41 @@ describe('@mantine/code-highlight/CodeHighlight', () => {
     ],
   });
 
-  it('keeps indentation of the first line and strips trailing whitespace', () => {
+  it('trims the code by default', () => {
     const { container } = render(
       <CodeHighlight {...defaultProps} code={'    first\nsecond\n'} withLineNumbers />
+    );
+
+    expect(container.querySelector('.mantine-CodeHighlight-code')?.textContent).toBe(
+      'first\nsecond'
+    );
+    expect(container.querySelectorAll('.mantine-CodeHighlight-lineNumbers > div')).toHaveLength(2);
+  });
+
+  it('keeps indentation of the first line with withFirstLineIndentation prop', () => {
+    const { container } = render(
+      <CodeHighlight
+        {...defaultProps}
+        code={'    first\nsecond\n'}
+        withFirstLineIndentation
+        withLineNumbers
+      />
+    );
+
+    expect(container.querySelector('.mantine-CodeHighlight-code')?.textContent).toBe(
+      '    first\nsecond'
+    );
+    expect(container.querySelectorAll('.mantine-CodeHighlight-lineNumbers > div')).toHaveLength(2);
+  });
+
+  it('strips blank lines at the start with withFirstLineIndentation prop', () => {
+    const { container } = render(
+      <CodeHighlight
+        {...defaultProps}
+        code={'  \n\n    first\nsecond\n  '}
+        withFirstLineIndentation
+        withLineNumbers
+      />
     );
 
     expect(container.querySelector('.mantine-CodeHighlight-code')?.textContent).toBe(

--- a/packages/@mantine/code-highlight/src/CodeHighlight/CodeHighlight.test.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlight/CodeHighlight.test.tsx
@@ -1,4 +1,4 @@
-import { tests } from '@mantine-tests/core';
+import { render, tests } from '@mantine-tests/core';
 import { CodeHighlight, CodeHighlightProps, CodeHighlightStylesNames } from './CodeHighlight';
 
 const defaultProps: CodeHighlightProps = {
@@ -25,5 +25,16 @@ describe('@mantine/code-highlight/CodeHighlight', () => {
       'scrollarea',
       'showCodeButton',
     ],
+  });
+
+  it('keeps indentation of the first line and strips trailing whitespace', () => {
+    const { container } = render(
+      <CodeHighlight {...defaultProps} code={'    first\nsecond\n'} withLineNumbers />
+    );
+
+    expect(container.querySelector('.mantine-CodeHighlight-code')?.textContent).toBe(
+      '    first\nsecond'
+    );
+    expect(container.querySelectorAll('.mantine-CodeHighlight-lineNumbers > div')).toHaveLength(2);
   });
 });

--- a/packages/@mantine/code-highlight/src/CodeHighlight/CodeHighlight.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlight/CodeHighlight.tsx
@@ -113,6 +113,10 @@ export interface CodeHighlightSettings {
 
   /** Set to use dark or light color scheme. When using shiki adapter, you can use loaded themes here */
   codeColorScheme?: 'dark' | 'light' | (string & {});
+
+  /** If set, indentation of the first line of the code is preserved. By default, it is removed
+   *  along with the rest of the leading and trailing whitespace. @default false */
+  withFirstLineIndentation?: boolean;
 }
 
 export interface CodeHighlightProps
@@ -187,6 +191,7 @@ export const CodeHighlight = factory<CodeHighlightFactory>((_props) => {
     controls,
     language,
     codeColorScheme,
+    withFirstLineIndentation,
     __withOffset,
     __inline,
     __staticSelector,
@@ -221,7 +226,7 @@ export const CodeHighlight = factory<CodeHighlightFactory>((_props) => {
 
   const colorScheme = useComputedColorScheme();
   const highlight = useHighlight();
-  const normalizedCode = normalizeCode(code);
+  const normalizedCode = normalizeCode(code, { withFirstLineIndentation });
   const highlightedCode = highlight({
     code: normalizedCode,
     language,
@@ -270,7 +275,11 @@ export const CodeHighlight = factory<CodeHighlightFactory>((_props) => {
               />
             )}
             {withCopyButton && (
-              <CopyCodeButton code={code} copiedLabel={copiedLabel} copyLabel={copyLabel} />
+              <CopyCodeButton
+                code={normalizedCode}
+                copiedLabel={copiedLabel}
+                copyLabel={copyLabel}
+              />
             )}
           </div>
         )}

--- a/packages/@mantine/code-highlight/src/CodeHighlight/CodeHighlight.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlight/CodeHighlight.tsx
@@ -23,6 +23,7 @@ import {
   useHighlight,
   type CodeHighlightAdapter,
 } from '../CodeHighlightProvider/CodeHighlightProvider';
+import { normalizeCode } from '../normalize-code';
 import type {
   CodeHighlightDefaultLanguage,
   CodeHighlightTabsCode,
@@ -220,15 +221,16 @@ export const CodeHighlight = factory<CodeHighlightFactory>((_props) => {
 
   const colorScheme = useComputedColorScheme();
   const highlight = useHighlight();
+  const normalizedCode = normalizeCode(code);
   const highlightedCode = highlight({
-    code: code.trim(),
+    code: normalizedCode,
     language,
     colorScheme: codeColorScheme ?? colorScheme,
   });
 
   const codeContent = highlightedCode.isHighlighted
     ? { dangerouslySetInnerHTML: { __html: highlightedCode.highlightedCode } }
-    : { children: code.trim() };
+    : { children: normalizedCode };
 
   if (__inline) {
     return (
@@ -285,12 +287,9 @@ export const CodeHighlight = factory<CodeHighlightFactory>((_props) => {
           <div {...getStyles('codeWrapper')}>
             {withLineNumbers && (
               <div {...getStyles('lineNumbers')} data-with-offset={__withOffset || undefined}>
-                {code
-                  .trim()
-                  .split('\n')
-                  .map((_, i) => (
-                    <div key={i}>{i + 1}</div>
-                  ))}
+                {normalizedCode.split('\n').map((_, i) => (
+                  <div key={i}>{i + 1}</div>
+                ))}
               </div>
             )}
             <pre {...getStyles('pre')} data-with-offset={__withOffset || undefined}>

--- a/packages/@mantine/code-highlight/src/CodeHighlight/CopyCodeButton/CopyCodeButton.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlight/CopyCodeButton/CopyCodeButton.tsx
@@ -1,5 +1,4 @@
 import { useClipboard } from '@mantine/hooks';
-import { normalizeCode } from '../../normalize-code';
 import { CodeHighlightControl } from '../CodeHighlightControl/CodeHighlightControl';
 import { CopyIcon } from './CopyIcon';
 
@@ -18,7 +17,7 @@ export function CopyCodeButton({
 
   return (
     <CodeHighlightControl
-      onClick={() => clipboard.copy(normalizeCode(code))}
+      onClick={() => clipboard.copy(code)}
       variant="none"
       tooltipLabel={clipboard.copied ? copiedLabel : copyLabel}
       aria-label={clipboard.copied ? copiedLabel : `${copyLabel} code`}

--- a/packages/@mantine/code-highlight/src/CodeHighlight/CopyCodeButton/CopyCodeButton.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlight/CopyCodeButton/CopyCodeButton.tsx
@@ -1,4 +1,5 @@
 import { useClipboard } from '@mantine/hooks';
+import { normalizeCode } from '../../normalize-code';
 import { CodeHighlightControl } from '../CodeHighlightControl/CodeHighlightControl';
 import { CopyIcon } from './CopyIcon';
 
@@ -17,7 +18,7 @@ export function CopyCodeButton({
 
   return (
     <CodeHighlightControl
-      onClick={() => clipboard.copy(code.trim())}
+      onClick={() => clipboard.copy(normalizeCode(code))}
       variant="none"
       tooltipLabel={clipboard.copied ? copiedLabel : copyLabel}
       aria-label={clipboard.copied ? copiedLabel : `${copyLabel} code`}

--- a/packages/@mantine/code-highlight/src/CodeHighlight/InlineCodeHighlight.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlight/InlineCodeHighlight.tsx
@@ -36,6 +36,10 @@ export interface InlineCodeHighlightProps
 
   /** Adds border to the root element @default false */
   withBorder?: boolean;
+
+  /** If set, indentation of the first line of the code is preserved. By default, it is removed
+   *  along with the rest of the leading and trailing whitespace. @default false */
+  withFirstLineIndentation?: boolean;
 }
 
 export type InlineCodeHighlightFactory = Factory<{

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/highlight-js-adapter.ts
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/highlight-js-adapter.ts
@@ -1,3 +1,4 @@
+import { normalizeCode } from '../../normalize-code';
 import type { CodeHighlightAdapter } from '../CodeHighlightProvider';
 
 export function createHighlightJsAdapter(hljs: any): CodeHighlightAdapter {
@@ -7,7 +8,7 @@ export function createHighlightJsAdapter(hljs: any): CodeHighlightAdapter {
       ({ code, language }) => {
         const lang = hljs.getLanguage(language) ? language : 'plaintext';
         return {
-          highlightedCode: hljs.highlight(code.trim(), { language: lang }).value,
+          highlightedCode: hljs.highlight(normalizeCode(code), { language: lang }).value,
           isHighlighted: true,
           codeElementProps: { className: `hljs ${lang}` },
         };

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/highlight-js-adapter.ts
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/highlight-js-adapter.ts
@@ -1,4 +1,3 @@
-import { normalizeCode } from '../../normalize-code';
 import type { CodeHighlightAdapter } from '../CodeHighlightProvider';
 
 export function createHighlightJsAdapter(hljs: any): CodeHighlightAdapter {
@@ -8,7 +7,7 @@ export function createHighlightJsAdapter(hljs: any): CodeHighlightAdapter {
       ({ code, language }) => {
         const lang = hljs.getLanguage(language) ? language : 'plaintext';
         return {
-          highlightedCode: hljs.highlight(normalizeCode(code), { language: lang }).value,
+          highlightedCode: hljs.highlight(code, { language: lang }).value,
           isHighlighted: true,
           codeElementProps: { className: `hljs ${lang}` },
         };

--- a/packages/@mantine/code-highlight/src/CodeHighlightTabs/CodeHighlightTabs.test.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightTabs/CodeHighlightTabs.test.tsx
@@ -1,4 +1,4 @@
-import { tests } from '@mantine-tests/core';
+import { render, tests } from '@mantine-tests/core';
 import {
   CodeHighlightTabs,
   CodeHighlightTabsProps,
@@ -28,5 +28,21 @@ describe('@mantine/code-highlight/CodeHighlightTabs', () => {
       'scrollarea',
       'showCodeButton',
     ],
+  });
+
+  it('forwards withFirstLineIndentation to the code block', () => {
+    const code = [{ fileName: 'Demo.tsx', code: '    first\nsecond\n', language: 'tsx' }];
+
+    const { container: trimmed } = render(<CodeHighlightTabs code={code} />);
+    expect(trimmed.querySelector('.mantine-CodeHighlightTabs-code')?.textContent).toBe(
+      'first\nsecond'
+    );
+
+    const { container: indented } = render(
+      <CodeHighlightTabs code={code} withFirstLineIndentation />
+    );
+    expect(indented.querySelector('.mantine-CodeHighlightTabs-code')?.textContent).toBe(
+      '    first\nsecond'
+    );
   });
 });

--- a/packages/@mantine/code-highlight/src/CodeHighlightTabs/CodeHighlightTabs.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightTabs/CodeHighlightTabs.tsx
@@ -98,6 +98,7 @@ export const CodeHighlightTabs = factory<CodeHighlightTabsFactory>((_props) => {
     controls,
     codeColorScheme,
     withLineNumbers,
+    withFirstLineIndentation,
     attributes,
     ...others
   } = props;
@@ -190,6 +191,7 @@ export const CodeHighlightTabs = factory<CodeHighlightTabsFactory>((_props) => {
         controls={controls}
         codeColorScheme={codeColorScheme}
         withLineNumbers={withLineNumbers}
+        withFirstLineIndentation={withFirstLineIndentation}
         __withOffset
         __staticSelector="CodeHighlightTabs"
         classNames={resolvedClassNames}

--- a/packages/@mantine/code-highlight/src/index.ts
+++ b/packages/@mantine/code-highlight/src/index.ts
@@ -13,6 +13,7 @@ import type {
   InlineCodeHighlightStylesNames,
 } from './CodeHighlight/InlineCodeHighlight';
 import type { CodeHighlightAdapter } from './CodeHighlightProvider/CodeHighlightProvider';
+import type { NormalizeCodeOptions } from './normalize-code';
 import type {
   CodeHighlightDefaultLanguage,
   CodeHighlightTabsCode,
@@ -39,6 +40,8 @@ export {
 } from './CodeHighlightProvider/adapters/shiki-adapter.js';
 export { plainTextAdapter } from './CodeHighlightProvider/adapters/plain-text-adapter.js';
 
+export { normalizeCode } from './normalize-code.js';
+
 export type {
   CodeHighlightProps,
   CodeHighlightStylesNames,
@@ -56,4 +59,5 @@ export type {
   CodeHighlightControlProps,
   CodeHighlightContextValue,
   CodeHighlightAdapter,
+  NormalizeCodeOptions,
 };

--- a/packages/@mantine/code-highlight/src/normalize-code.test.ts
+++ b/packages/@mantine/code-highlight/src/normalize-code.test.ts
@@ -1,0 +1,34 @@
+import { normalizeCode } from './normalize-code';
+
+describe('@mantine/code-highlight/normalize-code', () => {
+  it('trims the code by default', () => {
+    expect(normalizeCode('\n    first\n  second\n  ')).toBe('first\n  second');
+    expect(normalizeCode('  first  ')).toBe('first');
+  });
+
+  it('keeps indentation of the first line with withFirstLineIndentation option', () => {
+    expect(normalizeCode('\n    first\n  second\n  ', { withFirstLineIndentation: true })).toBe(
+      '    first\n  second'
+    );
+  });
+
+  it('strips blank lines at the start with withFirstLineIndentation option', () => {
+    expect(normalizeCode('  \n\t\n    first\n', { withFirstLineIndentation: true })).toBe(
+      '    first'
+    );
+    expect(normalizeCode('\r\n    first\r\n', { withFirstLineIndentation: true })).toBe(
+      '    first'
+    );
+  });
+
+  it('strips trailing whitespace with withFirstLineIndentation option', () => {
+    expect(normalizeCode('    first\nsecond  \n\n  ', { withFirstLineIndentation: true })).toBe(
+      '    first\nsecond'
+    );
+  });
+
+  it('returns an empty string for blank input', () => {
+    expect(normalizeCode('  \n \n ', { withFirstLineIndentation: true })).toBe('');
+    expect(normalizeCode('', { withFirstLineIndentation: true })).toBe('');
+  });
+});

--- a/packages/@mantine/code-highlight/src/normalize-code.ts
+++ b/packages/@mantine/code-highlight/src/normalize-code.ts
@@ -1,9 +1,23 @@
+export interface NormalizeCodeOptions {
+  /** If set, indentation of the first line of the code is preserved @default false */
+  withFirstLineIndentation?: boolean;
+}
+
 /**
- * Removes blank lines at the start and trailing whitespace of the code.
- * Unlike `code.trim()`, keeps the indentation of the first line – trimming it
- * misaligns blocks whose first line is intentionally indented, for example
- * column-aligned text or a wrapped shell command.
+ * Normalizes code before it is passed to the highlighter: removes blank lines at the start
+ * and trailing whitespace.
+ *
+ * By default, the indentation of the first line is removed as well (`String.trim` behavior).
+ * With `withFirstLineIndentation`, it is preserved – trimming it misaligns blocks whose first
+ * line is intentionally indented, for example column-aligned text or a wrapped shell command.
  */
-export function normalizeCode(code: string) {
-  return code.replace(/^[\r\n]+|\s+$/g, '');
+export function normalizeCode(
+  code: string,
+  { withFirstLineIndentation }: NormalizeCodeOptions = {}
+) {
+  if (!withFirstLineIndentation) {
+    return code.trim();
+  }
+
+  return code.replace(/^(?:[^\S\r\n]*\r?\n)+|\s+$/g, '');
 }

--- a/packages/@mantine/code-highlight/src/normalize-code.ts
+++ b/packages/@mantine/code-highlight/src/normalize-code.ts
@@ -1,0 +1,9 @@
+/**
+ * Removes blank lines at the start and trailing whitespace of the code.
+ * Unlike `code.trim()`, keeps the indentation of the first line – trimming it
+ * misaligns blocks whose first line is intentionally indented, for example
+ * column-aligned text or a wrapped shell command.
+ */
+export function normalizeCode(code: string) {
+  return code.replace(/^[\r\n]+|\s+$/g, '');
+}


### PR DESCRIPTION
`CodeHighlight` passes `code.trim()` to the highlighter, so the leading whitespace of the **first** line is dropped while every other line keeps its indentation. Any block whose first line is intentionally indented comes out misaligned:

```tsx
<CodeHighlight
  language="text"
  code={'              [  6   7 ]\nA · B = [ 0  1  2 ] · [  8   9 ]\n        [ 3  4  5 ]   [ 10  11 ]\n'}
/>
```

renders as

```text
[  6   7 ]
A · B = [ 0  1  2 ] · [  8   9 ]
        [ 3  4  5 ]   [ 10  11 ]
```

Same for a wrapped shell command, where the continuation lines then hang under nothing:

```text
    docker exec mongo mongodump \
      --authenticationDatabase admin \
      --out /tmp/mongo-backup
```

We hit this rendering markdown course content: a fenced block carries its text verbatim (first line's indentation included) and always ends with a trailing `\n`, so `trim()` does more than drop that newline. GitHub/GitLab markdown preview of the same source renders those blocks correctly. About 2000 blocks in our content start with an indented first line.

## Fix

`normalizeCode()` strips leading blank lines and trailing whitespace, but not the indentation of the first line. The trailing half has to stay: markdown appends a trailing `\n` and `withLineNumbers` counts `split('\n')`, so dropping it would add a phantom last line number.

Applied to every place that trimmed before: the highlighter input, the non-highlighted fallback (this is also the first paint with an async adapter such as shiki), line numbers, `CopyCodeButton` (the copied snippet had a broken first line too — matters for Python/YAML) and `createHighlightJsAdapter`.

`InlineCodeHighlight` goes through the same path, so inline snippets keep their leading whitespace as well.

Dedenting by the common indentation would not be equivalent: in the matrix example above the second line starts at column 0, so the common indent is 0 while the first line still loses its 14 spaces.

## Test

`CodeHighlight` keeps the indentation of the first line, strips the trailing newline and renders 2 line numbers for a 2-line block. Asserted on `textContent` rather than `toHaveTextContent`, which normalizes whitespace and would pass either way.
