### PR TITLE
[@mantine/core] Modal, Drawer: Handle Escape once per stack

### DIFF
--- a/packages/@mantine/core/src/components/Drawer/Drawer.tsx
+++ b/packages/@mantine/core/src/components/Drawer/Drawer.tsx
@@ -94,6 +94,7 @@ export const Drawer = factory<DrawerFactory>((_props) => {
           closeOnEscape: ctx.currentId === stackId,
           trapFocus: ctx.currentId === stackId,
           zIndex: ctx.getZIndex(stackId),
+          __handledEscapeEvents: ctx.handledEscapeEvents,
         }
       : {};
 

--- a/packages/@mantine/core/src/components/Drawer/DrawerStack.test.tsx
+++ b/packages/@mantine/core/src/components/Drawer/DrawerStack.test.tsx
@@ -1,23 +1,23 @@
 import { act, fireEvent, screen } from '@testing-library/react';
 import { render } from '@mantine-tests/core';
-import { Modal } from './Modal';
-import { useModalsStack } from './use-modals-stack';
+import { useDrawersStack } from '../Modal/use-modals-stack';
+import { Drawer } from './Drawer';
 
 function TestContainer() {
-  const stack = useModalsStack(['a', 'b']);
+  const stack = useDrawersStack(['a', 'b']);
 
   return (
     <>
-      <Modal.Stack>
+      <Drawer.Stack>
         {(['a', 'b'] as const).map((id) => (
-          <Modal
+          <Drawer
             key={id}
             {...stack.register(id)}
             onClose={() => act(() => stack.close(id))}
             title={id}
           />
         ))}
-      </Modal.Stack>
+      </Drawer.Stack>
       <button type="button" onClick={() => stack.open('a')}>
         Open a
       </button>
@@ -33,7 +33,7 @@ function pressEscape() {
   document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
 }
 
-describe('@mantine/core/Modal.Stack', () => {
+describe('@mantine/core/Drawer.Stack', () => {
   it.each([
     ['a', 'b'],
     ['b', 'a'],

--- a/packages/@mantine/core/src/components/Drawer/DrawerStack.tsx
+++ b/packages/@mantine/core/src/components/Drawer/DrawerStack.tsx
@@ -8,6 +8,7 @@ interface DrawerStackContext {
   getZIndex: (id: string) => string;
   currentId: string;
   maxZIndex: string | number;
+  handledEscapeEvents: WeakSet<KeyboardEvent>;
 }
 
 export const DrawerStackContext = createContext<DrawerStackContext | null>(null);
@@ -19,6 +20,7 @@ export interface DrawerStackProps {
 export function DrawerStack({ children }: DrawerStackProps) {
   const [stack, setStack] = useState<string[]>([]);
   const [maxZIndex, setMaxZIndex] = useState<number | string>(getDefaultZIndex('modal'));
+  const [handledEscapeEvents] = useState(() => new WeakSet<KeyboardEvent>());
 
   return (
     <DrawerStackContext
@@ -36,6 +38,7 @@ export function DrawerStack({ children }: DrawerStackProps) {
         getZIndex: (id) => `calc(${maxZIndex} + ${stack.indexOf(id)} + 1)`,
         currentId: stack[stack.length - 1],
         maxZIndex,
+        handledEscapeEvents,
       }}
     >
       {children}

--- a/packages/@mantine/core/src/components/Modal/Modal.tsx
+++ b/packages/@mantine/core/src/components/Modal/Modal.tsx
@@ -96,6 +96,7 @@ export const Modal = factory<ModalFactory>((_props) => {
           closeOnEscape: ctx.currentId === stackId,
           trapFocus: ctx.currentId === stackId,
           zIndex: ctx.getZIndex(stackId),
+          __handledEscapeEvents: ctx.handledEscapeEvents,
         }
       : {};
 

--- a/packages/@mantine/core/src/components/Modal/ModalStack.test.tsx
+++ b/packages/@mantine/core/src/components/Modal/ModalStack.test.tsx
@@ -1,0 +1,107 @@
+import { act, fireEvent, screen } from '@testing-library/react';
+import { render } from '@mantine-tests/core';
+import { Drawer } from '../Drawer';
+import { Modal } from './Modal';
+import { useModalsStack } from './use-modals-stack';
+
+function TestStack({ type }: { type: 'Modal' | 'Drawer' }) {
+  const Component = type === 'Modal' ? Modal : Drawer;
+  const stack = useModalsStack(['a', 'b']);
+
+  return (
+    <>
+      <Component.Stack>
+        {(['a', 'b'] as const).map((id) => (
+          <Component
+            key={id}
+            {...stack.register(id)}
+            onClose={() => act(() => stack.close(id))}
+            title={id}
+          />
+        ))}
+      </Component.Stack>
+      <button type="button" onClick={() => stack.open('a')}>
+        Open a
+      </button>
+      <button type="button" onClick={() => stack.open('b')}>
+        Open b
+      </button>
+      <output data-testid="state">{JSON.stringify(stack.state)}</output>
+    </>
+  );
+}
+
+describe.each(['Modal', 'Drawer'] as const)('@mantine/core/%s.Stack', (type) => {
+  it.each([
+    ['a', 'b'],
+    ['b', 'a'],
+  ] as const)(
+    'closes one layer per Escape when opening %s then %s and flushing close effects between listeners',
+    (first, second) => {
+      render(<TestStack type={type} />);
+      fireEvent.click(screen.getByText(`Open ${first}`));
+      fireEvent.click(screen.getByText(`Open ${second}`));
+      expect(screen.getByTestId('state')).toHaveTextContent('{"a":true,"b":true}');
+
+      document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      expect(screen.getByTestId('state')).toHaveTextContent(
+        JSON.stringify({ a: first === 'a', b: first === 'b' })
+      );
+
+      document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      expect(screen.getByTestId('state')).toHaveTextContent('{"a":false,"b":false}');
+    }
+  );
+
+  it('handles Escape independently in separate stacks', () => {
+    render(
+      <>
+        <TestStack type={type} />
+        <TestStack type={type} />
+      </>
+    );
+    screen.getAllByText('Open b').forEach((button) => fireEvent.click(button));
+    screen.getAllByText('Open a').forEach((button) => fireEvent.click(button));
+
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    screen.getAllByTestId('state').forEach((state) => {
+      expect(state).toHaveTextContent('{"a":false,"b":true}');
+    });
+  });
+
+  it('allows the handled Escape event to reach other listeners', () => {
+    render(<TestStack type={type} />);
+    fireEvent.click(screen.getByText('Open b'));
+    fireEvent.click(screen.getByText('Open a'));
+
+    const listener = jest.fn();
+    document.body.addEventListener('keydown', listener, { once: true });
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+    document.body.dispatchEvent(event);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(event);
+    expect(event.defaultPrevented).toBe(false);
+    expect(screen.getByTestId('state')).toHaveTextContent('{"a":false,"b":true}');
+  });
+
+  it('ignores composing Escape events and targets that stop propagation', () => {
+    render(
+      <>
+        <TestStack type={type} />
+        <input data-testid="input" data-mantine-stop-propagation="true" />
+      </>
+    );
+    fireEvent.click(screen.getByText('Open b'));
+    fireEvent.click(screen.getByText('Open a'));
+
+    fireEvent.keyDown(document.body, { key: 'Escape', isComposing: true });
+    expect(screen.getByTestId('state')).toHaveTextContent('{"a":true,"b":true}');
+
+    fireEvent.keyDown(screen.getByTestId('input'), { key: 'Escape' });
+    expect(screen.getByTestId('state')).toHaveTextContent('{"a":true,"b":true}');
+
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(screen.getByTestId('state')).toHaveTextContent('{"a":false,"b":true}');
+  });
+});

--- a/packages/@mantine/core/src/components/Modal/ModalStack.tsx
+++ b/packages/@mantine/core/src/components/Modal/ModalStack.tsx
@@ -8,6 +8,7 @@ interface ModalStackContext {
   getZIndex: (id: string) => string;
   currentId: string;
   maxZIndex: string | number;
+  handledEscapeEvents: WeakSet<KeyboardEvent>;
 }
 
 export const ModalStackContext = createContext<ModalStackContext | null>(null);
@@ -19,6 +20,7 @@ export interface ModalStackProps {
 export function ModalStack({ children }: ModalStackProps) {
   const [stack, setStack] = useState<string[]>([]);
   const [maxZIndex, setMaxZIndex] = useState<number | string>(getDefaultZIndex('modal'));
+  const [handledEscapeEvents] = useState(() => new WeakSet<KeyboardEvent>());
 
   return (
     <ModalStackContext
@@ -36,6 +38,7 @@ export function ModalStack({ children }: ModalStackProps) {
         getZIndex: (id) => `calc(${maxZIndex} + ${stack.indexOf(id)} + 1)`,
         currentId: stack[stack.length - 1],
         maxZIndex,
+        handledEscapeEvents,
       }}
     >
       {children}

--- a/packages/@mantine/core/src/components/ModalBase/ModalBase.tsx
+++ b/packages/@mantine/core/src/components/ModalBase/ModalBase.tsx
@@ -19,6 +19,7 @@ type RemoveScrollProps = Omit<React.ComponentProps<typeof RemoveScroll>, 'childr
 
 export interface ModalBaseProps extends BoxProps, ElementProps<'div', 'title'> {
   unstyled?: boolean;
+  __handledEscapeEvents?: WeakSet<KeyboardEvent>;
 
   /** If set modal/drawer is not unmounted from the DOM when hidden. `display: none` styles are applied instead. @default false */
   keepMounted?: boolean;
@@ -111,10 +112,20 @@ export function ModalBase({
   __vars,
   unstyled,
   removeScrollProps,
+  __handledEscapeEvents,
   ...others
 }: ModalBaseProps) {
   const { _id, titleMounted, bodyMounted, shouldLockScroll, setTitleMounted, setBodyMounted } =
-    useModal({ id, transitionProps, opened, trapFocus, closeOnEscape, onClose, returnFocus });
+    useModal({
+      id,
+      transitionProps,
+      opened,
+      trapFocus,
+      closeOnEscape,
+      onClose,
+      returnFocus,
+      handledEscapeEvents: __handledEscapeEvents,
+    });
 
   const { key: removeScrollKey, ...otherRemoveScrollProps } = removeScrollProps || {};
 

--- a/packages/@mantine/core/src/components/ModalBase/use-modal.ts
+++ b/packages/@mantine/core/src/components/ModalBase/use-modal.ts
@@ -11,6 +11,7 @@ interface UseModalInput {
   trapFocus: boolean | undefined;
   closeOnEscape: boolean | undefined;
   returnFocus: boolean | undefined;
+  handledEscapeEvents?: WeakSet<KeyboardEvent>;
 }
 
 export function useModal({
@@ -21,6 +22,7 @@ export function useModal({
   closeOnEscape,
   onClose,
   returnFocus,
+  handledEscapeEvents,
 }: UseModalInput) {
   const _id = useId(id);
   const [titleMounted, setTitleMounted] = useState(false);
@@ -34,10 +36,19 @@ export function useModal({
   useWindowEvent(
     'keydown',
     (event) => {
-      if (event.key === 'Escape' && closeOnEscape && !event.isComposing && opened) {
+      if (
+        event.key === 'Escape' &&
+        closeOnEscape &&
+        !event.isComposing &&
+        opened &&
+        !handledEscapeEvents?.has(event)
+      ) {
         const shouldTrigger =
           (event.target as HTMLElement)?.getAttribute('data-mantine-stop-propagation') !== 'true';
-        shouldTrigger && onClose();
+        if (shouldTrigger) {
+          handledEscapeEvents?.add(event);
+          onClose();
+        }
       }
     },
     { capture: true }


### PR DESCRIPTION
Fixes #9185

When the top modal or drawer mounts before the layer underneath it, closing it can flush React updates between the window's Escape listeners. The lower layer then becomes active and closes on the same keypress.

Each stack now tracks handled Escape events and records the event before calling `onClose`. One Escape closes only the top layer, and the next keypress closes the layer beneath it. Separate stacks handle events independently, and the event continues to reach other listeners.

Added regression tests for both opening orders, successive keypresses, separate stacks, event propagation, and the existing composition/stop-propagation guards. The tests flush close effects between native listeners to reproduce browser timing in jsdom; eight cases fail when the fix is removed.

Testing:

- Reproduced the original conditional `ScrollArea.Autosize` example in Chromium for both Modal and Drawer. Both opening orders pass with the fix.
- All 566 Modal and Drawer tests pass.
- `TZ=UTC npm test` passes: 16,699 tests across 689 suites, plus typechecks for packages and docs, linting, formatting, and dependency consistency checks.
- All 30 packages build successfully with `npm run build`.
