### PR TITLE
[@mantine/code-highlight] Add support for lazy languages loading

### DIFF
--- a/apps/mantine.dev/src/pages/x/code-highlight.mdx
+++ b/apps/mantine.dev/src/pages/x/code-highlight.mdx
@@ -140,6 +140,16 @@ const shikiAdapter = createShikiAdapter(loadShiki, {
 If `resolveLanguage` returns `null` or `undefined`, the language is considered unsupported and
 its code is displayed as plain text.
 
+## Unavailable languages
+
+If a code block uses a language that is not loaded in the highlighter and cannot be loaded on
+demand, its code is displayed as plain text instead of throwing an error. In development, a
+warning is logged to the console once per language – either add the language to the `langs`
+option of the highlighter, or load it on demand with `resolveLanguage`.
+
+If a grammar fails to load (for example, a dynamic import fails), the code stays plain text and
+the language is loaded again the next time a code block with that language is rendered.
+
 ## Usage with highlight.js
 
 [Highlight.js](https://highlightjs.org/) provides less accurate highlighting compared to shiki,

--- a/apps/mantine.dev/src/pages/x/code-highlight.mdx
+++ b/apps/mantine.dev/src/pages/x/code-highlight.mdx
@@ -85,6 +85,61 @@ After that, you can use the `CodeHighlight` component in your application:
 
 All further code highlighting examples on this page use the shiki adapter.
 
+## Lazy languages loading
+
+Shiki loads grammars of all languages that are given to the highlighter in advance. If your
+application highlights code in dozens of languages, all of these grammars are downloaded before
+the first code block can be highlighted.
+
+To load grammars on demand, pass `resolveLanguage` option to `createShikiAdapter`. It is called
+with the language of a code block that is not loaded in the highlighter yet, and its return value
+is passed to shiki `highlighter.loadLanguage`. Code is highlighted once the grammar is loaded,
+until then it is displayed as plain text:
+
+```tsx
+import { createShikiAdapter } from '@mantine/code-highlight';
+
+async function loadShiki() {
+  const { createHighlighter } = await import('shiki');
+  return createHighlighter({ langs: ['tsx'], themes: [] });
+}
+
+// Bundled highlighter resolves grammars by language name on its own
+const shikiAdapter = createShikiAdapter(loadShiki, {
+  resolveLanguage: (language) => language,
+});
+```
+
+Highlighters created with `shiki/core` do not bundle grammars – return a function that imports
+the grammar of the given language instead:
+
+```tsx
+import { createShikiAdapter } from '@mantine/code-highlight';
+
+const grammars: Record<string, () => Promise<any>> = {
+  python: () => import('@shikijs/langs/python'),
+  ruby: () => import('@shikijs/langs/ruby'),
+};
+
+async function loadShiki() {
+  const { createHighlighterCore } = await import('shiki/core');
+  const { createJavaScriptRegexEngine } = await import('shiki/engine/javascript');
+
+  return createHighlighterCore({
+    langs: [],
+    themes: [],
+    engine: createJavaScriptRegexEngine(),
+  });
+}
+
+const shikiAdapter = createShikiAdapter(loadShiki, {
+  resolveLanguage: (language) => grammars[language],
+});
+```
+
+If `resolveLanguage` returns `null` or `undefined`, the language is considered unsupported and
+its code is displayed as plain text.
+
 ## Usage with highlight.js
 
 [Highlight.js](https://highlightjs.org/) provides less accurate highlighting compared to shiki,

--- a/apps/mantine.dev/src/pages/x/code-highlight.mdx
+++ b/apps/mantine.dev/src/pages/x/code-highlight.mdx
@@ -148,7 +148,8 @@ warning is logged to the console once per language – either add the language t
 option of the highlighter, or load it on demand with `resolveLanguage`.
 
 If a grammar fails to load (for example, a dynamic import fails), the code stays plain text and
-the language is loaded again the next time a code block with that language is rendered.
+the failure is not cached – the language is requested again the next time a code block with that
+language is mounted.
 
 ## Usage with highlight.js
 

--- a/packages/@mantine/code-highlight/src/CodeHighlight/CodeHighlight.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlight/CodeHighlight.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import cx from 'clsx';
 import {
   Box,
@@ -21,6 +22,7 @@ import {
 import { useUncontrolled } from '@mantine/hooks';
 import {
   useHighlight,
+  useLoadLanguage,
   type CodeHighlightAdapter,
 } from '../CodeHighlightProvider/CodeHighlightProvider';
 import type {
@@ -220,6 +222,12 @@ export const CodeHighlight = factory<CodeHighlightFactory>((_props) => {
 
   const colorScheme = useComputedColorScheme();
   const highlight = useHighlight();
+  const loadLanguage = useLoadLanguage();
+
+  useEffect(() => {
+    loadLanguage(language);
+  }, [language, loadLanguage]);
+
   const highlightedCode = highlight({
     code: code.trim(),
     language,

--- a/packages/@mantine/code-highlight/src/CodeHighlight/CodeHighlight.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlight/CodeHighlight.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import cx from 'clsx';
 import {
   Box,
@@ -22,6 +22,7 @@ import {
 import { useUncontrolled } from '@mantine/hooks';
 import {
   useHighlight,
+  useIsLanguageLoaded,
   useLoadLanguage,
   type CodeHighlightAdapter,
 } from '../CodeHighlightProvider/CodeHighlightProvider';
@@ -223,20 +224,26 @@ export const CodeHighlight = factory<CodeHighlightFactory>((_props) => {
   const colorScheme = useComputedColorScheme();
   const highlight = useHighlight();
   const loadLanguage = useLoadLanguage();
+  const isLanguageLoaded = useIsLanguageLoaded();
 
   useEffect(() => {
     loadLanguage(language);
   }, [language, loadLanguage]);
 
-  const highlightedCode = highlight({
-    code: code.trim(),
-    language,
-    colorScheme: codeColorScheme ?? colorScheme,
-  });
+  const trimmedCode = code.trim();
+  const resolvedColorScheme = codeColorScheme ?? colorScheme;
+  const languageLoaded = isLanguageLoaded(language);
+
+  const highlightedCode = useMemo(
+    () => highlight({ code: trimmedCode, language, colorScheme: resolvedColorScheme }),
+    // `languageLoaded` is not used by the highlighter, it invalidates the result of the
+    // previous call once the grammar of the language has been loaded
+    [highlight, trimmedCode, language, resolvedColorScheme, languageLoaded]
+  );
 
   const codeContent = highlightedCode.isHighlighted
     ? { dangerouslySetInnerHTML: { __html: highlightedCode.highlightedCode } }
-    : { children: code.trim() };
+    : { children: trimmedCode };
 
   if (__inline) {
     return (
@@ -293,12 +300,9 @@ export const CodeHighlight = factory<CodeHighlightFactory>((_props) => {
           <div {...getStyles('codeWrapper')}>
             {withLineNumbers && (
               <div {...getStyles('lineNumbers')} data-with-offset={__withOffset || undefined}>
-                {code
-                  .trim()
-                  .split('\n')
-                  .map((_, i) => (
-                    <div key={i}>{i + 1}</div>
-                  ))}
+                {trimmedCode.split('\n').map((_, i) => (
+                  <div key={i}>{i + 1}</div>
+                ))}
               </div>
             )}
             <pre {...getStyles('pre')} data-with-offset={__withOffset || undefined}>

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.test.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.test.tsx
@@ -278,6 +278,29 @@ describe('@mantine/code-highlight/CodeHighlightProvider', () => {
     expect(freshAdapter.loadLanguage).toHaveBeenCalledWith({ name: 'fresh' }, 'python');
   });
 
+  it('calls loadLanguage once per language when there is nothing to load', async () => {
+    const loadLanguage = jest.fn(() => undefined);
+
+    const adapter: CodeHighlightAdapter = {
+      loadContext: () => Promise.resolve({}),
+      loadLanguage,
+      getHighlighter:
+        () =>
+        ({ code }) => ({ highlightedCode: code, isHighlighted: false }),
+    };
+
+    render(
+      <CodeHighlightAdapterProvider adapter={adapter}>
+        <CodeHighlight code="const a = 1" language="tsx" />
+        <CodeHighlight code="const b = 2" language="tsx" />
+        <CodeHighlight code="const c = 3" language="tsx" />
+      </CodeHighlightAdapterProvider>
+    );
+
+    await waitFor(() => expect(loadLanguage).toHaveBeenCalledTimes(1));
+    expect(loadLanguage).toHaveBeenCalledWith({}, 'tsx');
+  });
+
   it('does not call loadLanguage if adapter does not support it', async () => {
     const adapter: CodeHighlightAdapter = {
       loadContext: () => Promise.resolve({}),

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.test.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { render, screen } from '@mantine-tests/core';
 import { CodeHighlight } from '../CodeHighlight/CodeHighlight';
 import { CodeHighlightAdapterProvider, type CodeHighlightAdapter } from './CodeHighlightProvider';
@@ -123,6 +123,81 @@ describe('@mantine/code-highlight/CodeHighlightProvider', () => {
 
     expect(tsxCalls).toHaveLength(2);
     expect(pythonCalls).toHaveLength(2);
+  });
+
+  it('ignores pending language loads of a replaced adapter', async () => {
+    let resolveStaleLoad: () => void = () => {};
+    const staleLoad = new Promise<void>((resolve) => {
+      resolveStaleLoad = resolve;
+    });
+
+    const staleAdapter: CodeHighlightAdapter = {
+      loadContext: () => Promise.resolve({ name: 'stale' }),
+      loadLanguage: jest.fn(() => staleLoad),
+      getHighlighter:
+        () =>
+        ({ code }) => ({ highlightedCode: code, isHighlighted: false }),
+    };
+
+    let resolveFreshLoad: () => void = () => {};
+    const freshLoad = new Promise<void>((resolve) => {
+      resolveFreshLoad = resolve;
+    });
+
+    let freshGrammarLoaded = false;
+
+    const freshAdapter: CodeHighlightAdapter = {
+      loadContext: () => Promise.resolve({ name: 'fresh' }),
+      loadLanguage: jest.fn(() => freshLoad),
+      getHighlighter:
+        (ctx) =>
+        ({ code }) => {
+          if (!ctx || !freshGrammarLoaded) {
+            return { highlightedCode: code, isHighlighted: false };
+          }
+
+          return {
+            highlightedCode: `<span data-testid="highlighted-code">${code}</span>`,
+            isHighlighted: true,
+          };
+        },
+    };
+
+    const { rerender } = render(
+      <CodeHighlightAdapterProvider adapter={staleAdapter}>
+        <CodeHighlight code="const a = 1" language="tsx" />
+      </CodeHighlightAdapterProvider>
+    );
+
+    await waitFor(() => expect(staleAdapter.loadLanguage).toHaveBeenCalledTimes(1));
+
+    // wrapped in a fragment to match the tree that `render` creates, otherwise the provider
+    // is remounted instead of receiving a new adapter
+    rerender(
+      <>
+        <CodeHighlightAdapterProvider adapter={freshAdapter}>
+          <CodeHighlight code="const a = 1" language="tsx" />
+        </CodeHighlightAdapterProvider>
+      </>
+    );
+
+    await waitFor(() => expect(freshAdapter.loadLanguage).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      resolveStaleLoad();
+      await staleLoad;
+    });
+
+    expect(screen.queryByTestId('highlighted-code')).toBe(null);
+
+    freshGrammarLoaded = true;
+
+    await act(async () => {
+      resolveFreshLoad();
+      await freshLoad;
+    });
+
+    expect(screen.getByTestId('highlighted-code')).toBeInTheDocument();
   });
 
   it('does not call loadLanguage if adapter does not support it', async () => {

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.test.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@mantine-tests/core';
+import { CodeHighlight } from '../CodeHighlight/CodeHighlight';
+import { CodeHighlightAdapterProvider, type CodeHighlightAdapter } from './CodeHighlightProvider';
+
+function createLazyAdapter() {
+  const loadedLanguages = new Set<string>();
+
+  const loadLanguage = jest.fn((_ctx: any, language: string) => {
+    if (loadedLanguages.has(language)) {
+      return undefined;
+    }
+
+    return Promise.resolve().then(() => {
+      loadedLanguages.add(language);
+    });
+  });
+
+  const adapter: CodeHighlightAdapter = {
+    loadContext: () => Promise.resolve({ name: 'test-highlighter' }),
+    loadLanguage,
+    getHighlighter: (ctx) => {
+      return ({ code, language }) => {
+        if (!ctx || !language || !loadedLanguages.has(language)) {
+          return { highlightedCode: code, isHighlighted: false };
+        }
+
+        return {
+          highlightedCode: `<span data-testid="highlighted-code">${code}</span>`,
+          isHighlighted: true,
+        };
+      };
+    },
+  };
+
+  return { adapter, loadLanguage };
+}
+
+describe('@mantine/code-highlight/CodeHighlightProvider', () => {
+  it('highlights code again after adapter loads language', async () => {
+    const { adapter } = createLazyAdapter();
+
+    render(
+      <CodeHighlightAdapterProvider adapter={adapter}>
+        <CodeHighlight code="const a = 1" language="tsx" />
+      </CodeHighlightAdapterProvider>
+    );
+
+    expect(screen.queryByTestId('highlighted-code')).toBe(null);
+    expect(await screen.findByTestId('highlighted-code')).toBeInTheDocument();
+  });
+
+  it('loads the same language only once', async () => {
+    const { adapter, loadLanguage } = createLazyAdapter();
+
+    render(
+      <CodeHighlightAdapterProvider adapter={adapter}>
+        <CodeHighlight code="const a = 1" language="tsx" />
+        <CodeHighlight code="const b = 2" language="tsx" />
+      </CodeHighlightAdapterProvider>
+    );
+
+    expect(await screen.findAllByTestId('highlighted-code')).toHaveLength(2);
+    expect(loadLanguage).toHaveBeenCalledTimes(1);
+    expect(loadLanguage).toHaveBeenCalledWith({ name: 'test-highlighter' }, 'tsx');
+  });
+
+  it('does not call loadLanguage if adapter does not support it', async () => {
+    const adapter: CodeHighlightAdapter = {
+      loadContext: () => Promise.resolve({}),
+      getHighlighter:
+        () =>
+        ({ code }) => ({ highlightedCode: code, isHighlighted: false }),
+    };
+
+    render(
+      <CodeHighlightAdapterProvider adapter={adapter}>
+        <CodeHighlight code="const a = 1" language="tsx" />
+      </CodeHighlightAdapterProvider>
+    );
+
+    expect(await screen.findByText('const a = 1')).toBeInTheDocument();
+  });
+});

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.test.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.test.tsx
@@ -301,6 +301,46 @@ describe('@mantine/code-highlight/CodeHighlightProvider', () => {
     expect(loadLanguage).toHaveBeenCalledWith({}, 'tsx');
   });
 
+  it('requests the context again when an adapter is used after being replaced', async () => {
+    const contexts: { resolve: (ctx: any) => void }[] = [];
+
+    const loadContext = jest.fn(
+      () =>
+        new Promise<any>((resolve) => {
+          contexts.push({ resolve });
+        })
+    );
+
+    const { adapter: adapterA } = createLazyAdapter();
+    adapterA.loadContext = loadContext;
+
+    const adapterB: CodeHighlightAdapter = {
+      getHighlighter:
+        () =>
+        ({ code }) => ({ highlightedCode: code, isHighlighted: false }),
+    };
+
+    const tree = (adapter: CodeHighlightAdapter) => (
+      <CodeHighlightAdapterProvider adapter={adapter}>
+        <CodeHighlight code="const a = 1" language="tsx" />
+      </CodeHighlightAdapterProvider>
+    );
+
+    const { rerender } = render(tree(adapterA));
+    await waitFor(() => expect(loadContext).toHaveBeenCalledTimes(1));
+
+    rerender(<>{tree(adapterB)}</>);
+    rerender(<>{tree(adapterA)}</>);
+
+    await waitFor(() => expect(loadContext).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      contexts[1].resolve({ name: 'test-highlighter' });
+    });
+
+    expect(await screen.findByTestId('highlighted-code')).toBeInTheDocument();
+  });
+
   it('does not call loadLanguage if adapter does not support it', async () => {
     const adapter: CodeHighlightAdapter = {
       loadContext: () => Promise.resolve({}),

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.test.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import { render, screen } from '@mantine-tests/core';
 import { CodeHighlight } from '../CodeHighlight/CodeHighlight';
 import { CodeHighlightAdapterProvider, type CodeHighlightAdapter } from './CodeHighlightProvider';
@@ -15,24 +16,30 @@ function createLazyAdapter() {
     });
   });
 
+  const highlighter = jest.fn(({ code, language }: any) => {
+    if (!language || !loadedLanguages.has(language)) {
+      return { highlightedCode: code, isHighlighted: false };
+    }
+
+    return {
+      highlightedCode: `<span data-testid="highlighted-code">${code}</span>`,
+      isHighlighted: true,
+    };
+  });
+
   const adapter: CodeHighlightAdapter = {
     loadContext: () => Promise.resolve({ name: 'test-highlighter' }),
     loadLanguage,
     getHighlighter: (ctx) => {
-      return ({ code, language }) => {
-        if (!ctx || !language || !loadedLanguages.has(language)) {
-          return { highlightedCode: code, isHighlighted: false };
-        }
+      if (!ctx) {
+        return ({ code }) => ({ highlightedCode: code, isHighlighted: false });
+      }
 
-        return {
-          highlightedCode: `<span data-testid="highlighted-code">${code}</span>`,
-          isHighlighted: true,
-        };
-      };
+      return highlighter;
     },
   };
 
-  return { adapter, loadLanguage };
+  return { adapter, loadLanguage, highlighter };
 }
 
 describe('@mantine/code-highlight/CodeHighlightProvider', () => {
@@ -62,6 +69,60 @@ describe('@mantine/code-highlight/CodeHighlightProvider', () => {
     expect(await screen.findAllByTestId('highlighted-code')).toHaveLength(2);
     expect(loadLanguage).toHaveBeenCalledTimes(1);
     expect(loadLanguage).toHaveBeenCalledWith({ name: 'test-highlighter' }, 'tsx');
+  });
+
+  it('retries loading a language after a failed attempt', async () => {
+    const loadLanguage = jest
+      .fn()
+      .mockImplementationOnce(() => Promise.reject(new Error('Failed to load grammar')))
+      .mockImplementationOnce(() => Promise.resolve());
+
+    const adapter: CodeHighlightAdapter = {
+      loadContext: () => Promise.resolve({}),
+      loadLanguage,
+      getHighlighter:
+        () =>
+        ({ code }) => ({ highlightedCode: code, isHighlighted: false }),
+    };
+
+    const { unmount } = render(
+      <CodeHighlightAdapterProvider adapter={adapter}>
+        <CodeHighlight code="const a = 1" language="tsx" />
+      </CodeHighlightAdapterProvider>
+    );
+
+    await waitFor(() => expect(loadLanguage).toHaveBeenCalledTimes(1));
+    unmount();
+
+    render(
+      <CodeHighlightAdapterProvider adapter={adapter}>
+        <CodeHighlight code="const a = 1" language="tsx" />
+      </CodeHighlightAdapterProvider>
+    );
+
+    await waitFor(() => expect(loadLanguage).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not re-highlight code blocks of languages that were not loaded', async () => {
+    const { adapter, highlighter } = createLazyAdapter();
+
+    render(
+      <CodeHighlightAdapterProvider adapter={adapter}>
+        <CodeHighlight code="const a = 1" language="tsx" />
+        <CodeHighlight code="print(1)" language="python" />
+      </CodeHighlightAdapterProvider>
+    );
+
+    await screen.findAllByTestId('highlighted-code');
+    await waitFor(() => expect(highlighter).toHaveBeenCalledTimes(4));
+
+    const tsxCalls = highlighter.mock.calls.filter(([input]: any) => input.language === 'tsx');
+    const pythonCalls = highlighter.mock.calls.filter(
+      ([input]: any) => input.language === 'python'
+    );
+
+    expect(tsxCalls).toHaveLength(2);
+    expect(pythonCalls).toHaveLength(2);
   });
 
   it('does not call loadLanguage if adapter does not support it', async () => {

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.test.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.test.tsx
@@ -200,6 +200,84 @@ describe('@mantine/code-highlight/CodeHighlightProvider', () => {
     expect(screen.getByTestId('highlighted-code')).toBeInTheDocument();
   });
 
+  it('loads languages for adapters that do not have loadContext', async () => {
+    let grammarLoaded = false;
+
+    const adapter: CodeHighlightAdapter = {
+      loadLanguage: jest.fn(() =>
+        Promise.resolve().then(() => {
+          grammarLoaded = true;
+        })
+      ),
+      getHighlighter:
+        () =>
+        ({ code }) => {
+          if (!grammarLoaded) {
+            return { highlightedCode: code, isHighlighted: false };
+          }
+
+          return {
+            highlightedCode: `<span data-testid="highlighted-code">${code}</span>`,
+            isHighlighted: true,
+          };
+        },
+    };
+
+    render(
+      <CodeHighlightAdapterProvider adapter={adapter}>
+        <CodeHighlight code="const a = 1" language="tsx" />
+      </CodeHighlightAdapterProvider>
+    );
+
+    expect(await screen.findByTestId('highlighted-code')).toBeInTheDocument();
+    expect(adapter.loadLanguage).toHaveBeenCalledWith(null, 'tsx');
+  });
+
+  it('does not load languages with the context of a replaced adapter', async () => {
+    const { adapter: staleAdapter } = createLazyAdapter();
+
+    let resolveFreshContext: (ctx: any) => void = () => {};
+    const freshContext = new Promise<any>((resolve) => {
+      resolveFreshContext = resolve;
+    });
+
+    const freshAdapter: CodeHighlightAdapter = {
+      loadContext: () => freshContext,
+      loadLanguage: jest.fn(() => Promise.resolve()),
+      getHighlighter:
+        () =>
+        ({ code }) => ({ highlightedCode: code, isHighlighted: false }),
+    };
+
+    const { rerender } = render(
+      <CodeHighlightAdapterProvider adapter={staleAdapter}>
+        <CodeHighlight code="const a = 1" language="tsx" />
+      </CodeHighlightAdapterProvider>
+    );
+
+    await screen.findByTestId('highlighted-code');
+
+    rerender(
+      <>
+        <CodeHighlightAdapterProvider adapter={freshAdapter}>
+          <CodeHighlight code="const a = 1" language="tsx" />
+          <CodeHighlight code="print(1)" language="python" />
+        </CodeHighlightAdapterProvider>
+      </>
+    );
+
+    expect(freshAdapter.loadLanguage).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveFreshContext({ name: 'fresh' });
+      await freshContext;
+    });
+
+    await waitFor(() => expect(freshAdapter.loadLanguage).toHaveBeenCalledTimes(2));
+    expect(freshAdapter.loadLanguage).toHaveBeenCalledWith({ name: 'fresh' }, 'tsx');
+    expect(freshAdapter.loadLanguage).toHaveBeenCalledWith({ name: 'fresh' }, 'python');
+  });
+
   it('does not call loadLanguage if adapter does not support it', async () => {
     const adapter: CodeHighlightAdapter = {
       loadContext: () => Promise.resolve({}),

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.test.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.test.tsx
@@ -341,6 +341,65 @@ describe('@mantine/code-highlight/CodeHighlightProvider', () => {
     expect(await screen.findByTestId('highlighted-code')).toBeInTheDocument();
   });
 
+  it('does not load languages into the previous context of a reused adapter', async () => {
+    const contexts: { resolve: (ctx: any) => void }[] = [];
+    const loadContext = jest.fn(
+      () =>
+        new Promise<any>((resolve) => {
+          contexts.push({ resolve });
+        })
+    );
+
+    const loadedLanguages = new Set<string>();
+    const loadLanguage = jest.fn((_ctx: any, language: string) =>
+      Promise.resolve().then(() => {
+        loadedLanguages.add(language);
+      })
+    );
+
+    const adapterA: CodeHighlightAdapter = {
+      loadContext,
+      loadLanguage,
+      getHighlighter:
+        () =>
+        ({ code }) => ({ highlightedCode: code, isHighlighted: false }),
+    };
+
+    const adapterB: CodeHighlightAdapter = {
+      getHighlighter:
+        () =>
+        ({ code }) => ({ highlightedCode: code, isHighlighted: false }),
+    };
+
+    const tree = (adapter: CodeHighlightAdapter) => (
+      <CodeHighlightAdapterProvider adapter={adapter}>
+        <CodeHighlight code="const a = 1" language="tsx" />
+      </CodeHighlightAdapterProvider>
+    );
+
+    const { rerender } = render(tree(adapterA));
+
+    await waitFor(() => expect(loadContext).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      contexts[0].resolve({ name: 'first' });
+    });
+    await waitFor(() => expect(loadLanguage).toHaveBeenCalledTimes(1));
+
+    rerender(<>{tree(adapterB)}</>);
+    rerender(<>{tree(adapterA)}</>);
+
+    await waitFor(() => expect(loadContext).toHaveBeenCalledTimes(2));
+
+    expect(loadLanguage).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      contexts[1].resolve({ name: 'second' });
+    });
+
+    await waitFor(() => expect(loadLanguage).toHaveBeenCalledTimes(2));
+    expect(loadLanguage).toHaveBeenLastCalledWith({ name: 'second' }, 'tsx');
+  });
+
   it('does not call loadLanguage if adapter does not support it', async () => {
     const adapter: CodeHighlightAdapter = {
       loadContext: () => Promise.resolve({}),

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
@@ -59,18 +59,19 @@ export function CodeHighlightAdapterProvider({
 }: CodeHighlightAdapterProviderProps) {
   const [contextState, setContextState] = useState<{
     adapter: CodeHighlightAdapter;
+    epoch: number;
     ctx: any;
     loaded: boolean;
-  }>({ adapter, ctx: null, loaded: false });
+  }>({ adapter, epoch: 0, ctx: null, loaded: false });
 
   const [loadedLanguages, setLoadedLanguages] = useState<string[]>([]);
   const [epoch, setEpoch] = useState(0);
   const requestedLanguages = useRef<Set<string>>(new Set());
   const currentEpoch = useRef(0);
   const previousAdapter = useRef(adapter);
-  const contextRequestedFor = useRef<CodeHighlightAdapter | null>(null);
+  const contextRequestedFor = useRef<number | null>(null);
 
-  const isCurrentContext = contextState.adapter === adapter;
+  const isCurrentContext = contextState.adapter === adapter && contextState.epoch === epoch;
   const ctx = isCurrentContext ? contextState.ctx : null;
   const isContextLoaded = adapter.loadContext ? isCurrentContext && contextState.loaded : true;
 
@@ -79,24 +80,22 @@ export function CodeHighlightAdapterProvider({
   useEffect(() => {
     if (previousAdapter.current !== adapter) {
       previousAdapter.current = adapter;
-      contextRequestedFor.current = null;
       currentEpoch.current += 1;
       requestedLanguages.current.clear();
       setLoadedLanguages([]);
       setEpoch(currentEpoch.current);
     }
 
-    if (!adapter.loadContext || contextRequestedFor.current === adapter) {
+    if (!adapter.loadContext || contextRequestedFor.current === currentEpoch.current) {
       return;
     }
 
-    contextRequestedFor.current = adapter;
-
     const loadedWith = currentEpoch.current;
+    contextRequestedFor.current = loadedWith;
 
     adapter.loadContext().then((loadedCtx) => {
       if (loadedWith === currentEpoch.current) {
-        setContextState({ adapter, ctx: loadedCtx, loaded: true });
+        setContextState({ adapter, epoch: loadedWith, ctx: loadedCtx, loaded: true });
       }
     });
   }, [adapter]);

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
@@ -110,11 +110,11 @@ export function CodeHighlightAdapterProvider({
 
       const languagePromise = adapter.loadLanguage(ctx, language);
 
+      requestedLanguages.current.add(language);
+
       if (!languagePromise) {
         return;
       }
-
-      requestedLanguages.current.add(language);
 
       const loadedWith = currentEpoch.current;
 

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
@@ -57,25 +57,54 @@ export function CodeHighlightAdapterProvider({
   adapter,
   children,
 }: CodeHighlightAdapterProviderProps) {
-  const [ctx, setCtx] = useState<any>(null);
+  const [contextState, setContextState] = useState<{
+    adapter: CodeHighlightAdapter;
+    ctx: any;
+    loaded: boolean;
+  }>({ adapter, ctx: null, loaded: false });
+
   const [loadedLanguages, setLoadedLanguages] = useState<string[]>([]);
+  const [epoch, setEpoch] = useState(0);
   const requestedLanguages = useRef<Set<string>>(new Set());
-  const generation = useRef(0);
+  const currentEpoch = useRef(0);
+  const previousAdapter = useRef(adapter);
+
+  const isCurrentContext = contextState.adapter === adapter;
+  const ctx = isCurrentContext ? contextState.ctx : null;
+  const isContextLoaded = adapter.loadContext ? isCurrentContext && contextState.loaded : true;
+
   const highlight = useMemo(() => adapter.getHighlighter(ctx), [adapter, ctx]);
 
   useEffect(() => {
-    generation.current += 1;
-    requestedLanguages.current.clear();
-    setLoadedLanguages([]);
-
-    if (adapter.loadContext) {
-      adapter.loadContext().then(setCtx);
+    if (previousAdapter.current !== adapter) {
+      previousAdapter.current = adapter;
+      currentEpoch.current += 1;
+      requestedLanguages.current.clear();
+      setLoadedLanguages([]);
+      setEpoch(currentEpoch.current);
     }
+
+    if (!adapter.loadContext) {
+      return;
+    }
+
+    const loadedWith = currentEpoch.current;
+
+    adapter.loadContext().then((loadedCtx) => {
+      if (loadedWith === currentEpoch.current) {
+        setContextState({ adapter, ctx: loadedCtx, loaded: true });
+      }
+    });
   }, [adapter]);
 
   const loadLanguage = useCallback(
     (language: string | undefined) => {
-      if (!ctx || !language || !adapter.loadLanguage || requestedLanguages.current.has(language)) {
+      if (
+        !isContextLoaded ||
+        !language ||
+        !adapter.loadLanguage ||
+        requestedLanguages.current.has(language)
+      ) {
         return;
       }
 
@@ -87,24 +116,24 @@ export function CodeHighlightAdapterProvider({
 
       requestedLanguages.current.add(language);
 
-      const loadedWith = generation.current;
+      const loadedWith = currentEpoch.current;
 
       languagePromise.then(
         () => {
-          if (loadedWith === generation.current) {
+          if (loadedWith === currentEpoch.current) {
             setLoadedLanguages((current) =>
               current.includes(language) ? current : [...current, language]
             );
           }
         },
         () => {
-          if (loadedWith === generation.current) {
+          if (loadedWith === currentEpoch.current) {
             requestedLanguages.current.delete(language);
           }
         }
       );
     },
-    [adapter, ctx]
+    [adapter, ctx, isContextLoaded, epoch]
   );
 
   const isLanguageLoaded = useCallback(

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
@@ -79,6 +79,7 @@ export function CodeHighlightAdapterProvider({
   useEffect(() => {
     if (previousAdapter.current !== adapter) {
       previousAdapter.current = adapter;
+      contextRequestedFor.current = null;
       currentEpoch.current += 1;
       requestedLanguages.current.clear();
       setLoadedLanguages([]);

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, use, useEffect, useMemo, useState } from 'react';
+import { createContext, use, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { plainTextAdapter } from './adapters/plain-text-adapter';
 
 interface HighlighterInput {
@@ -21,16 +21,25 @@ type Highlighter = (input: HighlighterInput) => {
 export interface CodeHighlightAdapter {
   loadContext?: () => Promise<any>;
   getHighlighter: (ctx: any) => Highlighter;
+
+  /** Loads data that is required to highlight given language, for example language grammar.
+   * Called once per language, code is highlighted again when returned promise resolves.
+   * Should return `undefined` if there is nothing to load for the given language. */
+  loadLanguage?: (ctx: any, language: string) => Promise<any> | undefined;
 }
 
 interface CodeHighlightProviderContext {
   adapter: CodeHighlightAdapter;
   highlight: Highlighter;
+  loadLanguage: (language: string | undefined) => void;
 }
+
+function noop() {}
 
 export const CodeHighlightContext = createContext<CodeHighlightProviderContext>({
   adapter: plainTextAdapter,
   highlight: plainTextAdapter.getHighlighter(null),
+  loadLanguage: noop,
 });
 
 export interface CodeHighlightAdapterProviderProps {
@@ -43,18 +52,50 @@ export function CodeHighlightAdapterProvider({
   children,
 }: CodeHighlightAdapterProviderProps) {
   const [ctx, setCtx] = useState<any>(null);
+  const [, setLoadedLanguagesCount] = useState(0);
+  const requestedLanguages = useRef<Set<string>>(new Set());
   const highlight = useMemo(() => adapter.getHighlighter(ctx), [adapter, ctx]);
 
   useEffect(() => {
+    requestedLanguages.current.clear();
+
     if (adapter.loadContext) {
       adapter.loadContext().then(setCtx);
     }
   }, [adapter]);
 
-  return <CodeHighlightContext value={{ adapter, highlight }}>{children}</CodeHighlightContext>;
+  const loadLanguage = useCallback(
+    (language: string | undefined) => {
+      if (!ctx || !language || !adapter.loadLanguage || requestedLanguages.current.has(language)) {
+        return;
+      }
+
+      const languagePromise = adapter.loadLanguage(ctx, language);
+
+      if (!languagePromise) {
+        return;
+      }
+
+      requestedLanguages.current.add(language);
+      const rerender = () => setLoadedLanguagesCount((count) => count + 1);
+      languagePromise.then(rerender, rerender);
+    },
+    [adapter, ctx]
+  );
+
+  return (
+    <CodeHighlightContext value={{ adapter, highlight, loadLanguage }}>
+      {children}
+    </CodeHighlightContext>
+  );
 }
 
 export function useHighlight() {
   const ctx = use(CodeHighlightContext);
   return ctx?.highlight || plainTextAdapter.getHighlighter(null);
+}
+
+export function useLoadLanguage() {
+  const ctx = use(CodeHighlightContext);
+  return ctx?.loadLanguage || noop;
 }

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
@@ -68,6 +68,7 @@ export function CodeHighlightAdapterProvider({
   const requestedLanguages = useRef<Set<string>>(new Set());
   const currentEpoch = useRef(0);
   const previousAdapter = useRef(adapter);
+  const contextRequestedFor = useRef<CodeHighlightAdapter | null>(null);
 
   const isCurrentContext = contextState.adapter === adapter;
   const ctx = isCurrentContext ? contextState.ctx : null;
@@ -84,9 +85,11 @@ export function CodeHighlightAdapterProvider({
       setEpoch(currentEpoch.current);
     }
 
-    if (!adapter.loadContext) {
+    if (!adapter.loadContext || contextRequestedFor.current === adapter) {
       return;
     }
+
+    contextRequestedFor.current = adapter;
 
     const loadedWith = currentEpoch.current;
 

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
@@ -60,9 +60,11 @@ export function CodeHighlightAdapterProvider({
   const [ctx, setCtx] = useState<any>(null);
   const [loadedLanguages, setLoadedLanguages] = useState<string[]>([]);
   const requestedLanguages = useRef<Set<string>>(new Set());
+  const generation = useRef(0);
   const highlight = useMemo(() => adapter.getHighlighter(ctx), [adapter, ctx]);
 
   useEffect(() => {
+    generation.current += 1;
     requestedLanguages.current.clear();
     setLoadedLanguages([]);
 
@@ -85,13 +87,20 @@ export function CodeHighlightAdapterProvider({
 
       requestedLanguages.current.add(language);
 
+      const loadedWith = generation.current;
+
       languagePromise.then(
-        () =>
-          setLoadedLanguages((current) =>
-            current.includes(language) ? current : [...current, language]
-          ),
         () => {
-          requestedLanguages.current.delete(language);
+          if (loadedWith === generation.current) {
+            setLoadedLanguages((current) =>
+              current.includes(language) ? current : [...current, language]
+            );
+          }
+        },
+        () => {
+          if (loadedWith === generation.current) {
+            requestedLanguages.current.delete(language);
+          }
         }
       );
     },

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/CodeHighlightProvider.tsx
@@ -32,14 +32,20 @@ interface CodeHighlightProviderContext {
   adapter: CodeHighlightAdapter;
   highlight: Highlighter;
   loadLanguage: (language: string | undefined) => void;
+  isLanguageLoaded: (language: string | undefined) => boolean;
 }
 
 function noop() {}
+
+function alwaysTrue() {
+  return true;
+}
 
 export const CodeHighlightContext = createContext<CodeHighlightProviderContext>({
   adapter: plainTextAdapter,
   highlight: plainTextAdapter.getHighlighter(null),
   loadLanguage: noop,
+  isLanguageLoaded: alwaysTrue,
 });
 
 export interface CodeHighlightAdapterProviderProps {
@@ -52,12 +58,13 @@ export function CodeHighlightAdapterProvider({
   children,
 }: CodeHighlightAdapterProviderProps) {
   const [ctx, setCtx] = useState<any>(null);
-  const [, setLoadedLanguagesCount] = useState(0);
+  const [loadedLanguages, setLoadedLanguages] = useState<string[]>([]);
   const requestedLanguages = useRef<Set<string>>(new Set());
   const highlight = useMemo(() => adapter.getHighlighter(ctx), [adapter, ctx]);
 
   useEffect(() => {
     requestedLanguages.current.clear();
+    setLoadedLanguages([]);
 
     if (adapter.loadContext) {
       adapter.loadContext().then(setCtx);
@@ -77,17 +84,31 @@ export function CodeHighlightAdapterProvider({
       }
 
       requestedLanguages.current.add(language);
-      const rerender = () => setLoadedLanguagesCount((count) => count + 1);
-      languagePromise.then(rerender, rerender);
+
+      languagePromise.then(
+        () =>
+          setLoadedLanguages((current) =>
+            current.includes(language) ? current : [...current, language]
+          ),
+        () => {
+          requestedLanguages.current.delete(language);
+        }
+      );
     },
     [adapter, ctx]
   );
 
-  return (
-    <CodeHighlightContext value={{ adapter, highlight, loadLanguage }}>
-      {children}
-    </CodeHighlightContext>
+  const isLanguageLoaded = useCallback(
+    (language: string | undefined) => !language || loadedLanguages.includes(language),
+    [loadedLanguages]
   );
+
+  const value = useMemo(
+    () => ({ adapter, highlight, loadLanguage, isLanguageLoaded }),
+    [adapter, highlight, loadLanguage, isLanguageLoaded]
+  );
+
+  return <CodeHighlightContext value={value}>{children}</CodeHighlightContext>;
 }
 
 export function useHighlight() {
@@ -98,4 +119,11 @@ export function useHighlight() {
 export function useLoadLanguage() {
   const ctx = use(CodeHighlightContext);
   return ctx?.loadLanguage || noop;
+}
+
+/** Returns `true` if the adapter has finished loading the given language asynchronously.
+ *  Used to re-highlight the code once a lazily loaded grammar becomes available. */
+export function useIsLanguageLoaded() {
+  const ctx = use(CodeHighlightContext);
+  return ctx?.isLanguageLoaded || alwaysTrue;
 }

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.test.ts
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.test.ts
@@ -66,9 +66,11 @@ describe('@mantine/code-highlight/createShikiAdapter', () => {
     const adapter = createShikiAdapter(() => Promise.resolve(shiki));
     const highlight = adapter.getHighlighter(shiki);
 
-    expect(highlight({ code: 'test', language: 'text', colorScheme: 'light' }).isHighlighted).toBe(
-      true
-    );
+    ['text', 'plaintext', 'txt', 'plain', 'ansi'].forEach((language) => {
+      expect(highlight({ code: 'test', language, colorScheme: 'light' }).isHighlighted).toBe(true);
+    });
+
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it('resolves grammar of languages that are not loaded yet', () => {
@@ -97,6 +99,19 @@ describe('@mantine/code-highlight/createShikiAdapter', () => {
 
     expect(result).toBeInstanceOf(Promise);
     await expect(result).rejects.toThrow('is not included in this bundle');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('`python`');
+  });
+
+  it('warns when grammar loading rejects asynchronously', async () => {
+    const shiki = createShikiMock([]);
+    shiki.loadLanguage = jest.fn(() => Promise.reject(new Error('Failed to fetch chunk')));
+
+    const adapter = createShikiAdapter(() => Promise.resolve(shiki), {
+      resolveLanguage: (language) => language,
+    });
+
+    await expect(adapter.loadLanguage!(shiki, 'python')).rejects.toThrow('Failed to fetch chunk');
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0][0]).toContain('`python`');
   });

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.test.ts
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.test.ts
@@ -83,6 +83,24 @@ describe('@mantine/code-highlight/createShikiAdapter', () => {
     expect(shiki.loadLanguage).toHaveBeenCalledWith('python-grammar');
   });
 
+  it('converts synchronous loadLanguage errors into a rejected promise', async () => {
+    const shiki = createShikiMock([]);
+    shiki.loadLanguage = jest.fn(() => {
+      throw new Error('Language `python` is not included in this bundle.');
+    });
+
+    const adapter = createShikiAdapter(() => Promise.resolve(shiki), {
+      resolveLanguage: (language) => language,
+    });
+
+    const result = adapter.loadLanguage!(shiki, 'python');
+
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).rejects.toThrow('is not included in this bundle');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('`python`');
+  });
+
   it('does not load grammar of unsupported languages', () => {
     const shiki = createShikiMock([]);
     const adapter = createShikiAdapter(() => Promise.resolve(shiki), {

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.test.ts
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.test.ts
@@ -9,6 +9,31 @@ function createShikiMock(loadedLanguages: string[]) {
 }
 
 describe('@mantine/code-highlight/createShikiAdapter', () => {
+  it('does not highlight code with language that is not loaded', () => {
+    const shiki = createShikiMock(['tsx']);
+    const adapter = createShikiAdapter(() => Promise.resolve(shiki));
+    const highlight = adapter.getHighlighter(shiki);
+
+    expect(highlight({ code: 'test', language: 'python', colorScheme: 'light' })).toStrictEqual({
+      highlightedCode: 'test',
+      isHighlighted: false,
+    });
+
+    expect(highlight({ code: 'test', language: 'tsx', colorScheme: 'light' }).isHighlighted).toBe(
+      true
+    );
+  });
+
+  it('highlights plain text languages without loading grammar', () => {
+    const shiki = createShikiMock([]);
+    const adapter = createShikiAdapter(() => Promise.resolve(shiki));
+    const highlight = adapter.getHighlighter(shiki);
+
+    expect(highlight({ code: 'test', language: 'text', colorScheme: 'light' }).isHighlighted).toBe(
+      true
+    );
+  });
+
   it('resolves grammar of languages that are not loaded yet', () => {
     const shiki = createShikiMock(['tsx']);
     const resolveLanguage = jest.fn((language: string) => `${language}-grammar`);

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.test.ts
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.test.ts
@@ -1,0 +1,33 @@
+import { createShikiAdapter } from './shiki-adapter';
+
+function createShikiMock(loadedLanguages: string[]) {
+  return {
+    getLoadedLanguages: () => loadedLanguages,
+    loadLanguage: jest.fn(() => Promise.resolve()),
+    codeToHtml: (code: string) => `<pre><code>${code}</code></pre>`,
+  };
+}
+
+describe('@mantine/code-highlight/createShikiAdapter', () => {
+  it('resolves grammar of languages that are not loaded yet', () => {
+    const shiki = createShikiMock(['tsx']);
+    const resolveLanguage = jest.fn((language: string) => `${language}-grammar`);
+    const adapter = createShikiAdapter(() => Promise.resolve(shiki), { resolveLanguage });
+
+    expect(adapter.loadLanguage!(shiki, 'tsx')).toBeUndefined();
+    expect(resolveLanguage).not.toHaveBeenCalled();
+
+    expect(adapter.loadLanguage!(shiki, 'python')).toBeInstanceOf(Promise);
+    expect(shiki.loadLanguage).toHaveBeenCalledWith('python-grammar');
+  });
+
+  it('does not load grammar of unsupported languages', () => {
+    const shiki = createShikiMock([]);
+    const adapter = createShikiAdapter(() => Promise.resolve(shiki), {
+      resolveLanguage: () => null,
+    });
+
+    expect(adapter.loadLanguage!(shiki, 'python')).toBeUndefined();
+    expect(shiki.loadLanguage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.test.ts
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.test.ts
@@ -9,6 +9,16 @@ function createShikiMock(loadedLanguages: string[]) {
 }
 
 describe('@mantine/code-highlight/createShikiAdapter', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
   it('does not highlight code with language that is not loaded', () => {
     const shiki = createShikiMock(['tsx']);
     const adapter = createShikiAdapter(() => Promise.resolve(shiki));
@@ -22,6 +32,33 @@ describe('@mantine/code-highlight/createShikiAdapter', () => {
     expect(highlight({ code: 'test', language: 'tsx', colorScheme: 'light' }).isHighlighted).toBe(
       true
     );
+  });
+
+  it('warns once per language that is not loaded and cannot be loaded on demand', () => {
+    const shiki = createShikiMock(['tsx']);
+    const adapter = createShikiAdapter(() => Promise.resolve(shiki));
+    const highlight = adapter.getHighlighter(shiki);
+
+    highlight({ code: 'test', language: 'python', colorScheme: 'light' });
+    highlight({ code: 'test', language: 'python', colorScheme: 'light' });
+    highlight({ code: 'test', language: 'ruby', colorScheme: 'light' });
+    highlight({ code: 'test', language: 'tsx', colorScheme: 'light' });
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn.mock.calls[0][0]).toContain('`python`');
+    expect(warn.mock.calls[1][0]).toContain('`ruby`');
+  });
+
+  it('does not warn about languages that are loaded on demand', () => {
+    const shiki = createShikiMock(['tsx']);
+    const adapter = createShikiAdapter(() => Promise.resolve(shiki), {
+      resolveLanguage: (language) => language,
+    });
+
+    adapter.loadLanguage!(shiki, 'python');
+    adapter.getHighlighter(shiki)({ code: 'test', language: 'python', colorScheme: 'light' });
+
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it('highlights plain text languages without loading grammar', () => {
@@ -54,5 +91,7 @@ describe('@mantine/code-highlight/createShikiAdapter', () => {
 
     expect(adapter.loadLanguage!(shiki, 'python')).toBeUndefined();
     expect(shiki.loadLanguage).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('`python`');
   });
 });

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.test.ts
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.test.ts
@@ -116,6 +116,22 @@ describe('@mantine/code-highlight/createShikiAdapter', () => {
     expect(warn.mock.calls[0][0]).toContain('`python`');
   });
 
+  it('converts resolveLanguage exceptions into a rejected promise', async () => {
+    const shiki = createShikiMock([]);
+    const adapter = createShikiAdapter(() => Promise.resolve(shiki), {
+      resolveLanguage: () => {
+        throw new Error('resolver blew up');
+      },
+    });
+
+    const result = adapter.loadLanguage!(shiki, 'python');
+
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).rejects.toThrow('resolver blew up');
+    expect(shiki.loadLanguage).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
   it('does not load grammar of unsupported languages', () => {
     const shiki = createShikiMock([]);
     const adapter = createShikiAdapter(() => Promise.resolve(shiki), {

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.ts
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.ts
@@ -79,7 +79,12 @@ export const createShikiAdapter = (
             return undefined;
           }
 
-          return ctx.loadLanguage(grammar);
+          try {
+            return ctx.loadLanguage(grammar);
+          } catch (error) {
+            warnUnavailableLanguage(language, 'could not be loaded by the highlighter');
+            return Promise.reject(error);
+          }
         }
       : undefined,
     getHighlighter: (ctx) => {

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.ts
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.ts
@@ -31,7 +31,7 @@ interface CreateShikiAdapterOptions {
   resolveLanguage?: (language: string) => any;
 }
 
-const specialLanguages = ['text', 'plaintext', 'txt', 'ansi'];
+const specialLanguages = ['text', 'plaintext', 'txt', 'plain', 'ansi'];
 
 function isLanguageAvailable(ctx: any, language: string | undefined) {
   if (!language || specialLanguages.includes(language)) {
@@ -79,11 +79,15 @@ export const createShikiAdapter = (
             return undefined;
           }
 
-          try {
-            return ctx.loadLanguage(grammar);
-          } catch (error) {
+          const onLoadError = (error: any) => {
             warnUnavailableLanguage(language, 'could not be loaded by the highlighter');
-            return Promise.reject(error);
+            throw error;
+          };
+
+          try {
+            return Promise.resolve(ctx.loadLanguage(grammar)).catch(onLoadError);
+          } catch (error) {
+            return Promise.reject(error).catch(onLoadError);
           }
         }
       : undefined,

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.ts
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.ts
@@ -22,14 +22,45 @@ export function stripShikiCodeBlocks(data: string) {
 
 interface CreateShikiAdapterOptions {
   forceColorScheme?: 'dark' | 'light' | (string & {});
+
+  /** Resolves grammar of a language that is not loaded in the highlighter yet.
+   * Returned value is passed to shiki `highlighter.loadLanguage`: it can be a language name
+   * (bundled highlighters), a language registration or a function that imports one.
+   * Return `null` or `undefined` if the language is not supported. */
+  resolveLanguage?: (language: string) => any;
+}
+
+const specialLanguages = ['text', 'plaintext', 'txt', 'ansi'];
+
+function isLanguageAvailable(ctx: any, language: string | undefined) {
+  if (!language || specialLanguages.includes(language)) {
+    return true;
+  }
+
+  if (typeof ctx.getLoadedLanguages !== 'function') {
+    return true;
+  }
+
+  return ctx.getLoadedLanguages().includes(language);
 }
 
 export const createShikiAdapter = (
   loadShiki: () => Promise<any>,
-  { forceColorScheme }: CreateShikiAdapterOptions = {}
+  { forceColorScheme, resolveLanguage }: CreateShikiAdapterOptions = {}
 ): CodeHighlightAdapter => {
   return {
     loadContext: loadShiki,
+
+    loadLanguage: resolveLanguage
+      ? (ctx, language) => {
+          if (isLanguageAvailable(ctx, language)) {
+            return undefined;
+          }
+
+          const grammar = resolveLanguage(language);
+          return grammar ? ctx.loadLanguage(grammar) : undefined;
+        }
+      : undefined,
     getHighlighter: (ctx) => {
       if (!ctx) {
         return ({ code }) => ({ highlightedCode: code, isHighlighted: false });

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.ts
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.ts
@@ -72,19 +72,19 @@ export const createShikiAdapter = (
             return undefined;
           }
 
-          const grammar = resolveLanguage(language);
-
-          if (!grammar) {
-            warnUnavailableLanguage(language, 'was not resolved by `resolveLanguage` option');
-            return undefined;
-          }
-
           const onLoadError = (error: any) => {
             warnUnavailableLanguage(language, 'could not be loaded by the highlighter');
             throw error;
           };
 
           try {
+            const grammar = resolveLanguage(language);
+
+            if (!grammar) {
+              warnUnavailableLanguage(language, 'was not resolved by `resolveLanguage` option');
+              return undefined;
+            }
+
             return Promise.resolve(ctx.loadLanguage(grammar)).catch(onLoadError);
           } catch (error) {
             return Promise.reject(error).catch(onLoadError);

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.ts
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.ts
@@ -67,6 +67,10 @@ export const createShikiAdapter = (
       }
 
       return ({ code, language, colorScheme }) => {
+        if (!isLanguageAvailable(ctx, language)) {
+          return { highlightedCode: code, isHighlighted: false };
+        }
+
         let _colorScheme: any = colorScheme;
 
         if (colorScheme === 'light') {

--- a/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.ts
+++ b/packages/@mantine/code-highlight/src/CodeHighlightProvider/adapters/shiki-adapter.ts
@@ -1,3 +1,4 @@
+import { getEnv } from '@mantine/core';
 import type { CodeHighlightAdapter } from '../CodeHighlightProvider';
 import { dark, light } from './shiki-themes';
 
@@ -48,6 +49,20 @@ export const createShikiAdapter = (
   loadShiki: () => Promise<any>,
   { forceColorScheme, resolveLanguage }: CreateShikiAdapterOptions = {}
 ): CodeHighlightAdapter => {
+  const warnedLanguages = new Set<string>();
+
+  const warnUnavailableLanguage = (language: string, reason: string) => {
+    if (getEnv() === 'production' || warnedLanguages.has(language)) {
+      return;
+    }
+
+    warnedLanguages.add(language);
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[@mantine/code-highlight] Language \`${language}\` ${reason}, code is rendered as plain text.`
+    );
+  };
+
   return {
     loadContext: loadShiki,
 
@@ -58,7 +73,13 @@ export const createShikiAdapter = (
           }
 
           const grammar = resolveLanguage(language);
-          return grammar ? ctx.loadLanguage(grammar) : undefined;
+
+          if (!grammar) {
+            warnUnavailableLanguage(language, 'was not resolved by `resolveLanguage` option');
+            return undefined;
+          }
+
+          return ctx.loadLanguage(grammar);
         }
       : undefined,
     getHighlighter: (ctx) => {
@@ -68,6 +89,13 @@ export const createShikiAdapter = (
 
       return ({ code, language, colorScheme }) => {
         if (!isLanguageAvailable(ctx, language)) {
+          if (!resolveLanguage) {
+            warnUnavailableLanguage(
+              language!,
+              'is not loaded in the highlighter – add it to `langs` option or use `resolveLanguage` option to load it on demand'
+            );
+          }
+
           return { highlightedCode: code, isHighlighted: false };
         }
 

--- a/packages/@mantine/code-highlight/src/index.ts
+++ b/packages/@mantine/code-highlight/src/index.ts
@@ -30,6 +30,7 @@ export { useCodeHighlightContext } from './CodeHighlight/CodeHighlight.context.j
 export {
   CodeHighlightAdapterProvider,
   useHighlight,
+  useLoadLanguage,
 } from './CodeHighlightProvider/CodeHighlightProvider.js';
 
 export { createHighlightJsAdapter } from './CodeHighlightProvider/adapters/highlight-js-adapter.js';


### PR DESCRIPTION
## Problem

Shiki loads grammars of every language given to the highlighter up front. In an application that highlights code in many languages this means all of those grammars are downloaded before the first code block can be highlighted — in our case (~60 languages passed to `createHighlighterCore`) that is ~2.4 MB of grammar source, and a single `cpp` grammar alone is 524 KB.

Lazy loading is not expressible with the current adapter contract: `getHighlighter` is synchronous, so there is no point at which an adapter can await a grammar for the language it is asked to highlight.

## What this adds

`CodeHighlightAdapter` gets an optional `loadLanguage(ctx, language)`:

- `CodeHighlight` reports the language it renders via a new `useLoadLanguage` hook.
- The provider calls `adapter.loadLanguage` once per language (deduplicated, so N blocks with the same language load it once) and re-renders when the returned promise settles.
- Adapters that do not implement `loadLanguage` behave exactly as before.

For the shiki adapter this is opt-in via the `resolveLanguage` option, whose return value is passed to shiki's `highlighter.loadLanguage`:

```tsx
// bundled highlighter — resolves grammars by name itself
createShikiAdapter(loadShiki, { resolveLanguage: (language) => language });

// shiki/core — grammars are not bundled
const grammars = { python: () => import('@shikijs/langs/python') };
createShikiAdapter(loadShiki, { resolveLanguage: (language) => grammars[language] });
```

## Behavior change (second commit, separate on purpose)

Until a grammar is loaded the language is unavailable, so the shiki adapter needs to be able to render that state. `createShikiAdapter` now renders code as plain text when the language is not loaded, instead of letting shiki throw `Language ... not found` from render. This affects existing setups too: a code block with a language missing from `langs` used to crash, now it renders unhighlighted. It felt like a strict improvement, but it is isolated in its own commit in case you would rather not take it.

`getLoadedLanguages` is called defensively (`typeof ... === 'function'`) — `loadShiki` is typed as `() => Promise<any>`, so a context that does not expose it keeps its current behavior. Shiki's special languages (`text`, `plaintext`, `txt`, `ansi`) are always treated as available.

## Docs

Added a "Lazy languages loading" section to `x/code-highlight` with both the bundled and `shiki/core` setups.

## Verification

- `npx jest packages/@mantine/code-highlight` — 136 tests pass, including new provider tests (plain → highlighted transition, one `loadLanguage` call for two blocks of the same language) and shiki adapter tests.
- `npx oxlint -c oxlint.config.mjs packages/@mantine/code-highlight/src` — clean.
- `npm run format:write:files` on the changed files.
- `npm run typecheck` / `npm run build` could not run in my environment (`yarn install` fails to build `sharp`, so workspace type declarations are missing); instead I typechecked the package with `tsc` and paths mapped to workspace sources — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
