### PR TITLE
[@mantine/notifications] Add stacked drag-cancel regression coverage

### DIFF
--- a/packages/@mantine/notifications/src/Notifications.test.tsx
+++ b/packages/@mantine/notifications/src/Notifications.test.tsx
@@ -601,6 +601,59 @@ describe('@mantine/core/Notifications', () => {
     expect(Number(behind.style.zIndex)).toBeLessThan(Number(front.style.zIndex));
   });
 
+  it('preserves stacked transitions without style conflicts when dragging is canceled', () => {
+    jest.useFakeTimers();
+    const store = createNotificationsStore();
+    const consoleError = jest.spyOn(console, 'error');
+
+    render(
+      <Notifications
+        store={store}
+        withinPortal={false}
+        autoClose={false}
+        transitionDuration={100}
+        layout="stacked"
+      />
+    );
+
+    act(() => {
+      notifications.show({ id: 'drag-stacked-a', message: 'First stacked' }, store);
+      notifications.show({ id: 'drag-stacked-b', message: 'Second stacked' }, store);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    const notification = screen
+      .getByText('Second stacked')
+      .closest('[role="alert"]') as HTMLElement;
+    fireEvent.mouseEnter(notification);
+    expect(notification.style.transitionDelay).toBe('0ms');
+
+    act(() => {
+      pointerDown(notification, { clientX: 0 });
+      pointerMove({ clientX: 40 });
+    });
+
+    expect(notification.style.getPropertyValue('--notifications-swipe-offset')).toBe('40px');
+    expect(notification.style.transitionDelay).toBe('0ms');
+
+    act(() => {
+      document.dispatchEvent(new PointerEvent('pointercancel', { bubbles: true, pointerId: 1 }));
+    });
+
+    expect(notification.style.getPropertyValue('--notifications-swipe-offset')).toBe('0px');
+    expect(notification.style.transitionDelay).toBe('0ms');
+    expect(store.getState().notifications).toHaveLength(2);
+    expect(
+      consoleError.mock.calls.filter(([message]) =>
+        String(message).includes('conflicting property')
+      )
+    ).toEqual([]);
+    consoleError.mockRestore();
+  });
+
   it('keeps stacked styling while a stacked notification is exiting', () => {
     jest.useFakeTimers();
     const store = createNotificationsStore();


### PR DESCRIPTION
Regression coverage for #9168.

The transition warning was fixed upstream in a0ad393896a101503dc95e93ca33375ae247619b and released in 9.6.1. I rebased this PR and removed the overlapping implementation changes. The diff now only adds a drag/cancel regression test; it does not change production code or the existing exit-animation test.

The test starts a drag on a stacked notification, cancels it, checks that the offset resets without dismissing either notification, and checks that React does not report a transition style conflict. I verified that it fails with the original transition shorthand and passes with the upstream fix.

## Testing

- Notification package: 96 tests passed.
- Full Jest suite with `TZ=UTC`: 16,704 tests passed across 690 suites; one snapshot passed.
- Package and documentation typechecks passed.
- Package build and changed-file lint/format checks passed.
- Separate Codex CLI review found no actionable issues.

Local checks used Node 24.11.0. The full suite used UTC because unrelated schedule tests depend on that timezone. This update is test-only and does not add new visual behavior.

I used AI to help write and review the regression test.
