### PR TITLE
[@mantine/form] Fix removeListItem not clearing non-nested item errors

### DIFF
--- a/packages/@mantine/form/src/lists/change-error-indices.test.ts
+++ b/packages/@mantine/form/src/lists/change-error-indices.test.ts
@@ -97,6 +97,27 @@ describe('@mantine/form/change-error-indices', () => {
     });
   });
 
+  it('decrements error indices and removes the error of the removed element for a list of primitive values', () => {
+    const errors = {
+      name: 'name-error',
+      'fruits.0': 'fruit-error-1',
+      'fruits.1': 'fruit-error-2',
+      'fruits.2': 'fruit-error-3',
+    };
+
+    expect(changeErrorIndices('fruits', 0, errors, -1)).toStrictEqual({
+      name: 'name-error',
+      'fruits.0': 'fruit-error-2',
+      'fruits.1': 'fruit-error-3',
+    });
+
+    expect(changeErrorIndices('fruits', 1, errors, -1)).toStrictEqual({
+      name: 'name-error',
+      'fruits.0': 'fruit-error-1',
+      'fruits.1': 'fruit-error-3',
+    });
+  });
+
   describe('returns unchanged object', () => {
     it('if index is undefined', () => {
       expect(changeErrorIndices('fruits', undefined, TEST_ERRORS, 1)).toStrictEqual(TEST_ERRORS);

--- a/packages/@mantine/form/src/lists/change-error-indices.ts
+++ b/packages/@mantine/form/src/lists/change-error-indices.ts
@@ -26,6 +26,8 @@ export function changeErrorIndices<T extends Record<PropertyKey, any>>(
   // Remove all errors if the corresponding item was removed
   if (change === -1) {
     clearedErrors = clearListState(`${pathString}.${index}`, clearedErrors);
+    // clearListState matches nested keys only, the item's own error key has to be dropped separately
+    delete clearedErrors[`${pathString}.${index}`];
   }
 
   const cloned = { ...clearedErrors };

--- a/packages/@mantine/form/src/tests/use-form/removeListItem.test.ts
+++ b/packages/@mantine/form/src/tests/use-form/removeListItem.test.ts
@@ -71,6 +71,31 @@ function tests(mode: FormMode) {
     });
   });
 
+  it('updates errors of a list of primitive values when list item is removed', () => {
+    const hook = renderHook(() =>
+      useForm({
+        mode,
+        initialValues: {
+          name: '',
+          a: ['x', 'y', 'z'],
+        },
+        initialErrors: {
+          name: 'name-error',
+          'a.0': 'error-1',
+          'a.1': 'error-2',
+          'a.2': 'error-3',
+        },
+      })
+    );
+
+    act(() => hook.result.current.removeListItem('a', 1));
+    expect(hook.result.current.errors).toStrictEqual({
+      name: 'name-error',
+      'a.0': 'error-1',
+      'a.1': 'error-3',
+    });
+  });
+
   it('calls onValuesChange when removeListItem is called', () => {
     const spy = jest.fn();
     const hook = renderHook(() =>


### PR DESCRIPTION
## Bug

`form.removeListItem` does not remove the error of the deleted item when the error key is the item itself (`path.index`) rather than a field inside it (`path.index.field`). The stale error is then shifted down by one index, so it overwrites the error of the item before it. Removing index `0` produces a key with a negative index.

This affects lists of primitive values, where `form.getInputProps('tags.1')` reads `errors['tags.1']`, and any error set with `form.setFieldError('tags.1', ...)`.

## Reproduction

```tsx
const form = useForm({
  initialValues: { a: ['x', 'y', 'z'] },
  initialErrors: { 'a.0': 'error-1', 'a.1': 'error-2', 'a.2': 'error-3' },
});

form.removeListItem('a', 1);

// expected: { 'a.0': 'error-1', 'a.1': 'error-3' }
// actual:   { 'a.0': 'error-2', 'a.1': 'error-3' }
```

With index `0`:

```tsx
form.removeListItem('a', 0);

// expected: { 'a.0': 'error-2', 'a.1': 'error-3' }
// actual:   { 'a.-1': 'error-1', 'a.0': 'error-2', 'a.1': 'error-3' }
```

## Root cause

`changeErrorIndices` clears the removed item's errors with `clearListState(`${path}.${index}`, errors)`, but `clearListState` only matches keys that contain `` `${field}.` ``, so the exact key `path.index` never matches and survives into the reindexing loop. The increment branch (`insertListItem`) already handles these keys correctly, since it only shifts indices and never has to delete anything, so the two directions currently disagree.

Fix: delete the item's own error key alongside the nested ones. `clearListState` is left untouched because `use-form-status` relies on its current "nested keys only" behaviour for dirty state.

## Tests

- `change-error-indices.test.ts`: asserts the returned error object for `removeListItem` at index `0` and index `1` on a flat `path.index` error map. Without the fix the first case returns an extra `fruits.-1` key and the second returns `fruits.0: 'fruit-error-2'` instead of `'fruit-error-1'`.
- `removeListItem.test.ts`: the same assertion through `useForm` in both controlled and uncontrolled mode, mirroring the existing `updates errors of associated fields when list item is removed` test that covers the nested key case.

`@mantine/form` suite: 428 passing before, 431 after.
