### PR TITLE
[@mantine/schedule] MobileMonthView: Fix multi-day events not showing when they start in the previous month

### DIFF
--- a/packages/@mantine/schedule/src/components/MobileMonthView/get-mobile-month-view-events.test.ts
+++ b/packages/@mantine/schedule/src/components/MobileMonthView/get-mobile-month-view-events.test.ts
@@ -81,6 +81,34 @@ describe('@mantine/schedule/get-mobile-month-view-events', () => {
     });
   });
 
+  it('includes multi-day events that started in the previous month', () => {
+    const events: ScheduleEventData[] = [
+      testUtils.createEvent({ id: 1, start: '2025-10-30', end: '2025-11-02' }),
+    ];
+
+    const result = getMobileMonthViewEvents({ date: '2025-11-01', events });
+    expect(result).toStrictEqual({
+      '2025-10-30': [events[0]],
+      '2025-10-31': [events[0]],
+      '2025-11-01': [events[0]],
+      '2025-11-02': [events[0]],
+    });
+  });
+
+  it('includes multi-day events that end in the next month', () => {
+    const events: ScheduleEventData[] = [
+      testUtils.createEvent({ id: 1, start: '2025-11-29', end: '2025-12-02' }),
+    ];
+
+    const result = getMobileMonthViewEvents({ date: '2025-11-01', events });
+    expect(result).toStrictEqual({
+      '2025-11-29': [events[0]],
+      '2025-11-30': [events[0]],
+      '2025-12-01': [events[0]],
+      '2025-12-02': [events[0]],
+    });
+  });
+
   it('throws error on duplicate event IDs', () => {
     const events: ScheduleEventData[] = [
       testUtils.createEvent({ id: 1, start: '2025-11-05 10:00:00', end: '2025-11-05 11:00:00' }),

--- a/packages/@mantine/schedule/src/components/MobileMonthView/get-mobile-month-view-events.ts
+++ b/packages/@mantine/schedule/src/components/MobileMonthView/get-mobile-month-view-events.ts
@@ -43,6 +43,9 @@ export function getMobileMonthViewEvents({ date, events }: GetMobileMonthViewEve
     return groupedEvents;
   }
 
+  const monthStart = dayjs(date).startOf('month');
+  const monthEnd = dayjs(date).endOf('month');
+
   const ids = new Set<string | number>();
 
   for (const event of events) {
@@ -50,7 +53,10 @@ export function getMobileMonthViewEvents({ date, events }: GetMobileMonthViewEve
       continue;
     }
 
-    if (dayjs(event.start).isSame(dayjs(date), 'month')) {
+    const overlapsMonth =
+      !dayjs(event.end).isBefore(monthStart, 'day') && !dayjs(event.start).isAfter(monthEnd, 'day');
+
+    if (overlapsMonth) {
       groupEventByDate(validateEvent(event), groupedEvents);
 
       if (!ids.has(event.id)) {


### PR DESCRIPTION
## Problem
Multi-day events starting in the previous month were filtered out entirely, since the filter only checked if `event.start` was in the displayed month.

For example, the following event data:

```tsx
const date: ScheduleEventData[] = [
  {
    id: 1,
    title: 'Team Meeting',
    start: `2026-07-30`,
    end: `2026-08-03`,
    color: 'blue',
  },
];
```

would not show up at all when viewing August, even on August 1–3, which the event actually overlaps.

<img width="376" height="545" alt="스크린샷 2026-08-26 오후 4 04 51" src="https://github.com/user-attachments/assets/050930e3-7e43-4083-8027-8080dc291b3c" />

## Solve
Filter by month range overlap instead of start-month equality, matching `MonthView`'s existing approach.

<img width="376" height="542" alt="스크린샷 2026-08-26 오후 3 28 06" src="https://github.com/user-attachments/assets/6ceffd21-531f-4c1d-9ba8-80f407d15ff3" />