### PR TITLE
[@mantine/notifications] Fix uneven spacing in expanded stacks

### DIFF
--- a/packages/@mantine/notifications/src/Notifications.module.css
+++ b/packages/@mantine/notifications/src/Notifications.module.css
@@ -38,7 +38,7 @@
 }
 
 .notification {
-  & + & {
+  &:where(& + &) {
     margin-top: var(--mantine-spacing-md);
   }
 


### PR DESCRIPTION
## Description

When a notification stack is expanded, the gap after the first notification is larger than the gaps between the others. The normal sibling margin has higher specificity than the stacked-layout reset, so it still adds margin on top of the stack offsets.

This uses the same `&:where(& + &)` pattern already present in `ChartTooltip` to let the stacked reset take precedence. Default-layout spacing and the existing 16px expanded-stack gap are unchanged.

I noticed this while testing #9174. This PR is separate and only changes the spacing selector.

## Testing

- Reproduced in the local Storybook build: the first expanded gap was about 32px, while the others were about 16px. After the fix, all gaps were about 16px.
- A local browser layout check failed before the fix and passed afterward across 24 combinations: six positions, stacked/default layouts, and equal/mixed notification heights. This check was run locally; no new test framework or test files are included in the PR.
- Manually checked the corrected spacing in the local Storybook demo.
- Full Jest suite: 688 suites and 16,689 tests passed.
- Typecheck, oxlint, stylelint, changed-file formatting check, build, and diff checks passed.
- Separate Codex CLI review completed with no actionable findings.

I used AI to help with the fix, automated checks, and code review.
