### PR TITLE
[@mantine/hooks] use-hotkeys: Fix preventDefault not being applied when other hotkey options are set

### DIFF
--- a/packages/@mantine/hooks/src/use-hotkeys/parse-hotkey.test.ts
+++ b/packages/@mantine/hooks/src/use-hotkeys/parse-hotkey.test.ts
@@ -1,4 +1,4 @@
-import { getHotkeyMatcher, parseHotkey } from './parse-hotkey';
+import { getHotkeyHandler, getHotkeyMatcher, parseHotkey } from './parse-hotkey';
 
 describe('@mantine/hooks/use-hot-key/parse-hotkey', () => {
   it('should parse hotkey correctly', () => {
@@ -196,5 +196,31 @@ describe('@mantine/hooks/use-hot-key/parse-hotkey', () => {
         })
       )
     ).toBe(true);
+  });
+});
+
+describe('@mantine/hooks/use-hot-key/get-hotkey-handler', () => {
+  it('calls preventDefault by default when options are not provided', () => {
+    const handler = jest.fn();
+    const event = new KeyboardEvent('keydown', { ctrlKey: true, key: 'S', cancelable: true });
+    getHotkeyHandler([['ctrl+S', handler]])(event);
+    expect(handler).toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('calls preventDefault by default when only usePhysicalKeys option is provided', () => {
+    const handler = jest.fn();
+    const event = new KeyboardEvent('keydown', { code: 'KeyA', cancelable: true });
+    getHotkeyHandler([['A', handler, { usePhysicalKeys: true }]])(event);
+    expect(handler).toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('does not call preventDefault when preventDefault option is false', () => {
+    const handler = jest.fn();
+    const event = new KeyboardEvent('keydown', { ctrlKey: true, key: 'S', cancelable: true });
+    getHotkeyHandler([['ctrl+S', handler, { preventDefault: false }]])(event);
+    expect(handler).toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
   });
 });

--- a/packages/@mantine/hooks/src/use-hotkeys/parse-hotkey.ts
+++ b/packages/@mantine/hooks/src/use-hotkeys/parse-hotkey.ts
@@ -115,16 +115,16 @@ type HotkeyItem = [string, (event: any) => void, HotkeyItemOptions?];
 export function getHotkeyHandler(hotkeys: HotkeyItem[]) {
   return (event: React.KeyboardEvent<HTMLElement> | KeyboardEvent) => {
     const _event = 'nativeEvent' in event ? event.nativeEvent : event;
-    hotkeys.forEach(
-      ([hotkey, handler, options = { preventDefault: true, usePhysicalKeys: false }]) => {
-        if (getHotkeyMatcher(hotkey, options.usePhysicalKeys)(_event)) {
-          if (options.preventDefault) {
-            event.preventDefault();
-          }
+    hotkeys.forEach(([hotkey, handler, options]) => {
+      const { preventDefault = true, usePhysicalKeys = false } = options || {};
 
-          handler(_event);
+      if (getHotkeyMatcher(hotkey, usePhysicalKeys)(_event)) {
+        if (preventDefault) {
+          event.preventDefault();
         }
+
+        handler(_event);
       }
-    );
+    });
   };
 }

--- a/packages/@mantine/hooks/src/use-hotkeys/use-hotkeys.test.tsx
+++ b/packages/@mantine/hooks/src/use-hotkeys/use-hotkeys.test.tsx
@@ -4,6 +4,7 @@ import { useHotkeys } from './use-hotkeys';
 const dispatchEvent = (data: any) => {
   const event = new KeyboardEvent('keydown', data);
   document.documentElement.dispatchEvent(event);
+  return event;
 };
 
 describe('@mantine/hooks/use-hotkey', () => {
@@ -61,6 +62,30 @@ describe('@mantine/hooks/use-hotkey', () => {
     renderHook(() => useHotkeys([['A', handler, { usePhysicalKeys: true }]], [], true));
     dispatchEvent({ code: 'KeyA' });
     expect(handler).toHaveBeenCalled();
+  });
+
+  it('calls preventDefault by default when options are not provided', () => {
+    const handler = jest.fn();
+    renderHook(() => useHotkeys([['ctrl+S', handler]]));
+    const event = dispatchEvent({ ctrlKey: true, key: 'S', cancelable: true });
+    expect(handler).toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('calls preventDefault by default when only usePhysicalKeys option is provided', () => {
+    const handler = jest.fn();
+    renderHook(() => useHotkeys([['A', handler, { usePhysicalKeys: true }]]));
+    const event = dispatchEvent({ code: 'KeyA', cancelable: true });
+    expect(handler).toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('does not call preventDefault when preventDefault option is false', () => {
+    const handler = jest.fn();
+    renderHook(() => useHotkeys([['ctrl+S', handler, { preventDefault: false }]]));
+    const event = dispatchEvent({ ctrlKey: true, key: 'S', cancelable: true });
+    expect(handler).toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
   });
 
   it('does not re-register the listener when an inline array changes identity on rerender', () => {

--- a/packages/@mantine/hooks/src/use-hotkeys/use-hotkeys.ts
+++ b/packages/@mantine/hooks/src/use-hotkeys/use-hotkeys.ts
@@ -28,20 +28,20 @@ export function useHotkeys(
   triggerOnContentEditable = false
 ) {
   const handleKeydown = useEffectEvent((event: KeyboardEvent) => {
-    hotkeys.forEach(
-      ([hotkey, handler, options = { preventDefault: true, usePhysicalKeys: false }]) => {
-        if (
-          getHotkeyMatcher(hotkey, options.usePhysicalKeys)(event) &&
-          shouldFireEvent(event, tagsToIgnore, triggerOnContentEditable)
-        ) {
-          if (options.preventDefault) {
-            event.preventDefault();
-          }
+    hotkeys.forEach(([hotkey, handler, options]) => {
+      const { preventDefault = true, usePhysicalKeys = false } = options || {};
 
-          handler(event);
+      if (
+        getHotkeyMatcher(hotkey, usePhysicalKeys)(event) &&
+        shouldFireEvent(event, tagsToIgnore, triggerOnContentEditable)
+      ) {
+        if (preventDefault) {
+          event.preventDefault();
         }
+
+        handler(event);
       }
-    );
+    });
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

`useHotkeys` and `getHotkeyHandler` resolve hotkey item options with a destructuring default on the whole object:

```ts
([hotkey, handler, options = { preventDefault: true, usePhysicalKeys: false }]) => {
```

That default only applies when the third tuple element is absent. As soon as any options object is passed, `options.preventDefault` is `undefined` and `event.preventDefault()` is never called, even though `preventDefault` is meant to default to `true` (the option was added in #3044 to opt out of `preventDefault` always running).

The `use-hotkeys` documentation is affected by this. It shows `{ preventDefault: false }` as the way to opt out, and in the same example passes `{ usePhysicalKeys: true }` on its own:

```tsx
const hotkeys: HotkeyItem[] = [
  ['mod+J', () => {}, { preventDefault: false }],
  ['D', () => {}, { usePhysicalKeys: true }],
];
```

The second item silently loses `preventDefault`, so the browser default action for the key still runs.

## Solution

Resolve each option separately instead of defaulting the whole object:

```ts
const { preventDefault = true, usePhysicalKeys = false } = options || {};
```

Applied in both `useHotkeys` and `getHotkeyHandler`.

## Testing

Added tests to `use-hotkeys.test.tsx` and `parse-hotkey.test.ts` covering all three cases for both entry points: options omitted, a partial options object (`{ usePhysicalKeys: true }`), and an explicit `{ preventDefault: false }`.

Reverting the source change with the tests in place fails exactly the two partial options cases and leaves the other four passing.

- `npx jest packages/@mantine/hooks` - 63 suites, 551 tests passing
- `npx jest packages/@mantine/spotlight` - 44 tests passing (`Spotlight` is the in-repo `useHotkeys` consumer)
- `npm run typecheck`, `npm run build`, `npx oxlint`, `npm run format:write:files`
