### PR TITLE
[mantine.dev] Update Tabler Icons link

### DIFF
--- a/apps/mantine.dev/src/pages/guides/icons.mdx
+++ b/apps/mantine.dev/src/pages/guides/icons.mdx
@@ -9,7 +9,7 @@ export default Layout(MDX_DATA.Icons);
 You can use any icon library with Mantine components. The most popular options are:
 
 - [Phosphor icons](https://phosphoricons.com/)
-- [Tabler icons](https://tabler-icons.io/)
+- [Tabler icons](https://tabler.io/icons)
 - [Feather icons](https://feathericons.com/)
 - [Radix icons](https://icons.radix-ui.com/)
 - [react-icons](https://react-icons.github.io/react-icons/)


### PR DESCRIPTION
[mantine.dev] Update Tabler Icons documentation link

Hello! Thanks for taking the time to review this PR.

If this approach does not match the intended direction for the project, I am happy to adjust it or try an alternative approach based on your feedback.

Fixes #9150
## Description

Updates the Tabler Icons link in the icons guide from the outdated `tabler-icons.io` domain to the current official URL:

https://tabler.io/icons

This is a documentation-only change and does not affect any Mantine components or runtime behavior.

## Testing

- `npm run build`