### PR TITLE
[@mantine/hooks] use-roving-index: Fix disabled items not being skipped by ArrowLeft/ArrowRight in grid mode

### DIFF
--- a/packages/@mantine/hooks/src/use-roving-index/use-roving-index.test.ts
+++ b/packages/@mantine/hooks/src/use-roving-index/use-roving-index.test.ts
@@ -454,6 +454,76 @@ describe('@mantine/hooks/use-roving-index', () => {
       expect(result.current.focusedIndex).toBe(7);
     });
 
+    it('skips disabled items in horizontal grid navigation', () => {
+      const { result } = renderHook(() =>
+        useRovingIndex({
+          total: 9,
+          columns: 3,
+          initialIndex: 3,
+          isItemDisabled: (i) => i === 4,
+        })
+      );
+
+      act(() => {
+        result.current
+          .getItemProps({ index: 3 })
+          .onKeyDown(
+            new KeyboardEvent('keydown', { key: 'ArrowRight' }) as unknown as React.KeyboardEvent
+          );
+      });
+      expect(result.current.focusedIndex).toBe(5);
+
+      act(() => {
+        result.current
+          .getItemProps({ index: 5 })
+          .onKeyDown(
+            new KeyboardEvent('keydown', { key: 'ArrowLeft' }) as unknown as React.KeyboardEvent
+          );
+      });
+      expect(result.current.focusedIndex).toBe(3);
+    });
+
+    it('does not move horizontally when the rest of the row is disabled', () => {
+      const { result } = renderHook(() =>
+        useRovingIndex({
+          total: 9,
+          columns: 3,
+          initialIndex: 3,
+          isItemDisabled: (i) => i === 4 || i === 5,
+        })
+      );
+
+      act(() => {
+        result.current
+          .getItemProps({ index: 3 })
+          .onKeyDown(
+            new KeyboardEvent('keydown', { key: 'ArrowRight' }) as unknown as React.KeyboardEvent
+          );
+      });
+      expect(result.current.focusedIndex).toBe(3);
+    });
+
+    it('skips disabled items in horizontal grid navigation with RTL', () => {
+      const { result } = renderHook(() =>
+        useRovingIndex({
+          total: 9,
+          columns: 3,
+          dir: 'rtl',
+          initialIndex: 5,
+          isItemDisabled: (i) => i === 4,
+        })
+      );
+
+      act(() => {
+        result.current
+          .getItemProps({ index: 5 })
+          .onKeyDown(
+            new KeyboardEvent('keydown', { key: 'ArrowRight' }) as unknown as React.KeyboardEvent
+          );
+      });
+      expect(result.current.focusedIndex).toBe(3);
+    });
+
     it('Home navigates to first item in current row', () => {
       const { result } = renderHook(() =>
         useRovingIndex({ total: 9, columns: 3, initialIndex: 5 })

--- a/packages/@mantine/hooks/src/use-roving-index/use-roving-index.ts
+++ b/packages/@mantine/hooks/src/use-roving-index/use-roving-index.ts
@@ -126,6 +126,24 @@ function findLastEnabled(total: number, isItemDisabled: (index: number) => boole
   return 0;
 }
 
+function findEnabledInRow(
+  row: number,
+  startCol: number,
+  step: number,
+  columns: number,
+  total: number,
+  isItemDisabled: (index: number) => boolean
+): number | null {
+  for (let col = startCol; col >= 0 && col < columns; col += step) {
+    const candidate = row * columns + col;
+    if (candidate < total && !isItemDisabled(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
 const defaultIsItemDisabled = () => false;
 
 export function useRovingIndex(input: UseRovingIndexInput): UseRovingIndexReturnValue {
@@ -192,24 +210,14 @@ export function useRovingIndex(input: UseRovingIndexInput): UseRovingIndexReturn
 
       switch (event.key) {
         case 'ArrowRight': {
-          const targetCol = isRtl ? col - 1 : col + 1;
-          if (targetCol >= 0 && targetCol < columns! && row * columns! + targetCol < total) {
-            const candidate = row * columns! + targetCol;
-            if (!isItemDisabled(candidate)) {
-              nextIndex = candidate;
-            }
-          }
+          const step = isRtl ? -1 : 1;
+          nextIndex = findEnabledInRow(row, col + step, step, columns!, total, isItemDisabled);
           break;
         }
 
         case 'ArrowLeft': {
-          const targetCol = isRtl ? col + 1 : col - 1;
-          if (targetCol >= 0 && targetCol < columns! && row * columns! + targetCol < total) {
-            const candidate = row * columns! + targetCol;
-            if (!isItemDisabled(candidate)) {
-              nextIndex = candidate;
-            }
-          }
+          const step = isRtl ? 1 : -1;
+          nextIndex = findEnabledInRow(row, col + step, step, columns!, total, isItemDisabled);
           break;
         }
 


### PR DESCRIPTION
## What is broken

In grid mode (`columns` is set), `ArrowLeft` / `ArrowRight` do not skip disabled items. They look at the single adjacent cell only, and if that cell is disabled they leave focus where it is, so every cell after a disabled one is unreachable with horizontal arrow keys.

`packages/@mantine/hooks/src/use-roving-index/use-roving-index.ts:194-214` (before this change):

```tsx
case 'ArrowRight': {
  const targetCol = isRtl ? col - 1 : col + 1;
  if (targetCol >= 0 && targetCol < columns! && row * columns! + targetCol < total) {
    const candidate = row * columns! + targetCol;
    if (!isItemDisabled(candidate)) {
      nextIndex = candidate;
    }
  }
  break;
}
```

With `total: 9, columns: 3, isItemDisabled: (i) => i === 4`, pressing `ArrowRight` on index 3 keeps focus on index 3. Index 5 cannot be reached from index 3 at all.

## Why it is a bug

This contradicts the hook's own documented contract and its own behaviour everywhere else:

- The docs state it without qualification: "Disabled items are skipped during keyboard navigation" (`apps/mantine.dev/src/pages/hooks/use-roving-index.mdx`, Disabled items section).
- `ArrowUp` / `ArrowDown` in the same `handleGridKeyDown` switch do scan past disabled cells across rows.
- `Home` / `End` in the same switch scan past disabled cells within the row.
- List mode skips disabled items through `findNextEnabled` / `findPreviousEnabled`.

The existing suite already covers "skips disabled items in vertical grid navigation" but has no horizontal equivalent, which is why this was not caught.

The current behaviour is not the WAI-ARIA grid behaviour either. The APG grid pattern says Right Arrow "Moves focus one cell to the right", and today focus does not move at all, so the cell is neither skipped nor entered.

## Fix

Both horizontal cases now scan along the row in the travel direction through a shared `findEnabledInRow` helper, mirroring how the vertical cases already scan across rows. Boundary behaviour is unchanged: if there is no enabled cell left in the row, focus stays put.

## How it was verified

The jest suite resolves `@mantine/*` from source, not from build output (`jest.config.ts` `moduleNameMapper` maps `@mantine/(.*)` to `<rootDir>/packages/@mantine/$1/src`), so no rebuild is involved in the runs below.

Three tests were added. Reverting only the source file and re-running gives:

```
FAIL packages/@mantine/hooks/src/use-roving-index/use-roving-index.test.ts
  * grid navigation > skips disabled items in horizontal grid navigation
    expect(received).toBe(expected) // Object.is equality
    Expected: 5
    Received: 3

  * grid navigation > skips disabled items in horizontal grid navigation with RTL
    expect(received).toBe(expected) // Object.is equality
    Expected: 3
    Received: 5

Tests: 2 failed, 36 passed, 38 total
```

With the fix restored:

```
Tests: 38 passed, 38 total
```

The third added test ("does not move horizontally when the rest of the row is disabled") passes both before and after; it is there to pin the boundary case so the scan cannot over-reach into the next row.

Checks run on this branch:

- `yarn jest packages/@mantine/hooks` -> 63 suites, 548 tests passed
- `npx oxlint -c oxlint.config.mjs packages/@mantine/hooks/src/use-roving-index` -> exit 0
- `yarn format:test` -> "All matched files use the correct format"
- `npx tsc --noEmit` (root) -> exit 0
- `yarn build` -> 30 packages built

No stylelint run, since no CSS was touched. `apps/mantine.dev` typecheck reports one pre-existing error in `HomePageSponsors.tsx` caused by the un-generated `.docgen/sponsors.json` in a fresh clone; it reproduces with this branch's changes stashed.
