### PR TITLE
[@mantine/core] Textarea: Fix ResizeObserver loop error when autosize textarea width changes

### DIFF
--- a/packages/@mantine/core/src/components/Textarea/Autosize.tsx
+++ b/packages/@mantine/core/src/components/Textarea/Autosize.tsx
@@ -212,15 +212,26 @@ export function TextareaAutosize({
 
     widthRef.current = node.offsetWidth;
 
+    // The observer watches the textarea itself; writing its height inside
+    // the callback changes the size of an element whose notification is
+    // being delivered, which browsers report as
+    // "ResizeObserver loop completed with undelivered notifications"
+    // (a window `error` event). Defer the write to the next frame instead.
+    let frame = 0;
+
     const observer = new ResizeObserver(() => {
       if (libRef.current && libRef.current.offsetWidth !== widthRef.current) {
         widthRef.current = libRef.current.offsetWidth;
-        resizeTextarea();
+        cancelAnimationFrame(frame);
+        frame = requestAnimationFrame(resizeTextarea);
       }
     });
 
     observer.observe(node);
-    return () => observer.disconnect();
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
   }, []);
 
   useEffect(() => {

--- a/packages/@mantine/core/src/components/Textarea/Autosize.tsx
+++ b/packages/@mantine/core/src/components/Textarea/Autosize.tsx
@@ -212,11 +212,6 @@ export function TextareaAutosize({
 
     widthRef.current = node.offsetWidth;
 
-    // The observer watches the textarea itself; writing its height inside
-    // the callback changes the size of an element whose notification is
-    // being delivered, which browsers report as
-    // "ResizeObserver loop completed with undelivered notifications"
-    // (a window `error` event). Defer the write to the next frame instead.
     let frame = 0;
 
     const observer = new ResizeObserver(() => {

--- a/packages/@mantine/core/src/components/Textarea/Autosize.tsx
+++ b/packages/@mantine/core/src/components/Textarea/Autosize.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef } from 'react';
+import React, { useEffect, useEffectEvent, useLayoutEffect, useRef } from 'react';
 import { useMergedRef } from '@mantine/hooks';
 
 type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
@@ -188,6 +188,8 @@ export function TextareaAutosize({
     }
   };
 
+  const handleResize = useEffectEvent(resizeTextarea);
+
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (!isControlled) {
       resizeTextarea();
@@ -218,7 +220,7 @@ export function TextareaAutosize({
       if (libRef.current && libRef.current.offsetWidth !== widthRef.current) {
         widthRef.current = libRef.current.offsetWidth;
         cancelAnimationFrame(frame);
-        frame = requestAnimationFrame(resizeTextarea);
+        frame = requestAnimationFrame(handleResize);
       }
     });
 


### PR DESCRIPTION
Fixes #9161

## Summary

Since 9.4.0 (`TextareaAutosize` replacing `react-textarea-autosize`), `<Textarea autosize />` raises `ResizeObserver loop completed with undelivered notifications` as a window `error` whenever the textarea's width changes (resizable sidebar, `Splitter` pane, viewport resize).

The `ResizeObserver` in `Autosize.tsx` observes the `<textarea>` itself and, when its width changed, calls `resizeTextarea()` synchronously inside the callback. That writes `style.height` on the very element whose notification is being delivered, which the browser reports as the loop error (the second observation is delivered next frame, so there is no visible defect — but it is an uncaught error for `window.onerror`, error trackers, and test runners that fail on page errors).

## Fix

Defer the height write to `requestAnimationFrame`, cancelled on cleanup — the same pattern `ScrollArea/use-resize-observer.ts` already uses. Width tracking (`widthRef`) is unchanged, so the observer still only reacts to width changes.

## Verification

- Bisect with only `@mantine/*` varied: 9.3.0 ✅ → 9.4.0 ❌ → 9.5.2 ❌.
- With this change applied to the built `Autosize.mjs`, a Playwright test that keyboard-resizes a sidebar containing an autosize `Textarea` — which failed deterministically on stock 9.4.0–9.5.2 with the loop error — passes with no page errors; autosize behaviour (min/max rows, growth on typing) is unchanged.
