### PR TITLE
fix(core): avoid partially overridden shorthands in component CSS

### DIFF
--- a/packages/@mantine/core/src/components/Accordion/Accordion.module.css
+++ b/packages/@mantine/core/src/components/Accordion/Accordion.module.css
@@ -7,7 +7,8 @@
 }
 
 .content {
-  padding: var(--mantine-spacing-md);
+  padding-inline: var(--mantine-spacing-md);
+  padding-bottom: var(--mantine-spacing-md);
   padding-top: calc(var(--mantine-spacing-xs) / 2);
 }
 

--- a/packages/@mantine/core/src/components/Fieldset/Fieldset.module.css
+++ b/packages/@mantine/core/src/components/Fieldset/Fieldset.module.css
@@ -1,5 +1,6 @@
 .root {
-  padding: var(--mantine-spacing-lg);
+  padding-inline: var(--mantine-spacing-lg);
+  padding-bottom: var(--mantine-spacing-lg);
   padding-top: var(--mantine-spacing-xs);
   border-radius: var(--fieldset-radius, var(--mantine-radius-default));
   min-inline-size: auto;

--- a/packages/@mantine/core/src/components/Kbd/Kbd.module.css
+++ b/packages/@mantine/core/src/components/Kbd/Kbd.module.css
@@ -11,8 +11,9 @@
   font-weight: var(--mantine-font-weight-bold);
   font-size: var(--kbd-fz);
   border-radius: var(--mantine-radius-sm);
-  border: 1px solid;
-  border-bottom-width: 3px;
+  border-width: 1px 1px 3px;
+  border-style: solid;
+  border-color: currentColor;
   unicode-bidi: embed;
   text-align: center;
   padding: 0.12em 0.45em;

--- a/packages/@mantine/core/src/components/ModalBase/ModalBase.module.css
+++ b/packages/@mantine/core/src/components/ModalBase/ModalBase.module.css
@@ -48,7 +48,6 @@
 
 .body {
   padding: var(--mb-padding, var(--mantine-spacing-md));
-  padding-top: var(--mb-padding, var(--mantine-spacing-md));
 
   &:where(:not(:only-child)) {
     padding-top: 0;

--- a/packages/@mantine/core/src/components/Tabs/Tabs.module.css
+++ b/packages/@mantine/core/src/components/Tabs/Tabs.module.css
@@ -217,11 +217,9 @@
 }
 
 .tab--outline {
-  border-top: 1px solid transparent;
-  border-bottom: 1px solid transparent;
-  border-inline: 1px solid transparent;
-  border-top-color: var(--tab-border-top-color);
-  border-bottom-color: var(--tab-border-bottom-color);
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--tab-border-top-color) transparent var(--tab-border-bottom-color);
   border-radius: var(--tab-radius);
   position: relative;
 

--- a/packages/@mantine/core/src/components/Typography/Typography.module.css
+++ b/packages/@mantine/core/src/components/Typography/Typography.module.css
@@ -139,8 +139,9 @@
     padding: var(--kbd-padding);
     font-size: var(--kbd-fz);
     border-radius: var(--mantine-radius-sm);
-    border: 1px solid;
-    border-bottom-width: 3px;
+    border-width: 1px 1px 3px;
+    border-style: solid;
+    border-color: currentColor;
 
     @mixin where-light {
       border-color: var(--mantine-color-gray-3);
@@ -207,18 +208,21 @@
     }
 
     & :where(thead th) {
-      border-bottom: 1px solid;
+      border-bottom-width: 1px;
+      border-bottom-style: solid;
       border-color: var(--table-border-color);
     }
 
     & :where(tfoot th) {
-      border-top: 1px solid;
+      border-top-width: 1px;
+      border-top-style: solid;
       border-color: var(--table-border-color);
     }
 
     & :where(td) {
       padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
-      border-bottom: 1px solid;
+      border-bottom-width: 1px;
+      border-bottom-style: solid;
       border-color: var(--table-border-color);
       font-size: var(--mantine-font-size-sm);
     }


### PR DESCRIPTION
## What

Nine rules across six components declare a shorthand and then override part of it with a longhand in the same block:

```css
/* ModalBase.module.css */
.body {
  padding: var(--mb-padding, var(--mantine-spacing-md));
  padding-top: var(--mb-padding, var(--mantine-spacing-md));
}
```

This PR rewrites those rules using longhands. Rendering is unchanged.

## Why

When a shorthand contains `var()`, its longhands hold *pending-substitution values*, and the Custom Properties spec requires those to serialize as the empty string. As soon as another declaration in the same block forces the browser to serialize the rule as longhands instead of as the shorthand, the rest of the declaration is lost:

```js
rule.cssText
// ".m_5df29311 { padding-right: ; padding-bottom: ; padding-left: ; padding-top: var(…); }"
```

The padding is gone. This is spec-correct behaviour, not a browser bug, and it holds for every rule of this shape.

Worth noting: Mantine's own build introduces the `var()`. Several of these rules are authored with plain lengths — `border: 1px solid; border-bottom-width: 3px;` — and only become unserializable after the px → `calc(… * var(--mantine-scale))` transform. So the pattern is not visible in the source.

Any tool that reads styles back out through the CSSOM therefore sees these components without their paddings and borders. We hit it in session replay — rrweb inlines same-origin stylesheets by concatenating `cssRules[].cssText`, so in every recording the Modal and Drawer body loses its padding and the content sits flush against the edges — but the same applies to DOM-snapshot, screenshot and copy-styles tooling generally.

This is unlikely to be fixed on the consumer side. rrweb has an open report of the identical behaviour for `background` ([rrweb-io/rrweb#1667](https://github.com/rrweb-io/rrweb/issues/1667)) and a maintainer's failing-test PR for `animation` open since 2023 ([rrweb-io/rrweb#1322](https://github.com/rrweb-io/rrweb/pull/1322)), which concludes "I can't currently see a way around this" for statically serialized stylesheets. Not emitting the pattern is the practical remedy.

## Verification

For each of the nine rules I compared `getComputedStyle` across all four padding and border longhands, before and after, using the post-transform values that actually ship. All nine are identical. All nine now round-trip through `cssText` with no empty declarations.

`ModalBase .body` needed no rewrite: its `padding-top` is byte-identical to the `padding` above it, so the line is simply removed.

## Affected

ModalBase, Accordion, Fieldset, Kbd, Tabs, Typography (`kbd`, `thead th`, `tfoot th`, `td`).
