### PR TITLE
[@mantine/core] Rating: Fix value being changed by scroll gestures on touch devices

### DIFF
--- a/packages/@mantine/core/src/components/Rating/Rating.test.tsx
+++ b/packages/@mantine/core/src/components/Rating/Rating.test.tsx
@@ -1,8 +1,31 @@
+import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, screen, tests } from '@mantine-tests/core';
 import { Rating, RatingProps, RatingStylesNames } from './Rating';
 
 const defaultProps: RatingProps = {};
+
+function getRoot(container: HTMLElement) {
+  const root = container.querySelector('[class*="root"]') as HTMLElement;
+  root.getBoundingClientRect = () =>
+    ({
+      left: 0,
+      right: 500,
+      width: 500,
+      top: 0,
+      bottom: 20,
+      height: 20,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+
+  return root;
+}
+
+function touchList(...points: [number, number][]) {
+  return points.map(([clientX, clientY]) => ({ clientX, clientY }));
+}
 
 describe('@mantine/core/Rating', () => {
   tests.itSupportsSystemProps<RatingProps, RatingStylesNames>({
@@ -71,6 +94,91 @@ describe('@mantine/core/Rating', () => {
     await userEvent.click(targetInput!.nextElementSibling as HTMLElement);
 
     expect(spy).toHaveBeenCalledWith(0);
+  });
+
+  it('sets value on touch tap', () => {
+    const spy = jest.fn();
+    const { container } = render(<Rating onChange={spy} defaultValue={0} />);
+    const root = getRoot(container);
+
+    fireEvent.touchStart(root, { touches: touchList([250, 10]) });
+    fireEvent.touchEnd(root, { changedTouches: touchList([250, 10]) });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(3);
+  });
+
+  it('clears value on touch tap on the same value with allowClear=true', () => {
+    const spy = jest.fn();
+    const { container } = render(<Rating allowClear onChange={spy} defaultValue={3} />);
+    const root = getRoot(container);
+
+    fireEvent.touchStart(root, { touches: touchList([250, 10]) });
+    fireEvent.touchEnd(root, { changedTouches: touchList([250, 10]) });
+
+    expect(spy).toHaveBeenCalledWith(0);
+  });
+
+  it('does not change value when the touch moves before it ends', () => {
+    const spy = jest.fn();
+    const { container } = render(<Rating onChange={spy} defaultValue={0} />);
+    const root = getRoot(container);
+
+    fireEvent.touchStart(root, { touches: touchList([250, 10]) });
+    fireEvent.touchMove(root, { touches: touchList([255, 90]) });
+    fireEvent.touchEnd(root, { changedTouches: touchList([255, 90]) });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not change value when the touch is cancelled', () => {
+    const spy = jest.fn();
+    const { container } = render(<Rating onChange={spy} defaultValue={0} />);
+    const root = getRoot(container);
+
+    fireEvent.touchStart(root, { touches: touchList([250, 10]) });
+    fireEvent.touchCancel(root, { changedTouches: touchList([250, 10]) });
+    fireEvent.touchEnd(root, { changedTouches: touchList([250, 10]) });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not change value on multi touch gestures', () => {
+    const spy = jest.fn();
+    const { container } = render(<Rating onChange={spy} defaultValue={0} />);
+    const root = getRoot(container);
+
+    fireEvent.touchStart(root, { touches: touchList([100, 10], [400, 10]) });
+    fireEvent.touchEnd(root, { changedTouches: touchList([100, 10]) });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not change value on touch tap when readOnly', () => {
+    const spy = jest.fn();
+    const { container } = render(<Rating readOnly onChange={spy} value={2} />);
+    const root = getRoot(container);
+
+    fireEvent.touchStart(root, { touches: touchList([250, 10]) });
+    fireEvent.touchEnd(root, { changedTouches: touchList([250, 10]) });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('ignores the click emulated by the browser after a touch tap', () => {
+    const spy = jest.fn();
+    const { container } = render(<Rating allowClear onChange={spy} defaultValue={0} />);
+    const root = getRoot(container);
+
+    fireEvent.touchStart(root, { touches: touchList([250, 10]) });
+    fireEvent.touchEnd(root, { changedTouches: touchList([250, 10]) });
+
+    const inputs = screen.getAllByRole('radio') as HTMLInputElement[];
+    const thirdInput = inputs.find((input) => input.value === '3');
+    fireEvent.click(thirdInput!.nextElementSibling as HTMLElement);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(3);
   });
 
   it('changes value on Space key press', async () => {

--- a/packages/@mantine/core/src/components/Rating/Rating.tsx
+++ b/packages/@mantine/core/src/components/Rating/Rating.tsx
@@ -26,6 +26,9 @@ function roundValueTo(value: number, to: number) {
   return Number(rounded.toFixed(precision));
 }
 
+const TOUCH_MOVE_THRESHOLD = 10;
+const EMULATED_CLICK_TIMEOUT = 500;
+
 export type RatingStylesNames =
   | 'root'
   | 'starSymbol'
@@ -131,6 +134,8 @@ export const Rating = factory<RatingFactory>((_props) => {
     onHover,
     onMouseLeave,
     onTouchStart,
+    onTouchMove,
+    onTouchCancel,
     onTouchEnd,
     size,
     variant,
@@ -163,6 +168,8 @@ export const Rating = factory<RatingFactory>((_props) => {
   const _name = useId(name);
   const _id = useId(id);
   const rootRef = useRef<HTMLDivElement>(null);
+  const touchStartPosition = useRef<{ x: number; y: number } | null>(null);
+  const lastTouchTimestamp = useRef(0);
 
   const [_value, setValue] = useUncontrolled({
     value,
@@ -193,6 +200,15 @@ export const Rating = factory<RatingFactory>((_props) => {
     const hoverValue = hoverPosition / symbolWidth;
 
     return clamp(roundValueTo(hoverValue + decimalUnit / 2, decimalUnit), decimalUnit, _count);
+  };
+
+  const applyValue = (newValue: number) => {
+    // If allowClear is true and selecting the same value, reset to 0
+    if (allowClear && newValue === stableValueRounded) {
+      setValue(0);
+    } else {
+      setValue(newValue);
+    }
   };
 
   const handleMouseEnter = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -227,20 +243,45 @@ export const Rating = factory<RatingFactory>((_props) => {
 
   const handleTouchStart = (event: React.TouchEvent<HTMLDivElement>) => {
     const { touches } = event;
-    if (touches.length !== 1) {
-      return;
-    }
 
-    if (!readOnly) {
-      const touch = touches[0];
-      setValue(getRatingFromCoordinates(touch.clientX));
-    }
+    touchStartPosition.current =
+      touches.length === 1 ? { x: touches[0].clientX, y: touches[0].clientY } : null;
 
     onTouchStart?.(event);
   };
 
+  const handleTouchMove = (event: React.TouchEvent<HTMLDivElement>) => {
+    const startPosition = touchStartPosition.current;
+    const touch = event.touches[0];
+
+    if (
+      startPosition &&
+      touch &&
+      Math.hypot(touch.clientX - startPosition.x, touch.clientY - startPosition.y) >
+        TOUCH_MOVE_THRESHOLD
+    ) {
+      touchStartPosition.current = null;
+    }
+
+    onTouchMove?.(event);
+  };
+
+  const handleTouchCancel = (event: React.TouchEvent<HTMLDivElement>) => {
+    touchStartPosition.current = null;
+
+    onTouchCancel?.(event);
+  };
+
   const handleTouchEnd = (event: React.TouchEvent<HTMLDivElement>) => {
-    event.preventDefault();
+    const startPosition = touchStartPosition.current;
+    const touch = event.changedTouches[0];
+    touchStartPosition.current = null;
+
+    if (startPosition && touch && !readOnly) {
+      event.preventDefault();
+      applyValue(getRatingFromCoordinates(touch.clientX));
+      lastTouchTimestamp.current = Date.now();
+    }
 
     onTouchEnd?.(event);
   };
@@ -258,16 +299,11 @@ export const Rating = factory<RatingFactory>((_props) => {
   };
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement> | number) => {
-    if (!readOnly) {
-      const newValue = typeof event === 'number' ? event : parseFloat(event.target.value);
-
-      // If allowClear is true and clicking the same value, reset to 0
-      if (allowClear && newValue === stableValueRounded) {
-        setValue(0);
-      } else {
-        setValue(newValue);
-      }
+    if (readOnly || Date.now() - lastTouchTimestamp.current < EMULATED_CLICK_TIMEOUT) {
+      return;
     }
+
+    applyValue(typeof event === 'number' ? event : parseFloat(event.target.value));
   };
 
   const items = Array(_count)
@@ -322,6 +358,8 @@ export const Rating = factory<RatingFactory>((_props) => {
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchCancel={handleTouchCancel}
         onTouchEnd={handleTouchEnd}
         variant={variant}
         size={size}


### PR DESCRIPTION
## Problem

`Rating` commits a new value from `touchstart`, reading it off the finger's x coordinate against the root's bounding box:

```tsx
const handleTouchStart = (event) => {
  ...
  if (!readOnly) {
    const touch = touches[0];
    setValue(getRatingFromCoordinates(touch.clientX));
  }
};
```

Two things follow from that, neither of which reproduces with a mouse or in a desktop browser's device toolbar (that emulates pointer/mouse events, not real touch events):

**1. A scroll that starts on the component changes the value.** Putting a finger on the stars to scroll the page sets a rating on the way past — the value is committed on finger-down, before the browser has decided the gesture is a scroll. On a form with several `Rating`s this reads to the user as "scrolling changed an answer I already gave", and with `allowClear` it silently zeroes one out, because landing on the star that was already selected is treated as a re-select.

**2. A single tap can be applied twice.** After the touch, the browser synthesises a click on the label, which calls `onChange` again with the same value. `handleTouchEnd` tries to swallow that click with an unconditional `event.preventDefault()`; where that does not hold, the tap is applied a second time.

On `master` the second one is usually invisible, because re-applying the same value changes nothing you can see. It becomes visible as soon as the clear logic runs on the click path — see below.

## Relationship to #9122

#9122 fixes a third, separate symptom: with `allowClear`, tapping the already-selected star did not clear it, because `handleTouchStart` called `setValue` directly and so bypassed the clear logic. Its one-line change routes that call through `handleChange`.

It does not address either defect above. The value is still committed from `touchstart`, so a scroll that starts on the stars still changes the rating, and the emulated click still applies the tap a second time.

For the second defect the one-line change makes things worse. Once the emulated click goes through `handleChange`, it meets the `allowClear` branch and resets the value to 0. So on a rating with `allowClear`, every tap whose emulated click the `preventDefault` in `touchend` fails to swallow will set the score and immediately clear it. (This is not hypothetical — it is what happens today to anyone who has worked around #9122's symptom by reimplementing the clear in their own `onChange`.)

This PR fixes #9122's symptom too, as a side effect: moving the commit to `touchend` routes the touch path through the same clear logic as clicks. That does make the two branches conflict textually — happy to rebase on top of #9122 if it lands first.

## Solution

- The value is committed on `touchend`, from `changedTouches[0]`, instead of on `touchstart`.
- The touch is discarded — no value change — if it moves further than `TOUCH_MOVE_THRESHOLD` (10px, roughly the tap slop devices use) from where it landed, if `touchcancel` arrives (what the browser fires once it takes the gesture over for scrolling), or if a second finger lands. A swipe that begins on the stars now scrolls and changes nothing.
- `handleChange` ignores changes arriving within `EMULATED_CLICK_TIMEOUT` of a handled touch, so the emulated click cannot apply the tap a second time even where `preventDefault` is not honoured.
- `preventDefault()` is now called only when the tap was actually handled, rather than on every `touchend`, so a `readOnly` rating no longer swallows the click.
- The `allowClear` logic moved into `applyValue`, so the touch path and the click path share it.

Behaviour with a mouse and with the keyboard is unchanged.

## Reproducing it

On a phone, open <https://mantine.dev/core/rating>, put a finger on the stars of the first (Usage) demo and swipe up to scroll the page. The rating jumps to wherever your finger landed.

It also reproduces on the desktop docs site without any device emulation, by dispatching the touch events directly. Paste this into the console on <https://mantine.dev/core/rating>:

```js
function gesture(root, fromFraction, dy = 0) {
  const b = root.getBoundingClientRect();
  const x = b.left + b.width * fromFraction;
  const y = b.top + b.height / 2;
  const mk = (cy) => new Touch({ identifier: 1, target: root, clientX: x, clientY: cy });
  const fire = (type, cy) => {
    const list = type === 'touchend' ? [] : [mk(cy)];
    root.dispatchEvent(new TouchEvent(type, {
      bubbles: true, cancelable: true,
      touches: list, targetTouches: list, changedTouches: [mk(cy)],
    }));
  };
  fire('touchstart', y);
  if (dy) { fire('touchmove', y + dy); }
  fire('touchend', y + dy);
}

const value = (root) => root.querySelector('input:checked')?.value ?? null;
const ratings = document.querySelectorAll('.mantine-Rating-root');

// Defect 1 — a scroll gesture that starts on the "Usage" demo
const usage = ratings[0];
console.log('before:', value(usage));
gesture(usage, 0.9, 150);
setTimeout(() => console.log('after scroll gesture:', value(usage)), 100);
```

On `master` this prints `before: 2` then `after scroll gesture: 5` — the swipe set the rating. With this PR the value is unchanged.

The same helper shows #9122's symptom on the "Allow clear" demo, which starts at 3:

```js
const allowClear = ratings[2];
gesture(allowClear, 0.5); // tap the star that is already selected
setTimeout(() => console.log('after tap on selected star:', value(allowClear)), 100);
```

On `master` this prints `3` (nothing cleared). With this PR, or with #9122, it prints `0`.

## Verifying the fix

`npm run storybook`, then open **Rating → Controlled**, which renders the current value next to the component. Running the same helper there (against `.mantine-Rating-root`, reading the value from the label rather than the checked input) gives:

| Gesture | Before | After |
| --- | --- | --- |
| `touchstart` alone | value jumps immediately | no change |
| swipe down starting on the stars | value stuck at where the finger landed | no change |
| clean tap on star 4 | 4 | 4 |
| tap with a few px of drift | 1 | 1 |
| emulated click straight after a tap | applied a second time | ignored |
| mouse click well after a touch | works | works |

## Tests

Seven tests added in `Rating.test.tsx`. Four of them fail on `master` and pass with the fix:

- `does not change value when the touch moves before it ends`
- `does not change value when the touch is cancelled`
- `ignores the click emulated by the browser after a touch tap`
- `clears value on touch tap on the same value with allowClear=true` (the case #9122 covers)

The other three (`sets value on touch tap`, `does not change value on multi touch gestures`, `does not change value on touch tap when readOnly`) pass either way and are there to pin down the behaviour that should not regress.

`npx jest packages/@mantine/core/src/components/Rating` — 74 passed. `tsc --noEmit`, `oxlint` and `oxfmt` are clean on the changed files.
