### PR TITLE
[@mantine/hooks] use-throttled-callback: Fix callback becoming unresponsive after clearTimeout

### DIFF
--- a/packages/@mantine/hooks/src/use-throttled-callback/use-throttled-callback.test.ts
+++ b/packages/@mantine/hooks/src/use-throttled-callback/use-throttled-callback.test.ts
@@ -1,5 +1,8 @@
 import { act, renderHook } from '@testing-library/react';
-import { useThrottledCallback } from './use-throttled-callback';
+import {
+  useThrottledCallback,
+  useThrottledCallbackWithClearTimeout,
+} from './use-throttled-callback';
 
 describe('useThrottledCallback', () => {
   beforeEach(() => {
@@ -49,5 +52,26 @@ describe('useThrottledCallback', () => {
     });
 
     expect(callback).toHaveBeenCalledWith('test');
+  });
+
+  it('resets active state and permits subsequent calls after clearTimeout', () => {
+    const callback = jest.fn();
+    const { result } = renderHook(() => useThrottledCallbackWithClearTimeout(callback, 100));
+
+    act(() => {
+      result.current[0](1);
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(1);
+
+    act(() => {
+      result.current[1]();
+    });
+
+    act(() => {
+      result.current[0](2);
+    });
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenCalledWith(2);
   });
 });

--- a/packages/@mantine/hooks/src/use-throttled-callback/use-throttled-callback.ts
+++ b/packages/@mantine/hooks/src/use-throttled-callback/use-throttled-callback.ts
@@ -12,7 +12,13 @@ export function useThrottledCallbackWithClearTimeout<T extends (...args: any[]) 
   const waitRef = useRef(wait);
   const timeoutRef = useRef<number>(-1);
 
-  const clearTimeout = () => window.clearTimeout(timeoutRef.current);
+  const clearTimeout = () => {
+    window.clearTimeout(timeoutRef.current);
+    timeoutRef.current = -1;
+    active.current = true;
+    latestInArgsRef.current = null;
+    latestOutArgsRef.current = null;
+  };
 
   const callThrottledCallback = useCallback(
     (...args: Parameters<T>) => {


### PR DESCRIPTION
## Description
Fixes an issue where `useThrottledCallback` becomes permanently unresponsive after invoking `clearTimeout`.

Previously, `clearTimeout` only cancelled `timeoutRef.current` without resetting `active.current = true` or clearing internal argument refs. When the throttled function was invoked subsequently, it was trapped in the `else` branch (`active.current === false`), updating `latestInArgsRef.current` without scheduling a timer or resetting `active.current = true`. This caused the throttled callback to permanently discard all future invocations.

## Changes
- Reset `active.current = true`, `timeoutRef.current = -1`, `latestInArgsRef.current = null`, and `latestOutArgsRef.current = null` inside `clearTimeout`.
- Added unit test in `use-throttled-callback.test.ts` verifying that `clearTimeout()` permits subsequent calls to fire immediately.

## Checklist
- [x] Ran unit tests with `npm run jest packages/@mantine/hooks` (All 536 tests pass)
- [x] Ran `oxlint` and `oxfmt`
- [x] Ran `tsc --noEmit`
- [x] No unnecessary inline comments added