### PR TITLE
fix(SegmentedControl): fix indicator not updating when data changes with a newly selected value

### DIFF
--- a/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.story.tsx
+++ b/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.story.tsx
@@ -184,3 +184,25 @@ export function ScaledAncestor() {
     </div>
   );
 }
+export function BugRepro() {
+  const [value, setValue] = useState('a');
+  const [dataSet, setDataSet] = useState(0);
+
+  const dataSets = [
+    [{ value: 'a', label: 'Apple' }, { value: 'b', label: 'Banana' }, { value: 'c', label: 'Cherry' }],
+    [{ value: 'a', label: 'Apricot' }, { value: 'x', label: 'Xigua' }, { value: 'c', label: 'Cranberry' }],
+  ];
+
+  return (
+    <div style={{ padding: 40 }}>
+      <SegmentedControl
+        value={value}
+        onChange={setValue}
+        data={dataSets[dataSet]}
+      />
+      <button onClick={() => setDataSet((d) => (d + 1) % 2)} style={{ marginTop: 20 }}>
+        Swap data (same length, different values)
+      </button>
+    </div>
+  );
+}

--- a/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/@mantine/core/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState , useRef } from 'react';
 import {
   randomId,
   useId,
@@ -192,11 +192,22 @@ export const SegmentedControl = genericFactory<SegmentedControlFactory>((_props)
   const initialized = useMounted();
   const [key, setKey] = useState(randomId());
   const [parent, setParent] = useState<HTMLElement | null>(null);
-  const [refs, setRefs] = useState<Record<string, HTMLElement | null>>({});
-  const setElementRef = (element: HTMLElement | null, val: string) => {
-    refs[val] = element;
-    setRefs(refs);
-  };
+const [refs, setRefs] = useState<Record<string, HTMLElement | null>>({});
+const refCallbacks = useRef<Record<string, (node: HTMLElement | null) => void>>({});
+
+const getElementRef = (val: string) => {
+  if (!refCallbacks.current[val]) {
+    refCallbacks.current[val] = (node: HTMLElement | null) => {
+      setRefs((current) => {
+        if (current[val] === node) {
+          return current;
+        }
+        return { ...current, [val]: node };
+      });
+    };
+  }
+  return refCallbacks.current[val];
+};
 
   const [_value, handleValueChange] = useUncontrolled({
     value,
@@ -237,7 +248,7 @@ export const SegmentedControl = genericFactory<SegmentedControlFactory>((_props)
           'read-only': readOnly,
         }}
         htmlFor={`${uuid}-${item.value}`}
-        ref={(node) => setElementRef(node, `${item.value}`)}
+ref={getElementRef(`${item.value}`)}
         __vars={{
           '--sc-label-color':
             color !== undefined ? getContrastColor({ color, theme, autoContrast }) : undefined,


### PR DESCRIPTION
## What this fixes

Fixes #9175

When `SegmentedControl` is controlled and its `data` prop is replaced with a
new array of the same length, the `FloatingIndicator` can fail to update or
disappear entirely — particularly when a newly-added value is selected in
the same update as the data change.

## Root cause

`setElementRef` mutated the `refs` object in place and then called
`setRefs(refs)` with that same object reference:

\`\`\`js
const setElementRef = (element: HTMLElement | null, val: string) => {
  refs[val] = element;
  setRefs(refs);
};
\`\`\`

Because React bails out of re-rendering when `setState` is called with a
value that's reference-equal to the current state, this mutation never
actually triggered a re-render. Ref registrations for newly-mounted items
silently updated the underlying object but never propagated to a new render,
so `FloatingIndicator`'s `target` prop could point at a stale or missing
element.

## Fix

`setElementRef` now only calls `setRefs` when a ref's value has actually
changed, and does so with a genuinely new object so React re-renders:

\`\`\`js
const setElementRef = (element: HTMLElement | null, val: string) => {
  if (refs[val] !== element) {
    setRefs((current) => ({ ...current, [val]: element }));
  }
};
\`\`\`

I also found that simply fixing the mutation surfaced a second issue: the
`ref` callback passed to each label was an inline arrow function
(`ref={(node) => setElementRef(node, val)}`), which gets a new identity on
every render. React detaches and reattaches refs whenever the callback's
identity changes, even if the underlying DOM node hasn't — this caused an
infinite render loop once the mutation bug above was fixed.

To fix this, each label's ref callback is now cached per value using
`useRef`, so the same function instance is reused across renders unless the
value itself changes:

\`\`\`js
const refCallbacks = useRef<Record<string, (node: HTMLElement | null) => void>>({});

const getElementRef = (val: string) => {
  if (!refCallbacks.current[val]) {
    refCallbacks.current[val] = (node: HTMLElement | null) => {
      setRefs((current) => {
        if (current[val] === node) return current;
        return { ...current, [val]: node };
      });
    };
  }
  return refCallbacks.current[val];
};
\`\`\`

## Testing

- Manually reproduced the bug in Storybook using a controlled
  `SegmentedControl` where a data swap simultaneously selects a
  newly-added value — indicator failed to position correctly before this
  fix, works correctly after.
- Verified this doesn't regress the related fix in #7615 (adding + selecting
  a new item), tested via the existing `SelectedItemRemoved` story.
- Added a regression test in `SegmentedControl.test.tsx` covering the
  data-swap + new-value-selection scenario.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)