### PR TITLE
[@mantine/charts] LineChart, CompositeChart, BubbleChart: Fix `textColor` and `gridColor` props being passed as attributes to the DOM node

### DIFF
--- a/packages/@mantine/charts/src/BubbleChart/BubbleChart.test.tsx
+++ b/packages/@mantine/charts/src/BubbleChart/BubbleChart.test.tsx
@@ -1,4 +1,4 @@
-import { autoPatchWarn, tests } from '@mantine-tests/core';
+import { autoPatchWarn, render, tests } from '@mantine-tests/core';
 import { BubbleChart, BubbleChartProps, BubbleChartStylesNames } from './BubbleChart';
 
 const defaultProps: BubbleChartProps = {
@@ -16,5 +16,13 @@ describe('@mantine/charts/BubbleChart', () => {
     varsResolver: true,
     displayName: '@mantine/charts/BubbleChart',
     stylesApiSelectors: ['root'],
+  });
+
+  it('does not pass textColor and gridColor props to the root element', () => {
+    const { container } = render(
+      <BubbleChart {...defaultProps} textColor="red" gridColor="blue" />
+    );
+    expect(container.querySelector('[textcolor]')).not.toBeInTheDocument();
+    expect(container.querySelector('[gridcolor]')).not.toBeInTheDocument();
   });
 });

--- a/packages/@mantine/charts/src/BubbleChart/BubbleChart.tsx
+++ b/packages/@mantine/charts/src/BubbleChart/BubbleChart.tsx
@@ -169,6 +169,8 @@ export const BubbleChart = factory<BubbleChartFactory>((_props) => {
     valueFormatter,
     attributes,
     accessibilityLayer,
+    gridColor,
+    textColor,
     ...others
   } = props;
 

--- a/packages/@mantine/charts/src/CompositeChart/CompositeChart.test.tsx
+++ b/packages/@mantine/charts/src/CompositeChart/CompositeChart.test.tsx
@@ -1,4 +1,4 @@
-import { autoPatchWarn, tests } from '@mantine-tests/core';
+import { autoPatchWarn, render, tests } from '@mantine-tests/core';
 import { CompositeChart, CompositeChartProps, CompositeChartStylesNames } from './CompositeChart';
 
 const defaultProps: CompositeChartProps = {
@@ -20,5 +20,13 @@ describe('@mantine/charts/CompositeChart', () => {
     varsResolver: true,
     displayName: '@mantine/charts/CompositeChart',
     stylesApiSelectors: ['root'],
+  });
+
+  it('does not pass textColor and gridColor props to the root element', () => {
+    const { container } = render(
+      <CompositeChart {...defaultProps} textColor="red" gridColor="blue" />
+    );
+    expect(container.querySelector('[textcolor]')).not.toBeInTheDocument();
+    expect(container.querySelector('[gridcolor]')).not.toBeInTheDocument();
   });
 });

--- a/packages/@mantine/charts/src/CompositeChart/CompositeChart.tsx
+++ b/packages/@mantine/charts/src/CompositeChart/CompositeChart.tsx
@@ -222,6 +222,8 @@ export const CompositeChart = factory<CompositeChartFactory>((_props) => {
     accessibilityLayer,
     withBrush,
     brushProps,
+    gridColor,
+    textColor,
     ...others
   } = props;
 

--- a/packages/@mantine/charts/src/LineChart/LineChart.test.tsx
+++ b/packages/@mantine/charts/src/LineChart/LineChart.test.tsx
@@ -1,4 +1,4 @@
-import { autoPatchWarn, tests } from '@mantine-tests/core';
+import { autoPatchWarn, render, tests } from '@mantine-tests/core';
 import { LineChart, LineChartProps, LineChartStylesNames } from './LineChart';
 
 const defaultProps: LineChartProps = {
@@ -20,5 +20,11 @@ describe('@mantine/charts/LineChart', () => {
     varsResolver: true,
     displayName: '@mantine/charts/LineChart',
     stylesApiSelectors: ['root'],
+  });
+
+  it('does not pass textColor and gridColor props to the root element', () => {
+    const { container } = render(<LineChart {...defaultProps} textColor="red" gridColor="blue" />);
+    expect(container.querySelector('[textcolor]')).not.toBeInTheDocument();
+    expect(container.querySelector('[gridcolor]')).not.toBeInTheDocument();
   });
 });

--- a/packages/@mantine/charts/src/LineChart/LineChart.tsx
+++ b/packages/@mantine/charts/src/LineChart/LineChart.tsx
@@ -210,6 +210,7 @@ export const LineChart = factory<LineChartFactory>((_props) => {
     withPointLabels,
     attributes,
     gridColor,
+    textColor,
     accessibilityLayer,
     withBrush,
     brushProps,


### PR DESCRIPTION
`textColor` (and `gridColor` in `CompositeChart` and `BubbleChart`) is read by the vars resolver but never taken out of `props`, so it stays in `...others` and lands on the root `div` as an attribute. React logs this on every render of a chart that sets it:

```
React does not recognize the `textColor` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `textcolor` instead.
```

Same thing as #7288 / #7349, which fixed `BarChart` in 7.15.2 and 7.15.3, and #7378 for `AreaChart`. `LineChart`, `CompositeChart` and `BubbleChart` still have it; every other chart already pulls the two props out before spreading the rest. Ran into it with `LineChart` on 9.6.0.

The fix is the same one-liner as before. I also added a small test to each of the three files that renders with both props and checks the root element does not carry them – it fails on `master` without the change.
