### PR TITLE
[@mantine/schedule] WeekView, DayView: Fix same-day events ending at exclusive midnight being dropped

### DIFF
--- a/packages/@mantine/schedule/src/components/DayView/get-day-view-events/get-day-view-events.test.ts
+++ b/packages/@mantine/schedule/src/components/DayView/get-day-view-events/get-day-view-events.test.ts
@@ -56,6 +56,21 @@ describe('@mantine/schedule/get-day-view-events', () => {
     );
   });
 
+  it('keeps same-day events that end at exclusive midnight', () => {
+    const events = [
+      testUtils.createEvent({ id: 1, start: `${testDate} 17:15:00`, end: '2024-01-16 00:00:00' }),
+    ];
+
+    expect(
+      getDayViewEvents({ events, date: testDate, startTime: '00:00:00', endTime: '23:59:59' })
+    ).toStrictEqual({
+      allDayEvents: [],
+      regularEvents: [{ ...events[0], position: expect.any(Object) }],
+      backgroundTimedEvents: [],
+      backgroundAllDayEvents: [],
+    });
+  });
+
   it('filters events based on startTime and endTime', () => {
     const events = [
       testUtils.createEvent({ id: 1, start: `${testDate} 10:00:00`, end: `${testDate} 11:00:00` }),

--- a/packages/@mantine/schedule/src/components/WeekView/get-week-view-events/filter-week-view-events.test.ts
+++ b/packages/@mantine/schedule/src/components/WeekView/get-week-view-events/filter-week-view-events.test.ts
@@ -36,6 +36,21 @@ describe('@mantine/schedule/filter-week-view-events', () => {
     ).toStrictEqual([events[1]]);
   });
 
+  it('keeps same-day events that end at exclusive midnight', () => {
+    const events = [
+      testUtils.createEvent({ id: 1, start: '2024-01-10 17:15:00', end: '2024-01-11 00:00:00' }),
+    ];
+
+    expect(
+      filterWeekViewEvents({
+        date: '2024-01-08',
+        events,
+        startTime: '00:00:00',
+        endTime: '23:59:59',
+      })
+    ).toStrictEqual(events);
+  });
+
   it('throws error when duplicated event ids are found', () => {
     const events = [
       testUtils.createEvent({ id: 1, start: '2024-01-10 10:00:00', end: '2024-01-10 11:00:00' }),

--- a/packages/@mantine/schedule/src/utils/is-event-in-time-range/is-event-in-time-range.test.ts
+++ b/packages/@mantine/schedule/src/utils/is-event-in-time-range/is-event-in-time-range.test.ts
@@ -34,6 +34,30 @@ describe('@mantine/schedule/is-event-in-time-range', () => {
     expect(isEventInTimeRange({ event, startTime: '10:00', endTime: '22:00' })).toBe(false);
   });
 
+  it('returns true for same-day event that ends at exclusive midnight', () => {
+    const event = testUtils.createEvent({
+      start: `${testUtils.testDate} 17:15:00`,
+      end: '2025-01-16 00:00:00',
+    });
+    expect(isEventInTimeRange({ event, startTime: '00:00:00', endTime: '23:59:59' })).toBe(true);
+  });
+
+  it('returns true for event that ends one minute before midnight', () => {
+    const event = testUtils.createEvent({
+      start: `${testUtils.testDate} 17:15:00`,
+      end: `${testUtils.testDate} 23:59:00`,
+    });
+    expect(isEventInTimeRange({ event, startTime: '00:00:00', endTime: '23:59:59' })).toBe(true);
+  });
+
+  it('returns false for event that ends at exclusive midnight and starts after time window end', () => {
+    const event = testUtils.createEvent({
+      start: `${testUtils.testDate} 23:00:00`,
+      end: '2025-01-16 00:00:00',
+    });
+    expect(isEventInTimeRange({ event, startTime: '10:00', endTime: '22:00' })).toBe(false);
+  });
+
   it('returns true for event that starts before and ends after time window start', () => {
     const event = testUtils.createEvent({
       start: `${testUtils.testDate} 08:00:00`,

--- a/packages/@mantine/schedule/src/utils/is-event-in-time-range/is-event-in-time-range.test.ts
+++ b/packages/@mantine/schedule/src/utils/is-event-in-time-range/is-event-in-time-range.test.ts
@@ -50,6 +50,14 @@ describe('@mantine/schedule/is-event-in-time-range', () => {
     expect(isEventInTimeRange({ event, startTime: '00:00:00', endTime: '23:59:59' })).toBe(true);
   });
 
+  it('returns true for same-day event that ends at exclusive midnight with milliseconds', () => {
+    const event = testUtils.createEvent({
+      start: `${testUtils.testDate} 17:15:00`,
+      end: '2025-01-16 00:00:00.500',
+    });
+    expect(isEventInTimeRange({ event, startTime: '00:00:00', endTime: '23:59:59' })).toBe(true);
+  });
+
   it('returns false for event that ends at exclusive midnight and starts after time window end', () => {
     const event = testUtils.createEvent({
       start: `${testUtils.testDate} 23:00:00`,

--- a/packages/@mantine/schedule/src/utils/is-event-in-time-range/is-event-in-time-range.ts
+++ b/packages/@mantine/schedule/src/utils/is-event-in-time-range/is-event-in-time-range.ts
@@ -34,7 +34,7 @@ export function isEventInTimeRange({ event, startTime, endTime }: IsEventInTimeR
 
   const eventStart = dayjs(event.start);
   const eventEnd = dayjs(event.end);
-  const endsAtNextDayStart = eventEnd.isSame(eventStart.startOf('day').add(1, 'day'));
+  const endsAtNextDayStart = eventEnd.isSame(eventStart.startOf('day').add(1, 'day'), 'second');
   const eventStartMinutes = eventStart.hour() * 60 + eventStart.minute();
   const eventEndMinutes = endsAtNextDayStart ? 24 * 60 : eventEnd.hour() * 60 + eventEnd.minute();
 

--- a/packages/@mantine/schedule/src/utils/is-event-in-time-range/is-event-in-time-range.ts
+++ b/packages/@mantine/schedule/src/utils/is-event-in-time-range/is-event-in-time-range.ts
@@ -34,8 +34,9 @@ export function isEventInTimeRange({ event, startTime, endTime }: IsEventInTimeR
 
   const eventStart = dayjs(event.start);
   const eventEnd = dayjs(event.end);
+  const endsAtNextDayStart = eventEnd.isSame(eventStart.startOf('day').add(1, 'day'));
   const eventStartMinutes = eventStart.hour() * 60 + eventStart.minute();
-  const eventEndMinutes = eventEnd.hour() * 60 + eventEnd.minute();
+  const eventEndMinutes = endsAtNextDayStart ? 24 * 60 : eventEnd.hour() * 60 + eventEnd.minute();
 
   return !(eventEndMinutes <= timeWindowStartMinutes || eventStartMinutes >= timeWindowEndMinutes);
 }

--- a/packages/@mantine/schedule/src/utils/is-multiday-event/is-multiday-event.test.ts
+++ b/packages/@mantine/schedule/src/utils/is-multiday-event/is-multiday-event.test.ts
@@ -24,6 +24,11 @@ describe('@mantine/schedule/is-multiday-event', () => {
         testUtils.createEvent({ start: '2025-11-03 00:00:00', end: '2025-11-04 00:00:00' })
       )
     ).toBe(false);
+    expect(
+      isMultidayEvent(
+        testUtils.createEvent({ start: '2025-11-03 17:15:00', end: '2025-11-04 00:00:00' })
+      )
+    ).toBe(false);
   });
 
   it('returns true for multi-day events', () => {


### PR DESCRIPTION
Fixes #9147.

A same-day timed event whose `end` is the next day at `00:00:00` never renders in `WeekView` or `DayView`, neither in the timed grid nor in the all-day row.

## Cause

`isEventInTimeRange` compares clock minutes, and midnight collapses to `0`.

`packages/@mantine/schedule/src/utils/is-event-in-time-range/is-event-in-time-range.ts:38`

```ts
const eventEndMinutes = eventEnd.hour() * 60 + eventEnd.minute();
```

For `end: '2026-08-21 00:00:00'` that is `0`, so line 40 reads the event as ending before the window opens (`0 <= 0` with the default `startTime` of `00:00:00`) and filters it out.

Nothing else picks the event up. `isMultidayEvent` already subtracts a day when `end` is midnight (`is-multiday-event.ts:7-8`), so the event is classified as same-day, and `spansFullDay` requires a start at `00:00` (`is-event-in-time-range.ts:14`), so it is not all-day either.

Exclusive midnight is the encoding the package already uses everywhere else:

* `is-multiday-event.ts:7-8` and `get-event-end-date.ts:7-8` both treat a midnight `end` as belonging to the previous day.
* `spansFullDay` accepts `end.isSame(nextDayStart)` (`is-event-in-time-range.ts:18`).
* The published docs demo encodes a one day holiday that way: `AgendaView.demo.allDayAndMultiday.tsx:18-19` runs from `day+1 00:00:00` to `day+2 startOf('day')`.

`isEventInTimeRange` is the only helper in the chain that does not.

## Fix

Count an end that falls exactly on the start day's next midnight as `24:00` rather than `00:00`:

```ts
const endsAtNextDayStart = eventEnd.isSame(eventStart.startOf('day').add(1, 'day'));
const eventEndMinutes = endsAtNextDayStart ? 24 * 60 : eventEnd.hour() * 60 + eventEnd.minute();
```

Comparing against the start day's next midnight, rather than testing `hour()`/`minute()` directly, leaves a degenerate `00:00` to `00:00` same-day event on the old path.

Layout needed no change. `getDayPosition` already clips `eventEnd` to `literalEnd` (`get-day-position.ts:50`), so the event renders from its start time through the end of the day.

## Call sites

`isEventInTimeRange` has four call sites, all inside this package.

* `filter-week-view-events.ts:38` and `get-day-view-events.ts:47` are the reported paths. Both are covered by new tests.
* `get-resources-day-view-events.ts:82` is the same shape as the `DayView` call.
* `get-resources-day-view-events.ts:110` receives a clipped event, so I checked it by instrumenting the call. Everything reaching it arrives with `end` clipped to `dayEnd` (`23:59:59.999`) or to an instant strictly inside the day, so `endsAtNextDayStart` is always `false` there and the behaviour is unchanged.

## Tests

* `is-event-in-time-range.test.ts`: a same-day event ending at exclusive midnight is kept; an event ending at `23:59` is still kept; an event ending at exclusive midnight but starting after the window end is still rejected.
* `filter-week-view-events.test.ts` and `get-day-view-events.test.ts`: the reported event survives the filter.
* `is-multiday-event.test.ts`: one assertion locking in that a `17:15` to next `00:00` event stays same-day, since the fix depends on that classification.

Reverting only the source change turns the three positive tests red with `Expected: true / Received: false`. The controls stay green, so they are not passing for the wrong reason.

`npx jest packages/@mantine/schedule`: 1698 tests before, 1703 after, 88 suites passing in both runs.
Full suite: 16021 tests before, 16026 after, 659 suites passing in both runs.
`tsc --noEmit`, `oxlint`, `oxfmt` and `npm run build` are clean.
