### PR TITLE
fix(ComboboxPopover): add missing Styles API data and demo (#9135)

### DIFF
--- a/apps/mantine.dev/src/pages/core/combobox-popover.mdx
+++ b/apps/mantine.dev/src/pages/core/combobox-popover.mdx
@@ -124,3 +124,7 @@ Use `name` prop to set the input name. For multiple selection, values are joined
 by default – use `hiddenInputValuesDivider` to change the separator.
 
 <Demo data={ComboboxPopoverDemos.formSubmission} />
+
+<StylesApiSelectors component="ComboboxPopover" />
+
+<Demo data={ComboboxPopoverDemos.stylesApi} />

--- a/packages/@docs/demos/src/demos/core/ComboboxPopover/ComboboxPopover.demo.stylesApi.tsx
+++ b/packages/@docs/demos/src/demos/core/ComboboxPopover/ComboboxPopover.demo.stylesApi.tsx
@@ -1,0 +1,49 @@
+import { Button, ComboboxPopover } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+import { ComboboxStylesApi } from '@docs/styles-api';
+
+const code = `
+import { Button, ComboboxPopover } from '@mantine/core';
+
+function Demo() {
+  return (
+    <ComboboxPopover
+      dropdownOpened
+      data={[
+        { group: 'First group', items: ['First', 'Second'] },
+        { group: 'Second group', items: ['Third', 'Fourth'] },
+      ]}
+      {{props}}
+    >
+      <ComboboxPopover.Target>
+        <Button variant="default">Select value</Button>
+      </ComboboxPopover.Target>
+    </ComboboxPopover>
+  );
+}
+`;
+
+function Demo(props: any) {
+  return (
+    <ComboboxPopover
+      dropdownOpened
+      data={[
+        { group: 'First group', items: ['First', 'Second'] },
+        { group: 'Second group', items: ['Third', 'Fourth'] },
+      ]}
+      {...props}
+      comboboxProps={{ middlewares: { flip: false, shift: false } }}
+    >
+      <ComboboxPopover.Target>
+        <Button variant="default">Select value</Button>
+      </ComboboxPopover.Target>
+    </ComboboxPopover>
+  );
+}
+
+export const stylesApi: MantineDemo = {
+  type: 'styles-api',
+  data: ComboboxStylesApi,
+  component: Demo,
+  code,
+};

--- a/packages/@docs/demos/src/demos/core/ComboboxPopover/index.ts
+++ b/packages/@docs/demos/src/demos/core/ComboboxPopover/index.ts
@@ -16,3 +16,4 @@ export { formSubmission } from './ComboboxPopover.demo.formSubmission';
 export { sort } from './ComboboxPopover.demo.sort';
 export { limit } from './ComboboxPopover.demo.limit';
 export { dropdownWidth } from './ComboboxPopover.demo.dropdownWidth';
+export { stylesApi } from './ComboboxPopover.demo.stylesApi';

--- a/packages/@docs/styles-api/src/data/ComboboxPopover.styles-api.ts
+++ b/packages/@docs/styles-api/src/data/ComboboxPopover.styles-api.ts
@@ -1,0 +1,26 @@
+import type { ComboboxPopoverFactory } from '@mantine/core';
+import type { StylesApiData } from '../types';
+import { ComboboxLikeSelectors } from './Combobox.styles-api';
+
+export const ComboboxPopoverStylesApi: StylesApiData<ComboboxPopoverFactory> = {
+  selectors: ComboboxLikeSelectors,
+
+  vars: {
+    dropdown: {
+      '--combobox-option-fz': 'Controls option `font-size`',
+      '--combobox-option-padding': 'Controls option `padding`',
+      '--combobox-padding': 'Controls dropdown `padding`',
+    },
+
+    options: {
+      '--combobox-option-fz': 'Controls option `font-size`',
+      '--combobox-option-padding': 'Controls option `padding`',
+    },
+  },
+
+  modifiers: [
+    { modifier: 'data-checked', selector: 'option', condition: 'Option is selected' },
+    { modifier: 'data-reverse', selector: 'option', condition: '`checkIconPosition` is `right`' },
+    { modifier: 'data-disabled', selector: 'option', condition: 'Option is disabled' },
+  ],
+};

--- a/packages/@docs/styles-api/src/index.ts
+++ b/packages/@docs/styles-api/src/index.ts
@@ -35,6 +35,7 @@ export * from './data/ColorInput.styles-api';
 export * from './data/ColorPicker.styles-api';
 export * from './data/ColorSwatch.styles-api';
 export * from './data/Combobox.styles-api';
+export * from './data/ComboboxPopover.styles-api';
 export * from './data/CompositeChart.styles-api';
 export * from './data/Container.styles-api';
 export * from './data/DataList.styles-api';


### PR DESCRIPTION
Fixes #9135

## Issue

Opening the **Styles API** tab for `ComboboxPopover` resulted in a page error:

<img width="1918" height="967" alt="Screenshot 2026-08-22 153202" src="https://github.com/user-attachments/assets/1b34cf56-0e7c-45c7-b4b9-c1cc6fa32610" />

`ComboboxPopover` shipped in v9.4 without its Styles API demo and data being registered. However, the component already supports `classNames`, `styles`, and `vars` through the shared `ComboboxLike` Styles API (`ComboboxPopover.classes = Combobox.classes`).

This PR adds the missing:

* `ComboboxPopoverStylesApi` data
* Styles API demo
* MDX Styles API section

This allows the Styles API tab to render correctly instead of crashing.

## Result

<img width="1901" height="923" alt="Screenshot 2026-08-22 151423" src="https://github.com/user-attachments/assets/432605e7-0276-4b4f-b345-9546b431e4e7" />

<img width="1905" height="920" alt="Screenshot 2026-08-22 151431" src="https://github.com/user-attachments/assets/1b6ee85a-ec53-46c4-a8db-cbdedf9a5558" />

<img width="1909" height="903" alt="Screenshot 2026-08-22 151439" src="https://github.com/user-attachments/assets/f2dab9ac-816c-4563-a164-77aea6aa9712" />
