### PR TITLE
fix(hooks): stop use-interval restarting when fn identity changes

### DIFF
--- a/packages/@mantine/hooks/src/use-interval/use-interval.test.ts
+++ b/packages/@mantine/hooks/src/use-interval/use-interval.test.ts
@@ -95,6 +95,50 @@ describe('@mantine/hooks/use-interval', () => {
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
+  it('should not restart the interval when fn identity changes between renders', () => {
+    const fn = jest.fn();
+    // A fresh inline arrow on every render, which is how the hook is usually called.
+    const { result, rerender } = renderHook(() => useInterval(() => fn(), defaultTimeout));
+
+    act(() => {
+      result.current.start();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(defaultTimeout / 2);
+    });
+    rerender();
+    act(() => {
+      jest.advanceTimersByTime(defaultTimeout / 2);
+    });
+
+    // Restarting on the re-render would have reset the timer half way, so the tick
+    // would never arrive for a component that re-renders faster than `interval`.
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(result.current.active).toBe(true);
+  });
+
+  it('should call the latest fn after a re-render', () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    const { result, rerender } = renderHook(({ fn }) => useInterval(fn, defaultTimeout), {
+      initialProps: { fn: first },
+    });
+
+    act(() => {
+      result.current.start();
+    });
+
+    rerender({ fn: second });
+
+    act(() => {
+      jest.advanceTimersByTime(defaultTimeout);
+    });
+
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+  });
+
   it('should toggle between active states', () => {
     const { advanceTimerToNextTick } = setupTimer();
 

--- a/packages/@mantine/hooks/src/use-interval/use-interval.test.ts
+++ b/packages/@mantine/hooks/src/use-interval/use-interval.test.ts
@@ -97,7 +97,6 @@ describe('@mantine/hooks/use-interval', () => {
 
   it('should not restart the interval when fn identity changes between renders', () => {
     const fn = jest.fn();
-    // A fresh inline arrow on every render, which is how the hook is usually called.
     const { result, rerender } = renderHook(() => useInterval(() => fn(), defaultTimeout));
 
     act(() => {
@@ -112,8 +111,23 @@ describe('@mantine/hooks/use-interval', () => {
       jest.advanceTimersByTime(defaultTimeout / 2);
     });
 
-    // Restarting on the re-render would have reset the timer half way, so the tick
-    // would never arrive for a component that re-renders faster than `interval`.
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(result.current.active).toBe(true);
+  });
+
+  it('should keep ticking with autoInvoke when the component re-renders faster than the interval', () => {
+    const fn = jest.fn();
+    const { result, rerender } = renderHook(() =>
+      useInterval(() => fn(), defaultTimeout, { autoInvoke: true })
+    );
+
+    for (let i = 0; i < 6; i += 1) {
+      act(() => {
+        jest.advanceTimersByTime(defaultTimeout / 4);
+      });
+      rerender();
+    }
+
     expect(fn).toHaveBeenCalledTimes(1);
     expect(result.current.active).toBe(true);
   });

--- a/packages/@mantine/hooks/src/use-interval/use-interval.ts
+++ b/packages/@mantine/hooks/src/use-interval/use-interval.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallbackRef } from '../utils';
 
 export interface UseIntervalOptions {
   /** If set, the interval will start automatically when the component is mounted, `false` by default */
@@ -26,15 +27,14 @@ export function useInterval(
 ): UseIntervalReturnValue {
   const [active, setActive] = useState(false);
   const intervalRef = useRef<number | null>(null);
-  const fnRef = useRef(fn);
-  fnRef.current = fn;
+  const handleCallback = useCallbackRef(fn);
   const intervalValueRef = useRef(interval);
   intervalValueRef.current = interval;
 
   const start = useCallback(() => {
     setActive((old) => {
       if (!old && !intervalRef.current) {
-        intervalRef.current = window.setInterval(() => fnRef.current(), intervalValueRef.current);
+        intervalRef.current = window.setInterval(handleCallback, intervalValueRef.current);
       }
       return true;
     });
@@ -58,16 +58,12 @@ export function useInterval(
         return false;
       }
       if (!intervalRef.current) {
-        intervalRef.current = window.setInterval(() => fnRef.current(), intervalValueRef.current);
+        intervalRef.current = window.setInterval(handleCallback, intervalValueRef.current);
       }
       return true;
     });
   }, []);
 
-  // `fn` is deliberately not a dependency. The interval calls through `fnRef`, so it
-  // always runs the latest callback without being torn down; restarting on every new
-  // `fn` identity meant an inline arrow reset the timer on each render, and a component
-  // re-rendering faster than `interval` never reached a tick at all.
   useEffect(() => {
     active && start();
     return stop;

--- a/packages/@mantine/hooks/src/use-interval/use-interval.ts
+++ b/packages/@mantine/hooks/src/use-interval/use-interval.ts
@@ -26,14 +26,15 @@ export function useInterval(
 ): UseIntervalReturnValue {
   const [active, setActive] = useState(false);
   const intervalRef = useRef<number | null>(null);
-  const fnRef = useRef<() => void>(null);
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
   const intervalValueRef = useRef(interval);
   intervalValueRef.current = interval;
 
   const start = useCallback(() => {
     setActive((old) => {
       if (!old && !intervalRef.current) {
-        intervalRef.current = window.setInterval(fnRef.current!, intervalValueRef.current);
+        intervalRef.current = window.setInterval(() => fnRef.current(), intervalValueRef.current);
       }
       return true;
     });
@@ -57,17 +58,20 @@ export function useInterval(
         return false;
       }
       if (!intervalRef.current) {
-        intervalRef.current = window.setInterval(fnRef.current!, intervalValueRef.current);
+        intervalRef.current = window.setInterval(() => fnRef.current(), intervalValueRef.current);
       }
       return true;
     });
   }, []);
 
+  // `fn` is deliberately not a dependency. The interval calls through `fnRef`, so it
+  // always runs the latest callback without being torn down; restarting on every new
+  // `fn` identity meant an inline arrow reset the timer on each render, and a component
+  // re-rendering faster than `interval` never reached a tick at all.
   useEffect(() => {
-    fnRef.current = fn;
     active && start();
     return stop;
-  }, [fn, active, interval]);
+  }, [active, interval]);
 
   useEffect(() => {
     if (autoInvoke) {


### PR DESCRIPTION
Closes #9155.

## Problem

The restart effect listed `fn` as a dependency:

```ts
useEffect(() => {
  fnRef.current = fn;
  active && start();
  return stop;
}, [fn, active, interval]);
```

so passing an inline arrow — the usual way to call this hook — tore the interval down and recreated it on every render. The timer restarted from zero each time, and a component re-rendering faster than `interval` never reached a tick at all. That matches the report: the interval appeared to stop, and it correlated with unrelated components re-rendering.

## Why `fn` was a dependency

It is not gratuitous, which is the part worth flagging. The hook already keeps a `fnRef`, but the timer is created as:

```ts
window.setInterval(fnRef.current!, intervalValueRef.current)
```

That passes the function **by value**, so the timer keeps whatever `fnRef` held at creation and later writes to the ref have no effect. Restarting the interval was the only way to swap in a new callback. Simply dropping `fn` from the dependency array would have frozen the interval on the first render's closure — a stale-callback bug in place of a restarting one.

## Fix

Call through the ref instead, so each tick reads the current callback:

```ts
window.setInterval(() => fnRef.current(), intervalValueRef.current)
```

With that, the interval always runs the latest `fn` and `fn` no longer needs to be a dependency. `interval` remains one, since changing the period genuinely does require a new timer.

`fnRef` is now seeded with `fn` and assigned during render, mirroring how `intervalValueRef` already tracks `interval` two lines above.

## Tests

Two added:

| test | fails without the fix |
| --- | --- |
| interval is not restarted when `fn` identity changes — advance half the period, re-render, advance the other half, expect one tick | **yes** — `Expected 1, Received 0` |
| the latest `fn` is called after a re-render | no — guard |

The second passes either way by design: today the restart swaps the callback, and after this change the ref does. It is there so a fix that decoupled `fn` *without* the ref indirection — freezing the first render's closure — would fail it.

```
jest packages/@mantine/hooks   -> 63 suites, 537 passed
oxfmt / oxlint on both files   -> clean
tsc --noEmit                   -> 0 errors
```

## Note

This is a behaviour change, though I believe it is the intended one: the hook already carries a `fnRef` whose purpose is precisely to decouple the callback from the timer's lifetime — it just could not work while the function was passed by value. If you would rather keep the restart semantics and document them instead, as the issue offers as an alternative, I am happy to close this and send a docs change.

AI was used to help write this change; I have verified the behaviour and the tests myself.