### PR TITLE
fix(notifications): avoid transition shorthand in stacked layout

### DIFF
--- a/packages/@mantine/notifications/src/NotificationContainer.tsx
+++ b/packages/@mantine/notifications/src/NotificationContainer.tsx
@@ -337,9 +337,11 @@ export function NotificationContainer({
           zIndex: (stackSize || 5) - (stackIndex ?? 0),
           pointerEvents: isCollapsed ? ('none' as const) : undefined,
           alignSelf: stackDirection === 1 ? ('start' as const) : ('end' as const),
-          transition: isDragging
-            ? 'none'
-            : `transform ${transitionDuration}ms cubic-bezier(.51,.3,0,1.21), opacity ${transitionDuration}ms ease`,
+          transitionProperty: isDragging ? 'none' : 'transform, opacity',
+          transitionDuration: isDragging
+            ? '0ms, 0ms'
+            : `${transitionDuration}ms, ${transitionDuration}ms`,
+          transitionTimingFunction: 'cubic-bezier(.51,.3,0,1.21), ease',
           transitionDelay: isDragging || isExiting ? '0ms' : `${staggerDelay}ms`,
         }
       : {}),

--- a/packages/@mantine/notifications/src/Notifications.test.tsx
+++ b/packages/@mantine/notifications/src/Notifications.test.tsx
@@ -599,6 +599,11 @@ describe('@mantine/core/Notifications', () => {
     const behind = alerts.find((alert) => alert.textContent?.includes('First stacked'))!;
     const front = alerts.find((alert) => alert.textContent?.includes('Second stacked'))!;
     expect(Number(behind.style.zIndex)).toBeLessThan(Number(front.style.zIndex));
+    expect(front.style.transitionProperty).toBe('transform, opacity');
+    expect(front.style.transitionDuration).toBe('10ms, 10ms');
+    expect(front.style.transitionTimingFunction).toBe('cubic-bezier(.51,.3,0,1.21), ease');
+    expect(front.style.transitionDelay).toBe('0ms');
+    expect(behind.style.transitionDelay).toBe('30ms');
   });
 
   it('keeps stacked styling while a stacked notification is exiting', () => {
@@ -637,7 +642,7 @@ describe('@mantine/core/Notifications', () => {
     // Stays inside the shared grid cell so the remaining notifications do not jump
     expect(exiting.style.gridArea).toBe('1 / 1');
     // Keeps a transition so the exit animation actually plays
-    expect(exiting.style.transition).not.toBe('');
+    expect(exiting.style.transitionProperty).toBe('transform, opacity');
     // Does not instantly collapse its height (stacked notifications overlap, no space to collapse)
     expect(exiting.style.maxHeight).not.toBe('0px');
     // Exit animation starts immediately, without the entrance stagger delay


### PR DESCRIPTION
Fixes #9168

The stacked notification layout currently uses the `transition` shorthand together with `transitionDelay`, which triggers a React warning.

This replaces the shorthand with the corresponding transition properties while preserving the existing transition and staggered delay behavior.

Added test coverage for the stacked notification transition styles.